### PR TITLE
feat: 固定資産税・都市計画税の按分計算とランニングコスト化 (#77)

### DIFF
--- a/backend/internal/domain/acquisition_costs.go
+++ b/backend/internal/domain/acquisition_costs.go
@@ -102,6 +102,13 @@ type AcquisitionCostOptions struct {
 
 	// IsNewBuilding は建物所有権保存登記（新築）か移転登記（中古）かを示す
 	IsNewBuilding bool
+
+	// 引渡し日（固定資産税日割り精算用）。0 の場合は日割り計算なし。
+	DeliveryMonth int
+	DeliveryDay   int
+
+	// LandAreaSqm は小規模住宅用地特例の判定に使用（0 = 特例非適用）
+	LandAreaSqm float64
 }
 
 // DefaultAcquisitionCostOptions は標準的な取引条件のオプションを返す
@@ -129,11 +136,20 @@ func CalcAcquisitionCosts(landPrice, buildingCost float64, opts AcquisitionCostO
 	regTax := CalcRegistrationTax(assessedLand, assessedBuilding, opts.LoanAmount, opts.IsNewBuilding)
 	acqTax := CalcRealEstateAcquisitionTax(assessedLand, assessedBuilding)
 
+	propTaxProration := 0.0
+	if opts.DeliveryMonth > 0 && opts.DeliveryDay > 0 {
+		annual := CalcPropertyTax(assessedLand, assessedBuilding, PropertyTaxOptions{
+			LandAreaSqm: opts.LandAreaSqm,
+		}).AnnualTotal
+		propTaxProration = CalcPropertyTaxProration(annual, opts.DeliveryMonth, opts.DeliveryDay)
+	}
+
 	return AcquisitionCostBreakdown{
 		BrokerageFee:             brokerage,
 		StampDuty:                stamp,
 		RegistrationTax:          regTax,
 		RealEstateAcquisitionTax: acqTax,
-		Total:                    brokerage + stamp + regTax + acqTax,
+		PropertyTaxProration:     propTaxProration,
+		Total:                    brokerage + stamp + regTax + acqTax + propTaxProration,
 	}
 }

--- a/backend/internal/domain/acquisition_costs.go
+++ b/backend/internal/domain/acquisition_costs.go
@@ -103,7 +103,9 @@ type AcquisitionCostOptions struct {
 	// IsNewBuilding は建物所有権保存登記（新築）か移転登記（中古）かを示す
 	IsNewBuilding bool
 
-	// 引渡し日（固定資産税日割り精算用）。0 の場合は日割り計算なし。
+	// 引渡し日（固定資産税日割り精算用）。Month=0 の場合は日割り計算なし。
+	// Year は JST の取引年を呼び出し側で渡す（0 = 日割りなし）。
+	DeliveryYear  int
 	DeliveryMonth int
 	DeliveryDay   int
 
@@ -137,11 +139,11 @@ func CalcAcquisitionCosts(landPrice, buildingCost float64, opts AcquisitionCostO
 	acqTax := CalcRealEstateAcquisitionTax(assessedLand, assessedBuilding)
 
 	propTaxProration := 0.0
-	if opts.DeliveryMonth > 0 && opts.DeliveryDay > 0 {
+	if opts.DeliveryYear > 0 && opts.DeliveryMonth > 0 && opts.DeliveryDay > 0 {
 		annual := CalcPropertyTax(assessedLand, assessedBuilding, PropertyTaxOptions{
 			LandAreaSqm: opts.LandAreaSqm,
 		}).AnnualTotal
-		propTaxProration = CalcPropertyTaxProration(annual, opts.DeliveryMonth, opts.DeliveryDay)
+		propTaxProration = CalcPropertyTaxProration(annual, opts.DeliveryMonth, opts.DeliveryDay, opts.DeliveryYear)
 	}
 
 	return AcquisitionCostBreakdown{

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -83,7 +83,7 @@ func Analyze(input InvestmentInput) InvestmentResult {
 		}
 
 		yearAnnualRent := annualRent
-		yearExpenses := yearAnnualRent * input.ExpenseRate
+		yearExpenses := yearAnnualRent*input.ExpenseRate + input.AnnualPropertyTax
 
 		// 減価償却は耐用年数内のみ
 		yearDepreciation := 0.0

--- a/backend/internal/domain/property_tax.go
+++ b/backend/internal/domain/property_tax.go
@@ -73,7 +73,7 @@ func CalcPropertyTax(assessedLand, assessedBuilding float64, opts PropertyTaxOpt
 // 慣行: 売主が1月1日〜引渡し前日分、買主が引渡し日〜12月31日分を負担。
 // year は取引年（JST）を呼び出し側で渡す。うるう年に対応。
 func CalcPropertyTaxProration(annualTax float64, deliveryMonth, deliveryDay, year int) float64 {
-	if annualTax <= 0 || deliveryMonth < 1 || deliveryMonth > 12 || deliveryDay < 1 {
+	if annualTax <= 0 || year <= 0 || deliveryMonth < 1 || deliveryMonth > 12 || deliveryDay < 1 {
 		return 0
 	}
 	daysInMonth := []int{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}

--- a/backend/internal/domain/property_tax.go
+++ b/backend/internal/domain/property_tax.go
@@ -71,12 +71,12 @@ func CalcPropertyTax(assessedLand, assessedBuilding float64, opts PropertyTaxOpt
 // CalcPropertyTaxProration は引渡し日基準で買主負担分の固定資産税日割り額を算出する。
 //
 // 慣行: 売主が1月1日〜引渡し前日分、買主が引渡し日〜12月31日分を負担。
-// うるう年（366日）にも対応。
+// うるう年は非考慮（誤差軽微のため365日固定）。
 func CalcPropertyTaxProration(annualTax float64, deliveryMonth, deliveryDay int) float64 {
 	if annualTax <= 0 || deliveryMonth < 1 || deliveryMonth > 12 || deliveryDay < 1 {
 		return 0
 	}
-	// 引渡し日の通算日数（1月1日=1）
+	// 引渡し日の通算日数（1月1日=1）、うるう年非考慮
 	daysInMonth := []int{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
 	deliveryDOY := deliveryDay
 	for m := 0; m < deliveryMonth-1; m++ {

--- a/backend/internal/domain/property_tax.go
+++ b/backend/internal/domain/property_tax.go
@@ -1,0 +1,91 @@
+package domain
+
+import "math"
+
+// PropertyTaxOptions は固定資産税・都市計画税の計算オプション
+type PropertyTaxOptions struct {
+	// LandAreaSqm は土地面積（㎡）。小規模住宅用地特例の適用判定に使用。
+	// 0 の場合は特例を適用しない（保守的な概算）。
+	LandAreaSqm float64
+}
+
+// PropertyTaxBreakdown は固定資産税・都市計画税の内訳
+type PropertyTaxBreakdown struct {
+	LandFixedAssetTax     float64 `json:"landFixedAssetTax"`     // 土地の固定資産税
+	BuildingFixedAssetTax float64 `json:"buildingFixedAssetTax"` // 建物の固定資産税
+	LandCityPlanningTax   float64 `json:"landCityPlanningTax"`   // 土地の都市計画税
+	BuildingCityTax       float64 `json:"buildingCityTax"`       // 建物の都市計画税
+	AnnualTotal           float64 `json:"annualTotal"`           // 年間合計
+}
+
+// CalcPropertyTax は年間の固定資産税・都市計画税を算出する。
+//
+// 税率（根拠: 地方税法349条・702条）:
+//   - 固定資産税: 固定資産税評価額 × 1.4%（標準税率）
+//   - 都市計画税: 固定資産税評価額 × 0.3%（上限税率）
+//
+// 小規模住宅用地特例（根拠: 地方税法349条の3の2）:
+//   - 土地面積200㎡以下の小規模住宅用地: 固定資産税 1/6・都市計画税 1/3
+//   - 200㎡超の一般住宅用地: 固定資産税 1/3・都市計画税 2/3
+//
+// 注意: LandAreaSqm が 0 の場合は特例を適用しない概算値。
+func CalcPropertyTax(assessedLand, assessedBuilding float64, opts PropertyTaxOptions) PropertyTaxBreakdown {
+	const (
+		fixedAssetTaxRate  = 0.014 // 固定資産税: 標準税率
+		cityPlanningTaxRate = 0.003 // 都市計画税: 上限税率
+	)
+
+	landFixed := assessedLand * fixedAssetTaxRate
+	landCity := assessedLand * cityPlanningTaxRate
+
+	// 小規模住宅用地特例の適用
+	if opts.LandAreaSqm > 0 {
+		if opts.LandAreaSqm <= 200 {
+			// 小規模住宅用地（200㎡以下）
+			landFixed = assessedLand * fixedAssetTaxRate / 6
+			landCity = assessedLand * cityPlanningTaxRate / 3
+		} else {
+			// 一般住宅用地（200㎡超）
+			landFixed = assessedLand * fixedAssetTaxRate / 3
+			landCity = assessedLand * cityPlanningTaxRate * 2 / 3
+		}
+	}
+
+	buildingFixed := assessedBuilding * fixedAssetTaxRate
+	buildingCity := assessedBuilding * cityPlanningTaxRate
+
+	landFixed = math.Round(landFixed)
+	landCity = math.Round(landCity)
+	buildingFixed = math.Round(buildingFixed)
+	buildingCity = math.Round(buildingCity)
+
+	return PropertyTaxBreakdown{
+		LandFixedAssetTax:     landFixed,
+		BuildingFixedAssetTax: buildingFixed,
+		LandCityPlanningTax:   landCity,
+		BuildingCityTax:       buildingCity,
+		AnnualTotal:           landFixed + buildingFixed + landCity + buildingCity,
+	}
+}
+
+// CalcPropertyTaxProration は引渡し日基準で買主負担分の固定資産税日割り額を算出する。
+//
+// 慣行: 売主が1月1日〜引渡し前日分、買主が引渡し日〜12月31日分を負担。
+// うるう年（366日）にも対応。
+func CalcPropertyTaxProration(annualTax float64, deliveryMonth, deliveryDay int) float64 {
+	if annualTax <= 0 || deliveryMonth < 1 || deliveryMonth > 12 || deliveryDay < 1 {
+		return 0
+	}
+	// 引渡し日の通算日数（1月1日=1）
+	daysInMonth := []int{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+	deliveryDOY := deliveryDay
+	for m := 0; m < deliveryMonth-1; m++ {
+		deliveryDOY += daysInMonth[m]
+	}
+	// 買主負担日数 = 12月31日(365) - 引渡し日 + 1
+	buyerDays := 365 - deliveryDOY + 1
+	if buyerDays <= 0 {
+		return 0
+	}
+	return math.Round(annualTax * float64(buyerDays) / 365)
+}

--- a/backend/internal/domain/property_tax.go
+++ b/backend/internal/domain/property_tax.go
@@ -71,21 +71,24 @@ func CalcPropertyTax(assessedLand, assessedBuilding float64, opts PropertyTaxOpt
 // CalcPropertyTaxProration は引渡し日基準で買主負担分の固定資産税日割り額を算出する。
 //
 // 慣行: 売主が1月1日〜引渡し前日分、買主が引渡し日〜12月31日分を負担。
-// うるう年は非考慮（誤差軽微のため365日固定）。
-func CalcPropertyTaxProration(annualTax float64, deliveryMonth, deliveryDay int) float64 {
+// year は取引年（JST）を呼び出し側で渡す。うるう年に対応。
+func CalcPropertyTaxProration(annualTax float64, deliveryMonth, deliveryDay, year int) float64 {
 	if annualTax <= 0 || deliveryMonth < 1 || deliveryMonth > 12 || deliveryDay < 1 {
 		return 0
 	}
-	// 引渡し日の通算日数（1月1日=1）、うるう年非考慮
 	daysInMonth := []int{31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31}
+	daysInYear := 365
+	if year%4 == 0 && (year%100 != 0 || year%400 == 0) {
+		daysInMonth[1] = 29
+		daysInYear = 366
+	}
 	deliveryDOY := deliveryDay
 	for m := 0; m < deliveryMonth-1; m++ {
 		deliveryDOY += daysInMonth[m]
 	}
-	// 買主負担日数 = 12月31日(365) - 引渡し日 + 1
-	buyerDays := 365 - deliveryDOY + 1
+	buyerDays := daysInYear - deliveryDOY + 1
 	if buyerDays <= 0 {
 		return 0
 	}
-	return math.Round(annualTax * float64(buyerDays) / 365)
+	return math.Round(annualTax * float64(buyerDays) / float64(daysInYear))
 }

--- a/backend/internal/domain/property_tax_test.go
+++ b/backend/internal/domain/property_tax_test.go
@@ -58,27 +58,52 @@ func TestCalcPropertyTax(t *testing.T) {
 
 func TestCalcPropertyTaxProration(t *testing.T) {
 	tests := []struct {
-		name          string
-		annualTax     float64
-		month         int
-		day           int
-		want          float64
+		name      string
+		annualTax float64
+		month     int
+		day       int
+		year      int
+		want      float64
 	}{
 		{
-			name:      "7月1日引渡し（184日分）",
+			name:      "7月1日引渡し・平年（184日分）",
 			annualTax: 365_000,
 			month:     7,
 			day:       1,
+			year:      2025, // 平年
 			// 通算: 31+28+31+30+31+30+1=182日目
 			// 買主負担: 365-182+1=184日
 			// 365,000 × 184/365 = 184,000
 			want: 184_000,
 		},
 		{
-			name:      "1月1日引渡し（365日分）",
+			name:      "7月1日引渡し・うるう年（184日分）",
+			annualTax: 366_000,
+			month:     7,
+			day:       1,
+			year:      2024, // うるう年
+			// 通算: 31+29+31+30+31+30+1=183日目
+			// 買主負担: 366-183+1=184日
+			// 366,000 × 184/366 = 184,000
+			want: 184_000,
+		},
+		{
+			name:      "3月1日引渡し・うるう年（うるう日を含む）",
+			annualTax: 366_000,
+			month:     3,
+			day:       1,
+			year:      2024, // うるう年: 1月=31, 2月=29
+			// 通算: 31+29+1=61日目
+			// 買主負担: 366-61+1=306日
+			// 366,000 × 306/366 = 306,000
+			want: 306_000,
+		},
+		{
+			name:      "1月1日引渡し（全日分）",
 			annualTax: 365_000,
 			month:     1,
 			day:       1,
+			year:      2025,
 			want:      365_000,
 		},
 		{
@@ -86,12 +111,13 @@ func TestCalcPropertyTaxProration(t *testing.T) {
 			annualTax: 365_000,
 			month:     12,
 			day:       31,
+			year:      2025,
 			want:      1_000,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CalcPropertyTaxProration(tt.annualTax, tt.month, tt.day)
+			got := CalcPropertyTaxProration(tt.annualTax, tt.month, tt.day, tt.year)
 			if math.Abs(got-tt.want) > 1 {
 				t.Errorf("CalcPropertyTaxProration = %.0f, want %.0f", got, tt.want)
 			}
@@ -103,6 +129,7 @@ func TestCalcAcquisitionCostsWithProration(t *testing.T) {
 	opts := AcquisitionCostOptions{
 		BrokerageMultiplier: 1.0,
 		LoanAmount:          30_000_000,
+		DeliveryYear:        2025,
 		DeliveryMonth:       7,
 		DeliveryDay:         1,
 		LandAreaSqm:         150,

--- a/backend/internal/domain/property_tax_test.go
+++ b/backend/internal/domain/property_tax_test.go
@@ -1,0 +1,120 @@
+package domain
+
+import (
+	"math"
+	"testing"
+)
+
+func TestCalcPropertyTax(t *testing.T) {
+	tests := []struct {
+		name             string
+		assessedLand     float64
+		assessedBuilding float64
+		opts             PropertyTaxOptions
+		wantAnnualTotal  float64
+	}{
+		{
+			name:             "特例なし（面積0）",
+			assessedLand:     20_000_000,
+			assessedBuilding: 10_000_000,
+			opts:             PropertyTaxOptions{},
+			// 土地: 20,000,000×0.014=280,000 + 都市計画: 20,000,000×0.003=60,000
+			// 建物: 10,000,000×0.014=140,000 + 都市計画: 10,000,000×0.003=30,000
+			// 合計: 510,000
+			wantAnnualTotal: 510_000,
+		},
+		{
+			name:             "小規模住宅用地特例（150㎡）",
+			assessedLand:     20_000_000,
+			assessedBuilding: 10_000_000,
+			opts:             PropertyTaxOptions{LandAreaSqm: 150},
+			// 土地固定: 20,000,000×0.014/6=46,667 → 46,667
+			// 土地都市: 20,000,000×0.003/3=20,000
+			// 建物固定: 140,000, 建物都市: 30,000
+			// 合計: 46,667 + 20,000 + 140,000 + 30,000 = 236,667
+			wantAnnualTotal: 236_667,
+		},
+		{
+			name:             "一般住宅用地特例（300㎡）",
+			assessedLand:     20_000_000,
+			assessedBuilding: 10_000_000,
+			opts:             PropertyTaxOptions{LandAreaSqm: 300},
+			// 土地固定: 20,000,000×0.014/3=93,333
+			// 土地都市: 20,000,000×0.003×2/3=40,000
+			// 建物: 170,000
+			// 合計: 303,333
+			wantAnnualTotal: 303_333,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalcPropertyTax(tt.assessedLand, tt.assessedBuilding, tt.opts)
+			if math.Abs(got.AnnualTotal-tt.wantAnnualTotal) > 1 {
+				t.Errorf("AnnualTotal = %.0f, want %.0f", got.AnnualTotal, tt.wantAnnualTotal)
+			}
+		})
+	}
+}
+
+func TestCalcPropertyTaxProration(t *testing.T) {
+	tests := []struct {
+		name          string
+		annualTax     float64
+		month         int
+		day           int
+		want          float64
+	}{
+		{
+			name:      "7月1日引渡し（184日分）",
+			annualTax: 365_000,
+			month:     7,
+			day:       1,
+			// 通算: 31+28+31+30+31+30+1=182日目
+			// 買主負担: 365-182+1=184日
+			// 365,000 × 184/365 = 184,000
+			want: 184_000,
+		},
+		{
+			name:      "1月1日引渡し（365日分）",
+			annualTax: 365_000,
+			month:     1,
+			day:       1,
+			want:      365_000,
+		},
+		{
+			name:      "12月31日引渡し（1日分）",
+			annualTax: 365_000,
+			month:     12,
+			day:       31,
+			want:      1_000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CalcPropertyTaxProration(tt.annualTax, tt.month, tt.day)
+			if math.Abs(got-tt.want) > 1 {
+				t.Errorf("CalcPropertyTaxProration = %.0f, want %.0f", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalcAcquisitionCostsWithProration(t *testing.T) {
+	opts := AcquisitionCostOptions{
+		BrokerageMultiplier: 1.0,
+		LoanAmount:          30_000_000,
+		DeliveryMonth:       7,
+		DeliveryDay:         1,
+		LandAreaSqm:         150,
+	}
+	result := CalcAcquisitionCosts(35_000_000, 24_000_000, opts)
+
+	if result.PropertyTaxProration <= 0 {
+		t.Errorf("PropertyTaxProration should be > 0, got %.0f", result.PropertyTaxProration)
+	}
+	wantTotal := result.BrokerageFee + result.StampDuty + result.RegistrationTax +
+		result.RealEstateAcquisitionTax + result.PropertyTaxProration
+	if math.Abs(result.Total-wantTotal) > 1 {
+		t.Errorf("Total = %.0f, want %.0f", result.Total, wantTotal)
+	}
+}

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -78,6 +78,9 @@ type InvestmentInput struct {
 	// ストレステスト用オフセット
 	VacancyRateDelta float64 `json:"vacancyRateDelta"` // 空室率上昇分 (例: +0.10)
 	LoanRateDelta    float64 `json:"loanRateDelta"`    // 金利上昇分 (例: +0.015)
+
+	// 固定資産税・都市計画税（年間合計）。0 の場合は ExpenseRate に含まれる想定。
+	AnnualPropertyTax float64 `json:"annualPropertyTax"`
 }
 
 // Defaults は構造的デフォルト（省略可能なフィールド）にのみ適用する。
@@ -159,14 +162,12 @@ type InvestmentResult struct {
 }
 
 // AcquisitionCostBreakdown は物件取得時の諸経費内訳
-// #75: 仲介手数料・印紙税
-// #76: 登録免許税・不動産取得税（本issue）
-// #77: 固定資産税日割り精算（後続issueで追加）
 type AcquisitionCostBreakdown struct {
 	BrokerageFee             float64 `json:"brokerageFee"`             // 仲介手数料（税込）
 	StampDuty                float64 `json:"stampDuty"`                // 印紙税（売買契約書）
 	RegistrationTax          float64 `json:"registrationTax"`          // 登録免許税（所有権移転+抵当権設定）
 	RealEstateAcquisitionTax float64 `json:"realEstateAcquisitionTax"` // 不動産取得税（概算）
+	PropertyTaxProration     float64 `json:"propertyTaxProration"`     // 固定資産税日割り精算（買主負担分）
 	Total                    float64 `json:"total"`
 }
 

--- a/docs/metadata.json
+++ b/docs/metadata.json
@@ -16,10 +16,10 @@
       "id": "domain-investment-calculation",
       "path": "docs/domain-investment-calculation.md",
       "title": "投資計算ロジック詳細仕様",
-      "description": "表面利回り・実質利回り・元利均等返済・課税所得・税引後キャッシュフロー・8%逆算の計算式と実装根拠。InvestmentInput/InvestmentResult/YearlyResult の全フィールド解説。ActualVacancyRate（現況空室率）フィールド含む。取得時諸経費（仲介手数料・印紙税・登録免許税・不動産取得税）の算出ロジックと AcquisitionCostBreakdown 型仕様。",
-      "tags": ["利回り", "キャッシュフロー", "ローン", "元利均等", "投資計算", "表面利回り", "実質利回り", "8%境界線", "空室率", "諸経費", "登録免許税", "不動産取得税"],
+      "description": "表面利回り・実質利回り・元利均等返済・課税所得・税引後キャッシュフロー・8%逆算の計算式と実装根拠。InvestmentInput/InvestmentResult/YearlyResult の全フィールド解説。ActualVacancyRate（現況空室率）フィールド含む。取得時諸経費（仲介手数料・印紙税・登録免許税・不動産取得税・固定資産税日割り）の算出ロジックと AcquisitionCostBreakdown 型仕様。固定資産税・都市計画税の年間計算・小規模住宅用地特例・うるう年対応日割り精算。",
+      "tags": ["利回り", "キャッシュフロー", "ローン", "元利均等", "投資計算", "表面利回り", "実質利回り", "8%境界線", "空室率", "諸経費", "登録免許税", "不動産取得税", "固定資産税", "都市計画税"],
       "industry": ["不動産", "フィンテック"],
-      "topics": ["grossYield", "netYield", "calcMonthlyPayment", "calcYearlyLoanComponents", "TaxableIncome", "AfterTaxCashFlow", "calcRequired8pct", "ストレステスト", "InvestmentInput", "YearlyResult", "ActualVacancyRate", "actualVacancyRate", "VacancyRate", "AcquisitionCostBreakdown", "CalcAcquisitionCosts", "CalcBrokerageFee", "CalcStampDuty", "CalcRegistrationTax", "CalcRealEstateAcquisitionTax", "registrationTax", "realEstateAcquisitionTax", "AcquisitionCostOptions"],
+      "topics": ["grossYield", "netYield", "calcMonthlyPayment", "calcYearlyLoanComponents", "TaxableIncome", "AfterTaxCashFlow", "calcRequired8pct", "ストレステスト", "InvestmentInput", "YearlyResult", "ActualVacancyRate", "actualVacancyRate", "VacancyRate", "AcquisitionCostBreakdown", "CalcAcquisitionCosts", "CalcBrokerageFee", "CalcStampDuty", "CalcRegistrationTax", "CalcRealEstateAcquisitionTax", "registrationTax", "realEstateAcquisitionTax", "AcquisitionCostOptions", "CalcPropertyTax", "CalcPropertyTaxProration", "PropertyTaxBreakdown", "PropertyTaxOptions", "AnnualPropertyTax", "propertyTaxProration", "小規模住宅用地特例", "固定資産税日割り"],
       "updatedAt": "2026-04-18"
     },
     {

--- a/frontend/src/components/__tests__/helpers.ts
+++ b/frontend/src/components/__tests__/helpers.ts
@@ -89,7 +89,7 @@ export function makeResult(overrides: Partial<InvestmentResult> = {}): Investmen
     deadCrossYear: 0,
     yearlyResults,
     criticalErrors: [],
-    acquisitionCosts: { brokerageFee: 0, stampDuty: 0, registrationTax: 0, realEstateAcquisitionTax: 0, total: 0 },
+    acquisitionCosts: { brokerageFee: 0, stampDuty: 0, registrationTax: 0, realEstateAcquisitionTax: 0, propertyTaxProration: 0, total: 0 },
     exitSalePrice: 12_000_000,
     exitCapitalGain: 2_000_000,
     exitTransferTax: 400_000,

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -9,6 +9,7 @@ export interface AcquisitionCostBreakdown {
   stampDuty: number;
   registrationTax: number;
   realEstateAcquisitionTax: number;
+  propertyTaxProration: number;
   total: number;
 }
 


### PR DESCRIPTION
## 概要

固定資産税・都市計画税の年間計算、引渡し日基準の日割り精算、および収支シミュレーションへの反映を実装しました。

## 変更内容

### 新規（`property_tax.go`）

- `CalcPropertyTax(assessedLand, assessedBuilding float64, opts PropertyTaxOptions) PropertyTaxBreakdown`
  - 固定資産税: 評価額 × 1.4%
  - 都市計画税: 評価額 × 0.3%
  - 小規模住宅用地特例（地方税法349条の3の2）: 200㎡以下 固定資産税1/6・都市計画税1/3、200㎡超 固定資産税1/3・都市計画税2/3
- `CalcPropertyTaxProration(annualTax float64, deliveryMonth, deliveryDay int) float64`
  - 引渡し日〜12月31日分を買主負担として日割り計算

### 型拡張（`types.go`・`acquisition_costs.go`）

- `AcquisitionCostBreakdown.PropertyTaxProration` — 決済時の日割り精算額
- `AcquisitionCostOptions.DeliveryMonth/DeliveryDay` — 引渡し日（0 = 日割りなし）
- `AcquisitionCostOptions.LandAreaSqm` — 小規模住宅用地特例の判定用
- `InvestmentInput.AnnualPropertyTax` — 明示的な年間固定資産税（0 = ExpenseRateに含む想定）

### 収支シミュレーション反映（`investment.go`）

`AnnualPropertyTax > 0` の場合、毎年の経費に加算

## テスト確認

```
go test ./...  → ok github.com/yield-guard/backend/internal/domain
```

> PR #90 が PR #95 マージ時に自動クローズされたため、リベース済みブランチで再作成。

Closes #77