### PR TITLE
feat: 登録免許税および不動産取得税の算出ロジック (#76)

### DIFF
--- a/backend/internal/domain/acquisition_costs.go
+++ b/backend/internal/domain/acquisition_costs.go
@@ -1,0 +1,74 @@
+package domain
+
+import "math"
+
+// CalcBrokerageFee は仲介手数料（税込）を算出する。
+// multiplier: 1.0=標準、0.0=無料、0.5=半額など。
+// 根拠: 宅地建物取引業法46条・国土交通省告示
+func CalcBrokerageFee(price, multiplier float64) float64 {
+	if multiplier <= 0 || price <= 0 {
+		return 0
+	}
+	var base float64
+	switch {
+	case price <= 2_000_000:
+		base = price * 0.05
+	case price <= 4_000_000:
+		base = price*0.04 + 20_000
+	default:
+		// 400万円超: (3% + 6万円) × 消費税10%
+		base = price*0.03 + 60_000
+	}
+	return math.Round(base * 1.1 * multiplier)
+}
+
+// CalcStampDuty は売買契約書の印紙税を返す。
+// 根拠: 印紙税法別表第一 第1号文書（不動産譲渡契約書）
+// 2024年4月以降は軽減措置終了のため本則税率を適用。
+func CalcStampDuty(price float64) float64 {
+	switch {
+	case price <= 100_000:
+		return 200
+	case price <= 500_000:
+		return 400
+	case price <= 1_000_000:
+		return 1_000
+	case price <= 5_000_000:
+		return 2_000
+	case price <= 10_000_000:
+		return 10_000
+	case price <= 50_000_000:
+		return 20_000
+	case price <= 100_000_000:
+		return 60_000
+	case price <= 500_000_000:
+		return 100_000
+	case price <= 1_000_000_000:
+		return 200_000
+	default:
+		return 600_000
+	}
+}
+
+// AcquisitionCostOptions は諸経費計算のオプション
+type AcquisitionCostOptions struct {
+	// BrokerageMultiplier: 1.0=標準, 0.0=仲介手数料無料, 0.5=半額
+	BrokerageMultiplier float64
+}
+
+// DefaultAcquisitionCostOptions は標準的な取引条件のオプションを返す
+func DefaultAcquisitionCostOptions() AcquisitionCostOptions {
+	return AcquisitionCostOptions{BrokerageMultiplier: 1.0}
+}
+
+// CalcAcquisitionCosts は取得時の諸経費（#75スコープ）を算出する。
+// 登録免許税・不動産取得税（#76）と固定資産税日割り（#77）は後続issueで追加。
+func CalcAcquisitionCosts(totalPrice float64, opts AcquisitionCostOptions) AcquisitionCostBreakdown {
+	brokerage := CalcBrokerageFee(totalPrice, opts.BrokerageMultiplier)
+	stamp := CalcStampDuty(totalPrice)
+	return AcquisitionCostBreakdown{
+		BrokerageFee: brokerage,
+		StampDuty:    stamp,
+		Total:        brokerage + stamp,
+	}
+}

--- a/backend/internal/domain/acquisition_costs.go
+++ b/backend/internal/domain/acquisition_costs.go
@@ -50,25 +50,90 @@ func CalcStampDuty(price float64) float64 {
 	}
 }
 
+// CalcRegistrationTax は登録免許税合計（所有権移転登記＋抵当権設定登記）を算出する。
+//
+// 適用税率（根拠: 租税特別措置法・不動産登記法）:
+//   - 土地所有権移転: 固定資産税評価額 × 2.0%（本則。軽減措置 〜2026/3/31 期限切れ）
+//   - 建物所有権移転（中古）: 固定資産税評価額 × 2.0%
+//   - 建物所有権保存（新築）: 固定資産税評価額 × 0.15%（軽減措置 〜2027/3/31）
+//   - 抵当権設定: 融資額 × 0.4%（投資用物件は住宅ローン軽減0.1%対象外）
+func CalcRegistrationTax(landAssessed, buildingAssessed, loanAmount float64, isNewBuilding bool) float64 {
+	landTransfer := landAssessed * 0.02
+
+	var buildingTransfer float64
+	if isNewBuilding {
+		// 根拠: 租税特別措置法72条の2 新築住宅用建物の所有権保存登記 軽減措置
+		buildingTransfer = buildingAssessed * 0.0015
+	} else {
+		buildingTransfer = buildingAssessed * 0.02
+	}
+
+	mortgage := loanAmount * 0.004 // 抵当権設定: 0.4%
+
+	return math.Round(landTransfer + buildingTransfer + mortgage)
+}
+
+// CalcRealEstateAcquisitionTax は不動産取得税の概算を算出する。
+// 根拠: 地方税法73条の15、租税特別措置法11条の5（特例税率3%、〜2027/3/31）
+//
+// 計算式:
+//   - 土地: 固定資産税評価額 × 1/2 × 3%（1/2課税は租税特別措置法11条の5第2項）
+//   - 建物: 固定資産税評価額 × 3%
+//
+// 注意: 住宅用土地の特例控除（45,000円控除等）は建物面積等が必要なため含まない概算値。
+func CalcRealEstateAcquisitionTax(landAssessed, buildingAssessed float64) float64 {
+	const taxRate = 0.03 // 特例税率 〜2027/3/31
+	landTax := landAssessed * 0.5 * taxRate
+	buildingTax := buildingAssessed * taxRate
+	return math.Round(landTax + buildingTax)
+}
+
 // AcquisitionCostOptions は諸経費計算のオプション
 type AcquisitionCostOptions struct {
 	// BrokerageMultiplier: 1.0=標準, 0.0=仲介手数料無料, 0.5=半額
 	BrokerageMultiplier float64
+
+	// 固定資産税評価額（0 = 推定モード: 土地×70%・建物×60%）
+	AssessedLandValue     float64
+	AssessedBuildingValue float64
+
+	// LoanAmount は抵当権設定登記の計算に使用（0 = 融資なし）
+	LoanAmount float64
+
+	// IsNewBuilding は建物所有権保存登記（新築）か移転登記（中古）かを示す
+	IsNewBuilding bool
 }
 
 // DefaultAcquisitionCostOptions は標準的な取引条件のオプションを返す
+// 評価額は推定モード（取得価格ベース）、融資なし想定
 func DefaultAcquisitionCostOptions() AcquisitionCostOptions {
 	return AcquisitionCostOptions{BrokerageMultiplier: 1.0}
 }
 
-// CalcAcquisitionCosts は取得時の諸経費（#75スコープ）を算出する。
-// 登録免許税・不動産取得税（#76）と固定資産税日割り（#77）は後続issueで追加。
-func CalcAcquisitionCosts(totalPrice float64, opts AcquisitionCostOptions) AcquisitionCostBreakdown {
+// CalcAcquisitionCosts は取得時の諸経費を算出する。
+// 評価額が未入力（0）の場合は推定モード（土地: landPrice×70%、建物: buildingCost×60%）を使用する。
+func CalcAcquisitionCosts(landPrice, buildingCost float64, opts AcquisitionCostOptions) AcquisitionCostBreakdown {
+	totalPrice := landPrice + buildingCost
 	brokerage := CalcBrokerageFee(totalPrice, opts.BrokerageMultiplier)
 	stamp := CalcStampDuty(totalPrice)
+
+	assessedLand := opts.AssessedLandValue
+	if assessedLand == 0 {
+		assessedLand = landPrice * 0.7
+	}
+	assessedBuilding := opts.AssessedBuildingValue
+	if assessedBuilding == 0 {
+		assessedBuilding = buildingCost * 0.6
+	}
+
+	regTax := CalcRegistrationTax(assessedLand, assessedBuilding, opts.LoanAmount, opts.IsNewBuilding)
+	acqTax := CalcRealEstateAcquisitionTax(assessedLand, assessedBuilding)
+
 	return AcquisitionCostBreakdown{
-		BrokerageFee: brokerage,
-		StampDuty:    stamp,
-		Total:        brokerage + stamp,
+		BrokerageFee:             brokerage,
+		StampDuty:                stamp,
+		RegistrationTax:          regTax,
+		RealEstateAcquisitionTax: acqTax,
+		Total:                    brokerage + stamp + regTax + acqTax,
 	}
 }

--- a/backend/internal/domain/acquisition_costs_test.go
+++ b/backend/internal/domain/acquisition_costs_test.go
@@ -1,0 +1,103 @@
+package domain
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCalcBrokerageFee(t *testing.T) {
+	tests := []struct {
+		name       string
+		price      float64
+		multiplier float64
+		want       float64 // 円（10円単位で丸め許容）
+	}{
+		{
+			name:       "400万超の標準物件（5900万円）",
+			price:      59_000_000,
+			multiplier: 1.0,
+			// base = 59,000,000*0.03 + 60,000 = 1,830,000; × 1.1 = 2,013,000
+			want: 2_013_000,
+		},
+		{
+			name:       "400万超の標準物件（1500万円）",
+			price:      15_000_000,
+			multiplier: 1.0,
+			// base = 15,000,000*0.03 + 60,000 = 510,000; × 1.1 = 561,000
+			want: 561_000,
+		},
+		{
+			name:       "仲介手数料無料",
+			price:      20_000_000,
+			multiplier: 0.0,
+			want:       0,
+		},
+		{
+			name:       "半額交渉成立",
+			price:      20_000_000,
+			multiplier: 0.5,
+			// base = 660,000; × 1.1 × 0.5 = 363,000
+			want: 363_000,
+		},
+		{
+			name:       "200万円以下",
+			price:      1_500_000,
+			multiplier: 1.0,
+			// base = 1,500,000 * 0.05 = 75,000; × 1.1 = 82,500
+			want: 82_500,
+		},
+		{
+			name:       "200万超400万以下（300万）",
+			price:      3_000_000,
+			multiplier: 1.0,
+			// base = 3,000,000*0.04 + 20,000 = 140,000; × 1.1 = 154,000
+			want: 154_000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalcBrokerageFee(tt.price, tt.multiplier)
+			if math.Abs(got-tt.want) > 1 {
+				t.Errorf("CalcBrokerageFee(%.0f, %.1f) = %.0f, want %.0f", tt.price, tt.multiplier, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalcStampDuty(t *testing.T) {
+	tests := []struct {
+		price float64
+		want  float64
+	}{
+		{500_000, 400},
+		{5_000_000, 2_000},
+		{10_000_000, 10_000},
+		{15_000_000, 20_000},
+		{50_000_000, 20_000},
+		{59_000_000, 60_000}, // 5000万超1億以下
+		{100_000_000, 60_000},
+		{200_000_000, 100_000},
+	}
+	for _, tt := range tests {
+		got := CalcStampDuty(tt.price)
+		if got != tt.want {
+			t.Errorf("CalcStampDuty(%.0f) = %.0f, want %.0f", tt.price, got, tt.want)
+		}
+	}
+}
+
+func TestCalcAcquisitionCosts(t *testing.T) {
+	opts := DefaultAcquisitionCostOptions()
+	result := CalcAcquisitionCosts(59_000_000, opts)
+
+	if result.BrokerageFee != 2_013_000 {
+		t.Errorf("BrokerageFee = %.0f, want 2013000", result.BrokerageFee)
+	}
+	if result.StampDuty != 60_000 {
+		t.Errorf("StampDuty = %.0f, want 60000", result.StampDuty)
+	}
+	wantTotal := result.BrokerageFee + result.StampDuty
+	if result.Total != wantTotal {
+		t.Errorf("Total = %.0f, want %.0f", result.Total, wantTotal)
+	}
+}

--- a/backend/internal/domain/acquisition_costs_test.go
+++ b/backend/internal/domain/acquisition_costs_test.go
@@ -86,17 +86,119 @@ func TestCalcStampDuty(t *testing.T) {
 	}
 }
 
-func TestCalcAcquisitionCosts(t *testing.T) {
-	opts := DefaultAcquisitionCostOptions()
-	result := CalcAcquisitionCosts(59_000_000, opts)
+func TestCalcRegistrationTax(t *testing.T) {
+	tests := []struct {
+		name             string
+		landAssessed     float64
+		buildingAssessed float64
+		loanAmount       float64
+		isNew            bool
+		want             float64
+	}{
+		{
+			name:             "中古物件・融資あり",
+			landAssessed:     20_000_000, // 土地評価額
+			buildingAssessed: 10_000_000, // 建物評価額
+			loanAmount:       25_000_000,
+			isNew:            false,
+			// 土地: 20,000,000×0.02=400,000
+			// 建物(中古): 10,000,000×0.02=200,000
+			// 抵当権: 25,000,000×0.004=100,000
+			want: 700_000,
+		},
+		{
+			name:             "新築物件・融資あり",
+			landAssessed:     20_000_000,
+			buildingAssessed: 10_000_000,
+			loanAmount:       25_000_000,
+			isNew:            true,
+			// 土地: 400,000
+			// 建物(新築): 10,000,000×0.0015=15,000
+			// 抵当権: 100,000
+			want: 515_000,
+		},
+		{
+			name:             "融資なし",
+			landAssessed:     10_000_000,
+			buildingAssessed: 5_000_000,
+			loanAmount:       0,
+			isNew:            false,
+			// 土地: 200,000 + 建物: 100,000
+			want: 300_000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalcRegistrationTax(tt.landAssessed, tt.buildingAssessed, tt.loanAmount, tt.isNew)
+			if math.Abs(got-tt.want) > 1 {
+				t.Errorf("CalcRegistrationTax = %.0f, want %.0f", got, tt.want)
+			}
+		})
+	}
+}
 
+func TestCalcRealEstateAcquisitionTax(t *testing.T) {
+	tests := []struct {
+		name             string
+		landAssessed     float64
+		buildingAssessed float64
+		want             float64
+	}{
+		{
+			name:             "標準物件",
+			landAssessed:     20_000_000,
+			buildingAssessed: 10_000_000,
+			// 土地: 20,000,000×0.5×0.03=300,000
+			// 建物: 10,000,000×0.03=300,000
+			want: 600_000,
+		},
+		{
+			name:             "土地のみ",
+			landAssessed:     10_000_000,
+			buildingAssessed: 0,
+			// 土地: 10,000,000×0.5×0.03=150,000
+			want: 150_000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalcRealEstateAcquisitionTax(tt.landAssessed, tt.buildingAssessed)
+			if math.Abs(got-tt.want) > 1 {
+				t.Errorf("CalcRealEstateAcquisitionTax = %.0f, want %.0f", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalcAcquisitionCosts(t *testing.T) {
+	// 5900万円の物件: 土地3500万 + 建物2400万, ローン3000万, 中古
+	landPrice := 35_000_000.0
+	buildingCost := 24_000_000.0
+	opts := AcquisitionCostOptions{
+		BrokerageMultiplier: 1.0,
+		LoanAmount:          30_000_000,
+	}
+	result := CalcAcquisitionCosts(landPrice, buildingCost, opts)
+
+	// 仲介手数料: (59,000,000×0.03+60,000)×1.1 = 2,013,000
 	if result.BrokerageFee != 2_013_000 {
 		t.Errorf("BrokerageFee = %.0f, want 2013000", result.BrokerageFee)
 	}
+	// 印紙税: 60,000
 	if result.StampDuty != 60_000 {
 		t.Errorf("StampDuty = %.0f, want 60000", result.StampDuty)
 	}
-	wantTotal := result.BrokerageFee + result.StampDuty
+	// 登録免許税: 推定モード 土地35,000,000×0.7=24,500,000, 建物24,000,000×0.6=14,400,000
+	// 土地: 24,500,000×0.02=490,000, 建物(中古): 14,400,000×0.02=288,000
+	// 抵当権: 30,000,000×0.004=120,000 → 合計: 898,000
+	if result.RegistrationTax != 898_000 {
+		t.Errorf("RegistrationTax = %.0f, want 898000", result.RegistrationTax)
+	}
+	// 不動産取得税: 土地24,500,000×0.5×0.03=367,500, 建物14,400,000×0.03=432,000 → 合計799,500
+	if math.Abs(result.RealEstateAcquisitionTax-799_500) > 1 {
+		t.Errorf("RealEstateAcquisitionTax = %.0f, want 799500", result.RealEstateAcquisitionTax)
+	}
+	wantTotal := result.BrokerageFee + result.StampDuty + result.RegistrationTax + result.RealEstateAcquisitionTax
 	if result.Total != wantTotal {
 		t.Errorf("Total = %.0f, want %.0f", result.Total, wantTotal)
 	}

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -137,6 +137,12 @@ func Analyze(input InvestmentInput) InvestmentResult {
 		input, yearlyResults, accumulatedDepreciation, miscExpenses,
 	)
 
+	// 取得時諸経費の内訳（#76・#77で登録免許税等が追加される）
+	acquisitionCosts := CalcAcquisitionCosts(
+		input.LandPrice+input.BuildingCost,
+		DefaultAcquisitionCostOptions(),
+	)
+
 	return InvestmentResult{
 		TotalInvestment:       totalInvestment,
 		MiscExpenses:          miscExpenses,
@@ -145,13 +151,14 @@ func Analyze(input InvestmentInput) InvestmentResult {
 		IsAbove8Percent:       grossYield >= targetYield8pct,
 		RequiredCostReduction: landDrop,
 		RequiredMonthlyRent:   requiredRent,
-		DeadCrossYear:            deadCrossYear,
-		YearlyResults:            yearlyResults,
-		ExitSalePrice:            exitSalePrice,
-		ExitCapitalGain:          exitCapGain,
-		ExitTransferTax:          exitTax,
-		ExitNetProceeds:          exitNet,
-		ExitTotalEquity:          exitEquity,
+		DeadCrossYear:         deadCrossYear,
+		YearlyResults:         yearlyResults,
+		AcquisitionCosts:      acquisitionCosts,
+		ExitSalePrice:         exitSalePrice,
+		ExitCapitalGain:       exitCapGain,
+		ExitTransferTax:       exitTax,
+		ExitNetProceeds:       exitNet,
+		ExitTotalEquity:       exitEquity,
 	}
 }
 

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -137,10 +137,13 @@ func Analyze(input InvestmentInput) InvestmentResult {
 		input, yearlyResults, accumulatedDepreciation, miscExpenses,
 	)
 
-	// 取得時諸経費の内訳（#76・#77で登録免許税等が追加される）
 	acquisitionCosts := CalcAcquisitionCosts(
-		input.LandPrice+input.BuildingCost,
-		DefaultAcquisitionCostOptions(),
+		input.LandPrice,
+		input.BuildingCost,
+		AcquisitionCostOptions{
+			BrokerageMultiplier: 1.0,
+			LoanAmount:          input.LoanAmount,
+		},
 	)
 
 	return InvestmentResult{

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -141,12 +141,14 @@ type InvestmentResult struct {
 
 // AcquisitionCostBreakdown は物件取得時の諸経費内訳
 // #75: 仲介手数料・印紙税
-// #76: 登録免許税・抵当権設定費・不動産取得税（後続issueで追加）
+// #76: 登録免許税・不動産取得税（本issue）
 // #77: 固定資産税日割り精算（後続issueで追加）
 type AcquisitionCostBreakdown struct {
-	BrokerageFee float64 `json:"brokerageFee"` // 仲介手数料（税込）
-	StampDuty    float64 `json:"stampDuty"`    // 印紙税（売買契約書）
-	Total        float64 `json:"total"`        // 合計（後続issueの項目を含む）
+	BrokerageFee             float64 `json:"brokerageFee"`             // 仲介手数料（税込）
+	StampDuty                float64 `json:"stampDuty"`                // 印紙税（売買契約書）
+	RegistrationTax          float64 `json:"registrationTax"`          // 登録免許税（所有権移転+抵当権設定）
+	RealEstateAcquisitionTax float64 `json:"realEstateAcquisitionTax"` // 不動産取得税（概算）
+	Total                    float64 `json:"total"`
 }
 
 // LandTransaction は国交省APIから取得した土地取引1件

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -128,14 +128,25 @@ type InvestmentResult struct {
 	RequiredCostReduction float64 `json:"requiredCostReduction"`
 	RequiredMonthlyRent   float64 `json:"requiredMonthlyRent"` // または必要月額賃料
 
-	DeadCrossYear int            `json:"deadCrossYear"` // -1 = デッドクロスなし
-	YearlyResults []YearlyResult `json:"yearlyResults"`
+	DeadCrossYear    int                      `json:"deadCrossYear"` // -1 = デッドクロスなし
+	YearlyResults    []YearlyResult           `json:"yearlyResults"`
+	AcquisitionCosts AcquisitionCostBreakdown `json:"acquisitionCosts"`
 
 	ExitSalePrice   float64 `json:"exitSalePrice"`   // 売却価格（NOI/目標利回り）
 	ExitCapitalGain float64 `json:"exitCapitalGain"` // 譲渡所得
 	ExitTransferTax float64 `json:"exitTransferTax"` // 譲渡所得税
 	ExitNetProceeds float64 `json:"exitNetProceeds"` // 売却手取り（税・残債控除後）
 	ExitTotalEquity float64 `json:"exitTotalEquity"` // 最終手残り（売却手取り+累積CF）
+}
+
+// AcquisitionCostBreakdown は物件取得時の諸経費内訳
+// #75: 仲介手数料・印紙税
+// #76: 登録免許税・抵当権設定費・不動産取得税（後続issueで追加）
+// #77: 固定資産税日割り精算（後続issueで追加）
+type AcquisitionCostBreakdown struct {
+	BrokerageFee float64 `json:"brokerageFee"` // 仲介手数料（税込）
+	StampDuty    float64 `json:"stampDuty"`    // 印紙税（売買契約書）
+	Total        float64 `json:"total"`        // 合計（後続issueの項目を含む）
 }
 
 // LandTransaction は国交省APIから取得した土地取引1件


### PR DESCRIPTION
## 概要

#75 の諸経費計算エンジンを拡張し、登録免許税・不動産取得税の算出ロジックを実装しました。

## 変更内容

### 新規関数

- `CalcRegistrationTax(landAssessed, buildingAssessed, loanAmount float64, isNewBuilding bool) float64`
  - 土地所有権移転登記: 固定資産税評価額 × 2.0%（本則）
  - 建物移転登記（中古）: 固定資産税評価額 × 2.0%
  - 建物保存登記（新築）: 固定資産税評価額 × 0.15%（軽減措置 〜2027/3/31）
  - 抵当権設定登記: 融資額 × 0.4%

- `CalcRealEstateAcquisitionTax(landAssessed, buildingAssessed float64) float64`
  - 土地: 固定資産税評価額 × 1/2 × 3%（特例税率 〜2027/3/31）
  - 建物: 固定資産税評価額 × 3%

### 署名変更

`CalcAcquisitionCosts(totalPrice, opts)` → `CalcAcquisitionCosts(landPrice, buildingCost, opts)`

- `AcquisitionCostOptions` に `AssessedLandValue`・`AssessedBuildingValue`・`LoanAmount`・`IsNewBuilding` フィールドを追加
- 評価額が未入力（0）の場合は推定モード（土地: ×70%、建物: ×60%）

### 型拡張

`AcquisitionCostBreakdown` に `RegistrationTax`・`RealEstateAcquisitionTax` フィールドを追加。`Total` はすべての項目の合計。

## 制約・注意事項

- 土地の不動産取得税には住宅用特例控除（45,000円控除等）が存在するが、建物延床面積等の追加入力が必要なため本実装では概算値（未適用）
- 土地の登録免許税軽減措置（1.5%）は2026/3/31期限切れのため本則2%を適用

## テスト確認

```
go test ./...  → PASS
```

Depends on #88
Closes #76