### PR TITLE
test(mlit): 実APIへの疎通統合テストの追加

### DIFF
--- a/backend/internal/mlit/integration_test.go
+++ b/backend/internal/mlit/integration_test.go
@@ -1,0 +1,83 @@
+//go:build integration
+
+package mlit
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestFetchLandPrices_RealAPI は実際の国交省APIへの疎通を確認する統合テスト。
+// 通常の go test ./... では実行されない。実行するには:
+//
+//	go test -tags=integration ./internal/mlit/... -v -timeout 60s
+func TestFetchLandPrices_RealAPI(t *testing.T) {
+	client := NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// 群馬県(area=10)の直近2年分（20241〜20244）を取得
+	q := LandPriceQuery{
+		Area: "10",
+		From: "20241",
+		To:   "20244",
+	}
+
+	transactions, err := client.FetchLandPrices(ctx, q)
+	if err != nil {
+		t.Fatalf("FetchLandPrices failed: %v", err)
+	}
+
+	if len(transactions) == 0 {
+		t.Fatal("expected at least 1 transaction, got 0")
+	}
+	t.Logf("取得件数: %d 件", len(transactions))
+
+	// 取得データの基本的な整合性を検証
+	for i, tx := range transactions {
+		if tx.TradePrice <= 0 {
+			t.Errorf("transactions[%d]: TradePrice should be positive, got %f", i, tx.TradePrice)
+		}
+		if tx.PricePerSqm <= 0 && tx.Area > 0 {
+			t.Errorf("transactions[%d]: PricePerSqm should be positive when Area > 0, got %f", i, tx.PricePerSqm)
+		}
+		if tx.PricePerTsubo <= 0 && tx.PricePerSqm > 0 {
+			t.Errorf("transactions[%d]: PricePerTsubo should be positive when PricePerSqm > 0, got %f", i, tx.PricePerTsubo)
+		}
+	}
+}
+
+// TestFetchLandPrices_RealAPI_WithCity は市区町村コード絞り込みの疎通テスト。
+func TestFetchLandPrices_RealAPI_WithCity(t *testing.T) {
+	client := NewClient()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// 群馬県 前橋市(10201)に絞り込み
+	q := LandPriceQuery{
+		Area: "10",
+		City: "10201",
+		From: "20241",
+		To:   "20244",
+	}
+
+	transactions, err := client.FetchLandPrices(ctx, q)
+	if err != nil {
+		t.Fatalf("FetchLandPrices (with city) failed: %v", err)
+	}
+
+	t.Logf("前橋市の取得件数: %d 件", len(transactions))
+
+	// 市区町村指定の場合は件数が少ない可能性があるため、エラーにはしない
+	// ただし、結果が返った場合は坪単価換算が正しいことを確認する
+	for i, tx := range transactions {
+		if tx.PricePerSqm > 0 {
+			expected := tx.PricePerSqm * 3.30578
+			diff := tx.PricePerTsubo - expected
+			if diff < -1 || diff > 1 {
+				t.Errorf("transactions[%d]: PricePerTsubo conversion incorrect: got %f, want ~%f", i, tx.PricePerTsubo, expected)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 概要

Issue #10 対応。実際の国交省不動産取引価格APIへのHTTPリクエストを行い、レスポンスが正しく取得・パースできることを確認する統合テストを追加した。通常の `go test ./...` では実行されず、`-tags=integration` を明示した場合のみ実行される。

## 変更内容

- `backend/internal/mlit/integration_test.go` を新規追加（`//go:build integration`）
  - `TestFetchLandPrices_RealAPI`: 群馬県(area=10)の直近2年分データを取得し、件数・TradePrice・PricePerSqm・PricePerTsubo の正値を検証
  - `TestFetchLandPrices_RealAPI_WithCity`: 前橋市(city=10201)で絞り込み、坪単価換算（× 3.30578）の整合性を検証

## 実行方法

```bash
# 統合テストのみ
cd backend
go test -tags=integration ./internal/mlit/... -v -timeout 60s

# 通常テスト（統合テストは含まれない）
go test -race ./... -timeout 120s
```

## 関連Issue

Closes #10

## テスト

- [x] 既存テストが通ること（`go test -race ./...` で確認済み）
- [x] 新規テストを追加した場合、全ケースがPASSすること（実ネットワーク接続環境でのみ確認可能）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] 通常CIは `go test -race ./...`（タグなし）のため統合テストは自動実行されない