### PR TITLE
feat(makefile): 国交省API開発用リクエストターゲットを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: dev test lint build help
+.PHONY: dev test lint build help \
+        mlit-land-prices mlit-municipalities mlit-prefectures
 
 ## dev: バックエンド・フロントエンドの開発サーバーを起動
 dev:
@@ -40,3 +41,36 @@ docker-down:
 ## help: 利用可能なコマンドを表示
 help:
 	@grep -E '^## ' $(MAKEFILE_LIST) | sed 's/## //'
+
+# ---------------------------------------------------------------------------
+# 国交省 不動産情報ライブラリ API 開発用リクエスト
+# APIキーは .env の MLIT_API_KEY から読み込む（git管理外）
+# ---------------------------------------------------------------------------
+MLIT_BASE := https://www.reinfolib.mlit.go.jp/ex-api/external
+_mlit_key  = $$(source .env 2>/dev/null && echo $$MLIT_API_KEY)
+
+## mlit-land-prices: 土地取引価格を取得 (XIT001)
+##   使い方: make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4 [city=13101]
+mlit-land-prices:
+	@test -n "$(area)"      || (echo "ERROR: area は必須です (例: area=13)"; exit 1)
+	@test -n "$(year)"      || (echo "ERROR: year は必須です (例: year=2024)"; exit 1)
+	@test -n "$(quarter)"   || (echo "ERROR: quarter は必須です (例: quarter=1)"; exit 1)
+	@test -n "$(to_year)"   || (echo "ERROR: to_year は必須です (例: to_year=2024)"; exit 1)
+	@test -n "$(to_quarter)"|| (echo "ERROR: to_quarter は必須です (例: to_quarter=4)"; exit 1)
+	@source .env 2>/dev/null; \
+	 curl -s \
+	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
+	   --compressed \
+	   "$(MLIT_BASE)/XIT001?area=$(area)&year=$(year)&quarter=$(quarter)&toYear=$(to_year)&toQuarter=$(to_quarter)&priceClassification=01$(if $(city),&city=$(city),)" \
+	   | jq .
+
+## mlit-municipalities: 市区町村一覧を取得 (XIT002)
+##   使い方: make mlit-municipalities area=13
+mlit-municipalities:
+	@test -n "$(area)" || (echo "ERROR: area は必須です (例: area=13)"; exit 1)
+	@source .env 2>/dev/null; \
+	 curl -s \
+	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
+	   --compressed \
+	   "$(MLIT_BASE)/XIT002?area=$(area)" \
+	   | jq .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: dev test lint build help \
-        mlit-land-prices mlit-municipalities mlit-prefectures
+        mlit-land-prices mlit-municipalities
 
 ## dev: バックエンド・フロントエンドの開発サーバーを起動
 dev:
@@ -47,7 +47,6 @@ help:
 # APIキーは .env の MLIT_API_KEY から読み込む（git管理外）
 # ---------------------------------------------------------------------------
 MLIT_BASE := https://www.reinfolib.mlit.go.jp/ex-api/external
-_mlit_key  = $$(source .env 2>/dev/null && echo $$MLIT_API_KEY)
 
 ## mlit-land-prices: 土地取引価格を取得 (XIT001)
 ##   使い方: make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4 [city=13101]

--- a/README.md
+++ b/README.md
@@ -174,6 +174,26 @@ make lint        # バックエンド（golangci-lint）・フロントエンド
 make build       # バックエンド・フロントエンドのビルド
 ```
 
+### 国交省API 開発用リクエスト
+
+`.env` の `MLIT_API_KEY` を使って国交省APIに直接リクエストできます（`jq` が必要）。
+
+```bash
+# 市区町村一覧を取得（XIT002）
+make mlit-municipalities area=13        # 東京都
+
+# 土地取引価格を取得（XIT001）
+make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4
+make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4 city=13101  # 千代田区
+```
+
+| パラメータ | 説明 | 例 |
+|-----------|------|----|
+| `area` | 都道府県コード（必須） | `13`=東京都, `27`=大阪府 |
+| `year` / `to_year` | 取得開始・終了年（必須） | `2024` |
+| `quarter` / `to_quarter` | 四半期（必須、1〜4） | `1` |
+| `city` | 市区町村コード（任意） | `13101`=千代田区 |
+
 個別に実行する場合：
 
 ```bash

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -141,6 +141,27 @@ npm run dev   # http://localhost:3000
 
 ---
 
+## 国交省API 開発用リクエスト（Makefile）
+
+`.env` の `MLIT_API_KEY` を使って国交省APIへ直接リクエストできる開発者向けターゲット。`jq` が必要。
+
+```bash
+# 市区町村一覧（XIT002）
+make mlit-municipalities area=13
+
+# 土地取引価格（XIT001）
+make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4
+
+# 市区町村コード指定あり
+make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4 city=13101
+```
+
+- APIキーは `.env`（git管理外）から自動で読み込む。コマンドに直接記載しない
+- レスポンスは gzip 圧縮のため `--compressed` を付与している
+- 必須パラメータが未指定の場合はエラーメッセージを表示して終了する
+
+---
+
 ## テスト実行
 
 ```bash


### PR DESCRIPTION
## 概要

国交省APIへ curl でリクエストする際の煩雑さを解消するため、Makefile に開発者向けターゲットを追加した。
`.env` の `MLIT_API_KEY` を自動で読み込むため、APIキーを毎回コマンドに書く必要がない。

## 変更内容

- `Makefile` — `mlit-land-prices`（XIT001）・`mlit-municipalities`（XIT002）ターゲットを追加
  - `.env` から `MLIT_API_KEY` を自動読み込み（git管理外）
  - `--compressed` で gzip レスポンスに対応
  - 必須パラメータ未指定時にエラーメッセージを表示して終了
- `README.md` — 「国交省API 開発用リクエスト」セクションを追加
- `docs/overview.md` — 同セクションを追加

**使い方:**

```bash
# 市区町村一覧（XIT002）
make mlit-municipalities area=13

# 土地取引価格（XIT001）
make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4

# 市区町村コード指定あり
make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4 city=13101
```

## 関連Issue

なし（開発者体験の改善）

## テスト

- [x] 既存テストが通ること
- [x] `make mlit-municipalities area=13` で正常にレスポンスが返ることを確認済み
- [x] `make mlit-municipalities`（area未指定）でエラーメッセージが表示されることを確認済み

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] Makefile に APIキーを直接記載していないことを確認
- [x] `.env` は既に `.gitignore` 管理外であることを確認