### PR TITLE
fix(dependabot): npm の全パッケージのメジャーアップデートを無視

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,13 +25,5 @@ updates:
         patterns:
           - "*"
     ignore:
-      - dependency-name: next
-        update-types: ["version-update:semver-major"]
-      - dependency-name: react
-        update-types: ["version-update:semver-major"]
-      - dependency-name: react-dom
-        update-types: ["version-update:semver-major"]
-      - dependency-name: eslint
-        update-types: ["version-update:semver-major"]
-      - dependency-name: eslint-config-next
+      - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## 概要

Dependabot が npm の複数パッケージで連鎖的なメジャーアップデート PR を作成し、CI が失敗し続ける問題を解消する。

- `tailwindcss` v3→v4、`typescript` v5→v6、`vitest` v2→v4 等が一括で含まれ、CI が破壊されていた
- 個別パッケージの ignore 追加を繰り返す対症療法では追いつかない

## 変更内容

`.github/dependabot.yml` の npm ignore を個別指定から一括指定に変更：

```yaml
# 変更前
ignore:
  - dependency-name: next
    update-types: ["version-update:semver-major"]
  - dependency-name: react
    ...（5パッケージ個別指定）

# 変更後
ignore:
  - dependency-name: "*"
    update-types: ["version-update:semver-major"]
```

minor / patch の自動更新は引き続き有効。

## 関連

- issue #35 (Next.js v16 アップグレード) 完了後に ignore ルールを削除し、メジャー更新を再度受け入れる
- PR #41 は本 PR マージ後にクローズ

## 確認事項

- [ ] Dependabot が次回作成する npm PR に major 更新が含まれないこと