### PR TITLE
feat: 用途地域リスク警告表示

### DIFF
--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -9,7 +9,8 @@ import type { InvestmentInput, BuildingType } from "@/types/investment";
 import { DEFAULT_INPUT } from "@/types/investment";
 import { formatPct } from "@/lib/utils";
 import { fetchMunicipalities, type Municipality } from "@/lib/api";
-import { Search, Calculator, Info } from "lucide-react";
+import { Search, Calculator, Info, AlertTriangle, ShieldCheck } from "lucide-react";
+import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
 
 // 全47都道府県（法的に変容しない静的データ）
 const PREFECTURES = [
@@ -99,6 +100,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading }: Props)
   const [muniLoading, setMuniLoading] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
+  const [zoningType, setZoningType] = useState<ZoningType>("");
 
   const loadMunicipalities = useCallback(async (areaCode: string) => {
     setMuniLoading(true);
@@ -263,6 +265,47 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading }: Props)
                 onChange={(e) => setNum("exitYieldTarget", fromPct(e.target.value))}
                 error={errors.exitYieldTarget} />
             </div>
+          </div>
+
+          {/* 用途地域 */}
+          <div className="border-t pt-3 space-y-2">
+            <Select
+              label="用途地域（任意）"
+              value={zoningType}
+              onChange={(e) => setZoningType(e.target.value as ZoningType)}
+              options={[
+                { value: "", label: "（未選択）" },
+                ...ZONING_TYPES.map((z) => ({ value: z, label: z })),
+              ]}
+            />
+            {zoningType && (() => {
+              const meta = ZONING_META[zoningType];
+              if (!meta) return null;
+              if (meta.riskLevel === 0) return (
+                <div className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-2 text-green-800 text-xs">
+                  <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5" />
+                  <span>良好な住環境です（建ぺい率{meta.defaultBuildingCoverage}%・容積率{meta.defaultFloorAreaRatio}%）</span>
+                </div>
+              );
+              const color = meta.riskLevel === 2
+                ? "border-red-300 bg-red-50 text-red-800"
+                : "border-yellow-300 bg-yellow-50 text-yellow-800";
+              const icon = meta.riskLevel === 2
+                ? <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-red-600" />
+                : <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5 text-yellow-600" />;
+              return (
+                <div className={`flex items-start gap-2 rounded-md border p-2 text-xs ${color}`}>
+                  {icon}
+                  <div>
+                    <span className="font-semibold">{meta.riskLevel === 2 ? "高リスク" : "注意"}: </span>
+                    <span>{meta.riskMessage}</span>
+                    <span className="block mt-0.5 text-muted-foreground">
+                      建ぺい率{meta.defaultBuildingCoverage}%・容積率{meta.defaultFloorAreaRatio}%（標準値）
+                    </span>
+                  </div>
+                </div>
+              );
+            })()}
           </div>
 
           {/* 詳細設定 */}

--- a/frontend/src/lib/zoning.ts
+++ b/frontend/src/lib/zoning.ts
@@ -1,0 +1,42 @@
+export type ZoningRiskLevel = 0 | 1 | 2;
+
+export interface ZoningMeta {
+  defaultBuildingCoverage: number;
+  defaultFloorAreaRatio: number;
+  riskLevel: ZoningRiskLevel;
+  riskMessage: string;
+}
+
+export const ZONING_TYPES = [
+  "第一種低層住居専用地域",
+  "第二種低層住居専用地域",
+  "第一種中高層住居専用地域",
+  "第二種中高層住居専用地域",
+  "第一種住居地域",
+  "第二種住居地域",
+  "準住居地域",
+  "近隣商業地域",
+  "商業地域",
+  "準工業地域",
+  "工業地域",
+  "工業専用地域",
+  "田園住居地域",
+] as const;
+
+export type ZoningType = (typeof ZONING_TYPES)[number] | "";
+
+export const ZONING_META: Record<string, ZoningMeta> = {
+  第一種低層住居専用地域:    { defaultBuildingCoverage: 60, defaultFloorAreaRatio: 100, riskLevel: 0, riskMessage: "" },
+  第二種低層住居専用地域:    { defaultBuildingCoverage: 60, defaultFloorAreaRatio: 150, riskLevel: 0, riskMessage: "" },
+  第一種中高層住居専用地域:  { defaultBuildingCoverage: 60, defaultFloorAreaRatio: 200, riskLevel: 0, riskMessage: "" },
+  第二種中高層住居専用地域:  { defaultBuildingCoverage: 60, defaultFloorAreaRatio: 200, riskLevel: 0, riskMessage: "" },
+  第一種住居地域:            { defaultBuildingCoverage: 60, defaultFloorAreaRatio: 200, riskLevel: 0, riskMessage: "" },
+  第二種住居地域:            { defaultBuildingCoverage: 60, defaultFloorAreaRatio: 200, riskLevel: 0, riskMessage: "" },
+  準住居地域:                { defaultBuildingCoverage: 60, defaultFloorAreaRatio: 200, riskLevel: 0, riskMessage: "" },
+  近隣商業地域:              { defaultBuildingCoverage: 80, defaultFloorAreaRatio: 300, riskLevel: 1, riskMessage: "日用品以外の店舗・工場が混在する場合があります" },
+  商業地域:                  { defaultBuildingCoverage: 80, defaultFloorAreaRatio: 400, riskLevel: 1, riskMessage: "風俗施設の立地が可能なため騒音・治安リスクがあります" },
+  準工業地域:                { defaultBuildingCoverage: 60, defaultFloorAreaRatio: 200, riskLevel: 1, riskMessage: "工場・倉庫が混在し騒音・臭気リスクがあります" },
+  工業地域:                  { defaultBuildingCoverage: 60, defaultFloorAreaRatio: 200, riskLevel: 2, riskMessage: "工場が多く賃貸需要が限定的です。住宅建設は可能ですが将来空室リスクが高い" },
+  工業専用地域:              { defaultBuildingCoverage: 60, defaultFloorAreaRatio: 200, riskLevel: 2, riskMessage: "住宅建設が法律上禁止されています" },
+  田園住居地域:              { defaultBuildingCoverage: 50, defaultFloorAreaRatio: 100, riskLevel: 1, riskMessage: "農地転用規制があり開発・増築に制約があります" },
+};


### PR DESCRIPTION
## 概要

用途地域ドロップダウンをフォームに追加し、選択に応じてリスク警告バナーをリアルタイム表示。フロントエンドのみで完結。

## 変更内容（2コミット）

1. `frontend/src/lib/zoning.ts`（新規）: 13種の用途地域リスクメタデータ定義
2. `frontend/src/components/InvestmentForm.tsx`: 用途地域セレクト＋即時警告バナー

## 警告レベル

| リスク | 対象 | 表示 |
|--------|------|------|
| 高（赤） | 工業地域・工業専用地域 | 賃貸需要限定・住宅建設禁止 |
| 注意（黄） | 準工業・商業・近隣商業・田園住居 | 用途混在・農地規制 |
| なし（緑） | 住居系7種 | 良好な住環境 |

デフォルトの建ぺい率・容積率も表示（参考値）。

## 依存

- #80（`feature/zoning-type-enum`）のEnum定義を土台とするためそちらをbaseブランチに指定

## テスト

- [x] `npm run build` 型エラーなし

Closes #72