### PR TITLE
ci: Makefile 変更時に両 CI をトリガー

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -6,11 +6,13 @@ on:
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"
+      - "Makefile"
   pull_request:
     branches: [main]
     paths:
       - "frontend/**"
       - ".github/workflows/frontend-ci.yml"
+      - "Makefile"
 
 permissions:
   contents: read


### PR DESCRIPTION
## 概要

`Makefile` の変更が Backend CI・Frontend CI のトリガーパスに含まれていなかったため、Makefile を変更する PR で CI が走らずマージされていた。両ワークフローのトリガーパスに `Makefile` を追加する。

## 変更内容

- `frontend-ci.yml` のトリガーパスに `Makefile` を追加
- （`backend-ci.yml` は前コミットで追加済み）

## 関連

- #33（Makefile 整備）で CI なしにマージされたことが発端

## テスト

- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み