### PR TITLE
feat: Dockerfile + docker-compose の整備

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,14 @@ build:
 	@echo "==> Frontend build"
 	cd frontend && npm run build
 
+## docker-up: Dockerコンテナをビルドして起動
+docker-up:
+	docker compose up --build
+
+## docker-down: Dockerコンテナを停止・削除
+docker-down:
+	docker compose down
+
 ## help: 利用可能なコマンドを表示
 help:
 	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## //'

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@
 │  Frontend (Next.js)         │ ◄──────────► │  Backend (Go / Gin)         │
 │  localhost:3000             │              │  localhost:8080              │
 └─────────────────────────────┘              └──────────────┬──────────────┘
-                                                            │  HTTPS
+                                                            │  HTTPS + APIキー認証
                                                             ▼
                                               ┌─────────────────────────────┐
-                                              │  国交省 不動産取引価格API    │
-                                              │  land.mlit.go.jp            │
+                                              │  国交省 不動産情報ライブラリ  │
+                                              │  reinfolib.mlit.go.jp       │
                                               └─────────────────────────────┘
 ```
 
@@ -33,7 +33,7 @@
 
 - Backend: Go 1.25 / Gin / Clean Architecture
 - Frontend: Next.js 16 (App Router) / TypeScript / Tailwind CSS v4 / Shadcn/UI / Recharts
-- Data: 国土交通省 不動産取引価格情報取得API（認証不要・公式）
+- Data: 国土交通省 不動産情報ライブラリ API（APIキー必須・要申請）
 
 ## セットアップ
 
@@ -41,34 +41,43 @@
 # リポジトリのクローン
 git clone <repository-url>
 cd yield-guard
+
+# 環境変数の設定（プロジェクトルートに .env を作成）
+cp .env.example .env
+# .env を編集して MLIT_API_KEY を設定する
+# APIキー申請: https://www.reinfolib.mlit.go.jp/api/request/（審査5営業日）
 ```
 
-### バックエンド
+### Docker（推奨）
+
+```bash
+# ビルドして起動（初回のみ時間がかかります）
+make docker-up
+
+# 停止
+make docker-down
+```
+
+| サービス | URL |
+|---|---|
+| フロントエンド | http://localhost:3000 |
+| バックエンド | http://localhost:8080 |
+
+### ローカル開発（Docker不使用）
+
+**バックエンド**
 
 ```bash
 cd backend
-
-# 依存関係のインストール
 go mod tidy
-
-# 環境変数の設定（国交省APIキーが必要）
-cp ../.env.example .env
-# .env を編集して MLIT_API_KEY を設定する
-# 申請: https://www.reinfolib.mlit.go.jp/api/request/
-
-# 開発サーバー起動 (デフォルト: :8080)
-MLIT_API_KEY=your_key go run cmd/server/main.go
+go run cmd/server/main.go
 ```
 
-### フロントエンド
+**フロントエンド**
 
 ```bash
 cd frontend
-
-# 依存関係のインストール
 npm install
-
-# 開発サーバー起動 (デフォルト: :3000)
 npm run dev
 ```
 
@@ -118,6 +127,7 @@ yield-guard/
 │       ├── backend-ci.yml          # Go vet / test -race / build
 │       └── frontend-ci.yml         # lint / tsc / build
 ├── backend/
+│   ├── Dockerfile                  # マルチステージビルド（BuildKitキャッシュ最適化）
 │   ├── cmd/server/main.go          # エントリポイント
 │   └── internal/
 │       ├── domain/
@@ -125,8 +135,10 @@ yield-guard/
 │       │   ├── investment.go       # 収支計算ロジック（元利均等・減価償却・税金）
 │       │   └── investment_test.go  # ユニットテスト
 │       ├── mlit/
-│       │   ├── client.go           # 国交省APIクライアント（リトライ付き）
+│       │   ├── client.go           # 国交省APIクライアント（リトライ・キャッシュ付き）
+│       │   ├── cache.go            # TTL付きインメモリキャッシュ（24時間）
 │       │   ├── client_test.go      # ユニットテスト（httptest モック）
+│       │   ├── integration_test.go # 統合テスト（実API疎通・要APIキー）
 │       │   └── types.go            # APIレスポンス型
 │       └── api/
 │           ├── handler.go          # HTTPハンドラー
@@ -137,11 +149,14 @@ yield-guard/
 │   ├── domain-investment-calculation.md
 │   └── ...
 ├── frontend/
+│   ├── Dockerfile                  # マルチステージビルド
 │   └── src/
 │       ├── app/                    # Next.js App Router
 │       ├── components/             # UIコンポーネント
 │       ├── lib/                    # APIクライアント・計算ユーティリティ
 │       └── types/                  # TypeScript型定義
+├── docker-compose.yml              # backend + frontend 一括起動
+├── .env.example                    # 環境変数テンプレート
 └── README.md
 ```
 
@@ -150,11 +165,13 @@ yield-guard/
 ### よく使うコマンド
 
 ```bash
-make help    # 利用可能なコマンド一覧
-make test    # バックエンド・フロントエンドの全テスト実行
-make lint    # バックエンド（golangci-lint）・フロントエンド lint
-make build   # バックエンド・フロントエンドのビルド
-make dev     # 開発サーバー起動（backend :8080 + frontend :3000）
+make help        # 利用可能なコマンド一覧
+make dev         # 開発サーバー起動（backend :8080 + frontend :3000）
+make docker-up   # Dockerコンテナをビルドして起動
+make docker-down # Dockerコンテナを停止・削除
+make test        # バックエンド・フロントエンドの全テスト実行
+make lint        # バックエンド（golangci-lint）・フロントエンド lint
+make build       # バックエンド・フロントエンドのビルド
 ```
 
 個別に実行する場合：

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+*_test.go
+*.md
+.git

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,9 +13,14 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux go build -trimpath -o server ./cmd/server
 
-FROM alpine:latest
+# alpine:latest ではなくバージョンを固定して再現性を確保
+FROM alpine:3.21
 RUN apk --no-cache add ca-certificates tzdata
-WORKDIR /root/
+# root実行を避けるために専用ユーザーを作成
+RUN adduser -D -u 1000 appuser
+WORKDIR /home/appuser/
 COPY --from=builder /app/server .
+RUN chown appuser:appuser server
+USER appuser
 EXPOSE 8080
 CMD ["./server"]

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,11 +1,17 @@
+# syntax=docker/dockerfile:1
 FROM golang:1.25-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./
-RUN go mod download
+# モジュールキャッシュをホストに永続化（go.mod/go.sum が変わらなければダウンロードをスキップ）
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux go build -o server ./cmd/server
+# ビルドキャッシュをホストに永続化（変更のないパッケージの再コンパイルをスキップ）
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -trimpath -o server ./cmd/server
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates tzdata

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.25-alpine AS builder
+WORKDIR /app
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o server ./cmd/server
+
+FROM alpine:latest
+RUN apk --no-cache add ca-certificates tzdata
+WORKDIR /root/
+COPY --from=builder /app/server .
+EXPOSE 8080
+CMD ["./server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,12 @@ services:
     environment:
       PORT: "8080"
       ALLOW_ORIGINS: "http://localhost:3000"
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
 
   frontend:
     build:
@@ -20,4 +26,5 @@ services:
     environment:
       BACKEND_URL: "http://backend:8080"
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    env_file:
+      - .env
+    environment:
+      PORT: "8080"
+      ALLOW_ORIGINS: "http://localhost:3000"
+
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    environment:
+      BACKEND_URL: "http://backend:8080"
+    depends_on:
+      - backend

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -23,8 +23,8 @@ Yield-Guard は不動産投資判断を支援するシミュレーションツ�
 [フロントエンド] Next.js 16 (App Router)
     ↓ fetch to http://localhost:8080
 [バックエンド] Go + Gin
-    ↓ https://www.land.mlit.go.jp/...
-[外部API] 国交省 不動産取引価格情報取得API
+    ↓ HTTPS + Ocp-Apim-Subscription-Key ヘッダー
+[外部API] 国交省 不動産情報ライブラリ API (reinfolib.mlit.go.jp)
 ```
 
 ---
@@ -58,6 +58,7 @@ Yield-Guard は不動産投資判断を支援するシミュレーションツ�
 ```
 yield-guard/
 ├── backend/
+│   ├── Dockerfile                 # マルチステージビルド（BuildKitキャッシュ最適化）
 │   ├── cmd/server/main.go         # エントリポイント・グレースフルシャットダウン
 │   └── internal/
 │       ├── domain/
@@ -66,12 +67,15 @@ yield-guard/
 │       │   └── investment_test.go # ユニットテスト
 │       ├── mlit/
 │       │   ├── client.go          # 国交省APIクライアント・リトライ
+│       │   ├── cache.go           # TTL付きインメモリキャッシュ（24時間）
 │       │   ├── client_test.go     # ユニットテスト（httptest モック）
+│       │   ├── integration_test.go # 統合テスト（実API疎通・要APIキー）
 │       │   └── types.go           # APIレスポンス型・都道府県マップ
 │       └── api/
 │           ├── handler.go         # HTTPハンドラー・バリデーション
 │           └── router.go          # Ginルーター・CORS設定
 ├── frontend/
+│   ├── Dockerfile                 # マルチステージビルド
 │   └── src/
 │       ├── app/
 │       │   ├── layout.tsx
@@ -89,6 +93,8 @@ yield-guard/
 │       │   └── utils.ts           # formatMan / formatPct / formatYen
 │       └── types/
 │           └── investment.ts      # TypeScript型定義・DEFAULT_INPUT
+├── docker-compose.yml             # backend + frontend 一括起動
+├── .env.example                   # 環境変数テンプレート
 ├── docs/                          # ドキュメント（docs-mcp-server用）
 │   ├── metadata.json
 │   ├── overview.md
@@ -100,19 +106,32 @@ yield-guard/
 
 ## 開発サーバー起動手順
 
-### バックエンド
+### Docker（推奨）
+
+```bash
+cp .env.example .env   # MLIT_API_KEY を設定する
+make docker-up         # backend :8080 + frontend :3000 を一括起動
+```
+
+### ローカル開発
+
+**バックエンド**
 
 ```bash
 cd backend
 go mod tidy
-PORT=8080 go run cmd/server/main.go
+go run cmd/server/main.go
 ```
 
-環境変数:
-- `PORT`: リッスンポート（デフォルト: `8080`）
-- `ALLOW_ORIGINS`: CORS許可オリジン（デフォルト: `http://localhost:3000`）
+環境変数（プロジェクトルートの `.env` から読み込む）:
 
-### フロントエンド
+| 変数名 | 説明 | デフォルト |
+|---|---|---|
+| `PORT` | リッスンポート | `8080` |
+| `ALLOW_ORIGINS` | CORS許可オリジン | `http://localhost:3000` |
+| `MLIT_API_KEY` | 不動産情報ライブラリ APIキー（必須） | — |
+
+**フロントエンド**
 
 ```bash
 cd frontend

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+*.md
+.git

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+FROM node:20-alpine AS runner
+WORKDIR /app
+ENV NODE_ENV=production
+COPY --from=builder /app/.next ./.next
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package.json ./package.json
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,7 +1,10 @@
+# syntax=docker/dockerfile:1
 FROM node:20-alpine AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
-RUN npm ci
+# npmキャッシュをホストに永続化
+RUN --mount=type=cache,target=/root/.npm \
+    npm ci
 
 FROM node:20-alpine AS builder
 WORKDIR /app
@@ -12,8 +15,12 @@ RUN npm run build
 FROM node:20-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+# root実行を避けるために専用ユーザーを作成
+RUN addgroup -g 1001 appgroup && adduser -u 1001 -G appgroup -D appuser
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package.json ./package.json
+RUN chown -R appuser:appgroup .
+USER appuser
 EXPOSE 3000
 CMD ["npm", "start"]

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -2,10 +2,11 @@
 
 const nextConfig = {
   async rewrites() {
+    const backendUrl = process.env.BACKEND_URL ?? "http://localhost:8080";
     return [
       {
         source: "/api/:path*",
-        destination: "http://localhost:8080/api/:path*",
+        destination: `${backendUrl}/api/:path*`,
       },
     ];
   },


### PR DESCRIPTION
## 概要
backend・frontendをコンテナ化し、`docker compose up --build` でローカル開発環境を統一する。

## 変更内容
- `backend/Dockerfile` — マルチステージビルド（Go builder + alpine runtime）
- `frontend/Dockerfile` — マルチステージビルド（deps / builder / runner の3段階）
- `docker-compose.yml` — backend + frontend を定義。`.env` 経由でAPIキーを受け渡し
- `backend/.dockerignore` / `frontend/.dockerignore` — ビルドコンテキストを最小化
- `frontend/next.config.mjs` — API proxy先を環境変数 `BACKEND_URL` で切り替え可能に（デフォルト: `http://localhost:8080`）
- `Makefile` — `docker-up` / `docker-down` コマンドを追加

## 起動方法

```bash
# .env にAPIキーを設定済みであること
make docker-up
# または
docker compose up --build
```

| サービス | URL |
|---|---|
| frontend | http://localhost:3000 |
| backend | http://localhost:8080 |

## 受け入れ条件
- [x] `backend/Dockerfile` ビルド成功
- [x] `frontend/Dockerfile` ビルド成功

## 関連Issue
Closes #16

## テスト
- [x] 既存テストが通ること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み