### PR TITLE
chore: .envをgitignoreに追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 frontend/node_modules
 frontend/.next
 
+# 環境変数（APIキー等を含むためgit管理外）
+.env
+
 # docs-mcp-server 設定（絶対パスがマシン依存のため）
 .mcp.json


### PR DESCRIPTION
## 概要
不動産情報ライブラリのAPIキー取得（issue #26）に伴い、`.env` ファイルが誤ってコミットされないよう `.gitignore` に追加する。

## 変更内容
- `.gitignore` に `.env` を追加

## 関連Issue
Closes #26

## テスト
- [x] 既存テストが通ること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み