### PR TITLE
都道府県リストをフロントエンド静的定義に一本化し /api/prefectures を削除

### DIFF
--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -3,7 +3,6 @@ package api
 import (
 	"errors"
 	"net/http"
-	"sort"
 	"strconv"
 
 	"github.com/gin-gonic/gin"
@@ -140,27 +139,6 @@ func validateInvestmentInput(in domain.InvestmentInput) error {
 		return errors.New("holdingYears は 0〜50 年の範囲で指定してください")
 	}
 	return nil
-}
-
-// GetPrefectures は都道府県一覧をコード順で返す
-// GET /api/prefectures
-func (h *Handler) GetPrefectures(c *gin.Context) {
-	type Prefecture struct {
-		Code string `json:"code"`
-		Name string `json:"name"`
-	}
-
-	prefectures := make([]Prefecture, 0, len(mlit.Prefectures))
-	for code, name := range mlit.Prefectures {
-		prefectures = append(prefectures, Prefecture{Code: code, Name: name})
-	}
-	// マップのイテレーション順は非決定的なので数値コード順にソート
-	sort.Slice(prefectures, func(i, j int) bool {
-		ci, _ := strconv.Atoi(prefectures[i].Code)
-		cj, _ := strconv.Atoi(prefectures[j].Code)
-		return ci < cj
-	})
-	c.JSON(http.StatusOK, prefectures)
 }
 
 // HealthCheck はサーバーの生存確認

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -39,7 +39,6 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/land-prices", h.GetLandPrices)
 		api.GET("/land-prices/compare", h.CompareLandPrice)
 		api.POST("/analyze", h.Analyze)
-		api.GET("/prefectures", h.GetPrefectures)
 	}
 
 	return r

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useEffect } from "react";
+import React, { useState } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
@@ -8,11 +8,10 @@ import { Slider } from "@/components/ui/slider";
 import type { InvestmentInput, BuildingType } from "@/types/investment";
 import { DEFAULT_INPUT } from "@/types/investment";
 import { formatPct } from "@/lib/utils";
-import { fetchPrefectures } from "@/lib/api";
 import { Search, Calculator, Info } from "lucide-react";
 
-// 全都道府県のスタティックフォールバック（バックエンド未起動時用）
-const STATIC_PREFECTURES = [
+// 全47都道府県（法的に変容しない静的データ）
+const PREFECTURES = [
   { value: "01", label: "北海道" }, { value: "02", label: "青森県" },
   { value: "03", label: "岩手県" }, { value: "04", label: "宮城県" },
   { value: "05", label: "秋田県" }, { value: "06", label: "山形県" },
@@ -20,9 +19,23 @@ const STATIC_PREFECTURES = [
   { value: "09", label: "栃木県" }, { value: "10", label: "群馬県" },
   { value: "11", label: "埼玉県" }, { value: "12", label: "千葉県" },
   { value: "13", label: "東京都" }, { value: "14", label: "神奈川県" },
-  { value: "23", label: "愛知県" }, { value: "26", label: "京都府" },
+  { value: "15", label: "新潟県" }, { value: "16", label: "富山県" },
+  { value: "17", label: "石川県" }, { value: "18", label: "福井県" },
+  { value: "19", label: "山梨県" }, { value: "20", label: "長野県" },
+  { value: "21", label: "岐阜県" }, { value: "22", label: "静岡県" },
+  { value: "23", label: "愛知県" }, { value: "24", label: "三重県" },
+  { value: "25", label: "滋賀県" }, { value: "26", label: "京都府" },
   { value: "27", label: "大阪府" }, { value: "28", label: "兵庫県" },
-  { value: "40", label: "福岡県" }, { value: "47", label: "沖縄県" },
+  { value: "29", label: "奈良県" }, { value: "30", label: "和歌山県" },
+  { value: "31", label: "鳥取県" }, { value: "32", label: "島根県" },
+  { value: "33", label: "岡山県" }, { value: "34", label: "広島県" },
+  { value: "35", label: "山口県" }, { value: "36", label: "徳島県" },
+  { value: "37", label: "香川県" }, { value: "38", label: "愛媛県" },
+  { value: "39", label: "高知県" }, { value: "40", label: "福岡県" },
+  { value: "41", label: "佐賀県" }, { value: "42", label: "長崎県" },
+  { value: "43", label: "熊本県" }, { value: "44", label: "大分県" },
+  { value: "45", label: "宮崎県" }, { value: "46", label: "鹿児島県" },
+  { value: "47", label: "沖縄県" },
 ];
 
 const BUILDING_TYPES: { value: BuildingType; label: string }[] = [
@@ -51,18 +64,6 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading }: Props)
   const [area, setArea] = useState("10");
   const [city, setCity] = useState("10201");
   const [showAdvanced, setShowAdvanced] = useState(false);
-  const [prefectures, setPrefectures] = useState<{ value: string; label: string }[]>(STATIC_PREFECTURES);
-
-  useEffect(() => {
-    fetchPrefectures()
-      .then((list) =>
-        setPrefectures(list.map((p) => ({ value: p.code, label: p.name })))
-      )
-      .catch(() => {
-        // バックエンド未起動時: 全都道府県スタティックリストを維持
-      });
-  }, []);
-
   // 制御コンポーネント用ヘルパー
   const setNum = (key: keyof InvestmentInput, value: number) =>
     setInput((prev) => ({ ...prev, [key]: value }));
@@ -90,7 +91,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading }: Props)
               label="都道府県"
               value={area}
               onChange={(e) => setArea(e.target.value)}
-              options={prefectures}
+              options={PREFECTURES}
             />
             <Input
               label="市区町村コード"

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -59,8 +59,3 @@ export async function analyze(input: InvestmentInput): Promise<InvestmentResult>
   return handleResponse<InvestmentResult>(res);
 }
 
-/** 都道府県一覧を取得 */
-export async function fetchPrefectures(): Promise<{ code: string; name: string }[]> {
-  const res = await fetch(`${BASE}/prefectures`);
-  return handleResponse<{ code: string; name: string }[]>(res);
-}


### PR DESCRIPTION
## 概要
都道府県は法的に変容しない静的データであるため、バックエンドAPIへの依存を排除し、フロントエンドに完全な47都道府県リストを静的定義した。

## 変更内容
- `backend/internal/api/handler.go`
  - `GetPrefectures` ハンドラを削除
  - `sort` import を削除（`GetPrefectures` 専用だったため）
- `backend/internal/api/router.go`
  - `GET /api/prefectures` ルートを削除
- `frontend/src/components/InvestmentForm.tsx`
  - 20件の不完全な `STATIC_PREFECTURES` を全47都道府県の `PREFECTURES` 定数に置き換え
  - `fetchPrefectures()` の呼び出しと `useEffect` を削除
  - `fetchPrefectures` import を削除
  - `useEffect` import を削除
- `frontend/src/lib/api.ts`
  - `fetchPrefectures()` 関数を削除

## 関連Issue
Closes #8

## テスト
- [x] 既存テストが通ること
- [x] `go build ./...` および `tsc --noEmit` でエラーなし確認済み

## 確認事項
- [x] コードレビュー観点での自己レビュー済み