### PR TITLE
ci: Dependabot の設定

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,11 +6,21 @@ updates:
     schedule:
       interval: weekly
       day: monday
+      timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /frontend
     schedule:
       interval: weekly
       day: monday
+      timezone: "Asia/Tokyo"
     open-pull-requests-limit: 5
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       interval: weekly
       day: monday
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     groups:
       all-dependencies:
         patterns:
@@ -19,7 +19,7 @@ updates:
       interval: weekly
       day: monday
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 1
     groups:
       all-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /backend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5

--- a/README.md
+++ b/README.md
@@ -165,8 +165,10 @@ PR・mainへのpush時に GitHub Actions が自動実行される（ワークフ
 
 | ワークフロー | トリガーパス | チェック内容 |
 |---|---|---|
-| Backend CI | `backend/**`, `backend-ci.yml` | `go vet` / `go test -race` / `go build` |
+| Backend CI | `backend/**`, `backend-ci.yml` | `golangci-lint` / `go test -race` / `go build` |
 | Frontend CI | `frontend/**`, `frontend-ci.yml` | `lint` / `tsc --noEmit` / `vitest run` / `build` |
+
+Dependabot により Go modules・npm の依存パッケージが毎週月曜（JST）に自動更新される（エコシステムごとに1PR）。
 
 ### ビルド
 


### PR DESCRIPTION
## 概要

Go modules と npm の依存関係を Dependabot で週次自動更新する設定を追加する。

## 変更内容

- `.github/dependabot.yml` を新規作成
  - `gomod`（`/backend`）・`npm`（`/frontend`）を毎週月曜（Asia/Tokyo）に更新
  - `groups: patterns: ["*"]` で全依存を1PRにまとめる
  - `open-pull-requests-limit: 1`（グループ化により実質1PRのため）

## 関連Issue

Closes #19

## テスト

- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み