### PR TITLE
feat: 諸経費明細・コスト内訳の可視化 (#79)

### DIFF
--- a/frontend/src/components/CostBreakdown.tsx
+++ b/frontend/src/components/CostBreakdown.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from "recharts";
+import { AcquisitionCostBreakdown, InvestmentInput, YearlyResult } from "@/types/investment";
+
+interface Props {
+  input: InvestmentInput;
+  acquisitionCosts: AcquisitionCostBreakdown;
+  yearlyResults: YearlyResult[];
+  miscExpenses: number;
+}
+
+const fmt = (n: number) =>
+  n >= 10_000_000
+    ? `${(n / 10_000_000).toFixed(1)}千万円`
+    : `${Math.round(n / 10_000).toLocaleString()}万円`;
+
+const COLORS = [
+  "#3b82f6", "#10b981", "#f59e0b", "#ef4444",
+  "#8b5cf6", "#06b6d4", "#f97316",
+];
+
+export default function CostBreakdown({ input, acquisitionCosts, yearlyResults, miscExpenses }: Props) {
+  // 初期投資の内訳
+  const initialCostItems = [
+    { name: "土地", value: input.landPrice },
+    { name: "建物", value: input.buildingCost },
+    { name: "仲介手数料", value: acquisitionCosts.brokerageFee },
+    { name: "印紙税", value: acquisitionCosts.stampDuty },
+    { name: "登録免許税", value: acquisitionCosts.registrationTax },
+    { name: "不動産取得税", value: acquisitionCosts.realEstateAcquisitionTax },
+    ...(acquisitionCosts.propertyTaxProration > 0
+      ? [{ name: "固定資産税日割り", value: acquisitionCosts.propertyTaxProration }]
+      : []),
+    ...(miscExpenses > acquisitionCosts.brokerageFee + acquisitionCosts.stampDuty
+      ? [{ name: "その他諸経費", value: miscExpenses - acquisitionCosts.brokerageFee - acquisitionCosts.stampDuty - acquisitionCosts.registrationTax - acquisitionCosts.realEstateAcquisitionTax - acquisitionCosts.propertyTaxProration }]
+      : []),
+  ].filter((item) => item.value > 0);
+
+  // 選択年（1年目）の年間費用内訳
+  const year1 = yearlyResults[0];
+  const annualCostItems = year1
+    ? [
+        { name: "ローン返済", value: year1.annualLoanPayment },
+        { name: "運営経費", value: year1.annualExpenses },
+        { name: "所得税", value: year1.incomeTax },
+      ].filter((item) => item.value > 0)
+    : [];
+
+  const totalInitial = initialCostItems.reduce((s, i) => s + i.value, 0);
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold">コスト内訳</h2>
+
+      {/* 初期投資内訳 */}
+      <div>
+        <h3 className="text-sm font-medium text-gray-600 mb-3">
+          初期投資の内訳（合計: {fmt(totalInitial)}）
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
+          <ResponsiveContainer width="100%" height={220}>
+            <PieChart>
+              <Pie
+                data={initialCostItems}
+                cx="50%"
+                cy="50%"
+                innerRadius={55}
+                outerRadius={90}
+                dataKey="value"
+                nameKey="name"
+              >
+                {initialCostItems.map((_, idx) => (
+                  <Cell key={idx} fill={COLORS[idx % COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip formatter={(v: number) => fmt(v)} />
+            </PieChart>
+          </ResponsiveContainer>
+
+          <div className="space-y-1.5">
+            {initialCostItems.map((item, idx) => (
+              <div key={item.name} className="flex items-center justify-between text-sm">
+                <div className="flex items-center gap-2">
+                  <span
+                    className="inline-block w-3 h-3 rounded-sm"
+                    style={{ background: COLORS[idx % COLORS.length] }}
+                  />
+                  <span className="text-gray-700">{item.name}</span>
+                </div>
+                <span className="font-mono text-gray-900">
+                  {fmt(item.value)}
+                  <span className="text-xs text-gray-400 ml-1">
+                    ({((item.value / totalInitial) * 100).toFixed(1)}%)
+                  </span>
+                </span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* 諸経費明細テーブル */}
+      <div>
+        <h3 className="text-sm font-medium text-gray-600 mb-2">取得時諸経費の明細</h3>
+        <div className="rounded-lg border border-gray-200 overflow-hidden text-sm">
+          <table className="w-full">
+            <tbody className="divide-y divide-gray-100">
+              {[
+                ["仲介手数料（税込）", acquisitionCosts.brokerageFee],
+                ["印紙税", acquisitionCosts.stampDuty],
+                ["登録免許税", acquisitionCosts.registrationTax],
+                ["不動産取得税（概算）", acquisitionCosts.realEstateAcquisitionTax],
+                ...(acquisitionCosts.propertyTaxProration > 0
+                  ? [["固定資産税日割り精算", acquisitionCosts.propertyTaxProration] as [string, number]]
+                  : []),
+              ].map(([label, value]) => (
+                <tr key={label as string} className="hover:bg-gray-50">
+                  <td className="px-4 py-2 text-gray-600">{label as string}</td>
+                  <td className="px-4 py-2 text-right font-mono text-gray-900">
+                    {fmt(value as number)}
+                  </td>
+                </tr>
+              ))}
+              <tr className="bg-gray-50 font-semibold">
+                <td className="px-4 py-2 text-gray-800">合計</td>
+                <td className="px-4 py-2 text-right font-mono text-gray-900">
+                  {fmt(acquisitionCosts.total)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {/* 1年目の年間費用内訳 */}
+      {annualCostItems.length > 0 && (
+        <div>
+          <h3 className="text-sm font-medium text-gray-600 mb-3">年間費用の内訳（1年目）</h3>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
+            <ResponsiveContainer width="100%" height={180}>
+              <PieChart>
+                <Pie
+                  data={annualCostItems}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={45}
+                  outerRadius={75}
+                  dataKey="value"
+                  nameKey="name"
+                >
+                  {annualCostItems.map((_, idx) => (
+                    <Cell key={idx} fill={COLORS[idx % COLORS.length]} />
+                  ))}
+                </Pie>
+                <Tooltip formatter={(v: number) => fmt(v)} />
+                <Legend />
+              </PieChart>
+            </ResponsiveContainer>
+
+            <div className="space-y-1.5">
+              {annualCostItems.map((item, idx) => {
+                const total = annualCostItems.reduce((s, i) => s + i.value, 0);
+                return (
+                  <div key={item.name} className="flex items-center justify-between text-sm">
+                    <div className="flex items-center gap-2">
+                      <span
+                        className="inline-block w-3 h-3 rounded-sm"
+                        style={{ background: COLORS[idx % COLORS.length] }}
+                      />
+                      <span className="text-gray-700">{item.name}</span>
+                    </div>
+                    <span className="font-mono text-gray-900">
+                      {fmt(item.value)}
+                      <span className="text-xs text-gray-400 ml-1">
+                        ({((item.value / total) * 100).toFixed(1)}%)
+                      </span>
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -5,6 +5,7 @@ import { YieldAnalysis } from "@/components/YieldAnalysis";
 import { CashFlowChart } from "@/components/CashFlowChart";
 import { DeadCrossChart } from "@/components/DeadCrossChart";
 import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
+import CostBreakdown from "@/components/CostBreakdown";
 import type { InvestmentInput, InvestmentResult, LandPriceComparison } from "@/types/investment";
 import { analyze, compareLandPrice } from "@/lib/api";
 import { ShieldAlert } from "lucide-react";
@@ -109,6 +110,16 @@ export function Dashboard() {
             {result && lastInput && (
               <>
                 <YieldAnalysis result={result} />
+                {result.acquisitionCosts && (
+                  <div className="rounded-xl border bg-white p-5 shadow-sm">
+                    <CostBreakdown
+                      input={lastInput}
+                      acquisitionCosts={result.acquisitionCosts}
+                      yearlyResults={result.yearlyResults}
+                      miscExpenses={result.miscExpenses}
+                    />
+                  </div>
+                )}
                 {/* 自己資金 = 総投資額 - ローン金額（ISSUE-22: 投資回収年の正確な計算に使用） */}
                 <CashFlowChart result={result} equityInvested={result.totalInvestment - lastInput.loanAmount} />
                 <DeadCrossChart result={result} />

--- a/frontend/src/components/__tests__/helpers.ts
+++ b/frontend/src/components/__tests__/helpers.ts
@@ -69,6 +69,15 @@ export function makeResult(overrides: Partial<InvestmentResult> = {}): Investmen
     exitTransferTax: 400_000,
     exitNetProceeds: 11_600_000,
     exitTotalEquity: 3_000_000,
+    acquisitionCosts: {
+      brokerageFee: 561_000,
+      stampDuty: 20_000,
+      registrationTax: 420_000,
+      realEstateAcquisitionTax: 315_000,
+      propertyTaxProration: 0,
+      total: 1_316_000,
+    },
+    criticalErrors: [],
     ...overrides,
   };
 }

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -14,6 +14,7 @@ export interface InvestmentInput {
   miscExpenseRate: number;
   monthlyRent: number;
   vacancyRate: number;
+  actualVacancyRate: number;  // 現況空室率
   loanAmount: number;
   annualLoanRate: number;
   loanYears: number;
@@ -24,6 +25,7 @@ export interface InvestmentInput {
   exitYieldTarget: number;
   vacancyRateDelta: number;
   loanRateDelta: number;
+  annualPropertyTax: number;  // 固定資産税・都市計画税（年間）。0 = ExpenseRateに含む。
 }
 
 export interface YearlyResult {
@@ -44,16 +46,34 @@ export interface YearlyResult {
   isInDeadCrossZone: boolean;   // デッドクロス継続ゾーン
 }
 
+export interface AcquisitionCostBreakdown {
+  brokerageFee: number;               // 仲介手数料（税込）
+  stampDuty: number;                  // 印紙税
+  registrationTax: number;            // 登録免許税
+  realEstateAcquisitionTax: number;   // 不動産取得税
+  propertyTaxProration: number;       // 固定資産税日割り精算
+  total: number;
+}
+
+export interface CriticalError {
+  code: string;
+  level: "REJECT" | "WARNING";
+  message: string;
+  detail: string;
+}
+
 export interface InvestmentResult {
   totalInvestment: number;
   miscExpenses: number;
   grossYield: number;
   netYield: number;
   isAbove8Percent: boolean;
-  requiredCostReduction: number;  // 土地または建築費いずれか一方の削減必要額
+  requiredCostReduction: number;
   requiredMonthlyRent: number;
   deadCrossYear: number;
   yearlyResults: YearlyResult[];
+  acquisitionCosts: AcquisitionCostBreakdown;
+  criticalErrors: CriticalError[];
   exitSalePrice: number;
   exitCapitalGain: number;
   exitTransferTax: number;
@@ -102,6 +122,7 @@ export const DEFAULT_INPUT: InvestmentInput = {
   miscExpenseRate: 0.07,
   monthlyRent: 120_000,
   vacancyRate: 0.05,
+  actualVacancyRate: 0,
   loanAmount: 13_000_000,
   annualLoanRate: 0.015,
   loanYears: 35,
@@ -112,6 +133,7 @@ export const DEFAULT_INPUT: InvestmentInput = {
   exitYieldTarget: 0.06,
   vacancyRateDelta: 0,
   loanRateDelta: 0,
+  annualPropertyTax: 0,
 };
 
 export const BUILDING_USEFUL_LIFE: Record<BuildingType, number> = {


### PR DESCRIPTION
## 概要

取得時諸経費（#75-#77 で実装）の内訳をドーナツグラフ＋テーブルで可視化する `CostBreakdown` コンポーネントを実装しました。

## 変更内容

### フロントエンド

- `CostBreakdown.tsx`（新規）
  - **初期投資内訳**: 土地・建物・仲介手数料・印紙税・登録免許税・不動産取得税・固定資産税日割りをドーナツグラフ＋凡例テーブルで表示
  - **諸経費明細テーブル**: 各取得費用の金額と合計を一覧表示
  - **年間費用内訳（1年目）**: ローン返済・運営経費・所得税の割合をドーナツグラフで表示

- `Dashboard.tsx`: シミュレーション結果セクションに `CostBreakdown` を追加

- `types/investment.ts`: バックエンド #75-#77 の新フィールドに対応
  - `AcquisitionCostBreakdown` インターフェース追加（`registrationTax`, `realEstateAcquisitionTax`, `propertyTaxProration`）
  - `CriticalError` インターフェース追加
  - `InvestmentInput` に `actualVacancyRate`, `annualPropertyTax` 追加

## 依存

- #88（#75: 仲介手数料・印紙税）
- #89（#76: 登録免許税・不動産取得税）
- #90（#77: 固定資産税日割り）

Depends on #90
Closes #79