### PR TITLE
feat: 都市計画リスク検出と相場分析画面への警告表示

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -331,7 +331,44 @@ func CalcLandPriceStats(transactions []LandTransaction) LandPriceStats {
 		Transactions:   transactions,
 		LowDataWarning: len(prices) < lowDataThreshold,
 		WarningMessage: warning,
+		Zoning:         calcZoningSummary(transactions),
 	}
+}
+
+// calcZoningSummary は取引データから最頻の用途地域情報を抽出する
+func calcZoningSummary(transactions []LandTransaction) *ZoningSummary {
+	if len(transactions) == 0 {
+		return nil
+	}
+	cp := modalString(transactions, func(t LandTransaction) string { return t.CityPlanning })
+	bc := modalString(transactions, func(t LandTransaction) string { return t.BuildingCoverage })
+	far := modalString(transactions, func(t LandTransaction) string { return t.FloorAreaRatio })
+	if cp == "" && bc == "" && far == "" {
+		return nil
+	}
+	return &ZoningSummary{
+		CityPlanning:     cp,
+		BuildingCoverage: bc,
+		FloorAreaRatio:   far,
+	}
+}
+
+// modalString は transactions から getter で取得した文字列の最頻値を返す（空文字は除外）
+func modalString(transactions []LandTransaction, getter func(LandTransaction) string) string {
+	counts := make(map[string]int, len(transactions))
+	for _, t := range transactions {
+		v := getter(t)
+		if v != "" {
+			counts[v]++
+		}
+	}
+	best, bestCount := "", 0
+	for v, c := range counts {
+		if c > bestCount {
+			best, bestCount = v, c
+		}
+	}
+	return best
 }
 
 // CompareLandPrice は検討中の土地価格と相場を比較する

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strings"
 )
 
 const (
@@ -322,6 +323,7 @@ func CalcLandPriceStats(transactions []LandTransaction) LandPriceStats {
 		warning = fmt.Sprintf("取引件数が%d件と少ないため統計の信頼性が低い可能性があります", len(prices))
 	}
 
+	zoning := calcZoningSummary(transactions)
 	return LandPriceStats{
 		Count:          len(prices),
 		AverageTsubo:   avg,
@@ -331,7 +333,8 @@ func CalcLandPriceStats(transactions []LandTransaction) LandPriceStats {
 		Transactions:   transactions,
 		LowDataWarning: len(prices) < lowDataThreshold,
 		WarningMessage: warning,
-		Zoning:         calcZoningSummary(transactions),
+		Zoning:         zoning,
+		UrbanRisks:     detectUrbanRisks(transactions, zoning),
 	}
 }
 
@@ -351,6 +354,58 @@ func calcZoningSummary(transactions []LandTransaction) *ZoningSummary {
 		BuildingCoverage: bc,
 		FloorAreaRatio:   far,
 	}
+}
+
+// detectUrbanRisks は取引データと用途地域サマリーから都市計画リスクを検出する
+func detectUrbanRisks(transactions []LandTransaction, zoning *ZoningSummary) []UrbanRisk {
+	var risks []UrbanRisk
+	if zoning == nil {
+		return risks
+	}
+
+	// 市街化調整区域（最頻値が調整区域）
+	if strings.Contains(zoning.CityPlanning, "市街化調整区域") {
+		risks = append(risks, UrbanRisk{
+			Code:        "URBANIZATION_CONTROL_ZONE",
+			Level:       UrbanRiskLevelError,
+			Title:       "市街化調整区域",
+			Description: "原則として新たな建築・用途変更が制限されます。既存建物の建替えが困難になる可能性があります。",
+		})
+	}
+
+	// 都市計画区域外 / 非線引き区域
+	if strings.Contains(zoning.CityPlanning, "非線引") || zoning.CityPlanning == "都市計画区域外" {
+		risks = append(risks, UrbanRisk{
+			Code:        "UNZONED_AREA",
+			Level:       UrbanRiskLevelWarning,
+			Title:       "非線引き・都市計画区域外",
+			Description: "インフラ整備が遅れやすく、将来の資産価値が不安定になる可能性があります。",
+		})
+	}
+
+	// 調整区域が最頻値でなくとも30%以上混在する場合の注意
+	if !strings.Contains(zoning.CityPlanning, "市街化調整区域") {
+		controlCount, totalWithCP := 0, 0
+		for _, t := range transactions {
+			if t.CityPlanning != "" {
+				totalWithCP++
+				if strings.Contains(t.CityPlanning, "市街化調整区域") {
+					controlCount++
+				}
+			}
+		}
+		if totalWithCP > 0 && float64(controlCount)/float64(totalWithCP) >= 0.3 {
+			ratio := float64(controlCount) / float64(totalWithCP) * 100
+			risks = append(risks, UrbanRisk{
+				Code:        "MIXED_ZONE_CAUTION",
+				Level:       UrbanRiskLevelWarning,
+				Title:       "市街化調整区域が混在",
+				Description: fmt.Sprintf("エリア内取引の約%.0f%%が市街化調整区域です。対象物件の区域区分を必ず確認してください。", ratio),
+			})
+		}
+	}
+
+	return risks
 }
 
 // modalString は transactions から getter で取得した文字列の最頻値を返す（空文字は除外）

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -159,6 +159,23 @@ type ZoningSummary struct {
 	FloorAreaRatio   string `json:"floorAreaRatio"`   // 最頻の容積率（例: 200%）
 }
 
+// UrbanRiskLevel は都市計画リスクの深刻度
+type UrbanRiskLevel string
+
+const (
+	UrbanRiskLevelError   UrbanRiskLevel = "ERROR"
+	UrbanRiskLevelWarning UrbanRiskLevel = "WARNING"
+	UrbanRiskLevelInfo    UrbanRiskLevel = "INFO"
+)
+
+// UrbanRisk は都市計画上のリスク項目
+type UrbanRisk struct {
+	Code        string         `json:"code"`        // リスクコード（例: URBANIZATION_CONTROL）
+	Level       UrbanRiskLevel `json:"level"`       // ERROR / WARNING / INFO
+	Title       string         `json:"title"`       // 短いタイトル
+	Description string         `json:"description"` // 詳細説明
+}
+
 type LandPriceStats struct {
 	Count          int               `json:"count"`
 	AverageTsubo   float64           `json:"averageTsubo"`
@@ -168,7 +185,8 @@ type LandPriceStats struct {
 	Transactions   []LandTransaction `json:"transactions"`
 	LowDataWarning bool              `json:"lowDataWarning"` // 件数 < 10 件時 true
 	WarningMessage string            `json:"warningMessage,omitempty"`
-	Zoning         *ZoningSummary    `json:"zoning,omitempty"` // 取引データから抽出した用途地域情報
+	Zoning         *ZoningSummary    `json:"zoning,omitempty"`      // 取引データから抽出した用途地域情報
+	UrbanRisks     []UrbanRisk       `json:"urbanRisks,omitempty"` // 都市計画リスク一覧
 }
 
 // LandPriceComparison は検討中の土地価格と相場の比較

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -152,6 +152,13 @@ type LandTransaction struct {
 }
 
 // LandPriceStats は土地価格の統計情報
+// ZoningSummary はエリア内の取引から抽出した代表的な用途地域情報
+type ZoningSummary struct {
+	CityPlanning     string `json:"cityPlanning"`     // 最頻の都市計画区域（例: 第一種住居地域）
+	BuildingCoverage string `json:"buildingCoverage"` // 最頻の建ぺい率（例: 60%）
+	FloorAreaRatio   string `json:"floorAreaRatio"`   // 最頻の容積率（例: 200%）
+}
+
 type LandPriceStats struct {
 	Count          int               `json:"count"`
 	AverageTsubo   float64           `json:"averageTsubo"`
@@ -161,6 +168,7 @@ type LandPriceStats struct {
 	Transactions   []LandTransaction `json:"transactions"`
 	LowDataWarning bool              `json:"lowDataWarning"` // 件数 < 10 件時 true
 	WarningMessage string            `json:"warningMessage,omitempty"`
+	Zoning         *ZoningSummary    `json:"zoning,omitempty"` // 取引データから抽出した用途地域情報
 }
 
 // LandPriceComparison は検討中の土地価格と相場の比較

--- a/frontend/src/components/LandPriceAnalysis.tsx
+++ b/frontend/src/components/LandPriceAnalysis.tsx
@@ -14,7 +14,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { LandPriceComparison } from "@/types/investment";
 import { formatTsubo } from "@/lib/utils";
-import { MapPin, AlertTriangle, SearchX } from "lucide-react";
+import { MapPin, AlertTriangle, SearchX, Building2 } from "lucide-react";
 
 interface Props {
   comparison: LandPriceComparison;
@@ -128,6 +128,36 @@ export function LandPriceAnalysis({ comparison }: Props) {
             {stats.lowDataWarning && (
               <p className="text-xs mt-1 text-yellow-700">※ データ件数不足のため参考値</p>
             )}
+          </div>
+        )}
+
+        {/* 用途地域情報 */}
+        {stats.zoning && (
+          <div className="rounded-md border border-blue-200 bg-blue-50 p-3">
+            <p className="flex items-center gap-1 text-xs font-semibold text-blue-800 mb-2">
+              <Building2 className="h-3.5 w-3.5" />
+              このエリアの代表的な用途地域（取引データより）
+            </p>
+            <div className="grid grid-cols-3 gap-2">
+              {stats.zoning.cityPlanning && (
+                <div className="text-center">
+                  <p className="text-xs text-blue-600">用途地域</p>
+                  <p className="text-xs font-medium text-blue-900">{stats.zoning.cityPlanning}</p>
+                </div>
+              )}
+              {stats.zoning.buildingCoverage && (
+                <div className="text-center">
+                  <p className="text-xs text-blue-600">建ぺい率</p>
+                  <p className="text-xs font-medium text-blue-900">{stats.zoning.buildingCoverage}</p>
+                </div>
+              )}
+              {stats.zoning.floorAreaRatio && (
+                <div className="text-center">
+                  <p className="text-xs text-blue-600">容積率</p>
+                  <p className="text-xs font-medium text-blue-900">{stats.zoning.floorAreaRatio}</p>
+                </div>
+              )}
+            </div>
           </div>
         )}
 

--- a/frontend/src/components/LandPriceAnalysis.tsx
+++ b/frontend/src/components/LandPriceAnalysis.tsx
@@ -12,9 +12,9 @@ import {
 } from "recharts";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import type { LandPriceComparison } from "@/types/investment";
+import type { LandPriceComparison, UrbanRiskLevel } from "@/types/investment";
 import { formatTsubo } from "@/lib/utils";
-import { MapPin, AlertTriangle, SearchX, Building2 } from "lucide-react";
+import { MapPin, AlertTriangle, SearchX, Building2, ShieldAlert, ShieldCheck } from "lucide-react";
 
 interface Props {
   comparison: LandPriceComparison;
@@ -24,6 +24,27 @@ const ASSESSMENT_BADGE: Record<string, "success" | "warning" | "danger"> = {
   割安: "success",
   相場: "warning",
   割高: "danger",
+};
+
+const RISK_STYLE: Record<UrbanRiskLevel, { border: string; bg: string; text: string; icon: React.ReactNode }> = {
+  ERROR: {
+    border: "border-red-300",
+    bg: "bg-red-50",
+    text: "text-red-900",
+    icon: <ShieldAlert className="h-4 w-4 shrink-0 text-red-600 mt-0.5" />,
+  },
+  WARNING: {
+    border: "border-yellow-300",
+    bg: "bg-yellow-50",
+    text: "text-yellow-900",
+    icon: <AlertTriangle className="h-4 w-4 shrink-0 text-yellow-600 mt-0.5" />,
+  },
+  INFO: {
+    border: "border-blue-300",
+    bg: "bg-blue-50",
+    text: "text-blue-900",
+    icon: <ShieldCheck className="h-4 w-4 shrink-0 text-blue-600 mt-0.5" />,
+  },
 };
 
 export function LandPriceAnalysis({ comparison }: Props) {
@@ -86,6 +107,27 @@ export function LandPriceAnalysis({ comparison }: Props) {
               </p>
               <p className="text-xs mt-0.5">以下の結果は参考値としてご確認ください。</p>
             </div>
+          </div>
+        )}
+
+        {/* 都市計画リスク警告 */}
+        {stats.urbanRisks && stats.urbanRisks.length > 0 && (
+          <div className="space-y-2">
+            {stats.urbanRisks.map((risk) => {
+              const style = RISK_STYLE[risk.level];
+              return (
+                <div
+                  key={risk.code}
+                  className={`flex items-start gap-2 rounded-md border ${style.border} ${style.bg} px-3 py-2`}
+                >
+                  {style.icon}
+                  <div>
+                    <p className={`text-xs font-semibold ${style.text}`}>{risk.title}</p>
+                    <p className={`text-xs mt-0.5 ${style.text}`}>{risk.description}</p>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         )}
 

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -83,12 +83,22 @@ export interface LandPriceStats {
   lowDataWarning: boolean;
   warningMessage?: string;
   zoning?: ZoningSummary;
+  urbanRisks?: UrbanRisk[];
 }
 
 export interface ZoningSummary {
   cityPlanning: string;
   buildingCoverage: string;
   floorAreaRatio: string;
+}
+
+export type UrbanRiskLevel = "ERROR" | "WARNING" | "INFO";
+
+export interface UrbanRisk {
+  code: string;
+  level: UrbanRiskLevel;
+  title: string;
+  description: string;
 }
 
 export interface LandPriceComparison {

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -82,6 +82,13 @@ export interface LandPriceStats {
   transactions: LandTransaction[];
   lowDataWarning: boolean;
   warningMessage?: string;
+  zoning?: ZoningSummary;
+}
+
+export interface ZoningSummary {
+  cityPlanning: string;
+  buildingCoverage: string;
+  floorAreaRatio: string;
 }
 
 export interface LandPriceComparison {


### PR DESCRIPTION
## 概要

土地取引データ（XIT001）の `CityPlanning` フィールドを解析し、投資リスクとなる都市計画上の問題を自動検出して相場分析画面に警告バナーとして表示する。

## 変更内容

**バックエンド**
- `domain/types.go`: `UrbanRiskLevel`（ERROR/WARNING/INFO）・`UrbanRisk` 構造体を追加、`LandPriceStats.UrbanRisks` フィールドを追加
- `domain/investment.go`: `detectUrbanRisks` 関数を追加。以下のリスクパターンを検出:
  - `URBANIZATION_CONTROL_ZONE`（ERROR）: 最頻の都市計画が市街化調整区域
  - `UNZONED_AREA`（WARNING）: 非線引き・都市計画区域外
  - `MIXED_ZONE_CAUTION`（WARNING）: 調整区域が30%以上混在

**フロントエンド**
- `types/investment.ts`: `UrbanRiskLevel`・`UrbanRisk` 型を追加、`LandPriceStats.urbanRisks` フィールドを追加
- `LandPriceAnalysis.tsx`: 都市計画リスク警告バナーを追加（ERROR=赤・WARNING=黄・INFO=青で色分け）

## 備考

XKT001/XKT003/XKT020/XKT030/XST001 はタイル座標（z/x/y）のみ対応のため、現時点では XIT001 既存取引データから抽出できるリスクのみ実装。市区町村コード→代表座標の変換テーブルを整備することで将来的に各 XKT API への拡張が可能な設計にしてある。

## 関連Issue

Closes #66

## テスト

- [x] バックエンド全テスト PASS（`go test ./...`）
- [x] フロントエンド全テスト PASS（27件）
- [x] TypeScript 型チェック通過

## 確認事項

- [x] コードレビュー観点での自己レビュー済み