### PR TITLE
fix(dependabot): eslint/eslint-config-next のメジャーアップデートを無視

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,3 +31,7 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: react-dom
         update-types: ["version-update:semver-major"]
+      - dependency-name: eslint
+        update-types: ["version-update:semver-major"]
+      - dependency-name: eslint-config-next
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## 概要

Dependabot PR #39 が ESLint 8→10、eslint-config-next 14→16 のメジャーアップデートを含んでいたため CI が失敗していた。

- ESLint v9+ は `extensions`・`ignorePath` 等のオプションを廃止しており、Next.js 14 と互換性がない
- Next.js 14 自体のアップグレードが完了する（issue #35）まで、eslint のメジャー更新を保留する

## 変更内容

`.github/dependabot.yml` の npm ignore セクションに以下を追加：

- `eslint`: メジャーバージョンアップデートを無視
- `eslint-config-next`: メジャーバージョンアップデートを無視

## 関連

- Closes #39 相当（PR #39 は再実行で minor/patch のみになる）
- issue #35 (Next.js v16 アップグレード) 完了後に ignore ルールを削除する