### PR TITLE
ci: バックエンド・フロントエンドの GitHub Actions CI 整備

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -12,6 +12,13 @@ on:
       - "backend/**"
       - ".github/workflows/backend-ci.yml"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Test & Build

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - "backend/**"
+      - ".github/workflows/backend-ci.yml"
   pull_request:
     branches: [main]
     paths:
       - "backend/**"
+      - ".github/workflows/backend-ci.yml"
 
 jobs:
   test:
@@ -31,7 +33,7 @@ jobs:
         run: go vet ./...
 
       - name: go test
-        run: go test ./... -timeout 120s
+        run: go test -race ./... -timeout 120s
 
       - name: go build
         run: go build ./cmd/server

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -1,0 +1,37 @@
+name: Backend CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "backend/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "backend/**"
+
+jobs:
+  test:
+    name: Test & Build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: go test
+        run: go test ./... -timeout 120s
+
+      - name: go build
+        run: go build ./cmd/server

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,41 @@
+name: Frontend CI
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "frontend/**"
+  pull_request:
+    branches: [main]
+    paths:
+      - "frontend/**"
+
+jobs:
+  ci:
+    name: Lint, Type Check & Build
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -12,6 +12,13 @@ on:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: Lint, Type Check & Build

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
   pull_request:
     branches: [main]
     paths:
       - "frontend/**"
+      - ".github/workflows/frontend-ci.yml"
 
 jobs:
   ci:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 **技術スタック**
 
-- Backend: Go 1.21 / Gin / Clean Architecture
+- Backend: Go 1.25 / Gin / Clean Architecture
 - Frontend: Next.js 14 (App Router) / TypeScript / Tailwind CSS / Shadcn/UI / Recharts
 - Data: 国土交通省 不動産取引価格情報取得API（認証不要・公式）
 
@@ -111,6 +111,10 @@ npm run dev
 
 ```
 yield-guard/
+├── .github/
+│   └── workflows/
+│       ├── backend-ci.yml          # Go vet / test -race / build
+│       └── frontend-ci.yml         # lint / tsc / build
 ├── backend/
 │   ├── cmd/server/main.go          # エントリポイント
 │   └── internal/
@@ -119,7 +123,8 @@ yield-guard/
 │       │   ├── investment.go       # 収支計算ロジック（元利均等・減価償却・税金）
 │       │   └── investment_test.go  # ユニットテスト
 │       ├── mlit/
-│       │   ├── client.go           # 国交省APIクライアント
+│       │   ├── client.go           # 国交省APIクライアント（リトライ付き）
+│       │   ├── client_test.go      # ユニットテスト（httptest モック）
 │       │   └── types.go            # APIレスポンス型
 │       └── api/
 │           ├── handler.go          # HTTPハンドラー
@@ -139,8 +144,17 @@ yield-guard/
 
 ```bash
 cd backend
-go test ./internal/domain/... -v
+go test -race ./... -v
 ```
+
+### CI
+
+PR・mainへのpush時に GitHub Actions が自動実行される。
+
+| ワークフロー | トリガー | チェック内容 |
+|---|---|---|
+| Backend CI | `backend/**` 変更時 | `go vet` / `go test -race` / `go build` |
+| Frontend CI | `frontend/**` 変更時 | `lint` / `tsc --noEmit` / `build` |
 
 ### ビルド
 

--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ yield-guard/
 │       └── api/
 │           ├── handler.go          # HTTPハンドラー
 │           └── router.go           # Ginルーター
+├── docs/
+│   ├── overview.md                 # 全体設計概要
+│   ├── mlit-api-integration.md     # 国交省APIクライアント仕様
+│   ├── domain-investment-calculation.md
+│   └── ...
 ├── frontend/
 │   └── src/
 │       ├── app/                    # Next.js App Router
@@ -143,18 +148,24 @@ yield-guard/
 ### テスト実行
 
 ```bash
+# バックエンド
 cd backend
 go test -race ./... -v
+
+# フロントエンド（ローカル確認）
+cd frontend
+npm run lint
+npx tsc --noEmit
 ```
 
 ### CI
 
-PR・mainへのpush時に GitHub Actions が自動実行される。
+PR・mainへのpush時に GitHub Actions が自動実行される（ワークフロー自身の変更でも再トリガーされる）。
 
-| ワークフロー | トリガー | チェック内容 |
+| ワークフロー | トリガーパス | チェック内容 |
 |---|---|---|
-| Backend CI | `backend/**` 変更時 | `go vet` / `go test -race` / `go build` |
-| Frontend CI | `frontend/**` 変更時 | `lint` / `tsc --noEmit` / `build` |
+| Backend CI | `backend/**`, `backend-ci.yml` | `go vet` / `go test -race` / `go build` |
+| Frontend CI | `frontend/**`, `frontend-ci.yml` | `lint` / `tsc --noEmit` / `build` |
 
 ### ビルド
 

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}


### PR DESCRIPTION
## 概要
PR・mainへのpush時にバックエンド・フロントエンドのCIが自動実行されるよう GitHub Actions ワークフローを追加した。合わせてコードレビュー指摘事項（権限・並走制御）を修正し、CI 実行に必要な設定ファイルを追加した。

## 変更内容
- `.github/workflows/backend-ci.yml` を新規作成
  - `go vet ./...`
  - `go test -race ./... -timeout 120s`
  - `go build ./cmd/server`
  - `backend/**` およびワークフロー自身の変更時にトリガー
  - `permissions: contents: read`（最小権限）
  - `concurrency` 設定（同一 PR への連続 push で古い実行をキャンセル）
- `.github/workflows/frontend-ci.yml` を新規作成
  - `npm ci` / `npm run lint` / `npx tsc --noEmit` / `npm run build`
  - Node.js 22 (現行LTS) を使用
  - `frontend/**` およびワークフロー自身の変更時にトリガー
  - `permissions: contents: read` / `concurrency` 設定
- `frontend/.eslintrc.json` を新規作成
  - `next lint` が ESLint 設定未存在時に対話プロンプトを出して CI がフェイルする問題を修正
  - `next/core-web-vitals` を採用
- `README.md` を更新
  - Go バージョンを `1.21` → `1.25` に修正
  - テスト実行コマンドを `./...` に拡張、フロントエンドの確認コマンドを追加
  - CI テーブル・`docs/` ディレクトリをディレクトリ構成に追記

## 関連Issue
Closes #14
Closes #15

## テスト
- [x] 既存テストが通ること
- [x] Backend CI・Frontend CI ともに green 確認済み

## 確認事項
- [x] コードレビュー観点での自己レビュー済み