### PR TITLE
chore: Makefile の整備

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+.PHONY: dev test lint build help
+
+## dev: バックエンド・フロントエンドの開発サーバーを起動
+dev:
+	@echo "Starting backend..."
+	cd backend && go run ./cmd/server &
+	@echo "Starting frontend..."
+	cd frontend && npm run dev
+
+## test: 全テストを実行
+test:
+	@echo "==> Backend tests"
+	cd backend && go test -race ./... -timeout 120s
+	@echo "==> Frontend tests"
+	cd frontend && npm test
+
+## lint: 全lintを実行
+lint:
+	@echo "==> Backend lint"
+	cd backend && golangci-lint run ./...
+	@echo "==> Frontend lint"
+	cd frontend && npm run lint
+
+## build: 全ビルドを実行
+build:
+	@echo "==> Backend build"
+	cd backend && go build -o yield-guard-server ./cmd/server
+	@echo "==> Frontend build"
+	cd frontend && npm run build
+
+## help: 利用可能なコマンドを表示
+help:
+	@grep -E '^## ' Makefile | sed 's/## //'

--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,9 @@
 
 ## dev: バックエンド・フロントエンドの開発サーバーを起動
 dev:
-	@echo "Starting backend..."
+	@echo "==> Starting backend..."
 	cd backend && go run ./cmd/server &
-	@echo "Starting frontend..."
+	@echo "==> Starting frontend..."
 	cd frontend && npm run dev
 
 ## test: 全テストを実行
@@ -20,6 +20,7 @@ lint:
 	cd backend && golangci-lint run ./...
 	@echo "==> Frontend lint"
 	cd frontend && npm run lint
+	cd frontend && npx tsc --noEmit
 
 ## build: 全ビルドを実行
 build:
@@ -30,4 +31,4 @@ build:
 
 ## help: 利用可能なコマンドを表示
 help:
-	@grep -E '^## ' Makefile | sed 's/## //'
+	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## //'

--- a/README.md
+++ b/README.md
@@ -145,18 +145,24 @@ yield-guard/
 
 ## 開発
 
-### テスト実行
+### よく使うコマンド
+
+```bash
+make help    # 利用可能なコマンド一覧
+make test    # バックエンド・フロントエンドの全テスト実行
+make lint    # バックエンド（golangci-lint）・フロントエンド lint
+make build   # バックエンド・フロントエンドのビルド
+make dev     # 開発サーバー起動（backend :8080 + frontend :3000）
+```
+
+個別に実行する場合：
 
 ```bash
 # バックエンド
-cd backend
-go test -race ./... -v
+cd backend && go test -race ./... -v
 
 # フロントエンド
-cd frontend
-npm test           # Vitest（17テスト）
-npm run lint
-npx tsc --noEmit
+cd frontend && npm test
 ```
 
 ### CI
@@ -173,11 +179,7 @@ Dependabot により Go modules・npm の依存パッケージが毎週月曜（
 ### ビルド
 
 ```bash
-# バックエンド
-cd backend && go build -o yield-guard-server ./cmd/server
-
-# フロントエンド
-cd frontend && npm run build
+make build
 ```
 
 ### 計算ロジック仕様


### PR DESCRIPTION
## 概要

開発・テスト・ビルドコマンドを Makefile で統一し、ドキュメントなしでも操作できるようにする。

## 変更内容

- プロジェクトルートに `Makefile` を新規作成
  - `make dev` — バックエンド・フロントエンドの開発サーバーを起動
  - `make test` — バックエンド（`go test -race`）・フロントエンド（Vitest）を順次実行
  - `make lint` — バックエンド（`golangci-lint`）・フロントエンド（`next lint`）を順次実行
  - `make build` — バックエンド（`go build`）・フロントエンド（`next build`）を順次実行
  - `make help` — 利用可能なコマンド一覧を表示

## 動作確認

- `make help` — コマンド一覧表示を確認済み
- `make test` — バックエンド・フロントエンド全テスト（21件）通過を確認済み

## 関連Issue

Closes #20

## テスト

- [x] 既存テストが通ること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み