### PR TITLE
ci: React major 更新を Dependabot の ignore に追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,3 +27,7 @@ updates:
     ignore:
       - dependency-name: next
         update-types: ["version-update:semver-major"]
+      - dependency-name: react
+        update-types: ["version-update:semver-major"]
+      - dependency-name: react-dom
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## 概要

Dependabot PR #36 で `react@19` への major 更新が含まれたが、`next@14` が `react@^18.2.0` しか対応していないため `npm ci` が `ERESOLVE` で失敗した。Next.js のアップグレード（#35）が完了するまで `react` / `react-dom` の major 更新も ignore に追加する。

## 変更内容

- `dependabot.yml` の ignore に `react` / `react-dom` の major 更新を追加

## 関連Issue

- #35（Next.js v16 アップグレード）完了後に ignore を解除する

## テスト

- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み