### PR TITLE
feat(mlit): インメモリキャッシュの実装（TTL 24時間）

### DIFF
--- a/backend/internal/mlit/cache.go
+++ b/backend/internal/mlit/cache.go
@@ -1,0 +1,57 @@
+package mlit
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/yield-guard/backend/internal/domain"
+)
+
+const cacheTTL = 24 * time.Hour
+
+// cacheEntry はキャッシュの1エントリ
+type cacheEntry struct {
+	data      []domain.LandTransaction
+	expiresAt time.Time
+}
+
+// cache は TTL 付きインメモリキャッシュ
+type cache struct {
+	mu      sync.RWMutex
+	entries map[string]cacheEntry
+}
+
+func newCache() *cache {
+	return &cache{
+		entries: make(map[string]cacheEntry),
+	}
+}
+
+// get はキャッシュを取得する。TTL 切れの場合は (nil, false) を返す。
+func (c *cache) get(key string) ([]domain.LandTransaction, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	entry, ok := c.entries[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		return nil, false
+	}
+	return entry.data, true
+}
+
+// set はキャッシュに保存する。
+func (c *cache) set(key string, data []domain.LandTransaction) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.entries[key] = cacheEntry{
+		data:      data,
+		expiresAt: time.Now().Add(cacheTTL),
+	}
+}
+
+// cacheKey は LandPriceQuery からキャッシュキーを生成する。
+func cacheKey(q LandPriceQuery) string {
+	return fmt.Sprintf("%s:%s:%d:%d:%d:%d", q.Area, q.City, q.Year, q.Quarter, q.ToYear, q.ToQuarter)
+}

--- a/backend/internal/mlit/cache.go
+++ b/backend/internal/mlit/cache.go
@@ -28,16 +28,29 @@ func newCache() *cache {
 	}
 }
 
-// get はキャッシュを取得する。TTL 切れの場合は (nil, false) を返す。
+// get はキャッシュを取得する。TTL 切れの場合はエントリを削除して (nil, false) を返す。
+// 呼び出し元がスライスを変更してもキャッシュが汚染されないようコピーを返す。
 func (c *cache) get(key string) ([]domain.LandTransaction, bool) {
+	// まず読み取りロックで存在・有効期限を確認
 	c.mu.RLock()
-	defer c.mu.RUnlock()
-
 	entry, ok := c.entries[key]
-	if !ok || time.Now().After(entry.expiresAt) {
+	c.mu.RUnlock()
+
+	if !ok {
 		return nil, false
 	}
-	return entry.data, true
+	if time.Now().After(entry.expiresAt) {
+		// TTL 切れ: 書き込みロックに昇格してエントリを削除
+		c.mu.Lock()
+		delete(c.entries, key)
+		c.mu.Unlock()
+		return nil, false
+	}
+
+	// キャッシュヒット: コピーを返して呼び出し元による変更からキャッシュを保護する
+	copied := make([]domain.LandTransaction, len(entry.data))
+	copy(copied, entry.data)
+	return copied, true
 }
 
 // set はキャッシュに保存する。

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -29,6 +29,7 @@ type Client struct {
 	httpClient *http.Client
 	baseURL    string
 	apiKey     string
+	cache      *cache
 }
 
 // NewClient は新しい Client を返す。
@@ -38,12 +39,19 @@ func NewClient() *Client {
 		httpClient: &http.Client{Timeout: requestTimeout},
 		baseURL:    mlitBaseURL,
 		apiKey:     os.Getenv("MLIT_API_KEY"),
+		cache:      newCache(),
 	}
 }
 
 // FetchLandPrices は指定条件で土地取引価格を取得し、統計を返す。
+// キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 // 一時的なネットワーク障害や 5xx レスポンスに対して指数バックオフでリトライする（ISSUE-13）。
 func (c *Client) FetchLandPrices(ctx context.Context, q LandPriceQuery) ([]domain.LandTransaction, error) {
+	key := cacheKey(q)
+	if cached, ok := c.cache.get(key); ok {
+		return cached, nil
+	}
+
 	apiURL, err := c.buildURL(q)
 	if err != nil {
 		return nil, err
@@ -63,6 +71,7 @@ func (c *Client) FetchLandPrices(ctx context.Context, q LandPriceQuery) ([]domai
 
 		result, err := c.doRequest(ctx, apiURL)
 		if err == nil {
+			c.cache.set(key, result)
 			return result, nil
 		}
 		lastErr = err

--- a/backend/internal/mlit/client_test.go
+++ b/backend/internal/mlit/client_test.go
@@ -402,6 +402,34 @@ func TestCache_ReturnsCopy(t *testing.T) {
 	}
 }
 
+func TestCache_ConcurrentAccess(t *testing.T) {
+	// sync.RWMutex の正確な実装を -race フラグで検証する
+	// 複数ゴルーチンが同時に get / set を呼んでもデータレースが起きないことを確認する
+	c := newCache()
+	key := "concurrent-key"
+	data := []domain.LandTransaction{{Period: "2024年第1四半期", TradePrice: 10_000_000}}
+
+	const goroutines = 50
+	done := make(chan struct{})
+
+	// 書き込みゴルーチン
+	go func() {
+		for i := 0; i < goroutines; i++ {
+			c.set(key, data)
+		}
+		close(done)
+	}()
+
+	// 読み取りゴルーチン群（書き込みと並行）
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			c.get(key)
+		}()
+	}
+
+	<-done
+}
+
 func TestFetchLandPrices_APIStatusNotOK(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := APIResponse{Status: "ERROR", Data: nil}

--- a/backend/internal/mlit/client_test.go
+++ b/backend/internal/mlit/client_test.go
@@ -81,7 +81,7 @@ func TestIsLandType(t *testing.T) {
 // ---- buildURL ----
 
 func newTestClient(serverURL string) *Client {
-	return &Client{httpClient: &http.Client{}, baseURL: serverURL}
+	return &Client{httpClient: &http.Client{}, baseURL: serverURL, cache: newCache()}
 }
 
 func TestBuildURL(t *testing.T) {
@@ -291,6 +291,83 @@ func TestFetchLandPrices_ContextTimeout(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error after context timeout, got nil")
+	}
+}
+
+// ---- キャッシュ ----
+
+func TestFetchLandPrices_CacheHit(t *testing.T) {
+	apiCallCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCallCount++
+		okResponse(w)
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts.URL)
+	q := LandPriceQuery{Area: "13", Year: 2024, Quarter: 1, ToYear: 2024, ToQuarter: 4}
+
+	// 1回目: APIコール発生
+	result1, err := c.FetchLandPrices(context.Background(), q)
+	if err != nil {
+		t.Fatalf("1st call failed: %v", err)
+	}
+
+	// 2回目: キャッシュから返す（APIコールなし）
+	result2, err := c.FetchLandPrices(context.Background(), q)
+	if err != nil {
+		t.Fatalf("2nd call failed: %v", err)
+	}
+
+	if apiCallCount != 1 {
+		t.Errorf("apiCallCount = %d, want 1 (2nd call should hit cache)", apiCallCount)
+	}
+	if len(result1) != len(result2) {
+		t.Errorf("result length mismatch: %d vs %d", len(result1), len(result2))
+	}
+}
+
+func TestFetchLandPrices_CacheMissOnDifferentQuery(t *testing.T) {
+	apiCallCount := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiCallCount++
+		okResponse(w)
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts.URL)
+	q1 := LandPriceQuery{Area: "13", Year: 2024, Quarter: 1, ToYear: 2024, ToQuarter: 4}
+	q2 := LandPriceQuery{Area: "27", Year: 2024, Quarter: 1, ToYear: 2024, ToQuarter: 4} // 大阪府
+
+	if _, err := c.FetchLandPrices(context.Background(), q1); err != nil {
+		t.Fatalf("q1 call failed: %v", err)
+	}
+	if _, err := c.FetchLandPrices(context.Background(), q2); err != nil {
+		t.Fatalf("q2 call failed: %v", err)
+	}
+
+	// クエリが異なるので両方APIコールが発生する
+	if apiCallCount != 2 {
+		t.Errorf("apiCallCount = %d, want 2 (different queries must not share cache)", apiCallCount)
+	}
+}
+
+func TestCache_TTLExpiry(t *testing.T) {
+	c := newCache()
+	key := "test-key"
+	data := []domain.LandTransaction{{Period: "2024年第1四半期", TradePrice: 10_000_000}}
+
+	// 有効期限を過去に設定して直接注入
+	c.mu.Lock()
+	c.entries[key] = cacheEntry{
+		data:      data,
+		expiresAt: time.Now().Add(-1 * time.Second), // 1秒前に期限切れ
+	}
+	c.mu.Unlock()
+
+	_, ok := c.get(key)
+	if ok {
+		t.Error("expected cache miss after TTL expiry, got hit")
 	}
 }
 

--- a/backend/internal/mlit/client_test.go
+++ b/backend/internal/mlit/client_test.go
@@ -369,6 +369,37 @@ func TestCache_TTLExpiry(t *testing.T) {
 	if ok {
 		t.Error("expected cache miss after TTL expiry, got hit")
 	}
+
+	// TTL切れエントリは get 後に削除されていること（メモリリーク対策）
+	c.mu.RLock()
+	_, stillExists := c.entries[key]
+	c.mu.RUnlock()
+	if stillExists {
+		t.Error("expected expired entry to be deleted from map, but it still exists")
+	}
+}
+
+func TestCache_ReturnsCopy(t *testing.T) {
+	c := newCache()
+	key := "test-key"
+	original := []domain.LandTransaction{{Period: "2024年第1四半期", TradePrice: 10_000_000}}
+	c.set(key, original)
+
+	result, ok := c.get(key)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+
+	// 返されたスライスを変更してもキャッシュが汚染されないこと
+	result[0].TradePrice = 999
+
+	result2, ok := c.get(key)
+	if !ok {
+		t.Fatal("expected cache hit on 2nd get")
+	}
+	if result2[0].TradePrice != 10_000_000 {
+		t.Errorf("cache was mutated by caller: got TradePrice=%v, want 10000000", result2[0].TradePrice)
+	}
 }
 
 func TestFetchLandPrices_APIStatusNotOK(t *testing.T) {

--- a/docs/mlit-api-integration.md
+++ b/docs/mlit-api-integration.md
@@ -62,7 +62,7 @@ APIを使用するサービスには以下の文言を表示すること：
 
 - 同一APIキーで基準期間内に多数のリクエストがあった場合、**アクセス制限が設けられる**
 - 連続実行は避けることが推奨されている
-- 対策として本プロジェクトでは指数バックオフリトライを実装済み（issue #5 でキャッシュ実装予定）
+- 対策として本プロジェクトでは指数バックオフリトライとインメモリキャッシュ（TTL 24時間）を実装済み
 
 ---
 
@@ -247,6 +247,51 @@ for attempt := 0; attempt < maxRetries; attempt++ {
 - **`status != "OK"`（HTTP 200 だがAPIレベルのエラー）はリトライされる**（`clientError` に該当しないため）
 - `context.Done()` チェック付き（タイムアウト・キャンセル対応）
 - 3回失敗後: `"API request failed after 3 attempts: <error>"` を返す
+
+---
+
+## インメモリキャッシュ（`cache.go`）
+
+`Client` はインスタンスごとに TTL 付きインメモリキャッシュを持ち、同一クエリの繰り返しリクエストでAPIコールをスキップする。
+
+```go
+const cacheTTL = 24 * time.Hour
+
+type cacheEntry struct {
+    data      []domain.LandTransaction
+    expiresAt time.Time
+}
+
+type cache struct {
+    mu      sync.RWMutex
+    entries map[string]cacheEntry
+}
+```
+
+### キャッシュキー
+
+```
+area:city:year:quarter:toYear:toQuarter
+例: "13::2024:1:2024:4"（東京都・市区町村指定なし・2024年通年）
+```
+
+### 動作フロー
+
+```
+FetchLandPrices() 呼び出し
+  ├─ キャッシュヒット（TTL内）→ コピーを返す（APIコールなし）
+  └─ キャッシュミス / TTL切れ → API呼び出し → 成功時にキャッシュ保存
+```
+
+### 設計上の判断
+
+| 項目 | 内容 |
+|------|------|
+| **TTL: 24時間** | 土地価格データは四半期単位でしか更新されないため |
+| **返却値はコピー** | 呼び出し元によるスライス変更でキャッシュが汚染されるバグを防ぐ |
+| **Lazy Eviction** | TTL切れエントリは `get` アクセス時に削除。バックグラウンドGCゴルーチンは持たない |
+| **サーバー再起動でリセット** | インメモリのため。永続化の複雑さを避けた割り切り |
+| **API障害時の耐障害性** | TTL内であれば過去データを返し続けられる。ただし初回リクエスト時のAPI障害はカバーしない |
 
 ---
 


### PR DESCRIPTION
## 概要
同一クエリの繰り返しリクエストでAPIコールをスキップするインメモリキャッシュを実装する。API障害時の耐障害性向上とレート制限対策を兼ねる。

## 変更内容
- `backend/internal/mlit/cache.go` を新規作成
  - `sync.RWMutex` + TTL付き `map` によるスレッドセーフなキャッシュ
  - TTL: 24時間（土地価格データは日次更新されないため）
  - キャッシュキー: `area:city:year:quarter:toYear:toQuarter`
- `client.go`: `FetchLandPrices` にキャッシュ参照・保存を追加
- `client_test.go`: キャッシュ関連テスト3件追加
  - `TestFetchLandPrices_CacheHit` — 2回目以降はAPIコールなし
  - `TestFetchLandPrices_CacheMissOnDifferentQuery` — クエリが異なればキャッシュ共有しない
  - `TestCache_TTLExpiry` — TTL切れはキャッシュミスになる

## 関連Issue
Closes #5

## テスト
- [x] 既存テストが通ること
- [x] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み