### PR TITLE
refactor: 用途地域・都市計画区域のEnum型定義とドメイン型整備

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "docs": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["../docs-mcp-server/build/index.js"],
+      "env": {
+        "PROJECT_ROOT": "/path/to/yield-guard",
+        "LOCAL_MODE": "true",
+        "DOCS_BASE_PATH": "./docs"
+      }
+    }
+  }
+}

--- a/backend/internal/domain/zoning.go
+++ b/backend/internal/domain/zoning.go
@@ -1,0 +1,106 @@
+package domain
+
+// ZoningType は用途地域の種別（都市計画法第8条）
+type ZoningType string
+
+const (
+	ZoningFirstLowRise        ZoningType = "第一種低層住居専用地域"
+	ZoningSecondLowRise       ZoningType = "第二種低層住居専用地域"
+	ZoningFirstMidHighRise    ZoningType = "第一種中高層住居専用地域"
+	ZoningSecondMidHighRise   ZoningType = "第二種中高層住居専用地域"
+	ZoningFirstResidential    ZoningType = "第一種住居地域"
+	ZoningSecondResidential   ZoningType = "第二種住居地域"
+	ZoningQuasiResidential    ZoningType = "準住居地域"
+	ZoningNeighborhoodCommercial ZoningType = "近隣商業地域"
+	ZoningCommercial          ZoningType = "商業地域"
+	ZoningQuasiIndustrial     ZoningType = "準工業地域"
+	ZoningIndustrial          ZoningType = "工業地域"
+	ZoningExclusiveIndustrial ZoningType = "工業専用地域"
+	ZoningGardenCity          ZoningType = "田園住居地域"
+	ZoningUnknown             ZoningType = ""
+)
+
+// ZoningRiskLevel は用途地域の賃貸住宅投資リスクレベル
+type ZoningRiskLevel int
+
+const (
+	ZoningRiskNone    ZoningRiskLevel = 0 // 問題なし
+	ZoningRiskCaution ZoningRiskLevel = 1 // 注意（用途制限あり）
+	ZoningRiskHigh    ZoningRiskLevel = 2 // 高リスク（住居不適）
+)
+
+// ZoningMeta は用途地域のメタデータ
+type ZoningMeta struct {
+	DefaultBuildingCoverage int             // デフォルト建ぺい率（%）
+	DefaultFloorAreaRatio   int             // デフォルト容積率（%）
+	RiskLevel               ZoningRiskLevel // 賃貸住宅投資リスク
+	RiskMessage             string          // リスク説明
+}
+
+// zoningMetaMap は各用途地域のデフォルトメタデータ
+// 建ぺい率・容積率は都市計画法の標準値（実際は自治体により異なる）
+var zoningMetaMap = map[ZoningType]ZoningMeta{
+	ZoningFirstLowRise:        {60, 100, ZoningRiskNone, ""},
+	ZoningSecondLowRise:       {60, 150, ZoningRiskNone, ""},
+	ZoningFirstMidHighRise:    {60, 200, ZoningRiskNone, ""},
+	ZoningSecondMidHighRise:   {60, 200, ZoningRiskNone, ""},
+	ZoningFirstResidential:    {60, 200, ZoningRiskNone, ""},
+	ZoningSecondResidential:   {60, 200, ZoningRiskNone, ""},
+	ZoningQuasiResidential:    {60, 200, ZoningRiskNone, ""},
+	ZoningNeighborhoodCommercial: {80, 300, ZoningRiskCaution, "近隣商業地域: 日用品以外の店舗・工場が混在する場合があります"},
+	ZoningCommercial:          {80, 400, ZoningRiskCaution, "商業地域: 風俗施設の立地が可能なため騒音・治安リスクがあります"},
+	ZoningQuasiIndustrial:     {60, 200, ZoningRiskCaution, "準工業地域: 工場・倉庫が混在し騒音・臭気リスクがあります"},
+	ZoningIndustrial:          {60, 200, ZoningRiskHigh, "工業地域: 住宅建設は可能ですが工場が多く賃貸需要が限定的です"},
+	ZoningExclusiveIndustrial: {60, 200, ZoningRiskHigh, "工業専用地域: 住宅建設が法律上禁止されています"},
+	ZoningGardenCity:          {50, 100, ZoningRiskCaution, "田園住居地域: 農地転用規制があり開発・増築に制約があります"},
+}
+
+// Meta は用途地域のメタデータを返す。不明な場合はゼロ値を返す
+func (z ZoningType) Meta() ZoningMeta {
+	return zoningMetaMap[z]
+}
+
+// IsValid は認識できる用途地域かどうかを返す
+func (z ZoningType) IsValid() bool {
+	if z == ZoningUnknown {
+		return false
+	}
+	_, ok := zoningMetaMap[z]
+	return ok
+}
+
+// ParseZoningType はMLIT APIが返す文字列をZoningTypeに変換する
+// 認識できない場合はZoningUnknownを返す
+func ParseZoningType(s string) ZoningType {
+	z := ZoningType(s)
+	if z.IsValid() {
+		return z
+	}
+	return ZoningUnknown
+}
+
+// CityPlanningArea は都市計画区域の種別
+type CityPlanningArea string
+
+const (
+	CityPlanningUrbanized        CityPlanningArea = "市街化区域"
+	CityPlanningUrbanizationControlled CityPlanningArea = "市街化調整区域"
+	CityPlanningUnzoned          CityPlanningArea = "非線引き区域"
+	CityPlanningOutside          CityPlanningArea = "都市計画区域外"
+	CityPlanningAreaUnknown      CityPlanningArea = ""
+)
+
+// ParseCityPlanningArea はMLIT APIが返す文字列をCityPlanningAreaに変換する
+func ParseCityPlanningArea(s string) CityPlanningArea {
+	switch CityPlanningArea(s) {
+	case CityPlanningUrbanized, CityPlanningUrbanizationControlled, CityPlanningUnzoned, CityPlanningOutside:
+		return CityPlanningArea(s)
+	default:
+		return CityPlanningAreaUnknown
+	}
+}
+
+// IsHighRisk は市街化調整区域かどうかを返す（開発制限が厳しい）
+func (c CityPlanningArea) IsHighRisk() bool {
+	return c == CityPlanningUrbanizationControlled
+}

--- a/backend/internal/domain/zoning_test.go
+++ b/backend/internal/domain/zoning_test.go
@@ -1,0 +1,53 @@
+package domain
+
+import "testing"
+
+func TestParseZoningType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  ZoningType
+	}{
+		{"第一種低層住居専用地域", ZoningFirstLowRise},
+		{"商業地域", ZoningCommercial},
+		{"工業専用地域", ZoningExclusiveIndustrial},
+		{"田園住居地域", ZoningGardenCity},
+		{"不明な地域", ZoningUnknown},
+		{"", ZoningUnknown},
+	}
+	for _, tt := range tests {
+		if got := ParseZoningType(tt.input); got != tt.want {
+			t.Errorf("ParseZoningType(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestZoningMeta_RiskLevel(t *testing.T) {
+	if ZoningFirstLowRise.Meta().RiskLevel != ZoningRiskNone {
+		t.Error("first low rise should have no risk")
+	}
+	if ZoningExclusiveIndustrial.Meta().RiskLevel != ZoningRiskHigh {
+		t.Error("exclusive industrial should be high risk")
+	}
+	if ZoningCommercial.Meta().RiskLevel != ZoningRiskCaution {
+		t.Error("commercial should be caution risk")
+	}
+}
+
+func TestParseCityPlanningArea(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantHigh bool
+	}{
+		{"市街化区域", false},
+		{"市街化調整区域", true},
+		{"非線引き区域", false},
+		{"都市計画区域外", false},
+		{"不明", false},
+	}
+	for _, tt := range tests {
+		got := ParseCityPlanningArea(tt.input)
+		if got.IsHighRisk() != tt.wantHigh {
+			t.Errorf("ParseCityPlanningArea(%q).IsHighRisk() = %v, want %v", tt.input, got.IsHighRisk(), tt.wantHigh)
+		}
+	}
+}

--- a/docs/domain-zoning.md
+++ b/docs/domain-zoning.md
@@ -1,0 +1,115 @@
+# 用途地域・都市計画区域 ドメイン型仕様
+
+実装: `backend/internal/domain/zoning.go`
+テスト: `backend/internal/domain/zoning_test.go`
+
+---
+
+## ZoningType（用途地域）
+
+根拠: **都市計画法 第8条第1項第1号**
+
+MLIT API が返す生文字列をそのまま型の値として使用する。
+`ParseZoningType(string)` で変換し、認識できない文字列は `ZoningUnknown`（空文字列）を返す。
+
+| 定数 | 文字列 | リスクレベル |
+|------|--------|------------|
+| `ZoningFirstLowRise` | `"第一種低層住居専用地域"` | None |
+| `ZoningSecondLowRise` | `"第二種低層住居専用地域"` | None |
+| `ZoningFirstMidHighRise` | `"第一種中高層住居専用地域"` | None |
+| `ZoningSecondMidHighRise` | `"第二種中高層住居専用地域"` | None |
+| `ZoningFirstResidential` | `"第一種住居地域"` | None |
+| `ZoningSecondResidential` | `"第二種住居地域"` | None |
+| `ZoningQuasiResidential` | `"準住居地域"` | None |
+| `ZoningNeighborhoodCommercial` | `"近隣商業地域"` | Caution |
+| `ZoningCommercial` | `"商業地域"` | Caution |
+| `ZoningQuasiIndustrial` | `"準工業地域"` | Caution |
+| `ZoningIndustrial` | `"工業地域"` | High |
+| `ZoningExclusiveIndustrial` | `"工業専用地域"` | High |
+| `ZoningGardenCity` | `"田園住居地域"` | Caution |
+| `ZoningUnknown` | `""` | — |
+
+---
+
+## ZoningRiskLevel（リスクレベル）
+
+賃貸住宅投資の観点でのリスク分類。
+
+| 定数 | 値 | 意味 |
+|------|----|------|
+| `ZoningRiskNone` | `0` | 問題なし（住居系地域） |
+| `ZoningRiskCaution` | `1` | 注意（用途制限あり・混在リスク） |
+| `ZoningRiskHigh` | `2` | 高リスク（住居不適・建設禁止） |
+
+---
+
+## ZoningMeta（メタデータ）
+
+各用途地域に紐づくメタデータ。`ZoningType.Meta()` で取得。
+
+```go
+type ZoningMeta struct {
+    DefaultBuildingCoverage int             // デフォルト建ぺい率（%）
+    DefaultFloorAreaRatio   int             // デフォルト容積率（%）
+    RiskLevel               ZoningRiskLevel
+    RiskMessage             string
+}
+```
+
+> **注意**: 建ぺい率・容積率は都市計画法の標準値であり、実際の値は自治体の都市計画により異なる。
+> あくまで参考値として扱うこと。
+
+| 用途地域 | 建ぺい率 | 容積率 |
+|---------|---------|--------|
+| 第一種低層住居専用地域 | 60% | 100% |
+| 第二種低層住居専用地域 | 60% | 150% |
+| 第一種中高層住居専用地域 | 60% | 200% |
+| 第二種中高層住居専用地域 | 60% | 200% |
+| 第一種住居地域 | 60% | 200% |
+| 第二種住居地域 | 60% | 200% |
+| 準住居地域 | 60% | 200% |
+| 近隣商業地域 | 80% | 300% |
+| 商業地域 | 80% | 400% |
+| 準工業地域 | 60% | 200% |
+| 工業地域 | 60% | 200% |
+| 工業専用地域 | 60% | 200% |
+| 田園住居地域 | 50% | 100% |
+
+---
+
+## CityPlanningArea（都市計画区域）
+
+| 定数 | 文字列 | `IsHighRisk()` |
+|------|--------|---------------|
+| `CityPlanningUrbanized` | `"市街化区域"` | false |
+| `CityPlanningUrbanizationControlled` | `"市街化調整区域"` | **true** |
+| `CityPlanningUnzoned` | `"非線引き区域"` | false |
+| `CityPlanningOutside` | `"都市計画区域外"` | false |
+| `CityPlanningAreaUnknown` | `""` | false |
+
+`IsHighRisk()` は市街化調整区域のみ `true` を返す。
+市街化調整区域は原則として開発行為が制限されており、建築・増改築に自治体の許可が必要なため投資リスクが高い。
+
+---
+
+## 変換関数
+
+### `ParseZoningType(s string) ZoningType`
+
+MLIT API の `CityPlanning` フィールドの生文字列を `ZoningType` に変換する。
+`zoningMetaMap` に存在しない文字列は `ZoningUnknown` を返す。
+
+### `ParseCityPlanningArea(s string) CityPlanningArea`
+
+MLIT API の `CityPlanning` フィールドの生文字列を `CityPlanningArea` に変換する。
+4種の既定値以外は `CityPlanningAreaUnknown` を返す。
+
+---
+
+## 後続機能との関係
+
+| issue | 機能 | 使用する型 |
+|-------|------|-----------|
+| #72 | 用途地域リスク警告表示 | `ZoningType.Meta().RiskLevel` |
+| #66 | 都市計画リスク警告 | `CityPlanningArea.IsHighRisk()` |
+| #61 | 建ぺい率・容積率の自動入力 | `ZoningMeta.DefaultBuildingCoverage/FloorAreaRatio` |


### PR DESCRIPTION
## 概要

用途地域（13種）と都市計画区域をGoの型（Enum相当）として定義し、ドメイン層に型安全性を導入。

## 変更内容

### 新規ファイル: `backend/internal/domain/zoning.go`

**`ZoningType`（13種）**
- 第一種低層住居専用地域〜田園住居地域の全13種を定数定義
- 各用途地域にメタデータを紐付け（デフォルト建ぺい率・容積率・リスクレベル・リスクメッセージ）
- リスクレベル: `None` / `Caution`（商業・準工業など） / `High`（工業・工業専用地域）
- `ParseZoningType(string) ZoningType` — MLIT APIの生文字列から変換

**`CityPlanningArea`（4種）**
- 市街化区域 / 市街化調整区域 / 非線引き区域 / 都市計画区域外
- `IsHighRisk()` — 市街化調整区域を判定
- `ParseCityPlanningArea(string) CityPlanningArea` — 変換関数

## 後続issueへの貢献

- #72 用途地域リスク警告表示
- #66 都市計画リスク警告
- #61 用途地域APIによる建ぺい率・容積率の自動入力

## テスト

- [x] `go test ./...` 全通過（`zoning_test.go` 新規追加）

Closes #80