### PR TITLE
test(mlit): mlit/client.go の単体テスト追加

### DIFF
--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -13,8 +13,10 @@ import (
 	"github.com/yield-guard/backend/internal/domain"
 )
 
+// baseURL はテストで上書き可能にするため var として定義
+var baseURL = "https://www.land.mlit.go.jp/webland/api/TradeListSearch"
+
 const (
-	baseURL        = "https://www.land.mlit.go.jp/webland/api/TradeListSearch"
 	requestTimeout = 30 * time.Second
 
 	// リトライ設定: 国交省APIは一時的な障害が多いため指数バックオフで再試行する

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -13,33 +13,33 @@ import (
 	"github.com/yield-guard/backend/internal/domain"
 )
 
-// baseURL はテストで上書き可能にするため var として定義
-var baseURL = "https://www.land.mlit.go.jp/webland/api/TradeListSearch"
-
 const (
+	mlitBaseURL    = "https://www.land.mlit.go.jp/webland/api/TradeListSearch"
 	requestTimeout = 30 * time.Second
 
 	// リトライ設定: 国交省APIは一時的な障害が多いため指数バックオフで再試行する
-	maxRetries      = 3
-	retryBaseDelay  = 1 * time.Second
+	maxRetries     = 3
+	retryBaseDelay = 1 * time.Second
 )
 
 // Client は国交省 不動産取引価格情報取得APIのクライアント
 type Client struct {
 	httpClient *http.Client
+	baseURL    string
 }
 
 // NewClient は新しい Client を返す
 func NewClient() *Client {
 	return &Client{
 		httpClient: &http.Client{Timeout: requestTimeout},
+		baseURL:    mlitBaseURL,
 	}
 }
 
 // FetchLandPrices は指定条件で土地取引価格を取得し、統計を返す。
 // 一時的なネットワーク障害や 5xx レスポンスに対して指数バックオフでリトライする（ISSUE-13）。
 func (c *Client) FetchLandPrices(ctx context.Context, q LandPriceQuery) ([]domain.LandTransaction, error) {
-	apiURL, err := buildURL(q)
+	apiURL, err := c.buildURL(q)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func isClientError(err error) bool {
 }
 
 // buildURL はAPIのクエリURLを生成する
-func buildURL(q LandPriceQuery) (string, error) {
+func (c *Client) buildURL(q LandPriceQuery) (string, error) {
 	if q.Area == "" {
 		return "", fmt.Errorf("area is required")
 	}
@@ -129,7 +129,7 @@ func buildURL(q LandPriceQuery) (string, error) {
 		params.Set("city", q.City)
 	}
 
-	return baseURL + "?" + params.Encode(), nil
+	return c.baseURL + "?" + params.Encode(), nil
 }
 
 // parseTransactions はAPIレスポンスを domain.LandTransaction スライスに変換する

--- a/backend/internal/mlit/client_test.go
+++ b/backend/internal/mlit/client_test.go
@@ -1,0 +1,292 @@
+package mlit
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// ---- parseFloat ----
+
+func TestParseFloat(t *testing.T) {
+	tests := []struct {
+		input string
+		want  float64
+	}{
+		{"", 0},
+		{"－", 0},
+		{"-", 0},
+		{"1000000", 1_000_000},
+		{"1,000,000", 1_000_000},
+		{"１２３４５６", 123_456},
+		{"１００", 100},
+		{"100以上", 100},
+		{"500未満", 500},
+		{"100m²", 100},
+		{"200㎡", 200},
+		{"50坪", 50},
+		{"300000円", 300_000},
+		{"  1000  ", 1_000},
+		{"abc", 0},
+		{"1,234,567", 1_234_567},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := parseFloat(tt.input)
+			if got != tt.want {
+				t.Errorf("parseFloat(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---- isLandType ----
+
+func TestIsLandType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"宅地(土地)", true},
+		{"宅地のみ", false},   // "土地" を含まない
+		{"土地のみ", false},   // "宅地" を含まない
+		{"中古マンション等", false},
+		{"農地", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := isLandType(tt.input)
+			if got != tt.want {
+				t.Errorf("isLandType(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// ---- buildURL ----
+
+func TestBuildURL(t *testing.T) {
+	t.Run("area が空のときエラー", func(t *testing.T) {
+		_, err := buildURL(LandPriceQuery{From: "20231", To: "20234"})
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("from が空のときエラー", func(t *testing.T) {
+		_, err := buildURL(LandPriceQuery{Area: "13", To: "20234"})
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("to が空のときエラー", func(t *testing.T) {
+		_, err := buildURL(LandPriceQuery{Area: "13", From: "20231"})
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("必須パラメータが揃っているとき URL を生成する", func(t *testing.T) {
+		got, err := buildURL(LandPriceQuery{Area: "13", From: "20231", To: "20234"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == "" {
+			t.Error("expected non-empty URL")
+		}
+		// area / from / to がクエリに含まれること
+		for _, param := range []string{"area=13", "from=20231", "to=20234"} {
+			if !strings.Contains(got, param) {
+				t.Errorf("URL %q does not contain %q", got, param)
+			}
+		}
+	})
+
+	t.Run("city が指定されているときクエリに含まれる", func(t *testing.T) {
+		got, err := buildURL(LandPriceQuery{Area: "13", From: "20231", To: "20234", City: "13101"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !strings.Contains(got, "city=13101") {
+			t.Errorf("URL %q does not contain city=13101", got)
+		}
+	})
+}
+
+// ---- parseTransactions ----
+
+func TestParseTransactions(t *testing.T) {
+	t.Run("宅地(土地)のみ抽出される", func(t *testing.T) {
+		raw := []Transaction{
+			{Type: "宅地(土地)", TradePrice: "10000000", Area: "100", PricePerUnit: "100000"},
+			{Type: "中古マンション等", TradePrice: "20000000", Area: "60", PricePerUnit: "333333"},
+			{Type: "宅地(土地)", TradePrice: "5000000", Area: "50", PricePerUnit: "100000"},
+		}
+		got := parseTransactions(raw)
+		if len(got) != 2 {
+			t.Errorf("len = %d, want 2", len(got))
+		}
+	})
+
+	t.Run("単価が空のとき総額と面積から算出", func(t *testing.T) {
+		raw := []Transaction{
+			{Type: "宅地(土地)", TradePrice: "10000000", Area: "100", PricePerUnit: ""},
+		}
+		got := parseTransactions(raw)
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+		// 10,000,000 / 100 = 100,000 円/m²
+		if got[0].PricePerSqm != 100_000 {
+			t.Errorf("PricePerSqm = %v, want 100000", got[0].PricePerSqm)
+		}
+	})
+
+	t.Run("空スライスのとき空スライスを返す", func(t *testing.T) {
+		got := parseTransactions([]Transaction{})
+		if len(got) != 0 {
+			t.Errorf("len = %d, want 0", len(got))
+		}
+	})
+}
+
+// ---- FetchLandPrices リトライロジック ----
+
+func okResponse(w http.ResponseWriter) {
+	resp := APIResponse{Status: "OK", Data: []Transaction{
+		{Type: "宅地(土地)", TradePrice: "10000000", Area: "100", PricePerUnit: "100000", Period: "令和5年第3四半期"},
+	}}
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		panic(err)
+	}
+}
+
+func TestFetchLandPrices_RetryOn5xx(t *testing.T) {
+	attempt := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt++
+		if attempt < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable) // 5xx
+			return
+		}
+		okResponse(w)
+	}))
+	defer ts.Close()
+
+	origBaseURL := baseURL
+	baseURL = ts.URL
+	defer func() { baseURL = origBaseURL }()
+
+	c := &Client{httpClient: &http.Client{}}
+	// retryBaseDelay=1s のため遅延が発生するが許容範囲内
+	result, err := c.FetchLandPrices(context.Background(), LandPriceQuery{
+		Area: "13", From: "20231", To: "20234",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result) != 1 {
+		t.Errorf("len = %d, want 1", len(result))
+	}
+	if attempt != 3 {
+		t.Errorf("attempt = %d, want 3 (2 failures + 1 success)", attempt)
+	}
+}
+
+func TestFetchLandPrices_AllAttemptsFailWith5xx(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	origBaseURL := baseURL
+	baseURL = ts.URL
+	defer func() { baseURL = origBaseURL }()
+
+	c := &Client{httpClient: &http.Client{}}
+	_, err := c.FetchLandPrices(context.Background(), LandPriceQuery{
+		Area: "13", From: "20231", To: "20234",
+	})
+	if err == nil {
+		t.Fatal("expected error after all retries, got nil")
+	}
+}
+
+func TestFetchLandPrices_NoRetryOn4xx(t *testing.T) {
+	attempt := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempt++
+		w.WriteHeader(http.StatusBadRequest) // 4xx
+	}))
+	defer ts.Close()
+
+	origBaseURL := baseURL
+	baseURL = ts.URL
+	defer func() { baseURL = origBaseURL }()
+
+	c := &Client{httpClient: &http.Client{}}
+	_, err := c.FetchLandPrices(context.Background(), LandPriceQuery{
+		Area: "13", From: "20231", To: "20234",
+	})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if attempt != 1 {
+		t.Errorf("attempt = %d, want 1 (no retry on 4xx)", attempt)
+	}
+}
+
+func TestFetchLandPrices_ContextCancel(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	origBaseURL := baseURL
+	baseURL = ts.URL
+	defer func() { baseURL = origBaseURL }()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	// 1回目が終わったらすぐキャンセル
+	go func() { cancel() }()
+
+	c := &Client{httpClient: &http.Client{}}
+	_, err := c.FetchLandPrices(ctx, LandPriceQuery{
+		Area: "13", From: "20231", To: "20234",
+	})
+	if err == nil {
+		t.Fatal("expected error after context cancel, got nil")
+	}
+}
+
+func TestFetchLandPrices_APIStatusNotOK(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := APIResponse{Status: "ERROR", Data: nil}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(resp); err != nil {
+			panic(err)
+		}
+	}))
+	defer ts.Close()
+
+	origBaseURL := baseURL
+	baseURL = ts.URL
+	defer func() { baseURL = origBaseURL }()
+
+	c := &Client{httpClient: &http.Client{}}
+	_, err := c.FetchLandPrices(context.Background(), LandPriceQuery{
+		Area: "13", From: "20231", To: "20234",
+	})
+	if err == nil {
+		t.Fatal("expected error for status=ERROR, got nil")
+	}
+}
+

--- a/backend/internal/mlit/client_test.go
+++ b/backend/internal/mlit/client_test.go
@@ -3,10 +3,14 @@ package mlit
 import (
 	"context"
 	"encoding/json"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/yield-guard/backend/internal/domain"
 )
 
 // ---- parseFloat ----
@@ -32,6 +36,11 @@ func TestParseFloat(t *testing.T) {
 		{"  1000  ", 1_000},
 		{"abc", 0},
 		{"1,234,567", 1_234_567},
+		// 浮動小数点
+		{"1.5", 1.5},
+		{"3.30578", 3.30578},
+		// 負数: "-" 単体のみゼロ扱い。"-100" のような数値は正しく解析される
+		{"-100", -100},
 	}
 
 	for _, tt := range tests {
@@ -52,8 +61,8 @@ func TestIsLandType(t *testing.T) {
 		want  bool
 	}{
 		{"宅地(土地)", true},
-		{"宅地のみ", false},   // "土地" を含まない
-		{"土地のみ", false},   // "宅地" を含まない
+		{"宅地のみ", false},  // "土地" を含まない
+		{"土地のみ", false},  // "宅地" を含まない
 		{"中古マンション等", false},
 		{"農地", false},
 		{"", false},
@@ -71,37 +80,39 @@ func TestIsLandType(t *testing.T) {
 
 // ---- buildURL ----
 
+func newTestClient(serverURL string) *Client {
+	return &Client{httpClient: &http.Client{}, baseURL: serverURL}
+}
+
 func TestBuildURL(t *testing.T) {
+	c := &Client{baseURL: "http://example.com"}
+
 	t.Run("area が空のときエラー", func(t *testing.T) {
-		_, err := buildURL(LandPriceQuery{From: "20231", To: "20234"})
+		_, err := c.buildURL(LandPriceQuery{From: "20231", To: "20234"})
 		if err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
 
 	t.Run("from が空のときエラー", func(t *testing.T) {
-		_, err := buildURL(LandPriceQuery{Area: "13", To: "20234"})
+		_, err := c.buildURL(LandPriceQuery{Area: "13", To: "20234"})
 		if err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
 
 	t.Run("to が空のときエラー", func(t *testing.T) {
-		_, err := buildURL(LandPriceQuery{Area: "13", From: "20231"})
+		_, err := c.buildURL(LandPriceQuery{Area: "13", From: "20231"})
 		if err == nil {
 			t.Error("expected error, got nil")
 		}
 	})
 
 	t.Run("必須パラメータが揃っているとき URL を生成する", func(t *testing.T) {
-		got, err := buildURL(LandPriceQuery{Area: "13", From: "20231", To: "20234"})
+		got, err := c.buildURL(LandPriceQuery{Area: "13", From: "20231", To: "20234"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if got == "" {
-			t.Error("expected non-empty URL")
-		}
-		// area / from / to がクエリに含まれること
 		for _, param := range []string{"area=13", "from=20231", "to=20234"} {
 			if !strings.Contains(got, param) {
 				t.Errorf("URL %q does not contain %q", got, param)
@@ -110,7 +121,7 @@ func TestBuildURL(t *testing.T) {
 	})
 
 	t.Run("city が指定されているときクエリに含まれる", func(t *testing.T) {
-		got, err := buildURL(LandPriceQuery{Area: "13", From: "20231", To: "20234", City: "13101"})
+		got, err := c.buildURL(LandPriceQuery{Area: "13", From: "20231", To: "20234", City: "13101"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -149,6 +160,21 @@ func TestParseTransactions(t *testing.T) {
 		}
 	})
 
+	t.Run("PricePerTsubo が正しく算出される", func(t *testing.T) {
+		raw := []Transaction{
+			{Type: "宅地(土地)", TradePrice: "10000000", Area: "100", PricePerUnit: "100000"},
+		}
+		got := parseTransactions(raw)
+		if len(got) != 1 {
+			t.Fatalf("len = %d, want 1", len(got))
+		}
+		// 100,000 円/m² × 3.30578 m²/坪 ≈ 330,578 円/坪
+		wantTsubo := 100_000.0 * domain.SqmPerTsubo
+		if math.Abs(got[0].PricePerTsubo-wantTsubo) > 1 {
+			t.Errorf("PricePerTsubo = %v, want ≈ %v", got[0].PricePerTsubo, wantTsubo)
+		}
+	})
+
 	t.Run("空スライスのとき空スライスを返す", func(t *testing.T) {
 		got := parseTransactions([]Transaction{})
 		if len(got) != 0 {
@@ -169,24 +195,28 @@ func okResponse(w http.ResponseWriter) {
 	}
 }
 
+func TestFetchLandPrices_InvalidQuery(t *testing.T) {
+	c := newTestClient("http://example.com")
+	// Area が空 → buildURL がエラーを返し HTTP リクエストは発生しない
+	_, err := c.FetchLandPrices(context.Background(), LandPriceQuery{From: "20231", To: "20234"})
+	if err == nil {
+		t.Fatal("expected error for missing area, got nil")
+	}
+}
+
 func TestFetchLandPrices_RetryOn5xx(t *testing.T) {
 	attempt := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempt++
 		if attempt < 3 {
-			w.WriteHeader(http.StatusServiceUnavailable) // 5xx
+			w.WriteHeader(http.StatusServiceUnavailable)
 			return
 		}
 		okResponse(w)
 	}))
 	defer ts.Close()
 
-	origBaseURL := baseURL
-	baseURL = ts.URL
-	defer func() { baseURL = origBaseURL }()
-
-	c := &Client{httpClient: &http.Client{}}
-	// retryBaseDelay=1s のため遅延が発生するが許容範囲内
+	c := newTestClient(ts.URL)
 	result, err := c.FetchLandPrices(context.Background(), LandPriceQuery{
 		Area: "13", From: "20231", To: "20234",
 	})
@@ -207,11 +237,7 @@ func TestFetchLandPrices_AllAttemptsFailWith5xx(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	origBaseURL := baseURL
-	baseURL = ts.URL
-	defer func() { baseURL = origBaseURL }()
-
-	c := &Client{httpClient: &http.Client{}}
+	c := newTestClient(ts.URL)
 	_, err := c.FetchLandPrices(context.Background(), LandPriceQuery{
 		Area: "13", From: "20231", To: "20234",
 	})
@@ -224,15 +250,11 @@ func TestFetchLandPrices_NoRetryOn4xx(t *testing.T) {
 	attempt := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		attempt++
-		w.WriteHeader(http.StatusBadRequest) // 4xx
+		w.WriteHeader(http.StatusBadRequest)
 	}))
 	defer ts.Close()
 
-	origBaseURL := baseURL
-	baseURL = ts.URL
-	defer func() { baseURL = origBaseURL }()
-
-	c := &Client{httpClient: &http.Client{}}
+	c := newTestClient(ts.URL)
 	_, err := c.FetchLandPrices(context.Background(), LandPriceQuery{
 		Area: "13", From: "20231", To: "20234",
 	})
@@ -244,26 +266,22 @@ func TestFetchLandPrices_NoRetryOn4xx(t *testing.T) {
 	}
 }
 
-func TestFetchLandPrices_ContextCancel(t *testing.T) {
+func TestFetchLandPrices_ContextTimeout(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 	}))
 	defer ts.Close()
 
-	origBaseURL := baseURL
-	baseURL = ts.URL
-	defer func() { baseURL = origBaseURL }()
+	// リトライ待機中にタイムアウトさせる（retryBaseDelay=1s より短い）
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	// 1回目が終わったらすぐキャンセル
-	go func() { cancel() }()
-
-	c := &Client{httpClient: &http.Client{}}
+	c := newTestClient(ts.URL)
 	_, err := c.FetchLandPrices(ctx, LandPriceQuery{
 		Area: "13", From: "20231", To: "20234",
 	})
 	if err == nil {
-		t.Fatal("expected error after context cancel, got nil")
+		t.Fatal("expected error after context timeout, got nil")
 	}
 }
 
@@ -277,16 +295,16 @@ func TestFetchLandPrices_APIStatusNotOK(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	origBaseURL := baseURL
-	baseURL = ts.URL
-	defer func() { baseURL = origBaseURL }()
+	// status!=OK は HTTP 200 として返るため clientError にならずリトライされる。
+	// 3回失敗後にエラーを返すことを確認する。
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
 
-	c := &Client{httpClient: &http.Client{}}
-	_, err := c.FetchLandPrices(context.Background(), LandPriceQuery{
+	c := newTestClient(ts.URL)
+	_, err := c.FetchLandPrices(ctx, LandPriceQuery{
 		Area: "13", From: "20231", To: "20234",
 	})
 	if err == nil {
 		t.Fatal("expected error for status=ERROR, got nil")
 	}
 }
-

--- a/backend/internal/mlit/client_test.go
+++ b/backend/internal/mlit/client_test.go
@@ -85,7 +85,7 @@ func newTestClient(serverURL string) *Client {
 }
 
 func TestBuildURL(t *testing.T) {
-	c := &Client{baseURL: "http://example.com"}
+	c := newTestClient("http://example.com")
 
 	t.Run("area が空のときエラー", func(t *testing.T) {
 		_, err := c.buildURL(LandPriceQuery{From: "20231", To: "20234"})
@@ -272,8 +272,8 @@ func TestFetchLandPrices_ContextTimeout(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	// リトライ待機中にタイムアウトさせる（retryBaseDelay=1s より短い）
-	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	// リトライ待機中にタイムアウトさせる（retryBaseDelay=1s より短く、CI高負荷時の余裕も考慮）
+	ctx, cancel := context.WithTimeout(context.Background(), 700*time.Millisecond)
 	defer cancel()
 
 	c := newTestClient(ts.URL)
@@ -297,7 +297,7 @@ func TestFetchLandPrices_APIStatusNotOK(t *testing.T) {
 
 	// status!=OK は HTTP 200 として返るため clientError にならずリトライされる。
 	// 3回失敗後にエラーを返すことを確認する。
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	c := newTestClient(ts.URL)

--- a/docs/mlit-api-integration.md
+++ b/docs/mlit-api-integration.md
@@ -1,6 +1,6 @@
 # 国交省不動産取引価格APIクライアント仕様
 
-`backend/internal/mlit/client.go` / `types.go`
+`backend/internal/mlit/client.go` / `client_test.go` / `types.go`
 
 ---
 
@@ -109,6 +109,27 @@ func parseFloat(s string) float64 {
 
 ---
 
+## Client 構造体
+
+```go
+type Client struct {
+    httpClient *http.Client
+    baseURL    string  // デフォルト: mlitBaseURL（テスト時にモックサーバURLを注入可能）
+}
+
+func NewClient() *Client {
+    return &Client{
+        httpClient: &http.Client{Timeout: requestTimeout},
+        baseURL:    mlitBaseURL,
+    }
+}
+```
+
+`baseURL` をフィールドとして持つことで、`httptest.NewServer` で立てたモックサーバを差し込んでテストできる。
+`buildURL` は `Client` のメソッドとして実装されており、`c.baseURL` を参照してURLを生成する。
+
+---
+
 ## 指数バックオフリトライ
 
 ```go
@@ -182,3 +203,27 @@ if diffFromMedian > stats.MedianTsubo * 0.10 {
 ```
 
 `GET /api/prefectures` はこのマップをコード昇順にソートして返す。
+
+---
+
+## テスト (`client_test.go`)
+
+`net/http/httptest` のモックサーバを使い、実ネットワークなしで全ロジックを検証する。
+
+| テスト | 内容 |
+|--------|------|
+| `TestParseFloat` | 全角数字・カンマ・接尾辞・空文字・浮動小数点・負数 |
+| `TestIsLandType` | 宅地(土地) / 非土地 / 空文字 |
+| `TestBuildURL` | 必須パラメータ欠落エラー・正常生成・cityオプション |
+| `TestParseTransactions` | フィルタリング・単価算出・PricePerTsubo換算・空スライス |
+| `TestFetchLandPrices_InvalidQuery` | buildURL エラーで HTTP リクエストが発生しないこと |
+| `TestFetchLandPrices_RetryOn5xx` | 5xx → リトライ → 成功（3回目） |
+| `TestFetchLandPrices_AllAttemptsFailWith5xx` | 3回連続5xx → エラー返却 |
+| `TestFetchLandPrices_NoRetryOn4xx` | 4xx → リトライなし即エラー |
+| `TestFetchLandPrices_ContextTimeout` | コンテキストタイムアウトでリトライ待機を中断 |
+| `TestFetchLandPrices_APIStatusNotOK` | status!=OK → 3回リトライ後エラー |
+
+```bash
+cd backend
+go test -race ./internal/mlit/... -v
+```

--- a/docs/mlit-api-integration.md
+++ b/docs/mlit-api-integration.md
@@ -15,6 +15,27 @@
 
 ---
 
+## Client 構造体
+
+```go
+type Client struct {
+    httpClient *http.Client
+    baseURL    string  // デフォルト: mlitBaseURL（テスト時にモックサーバURLを注入可能）
+}
+
+func NewClient() *Client {
+    return &Client{
+        httpClient: &http.Client{Timeout: requestTimeout},
+        baseURL:    mlitBaseURL,
+    }
+}
+```
+
+`baseURL` をフィールドとして持つことで、`httptest.NewServer` で立てたモックサーバを差し込んでテストできる。
+`buildURL` は `Client` のメソッドとして実装されており、`c.baseURL` を参照してURLを生成する。
+
+---
+
 ## クエリパラメータ仕様
 
 `LandPriceQuery` 構造体にマップされる。
@@ -97,7 +118,10 @@ pricePerTsubo := pricePerSqm * domain.SqmPerTsubo  // × 3.30578
 
 ```go
 func parseFloat(s string) float64 {
-    // 1. 空文字・ダッシュ → 0
+    // 1. 空文字 ("") → 0
+    //    全角ダッシュ ("－") → 0（MLIT APIが「データなし」を示す文字）
+    //    半角ダッシュ単体 ("-") → 0
+    //    ※ "-100" のような負数はそのまま解析される（早期returnの対象外）
     // 2. カンマ除去 ("8,500,000" → "8500000")
     // 3. 全角数字→半角（"１２３" → "123"）
     // 4. 接尾辞除去（"以上", "未満", "m²", "㎡", "坪", "円"）
@@ -106,27 +130,6 @@ func parseFloat(s string) float64 {
 ```
 
 変換失敗（パースエラー）は `0` を返す。
-
----
-
-## Client 構造体
-
-```go
-type Client struct {
-    httpClient *http.Client
-    baseURL    string  // デフォルト: mlitBaseURL（テスト時にモックサーバURLを注入可能）
-}
-
-func NewClient() *Client {
-    return &Client{
-        httpClient: &http.Client{Timeout: requestTimeout},
-        baseURL:    mlitBaseURL,
-    }
-}
-```
-
-`baseURL` をフィールドとして持つことで、`httptest.NewServer` で立てたモックサーバを差し込んでテストできる。
-`buildURL` は `Client` のメソッドとして実装されており、`c.baseURL` を参照してURLを生成する。
 
 ---
 
@@ -153,6 +156,7 @@ for attempt := 0; attempt < maxRetries; attempt++ {
 | 3回目 | 2秒 |
 
 - **4xx クライアントエラーはリトライしない**（`clientError` 型でマーク）
+- **`status != "OK"`（HTTP 200 だがAPIレベルのエラー）はリトライされる**（`clientError` に該当しないため）
 - `context.Done()` チェック付き（タイムアウト・キャンセル対応）
 - 3回失敗後: `"API request failed after 3 attempts: <error>"` を返す
 


### PR DESCRIPTION
## 概要
`mlit/client.go` に対する単体テストが存在しなかったため、全ロジックをカバーするテストを追加した。コードレビュー指摘事項（グローバル変数によるレース競合・テスト設計）も合わせて修正した。

## 変更内容
- `backend/internal/mlit/client.go`
  - `baseURL` を定数からフィールド（`Client.baseURL`）へ移動し、グローバル可変状態を排除
  - `buildURL` をパッケージ関数からメソッドへ変更
- `backend/internal/mlit/client_test.go` を新規作成
  - `parseFloat`: 全角数字・カンマ区切り・接尾辞・浮動小数点・負数など19ケース
  - `isLandType`: 宅地(土地) / 非土地 / 空文字など6ケース
  - `buildURL`: 必須パラメータ欠落エラー・正常生成・cityオプション
  - `parseTransactions`: フィルタリング・単価算出・PricePerTsubo換算・空スライス
  - `FetchLandPrices`: 5xxリトライ・全失敗・4xx即終了・コンテキストタイムアウト・status!=OK・buildURLエラー
  - `go test -race` でレースコンディション検出済み
  - `newTestClient` で URL 注入を統一、timeout 値をレビューで調整
- `docs/mlit-api-integration.md`
  - `Client` 構造体セクションを先頭付近に移動
  - `parseFloat` の負数挙動（`"-100"` は解析される）を補足
  - `status != "OK"` がリトライされる挙動を明記
  - テスト一覧セクションを追加

## 関連Issue
Closes #9

## テスト
- [x] 既存テストが通ること
- [x] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み