### PR TITLE
refactor(api): エンドポイント名をRESTの慣例に合わせて整理

### DIFF
--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -144,7 +144,7 @@ func TestAnalyze_ValidInput(t *testing.T) {
 	r := newTestRouter(&mockMLITClient{})
 
 	body, _ := json.Marshal(validBase)
-	req := httptest.NewRequest(http.MethodPost, "/api/analyze", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/investment/analyze", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -164,7 +164,7 @@ func TestAnalyze_ValidInput(t *testing.T) {
 func TestAnalyze_InvalidJSON(t *testing.T) {
 	r := newTestRouter(&mockMLITClient{})
 
-	req := httptest.NewRequest(http.MethodPost, "/api/analyze", bytes.NewBufferString("not-json"))
+	req := httptest.NewRequest(http.MethodPost, "/api/investment/analyze", bytes.NewBufferString("not-json"))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -180,7 +180,7 @@ func TestAnalyze_ValidationError(t *testing.T) {
 	invalid := validBase
 	invalid.LandPrice = -1
 	body, _ := json.Marshal(invalid)
-	req := httptest.NewRequest(http.MethodPost, "/api/analyze", bytes.NewReader(body))
+	req := httptest.NewRequest(http.MethodPost, "/api/investment/analyze", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -197,7 +197,7 @@ func TestAnalyze_ValidationError(t *testing.T) {
 
 func TestGetLandPrices_MissingArea(t *testing.T) {
 	r := newTestRouter(&mockMLITClient{})
-	req := httptest.NewRequest(http.MethodGet, "/api/land-prices?year=2024&quarter=1&to_year=2024&to_quarter=4", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/stats?year=2024&quarter=1&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -208,7 +208,7 @@ func TestGetLandPrices_MissingArea(t *testing.T) {
 
 func TestGetLandPrices_InvalidYear(t *testing.T) {
 	r := newTestRouter(&mockMLITClient{})
-	req := httptest.NewRequest(http.MethodGet, "/api/land-prices?area=13&year=2000&quarter=1&to_year=2024&to_quarter=4", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/stats?area=13&year=2000&quarter=1&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -219,7 +219,7 @@ func TestGetLandPrices_InvalidYear(t *testing.T) {
 
 func TestGetLandPrices_InvalidQuarter(t *testing.T) {
 	r := newTestRouter(&mockMLITClient{})
-	req := httptest.NewRequest(http.MethodGet, "/api/land-prices?area=13&year=2024&quarter=5&to_year=2024&to_quarter=4", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/stats?area=13&year=2024&quarter=5&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -235,7 +235,7 @@ func TestGetLandPrices_APIError(t *testing.T) {
 		},
 	}
 	r := newTestRouter(client)
-	req := httptest.NewRequest(http.MethodGet, "/api/land-prices?area=13&year=2024&quarter=1&to_year=2024&to_quarter=4", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/stats?area=13&year=2024&quarter=1&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -253,7 +253,7 @@ func TestGetLandPrices_Success(t *testing.T) {
 		},
 	}
 	r := newTestRouter(client)
-	req := httptest.NewRequest(http.MethodGet, "/api/land-prices?area=13&year=2024&quarter=1&to_year=2024&to_quarter=4", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/stats?area=13&year=2024&quarter=1&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -36,9 +36,9 @@ func NewRouter(h *Handler) *gin.Engine {
 
 	api := r.Group("/api")
 	{
-		api.GET("/land-prices", h.GetLandPrices)
+		api.GET("/land-prices/stats", h.GetLandPrices)
 		api.GET("/land-prices/compare", h.CompareLandPrice)
-		api.POST("/analyze", h.Analyze)
+		api.POST("/investment/analyze", h.Analyze)
 		api.GET("/municipalities", h.GetMunicipalities)
 	}
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -19,7 +19,7 @@
 
 ---
 
-## GET /api/land-prices
+## GET /api/land-prices/stats
 
 国交省APIから土地取引価格を取得し、統計を返す。
 
@@ -118,7 +118,7 @@
 
 ---
 
-## POST /api/analyze
+## POST /api/investment/analyze
 
 投資シミュレーションを実行する。
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -32,7 +32,7 @@ export async function fetchLandPrices(params: {
     to_quarter: String(params.toQuarter),
   });
   if (params.city) q.set("city", params.city);
-  const res = await fetch(`${BASE}/land-prices?${q}`);
+  const res = await fetch(`${BASE}/land-prices/stats?${q}`);
   return handleResponse<LandPriceStats>(res);
 }
 
@@ -74,7 +74,7 @@ export async function fetchMunicipalities(area: string): Promise<Municipality[]>
 
 /** 投資シミュレーションを実行 */
 export async function analyze(input: InvestmentInput): Promise<InvestmentResult> {
-  const res = await fetch(`${BASE}/analyze`, {
+  const res = await fetch(`${BASE}/investment/analyze`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(input),


### PR DESCRIPTION
## 概要

- `GET /api/land-prices` → `GET /api/land-prices/stats`（レスポンスが統計であることを明示）
- `POST /api/analyze` → `POST /api/investment/analyze`（対象リソース `investment` を明示）

## 変更ファイル

- `backend/internal/api/router.go` — ルート定義更新
- `backend/internal/api/handler_test.go` — テストのリクエストURL更新
- `frontend/src/lib/api.ts` — fetch先URL更新
- `docs/api-reference.md` — ドキュメント更新

## テスト

- [x] `go test ./...` 全通過
- [x] `npm test` 全27件通過

Closes #67