### PR TITLE
fix: XKT015駅別乗降客数APIをタイル座標形式・実フィールド名に修正 (#102)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: dev test lint build help \
-        mlit-land-prices mlit-municipalities
+        mlit-land-prices mlit-municipalities mlit-station-ridership \
+        api-station-ridership api-estimate-ridership
 
 ## dev: バックエンド・フロントエンドの開発サーバーを起動
 dev:
@@ -73,3 +74,42 @@ mlit-municipalities:
 	   --compressed \
 	   "$(MLIT_BASE)/XIT002?area=$(area)" \
 	   | jq .
+
+## mlit-station-ridership: 駅別乗降客数を取得 (XKT015) ※国交省APIへ直接リクエスト
+##   使い方: make mlit-station-ridership z=14 x=14547 y=6451
+##   緯度経度→タイル変換例(z=14): 渋谷付近 → x=14547 y=6451
+mlit-station-ridership:
+	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
+	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
+	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
+	@source .env 2>/dev/null; \
+	 curl -s \
+	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
+	   --compressed \
+	   "$(MLIT_BASE)/XKT015?response_format=geojson&z=$(z)&x=$(x)&y=$(y)" \
+	   | jq .
+
+# ---------------------------------------------------------------------------
+# ローカル開発サーバー向けAPIテスト (backend が :8080 で起動中であること)
+# ---------------------------------------------------------------------------
+API_BASE := http://localhost:8080/api
+
+## api-station-ridership: ローカルの /api/station-ridership を呼び出す
+##   使い方: make api-station-ridership lat=35.6762 lng=139.6503 [z=14]
+api-station-ridership:
+	@test -n "$(lat)" || (echo "ERROR: lat は必須です (例: lat=35.6762)"; exit 1)
+	@test -n "$(lng)" || (echo "ERROR: lng は必須です (例: lng=139.6503)"; exit 1)
+	curl -s \
+	  "$(API_BASE)/station-ridership?lat=$(lat)&lng=$(lng)$(if $(z),&z=$(z),)" \
+	  | jq .
+
+## api-estimate-ridership: 需要スコア補正付き理論価格推定を呼び出す
+##   使い方: make api-estimate-ridership area=13 city=13113 price=50000000 area_sqm=100 building_age=10 station_minutes=5 ridership_score=A
+api-estimate-ridership:
+	@test -n "$(area)"           || (echo "ERROR: area は必須です";           exit 1)
+	@test -n "$(price)"          || (echo "ERROR: price は必須です";          exit 1)
+	@test -n "$(area_sqm)"       || (echo "ERROR: area_sqm は必須です";       exit 1)
+	@test -n "$(building_age)"   || (echo "ERROR: building_age は必須です";   exit 1)
+	curl -s \
+	  "$(API_BASE)/land-prices/estimate?area=$(area)$(if $(city),&city=$(city),)&year=2024&quarter=1&to_year=2024&to_quarter=4&price=$(price)&area_sqm=$(area_sqm)&building_age=$(building_age)$(if $(station_minutes),&station_minutes=$(station_minutes),)$(if $(ridership_score),&ridership_score=$(ridership_score),)" \
+	  | jq .

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/yield-guard/backend/internal/domain"
@@ -16,7 +15,7 @@ import (
 type MLITClient interface {
 	FetchLandPrices(ctx context.Context, q mlit.LandPriceQuery) ([]domain.LandTransaction, error)
 	FetchMunicipalities(ctx context.Context, area string) ([]mlit.Municipality, error)
-	FetchStationRidership(ctx context.Context, area, city string) ([]mlit.StationRidership, error)
+	FetchStationRidership(ctx context.Context, z, x, y int) ([]mlit.StationRidership, error)
 }
 
 type Handler struct {
@@ -252,17 +251,36 @@ func (h *Handler) EstimateLandPrice(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
-// GetStationRidership は指定エリアの駅別乗降客数と需要スコアを返す（XKT015）
-// GET /api/station-ridership?area=13&city=13113
+// GetStationRidership は物件の緯度経度からタイル座標を計算し、駅別乗降客数と需要スコアを返す（XKT015）
+// GET /api/station-ridership?lat=35.6762&lng=139.6503[&z=14]
 func (h *Handler) GetStationRidership(c *gin.Context) {
-	area := c.Query("area")
-	if area == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "area は必須パラメータです"})
+	latStr := c.Query("lat")
+	lngStr := c.Query("lng")
+	if latStr == "" || lngStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lat と lng は必須パラメータです"})
 		return
 	}
-	city := c.Query("city")
+	lat, err := strconv.ParseFloat(latStr, 64)
+	if err != nil || lat < -90 || lat > 90 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lat は -90〜90 の数値で指定してください"})
+		return
+	}
+	lng, err := strconv.ParseFloat(lngStr, 64)
+	if err != nil || lng < -180 || lng > 180 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lng は -180〜180 の数値で指定してください"})
+		return
+	}
 
-	stations, err := h.mlitClient.FetchStationRidership(c.Request.Context(), area, city)
+	z := 14
+	if zStr := c.Query("z"); zStr != "" {
+		if zv, err := strconv.Atoi(zStr); err == nil && zv >= 11 && zv <= 15 {
+			z = zv
+		}
+	}
+
+	tx, ty := mlit.LatLngToTile(lat, lng, z)
+
+	stations, err := h.mlitClient.FetchStationRidership(c.Request.Context(), z, tx, ty)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": "駅別乗降客数の取得に失敗しました: " + err.Error()})
 		return
@@ -270,36 +288,17 @@ func (h *Handler) GetStationRidership(c *gin.Context) {
 
 	results := make([]domain.StationRidershipResult, 0, len(stations))
 	for _, s := range stations {
-		passengers := parsePassengers(s.Passengers)
-		score := domain.CalcRidershipDemandScore(passengers)
+		score := domain.CalcRidershipDemandScore(s.Passengers)
 		results = append(results, domain.StationRidershipResult{
 			StationName: s.StationName,
 			LineName:    s.LineName,
-			Passengers:  passengers,
+			Passengers:  s.Passengers,
 			DemandScore: score,
 			Correction:  domain.RidershipCorrectionFactor(score),
 		})
 	}
 
 	c.JSON(http.StatusOK, results)
-}
-
-// parsePassengers は乗降客数の文字列を int にパースする。
-// カンマ区切り・全角数字に対応（XKT015 レスポンスの表記揺れを吸収）。
-func parsePassengers(s string) int {
-	s = strings.TrimSpace(s)
-	s = strings.ReplaceAll(s, ",", "")
-	s = strings.Map(func(r rune) rune {
-		if r >= '０' && r <= '９' {
-			return r - '０' + '0'
-		}
-		return r
-	}, s)
-	v, err := strconv.ParseFloat(s, 64)
-	if err != nil {
-		return 0
-	}
-	return int(v)
 }
 
 // GetMunicipalities は指定都道府県の市区町村一覧を返す（XIT002）

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -273,9 +273,12 @@ func (h *Handler) GetStationRidership(c *gin.Context) {
 
 	z := 14
 	if zStr := c.Query("z"); zStr != "" {
-		if zv, err := strconv.Atoi(zStr); err == nil && zv >= 11 && zv <= 15 {
-			z = zv
+		zv, err := strconv.Atoi(zStr)
+		if err != nil || zv < 11 || zv > 15 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "z は 11〜15 の整数で指定してください"})
+			return
 		}
+		z = zv
 	}
 
 	tx, ty := mlit.LatLngToTile(lat, lng, z)

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -403,11 +403,23 @@ func TestGetStationRidership_InvalidLatLng(t *testing.T) {
 	}
 }
 
+func TestGetStationRidership_InvalidZ(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{})
+	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership?lat=35.6762&lng=139.6503&z=16", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestGetStationRidership_Success(t *testing.T) {
 	client := &mockMLITClient{
 		ridershipFunc: func(_ context.Context, z, x, y int) ([]mlit.StationRidership, error) {
-			if z != 14 {
-				t.Errorf("unexpected z: %d", z)
+			// lat=35.6762, lng=139.6503, z=14 → x=14547, y=6451
+			if z != 14 || x != 14547 || y != 6451 {
+				t.Errorf("unexpected tile: z=%d x=%d y=%d", z, x, y)
 			}
 			return []mlit.StationRidership{
 				{StationName: "渋谷", LineName: "JR山手線", Passengers: 360000},

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -23,7 +23,7 @@ func init() {
 type mockMLITClient struct {
 	fetchFunc      func(ctx context.Context, q mlit.LandPriceQuery) ([]domain.LandTransaction, error)
 	muniFunc       func(ctx context.Context, area string) ([]mlit.Municipality, error)
-	ridershipFunc  func(ctx context.Context, area, city string) ([]mlit.StationRidership, error)
+	ridershipFunc  func(ctx context.Context, z, x, y int) ([]mlit.StationRidership, error)
 }
 
 func (m *mockMLITClient) FetchLandPrices(ctx context.Context, q mlit.LandPriceQuery) ([]domain.LandTransaction, error) {
@@ -40,11 +40,11 @@ func (m *mockMLITClient) FetchMunicipalities(ctx context.Context, area string) (
 	return m.muniFunc(ctx, area)
 }
 
-func (m *mockMLITClient) FetchStationRidership(ctx context.Context, area, city string) ([]mlit.StationRidership, error) {
+func (m *mockMLITClient) FetchStationRidership(ctx context.Context, z, x, y int) ([]mlit.StationRidership, error) {
 	if m.ridershipFunc == nil {
 		return []mlit.StationRidership{}, nil
 	}
-	return m.ridershipFunc(ctx, area, city)
+	return m.ridershipFunc(ctx, z, x, y)
 }
 
 // newTestRouter はモッククライアントを使ったテスト用ルーターを返す
@@ -381,7 +381,7 @@ func TestGetMunicipalities_Success(t *testing.T) {
 	}
 }
 
-func TestGetStationRidership_MissingArea(t *testing.T) {
+func TestGetStationRidership_MissingLatLng(t *testing.T) {
 	r := newTestRouter(&mockMLITClient{})
 	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership", nil)
 	w := httptest.NewRecorder()
@@ -392,20 +392,31 @@ func TestGetStationRidership_MissingArea(t *testing.T) {
 	}
 }
 
+func TestGetStationRidership_InvalidLatLng(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{})
+	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership?lat=999&lng=139.6503", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
 func TestGetStationRidership_Success(t *testing.T) {
 	client := &mockMLITClient{
-		ridershipFunc: func(_ context.Context, area, city string) ([]mlit.StationRidership, error) {
-			if area != "13" || city != "13113" {
-				t.Errorf("unexpected params: area=%s city=%s", area, city)
+		ridershipFunc: func(_ context.Context, z, x, y int) ([]mlit.StationRidership, error) {
+			if z != 14 {
+				t.Errorf("unexpected z: %d", z)
 			}
 			return []mlit.StationRidership{
-				{StationName: "渋谷", LineName: "JR山手線", Passengers: "360000"},
-				{StationName: "代々木上原", LineName: "小田急小田原線", Passengers: "85,000"},
+				{StationName: "渋谷", LineName: "JR山手線", Passengers: 360000},
+				{StationName: "代々木上原", LineName: "小田急小田原線", Passengers: 85000},
 			}, nil
 		},
 	}
 	r := newTestRouter(client)
-	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership?area=13&city=13113", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership?lat=35.6762&lng=139.6503", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
@@ -428,19 +439,16 @@ func TestGetStationRidership_Success(t *testing.T) {
 	if result[0].DemandScore != domain.RidershipScoreA {
 		t.Errorf("expected score A, got %s", result[0].DemandScore)
 	}
-	if result[1].Passengers != 85000 {
-		t.Errorf("expected 85000 passengers (comma-separated), got %d", result[1].Passengers)
-	}
 }
 
 func TestGetStationRidership_APIError(t *testing.T) {
 	client := &mockMLITClient{
-		ridershipFunc: func(_ context.Context, _, _ string) ([]mlit.StationRidership, error) {
+		ridershipFunc: func(_ context.Context, _, _, _ int) ([]mlit.StationRidership, error) {
 			return nil, fmt.Errorf("upstream error")
 		},
 	}
 	r := newTestRouter(client)
-	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership?area=13", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership?lat=35.6762&lng=139.6503", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -138,23 +139,28 @@ func (c *Client) FetchMunicipalities(ctx context.Context, area string) ([]Munici
 	return apiResp.Data, nil
 }
 
-// FetchStationRidership は指定エリアの駅別乗降客数を取得する（XKT015）。
-// キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
-func (c *Client) FetchStationRidership(ctx context.Context, area, city string) ([]StationRidership, error) {
-	if area == "" {
-		return nil, fmt.Errorf("area is required")
-	}
+// LatLngToTile は緯度経度をWebMercatorタイル座標に変換する。
+func LatLngToTile(lat, lng float64, z int) (x, y int) {
+	n := math.Pow(2, float64(z))
+	x = int(math.Floor((lng + 180.0) / 360.0 * n))
+	latRad := lat * math.Pi / 180.0
+	y = int(math.Floor((1.0 - math.Log(math.Tan(latRad)+1.0/math.Cos(latRad))/math.Pi) / 2.0 * n))
+	return x, y
+}
 
-	key := fmt.Sprintf("ridership:%s:%s", area, city)
+// FetchStationRidership はタイル座標で XKT015 を呼び出し駅別乗降客数を取得する。
+// キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
+func (c *Client) FetchStationRidership(ctx context.Context, z, x, y int) ([]StationRidership, error) {
+	key := fmt.Sprintf("ridership:%d:%d:%d", z, x, y)
 	if cached, ok := c.cache.getRidership(key); ok {
 		return cached, nil
 	}
 
 	params := url.Values{}
-	params.Set("area", area)
-	if city != "" {
-		params.Set("city", city)
-	}
+	params.Set("response_format", "geojson")
+	params.Set("z", strconv.Itoa(z))
+	params.Set("x", strconv.Itoa(x))
+	params.Set("y", strconv.Itoa(y))
 	apiURL := c.baseURL + endpointStationRidership + "?" + params.Encode()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
@@ -178,16 +184,49 @@ func (c *Client) FetchStationRidership(ctx context.Context, area, city string) (
 		return nil, fmt.Errorf("station ridership API returned status %d", resp.StatusCode)
 	}
 
-	var apiResp StationRidershipResponse
-	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
-		return nil, fmt.Errorf("station ridership JSON decode error: %w", err)
-	}
-	if apiResp.Status != "OK" {
-		return nil, fmt.Errorf("station ridership API status: %s", apiResp.Status)
+	var geoResp StationRidershipGeoJSON
+	if err := json.NewDecoder(resp.Body).Decode(&geoResp); err != nil {
+		return nil, fmt.Errorf("station ridership GeoJSON decode error: %w", err)
 	}
 
-	c.cache.setRidership(key, apiResp.Data)
-	return apiResp.Data, nil
+	result := parseStationRiderships(geoResp.Features)
+	c.cache.setRidership(key, result)
+	return result, nil
+}
+
+// parseStationRiderships は GeoJSON フィーチャを StationRidership スライスに変換する。
+func parseStationRiderships(features []StationRidershipFeature) []StationRidership {
+	result := make([]StationRidership, 0, len(features))
+	for _, f := range features {
+		result = append(result, StationRidership{
+			StationName: f.Properties.StationName,
+			LineName:    f.Properties.LineName,
+			Passengers:  latestPassengers(f.Properties),
+		})
+	}
+	return result
+}
+
+// latestPassengers は年別乗降客数フィールドから最新の有効値（非ゼロ）を返す。
+// 2023年（S12_057）を優先し、欠損時は2011年（S12_009）にフォールバックする。
+func latestPassengers(p StationRidershipProperties) int {
+	for _, s := range []string{p.P2023, p.P2011} {
+		if v := parsePassengerInt(s); v > 0 {
+			return v
+		}
+	}
+	return 0
+}
+
+// parsePassengerInt は乗降客数の文字列を int にパースする。カンマ区切りに対応。
+func parsePassengerInt(s string) int {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, ",", "")
+	v, err := strconv.ParseFloat(s, 64)
+	if err != nil || v <= 0 {
+		return 0
+	}
+	return int(v)
 }
 
 // doRequest は単一のHTTPリクエストを実行し、レスポンスをパースして返す

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -195,25 +195,42 @@ func (c *Client) FetchStationRidership(ctx context.Context, z, x, y int) ([]Stat
 }
 
 // parseStationRiderships は GeoJSON フィーチャを StationRidership スライスに変換する。
+// 同一（駅名, 路線名）の重複フィーチャは乗降客数が最大のものを残す。
 func parseStationRiderships(features []StationRidershipFeature) []StationRidership {
-	result := make([]StationRidership, 0, len(features))
+	type key struct{ station, line string }
+	best := make(map[key]StationRidership, len(features))
 	for _, f := range features {
-		result = append(result, StationRidership{
-			StationName: f.Properties.StationName,
-			LineName:    f.Properties.LineName,
+		p := f.Properties.StationName
+		l := f.Properties.LineName
+		if p == "" {
+			continue
+		}
+		k := key{p, l}
+		s := StationRidership{
+			StationName: p,
+			LineName:    l,
 			Passengers:  latestPassengers(f.Properties),
-		})
+		}
+		if prev, ok := best[k]; !ok || s.Passengers > prev.Passengers {
+			best[k] = s
+		}
+	}
+	result := make([]StationRidership, 0, len(best))
+	for _, s := range best {
+		result = append(result, s)
 	}
 	return result
 }
 
 // latestPassengers は年別乗降客数フィールドから最新の有効値（非ゼロ）を返す。
-// 2023年（S12_057）を優先し、欠損時は2011年（S12_009）にフォールバックする。
+// 2023年（S12_057）から降順にスキャンし、最初に非ゼロの値を返す。全年ゼロなら 0 を返す。
 func latestPassengers(p StationRidershipProperties) int {
-	if p.P2023 > 0 {
-		return p.P2023
+	for _, v := range []int{p.P2023, p.P2022, p.P2021, p.P2020, p.P2019, p.P2018, p.P2017, p.P2016, p.P2015, p.P2014, p.P2013, p.P2012, p.P2011} {
+		if v > 0 {
+			return v
+		}
 	}
-	return p.P2011
+	return 0
 }
 
 // doRequest は単一のHTTPリクエストを実行し、レスポンスをパースして返す

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -210,23 +210,10 @@ func parseStationRiderships(features []StationRidershipFeature) []StationRidersh
 // latestPassengers は年別乗降客数フィールドから最新の有効値（非ゼロ）を返す。
 // 2023年（S12_057）を優先し、欠損時は2011年（S12_009）にフォールバックする。
 func latestPassengers(p StationRidershipProperties) int {
-	for _, s := range []string{p.P2023, p.P2011} {
-		if v := parsePassengerInt(s); v > 0 {
-			return v
-		}
+	if p.P2023 > 0 {
+		return p.P2023
 	}
-	return 0
-}
-
-// parsePassengerInt は乗降客数の文字列を int にパースする。カンマ区切りに対応。
-func parsePassengerInt(s string) int {
-	s = strings.TrimSpace(s)
-	s = strings.ReplaceAll(s, ",", "")
-	v, err := strconv.ParseFloat(s, 64)
-	if err != nil || v <= 0 {
-		return 0
-	}
-	return int(v)
+	return p.P2011
 }
 
 // doRequest は単一のHTTPリクエストを実行し、レスポンスをパースして返す

--- a/backend/internal/mlit/client_test.go
+++ b/backend/internal/mlit/client_test.go
@@ -569,3 +569,27 @@ func TestFetchMunicipalities_4xxNoRetry(t *testing.T) {
 		t.Fatal("expected error for 4xx, got nil")
 	}
 }
+
+func TestLatLngToTile(t *testing.T) {
+	tests := []struct {
+		name    string
+		lat     float64
+		lng     float64
+		z       int
+		wantX   int
+		wantY   int
+	}{
+		{"渋谷付近 z=14", 35.6762, 139.6503, 14, 14547, 6451},
+		{"世界の端（東経180度）z=1", 0, 180, 1, 2, 1},
+		{"赤道・本初子午線 z=1", 0, 0, 1, 1, 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			x, y := LatLngToTile(tt.lat, tt.lng, tt.z)
+			if x != tt.wantX || y != tt.wantY {
+				t.Errorf("LatLngToTile(%v, %v, %d) = (%d, %d), want (%d, %d)",
+					tt.lat, tt.lng, tt.z, x, y, tt.wantX, tt.wantY)
+			}
+		})
+	}
+}

--- a/backend/internal/mlit/types.go
+++ b/backend/internal/mlit/types.go
@@ -86,10 +86,9 @@ type StationRidershipProperties struct {
 	P2023 int `json:"S12_057"`
 }
 
-// StationRidershipGeometry は GeoJSON Geometry（実際は LineString 形式で返る）
+// StationRidershipGeometry は GeoJSON Geometry（実際は LineString 形式で返る）。座標は使用しないため省略。
 type StationRidershipGeometry struct {
 	Type string `json:"type"`
-	// Coordinates はパース不要のため raw で保持
 }
 
 // StationRidership はハンドラ層との橋渡し用の処理済みレコード

--- a/backend/internal/mlit/types.go
+++ b/backend/internal/mlit/types.go
@@ -81,8 +81,19 @@ type StationRidershipProperties struct {
 	StationName  string `json:"S12_001_ja"` // 駅名
 	OperatorName string `json:"S12_002_ja"` // 運営会社名
 	LineName     string `json:"S12_003_ja"` // 路線名
-	// 年別乗降客数（整数値）。S12_009=2011年、S12_057=2023年（最新）。
+	// 年別乗降客数（整数値）。フィールドは +4 刻み: S12_009=2011〜S12_057=2023。
 	P2011 int `json:"S12_009"`
+	P2012 int `json:"S12_013"`
+	P2013 int `json:"S12_017"`
+	P2014 int `json:"S12_021"`
+	P2015 int `json:"S12_025"`
+	P2016 int `json:"S12_029"`
+	P2017 int `json:"S12_033"`
+	P2018 int `json:"S12_037"`
+	P2019 int `json:"S12_041"`
+	P2020 int `json:"S12_045"`
+	P2021 int `json:"S12_049"`
+	P2022 int `json:"S12_053"`
 	P2023 int `json:"S12_057"`
 }
 

--- a/backend/internal/mlit/types.go
+++ b/backend/internal/mlit/types.go
@@ -61,19 +61,41 @@ type LandPriceQuery struct {
 	ToQuarter    int    // 取得終了四半期 (1〜4)
 }
 
-// StationRidershipResponse は XKT015 駅別乗降客数APIのレスポンス
-type StationRidershipResponse struct {
-	Status string             `json:"status"`
-	Data   []StationRidership `json:"data"`
+// StationRidershipGeoJSON は XKT015 駅別乗降客数APIのGeoJSONレスポンス
+type StationRidershipGeoJSON struct {
+	Type     string                   `json:"type"`
+	Features []StationRidershipFeature `json:"features"`
 }
 
-// StationRidership は駅別乗降客数の1レコード
+// StationRidershipFeature は GeoJSON の1フィーチャ（駅1件）
+type StationRidershipFeature struct {
+	Type       string                     `json:"type"`
+	Properties StationRidershipProperties `json:"properties"`
+	Geometry   StationRidershipGeometry   `json:"geometry"`
+}
+
+// StationRidershipProperties は駅別乗降客数の属性。フィールド名は国交省 XKT015 仕様に準拠（S12_XXX 形式）。
+type StationRidershipProperties struct {
+	StationCode  string `json:"S12_001c"`   // 駅コード
+	StationName  string `json:"S12_001_ja"` // 駅名
+	OperatorName string `json:"S12_002_ja"` // 運営会社名
+	LineName     string `json:"S12_003_ja"` // 路線名
+	// 年別乗降客数。S12_009=2011年、S12_057=2023年（最新）。
+	P2011 string `json:"S12_009"`
+	P2023 string `json:"S12_057"`
+}
+
+// StationRidershipGeometry は GeoJSON Geometry（Point）
+type StationRidershipGeometry struct {
+	Type        string    `json:"type"`
+	Coordinates []float64 `json:"coordinates"` // [lng, lat]
+}
+
+// StationRidership はハンドラ層との橋渡し用の処理済みレコード
 type StationRidership struct {
-	StationName  string `json:"StationName"`  // 駅名
-	LineName     string `json:"LineName"`     // 路線名
-	Passengers   string `json:"Passengers"`   // 乗降客数/日
-	Prefecture   string `json:"Prefecture"`   // 都道府県名
-	Municipality string `json:"Municipality"` // 市区町村名
+	StationName string `json:"stationName"`
+	LineName    string `json:"lineName"`
+	Passengers  int    `json:"passengers"` // 乗降客数/日
 }
 
 // Prefectures は都道府県コードマップ

--- a/backend/internal/mlit/types.go
+++ b/backend/internal/mlit/types.go
@@ -75,20 +75,21 @@ type StationRidershipFeature struct {
 }
 
 // StationRidershipProperties は駅別乗降客数の属性。フィールド名は国交省 XKT015 仕様に準拠（S12_XXX 形式）。
+// 年別乗降客数フィールドは4フィールド1組: S12_009=2011年、S12_013=2012年、…、S12_057=2023年（最新）。
 type StationRidershipProperties struct {
 	StationCode  string `json:"S12_001c"`   // 駅コード
 	StationName  string `json:"S12_001_ja"` // 駅名
 	OperatorName string `json:"S12_002_ja"` // 運営会社名
 	LineName     string `json:"S12_003_ja"` // 路線名
-	// 年別乗降客数。S12_009=2011年、S12_057=2023年（最新）。
-	P2011 string `json:"S12_009"`
-	P2023 string `json:"S12_057"`
+	// 年別乗降客数（整数値）。S12_009=2011年、S12_057=2023年（最新）。
+	P2011 int `json:"S12_009"`
+	P2023 int `json:"S12_057"`
 }
 
-// StationRidershipGeometry は GeoJSON Geometry（Point）
+// StationRidershipGeometry は GeoJSON Geometry（実際は LineString 形式で返る）
 type StationRidershipGeometry struct {
-	Type        string    `json:"type"`
-	Coordinates []float64 `json:"coordinates"` // [lng, lat]
+	Type string `json:"type"`
+	// Coordinates はパース不要のため raw で保持
 }
 
 // StationRidership はハンドラ層との橋渡し用の処理済みレコード

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -188,35 +188,40 @@ DeviationPct         = (price - TheoreticalPrice) / TheoreticalPrice × 100
 
 ## GET /api/station-ridership
 
-指定エリアの駅別乗降客数と賃貸需要スコアを返す（国交省 XKT015）。
+物件の緯度経度からタイル座標を算出し、周辺駅の乗降客数と賃貸需要スコアを返す（国交省 XKT015）。
 
 ### クエリパラメータ
 
 | パラメータ | 必須 | 説明 |
 |-----------|------|------|
-| `area` | 必須 | 都道府県コード（例: `"13"` = 東京都） |
-| `city` | 任意 | 市区町村コード（例: `"13113"` = 渋谷区） |
+| `lat` | 必須 | 緯度（-90〜90） |
+| `lng` | 必須 | 経度（-180〜180） |
+| `z` | 任意 | ズームレベル（11〜15、デフォルト: 14）。値が大きいほど狭域・詳細 |
+
+バックエンドで緯度経度を WebMercator タイル座標（x, y）に変換し、XKT015 に `response_format=geojson&z=Z&x=X&y=Y` 形式でリクエストする。
 
 ### レスポンス: `StationRidershipResult[]`
 
 ```json
 [
   {
-    "stationName": "渋谷",
-    "lineName": "JR山手線",
-    "passengers": 360000,
-    "demandScore": "A",
-    "correction": 0.15
+    "stationName": "方南町",
+    "lineName": "4号線丸ノ内線分岐線",
+    "passengers": 38148,
+    "demandScore": "B",
+    "correction": 0.08
   },
   {
-    "stationName": "代々木上原",
-    "lineName": "小田急小田原線",
-    "passengers": 85000,
-    "demandScore": "A",
-    "correction": 0.15
+    "stationName": "永福町",
+    "lineName": "井の頭線",
+    "passengers": 29479,
+    "demandScore": "B",
+    "correction": 0.08
   }
 ]
 ```
+
+乗降客数は最新年（2023年, `S12_057`）を優先し、欠損時は2011年（`S12_009`）を使用する。
 
 ### 需要スコア変換基準
 
@@ -228,14 +233,15 @@ DeviationPct         = (price - TheoreticalPrice) / TheoreticalPrice × 100
 | D | ≥ 2,000人 | -0.08 | 小型駅 |
 | E | < 2,000人 | -0.15 | 極小駅（地方小規模駅） |
 
-- 結果は TTL 24時間でインメモリキャッシュされる
+- 結果は TTL 24時間でインメモリキャッシュされる（キー: `ridership:z:x:y`）
 - `correction` の値を `GET /api/land-prices/estimate` の `ridership_score` パラメータに渡すことで理論価格に反映できる
 
 ### エラー
 
 | コード | 条件 |
 |--------|------|
-| 400 | `area` が未指定 |
+| 400 | `lat` または `lng` が未指定・範囲外 |
+| 400 | `z` が 11〜15 の範囲外 |
 | 502 | 国交省APIへのリクエスト失敗 |
 
 ---

--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -28,7 +28,12 @@ page.tsx
 **状態管理**:
 - `result`: `InvestmentResult | null`
 - `comparison`: `LandPriceComparison | null`
+- `stationRidership`: `StationRidershipResult[] | null` — 緯度・経度が指定された場合に `GET /api/station-ridership` から取得
 - `loading`, `error`: ローディング・エラー状態
+
+**`handleFetchLandPrices(area, city, lat?, lng?)`**:
+
+lat/lng が両方渡された場合のみ `fetchStationRidership({lat, lng})` を呼び出し、結果を `stationRidership` ステートに保存する。取得失敗はログに記録するのみで相場データ取得（`fetchLandPrices`）はブロックしない。呼び出し開始時に `setStationRidership(null)` でリセットする。
 
 **`equityInvested` の計算**:
 ```typescript
@@ -81,6 +86,10 @@ const equityInvested = result.totalInvestment - input.loanAmount
 **最寄り駅徒歩（`stationMinutes`）**:
 
 `InvestmentInput.stationMinutes`（0=未入力）。「相場データを取得」押下時に `GET /api/land-prices/estimate` へ渡され、理論価格の駅距離補正に使用される。0のままでも理論価格は築年数補正のみで算出される。
+
+**物件の緯度・経度（任意入力）**:
+
+`propertyLat`, `propertyLng`（コンポーネント内ローカル状態、`InvestmentInput` には含まれない）。都道府県・市区町村セレクトの下に2カラムグリッドで配置。「相場データを取得」押下時に有効な数値が入力されていれば `Dashboard.handleFetchLandPrices` に渡され、`GET /api/station-ridership?lat=&lng=` の呼び出しに使用される。未入力または不正値（`parseFloat` → `NaN`）の場合は undefined として渡され、駅別乗降客数の取得はスキップされる。
 
 **詳細設定トグル（showAdvanced）**:
 `expenseRate`, `incomeTaxRate`, `buildingAge`, `buildingType`, `exitYieldTarget` は
@@ -348,7 +357,7 @@ const deadCrossEndYear = yearlyResults.slice(0, 35)
 | `fetchLandPrices(params)` | `GET /api/land-prices/stats` | 土地取引統計 |
 | `compareLandPrice(params)` | `GET /api/land-prices/compare` | 相場比較 |
 | `estimateLandPrice(params)` | `GET /api/land-prices/estimate` | 理論価格推定（築年数・駅距離・需要スコア補正） |
-| `fetchStationRidership(params)` | `GET /api/station-ridership` | 駅別乗降客数・需要スコア（XKT015） |
+| `fetchStationRidership({lat, lng, z?})` | `GET /api/station-ridership` | 物件緯度経度から周辺駅の乗降客数・需要スコア（XKT015） |
 | `analyze(input)` | `POST /api/investment/analyze` | 投資シミュレーション |
 | `fetchMunicipalities(area)` | `GET /api/municipalities` | 市区町村一覧（XIT002） |
 | `fetchPrefectures()` | `GET /api/prefectures` | 都道府県一覧 |

--- a/docs/metadata.json
+++ b/docs/metadata.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "lastUpdated": "2026-04-18",
+  "lastUpdated": "2026-04-19",
   "documents": [
     {
       "id": "overview",
@@ -56,21 +56,21 @@
       "id": "api-reference",
       "path": "docs/api-reference.md",
       "title": "APIリファレンス",
-      "description": "全エンドポイント（/api/land-prices/stats、/api/land-prices/compare、/api/land-prices/estimate、/api/investment/analyze、/api/municipalities、/api/station-ridership、/health）の入出力・バリデーション範囲・エラー仕様。CORS設定とALLOW_ORIGINS環境変数。/api/land-prices/estimate は築年数・駅距離・需要スコア補正による理論価格推定（TheoreticalPriceResult）。/api/station-ridership は XKT015 駅別乗降客数・需要スコア（A〜E）・補正係数を返す。",
-      "tags": ["API", "エンドポイント", "REST", "バリデーション", "CORS", "理論価格", "築年数補正", "駅距離補正", "需要スコア", "乗降客数", "XKT015"],
+      "description": "全エンドポイント（/api/land-prices/stats、/api/land-prices/compare、/api/land-prices/estimate、/api/investment/analyze、/api/municipalities、/api/station-ridership、/health）の入出力・バリデーション範囲・エラー仕様。CORS設定とALLOW_ORIGINS環境変数。/api/land-prices/estimate は築年数・駅距離・需要スコア補正による理論価格推定（TheoreticalPriceResult）。/api/station-ridership は lat/lng/z（タイル座標）パラメータで XKT015 駅別乗降客数・需要スコア（A〜E）・補正係数を返す。z は省略時 14（範囲 11〜15）。",
+      "tags": ["API", "エンドポイント", "REST", "バリデーション", "CORS", "理論価格", "築年数補正", "駅距離補正", "需要スコア", "乗降客数", "XKT015", "タイル座標", "lat", "lng"],
       "industry": ["不動産", "フィンテック"],
-      "topics": ["GET /api/land-prices/stats", "GET /api/land-prices/compare", "GET /api/land-prices/estimate", "GET /api/station-ridership", "POST /api/investment/analyze", "GET /api/municipalities", "GET /health", "InvestmentInput", "InvestmentResult", "LandPriceStats", "LandPriceComparison", "TheoreticalPriceResult", "StationRidershipResult", "RidershipDemandScore", "deviationPct", "ageCorrection", "stationCorrection", "ridershipCorrection", "ridership_score", "エラーレスポンス", "Gin"],
-      "updatedAt": "2026-04-18"
+      "topics": ["GET /api/land-prices/stats", "GET /api/land-prices/compare", "GET /api/land-prices/estimate", "GET /api/station-ridership", "POST /api/investment/analyze", "GET /api/municipalities", "GET /health", "InvestmentInput", "InvestmentResult", "LandPriceStats", "LandPriceComparison", "TheoreticalPriceResult", "StationRidershipResult", "RidershipDemandScore", "deviationPct", "ageCorrection", "stationCorrection", "ridershipCorrection", "ridership_score", "lat", "lng", "z", "タイル座標", "エラーレスポンス", "Gin"],
+      "updatedAt": "2026-04-19"
     },
     {
       "id": "mlit-api-integration",
       "path": "docs/mlit-api-integration.md",
       "title": "国交省不動産取引価格APIクライアント仕様",
-      "description": "国土交通省不動産取引価格情報取得APIのクエリパラメータ・宅地フィルタリング・坪単価算出・parseFloat正規化・parseJapaneseYear（和暦→西暦変換）・指数バックオフリトライ・相場判定ロジック（中央値±10%）・取引データからの用途地域サマリー抽出（ZoningSummary・calcZoningSummary・modalString）・都市計画リスク検出（UrbanRisk・detectUrbanRisks）。LandTransaction に BuildingYear・StationMinutes フィールド追加済み。XKT015 駅別乗降客数（FetchStationRidership）・需要スコア変換・キャッシュ（ridershipEntries）追加済み。",
-      "tags": ["国交省API", "土地価格", "相場", "外部API", "リトライ", "坪単価", "用途地域", "都市計画リスク", "和暦変換", "建築年", "駅距離", "駅別乗降客数", "需要スコア", "XKT015"],
+      "description": "国土交通省不動産取引価格情報取得APIのクエリパラメータ・宅地フィルタリング・坪単価算出・parseFloat正規化・parseJapaneseYear（和暦→西暦変換）・指数バックオフリトライ・相場判定ロジック（中央値±10%）・取引データからの用途地域サマリー抽出（ZoningSummary・calcZoningSummary・modalString）・都市計画リスク検出（UrbanRisk・detectUrbanRisks）。LandTransaction に BuildingYear・StationMinutes フィールド追加済み。XKT015 駅別乗降客数は GeoJSON タイル座標形式（z/x/y + response_format=geojson）で取得。FetchStationRidership(ctx, z, x, y int) → LatLngToTile(lat, lng, z) で WebMercator 変換。キャッシュキー ridership:z:x:y。StationRidershipGeoJSON/StationRidershipProperties/StationRidershipGeometry 型定義。",
+      "tags": ["国交省API", "土地価格", "相場", "外部API", "リトライ", "坪単価", "用途地域", "都市計画リスク", "和暦変換", "建築年", "駅距離", "駅別乗降客数", "需要スコア", "XKT015", "タイル座標", "GeoJSON", "WebMercator"],
       "industry": ["不動産"],
-      "topics": ["FetchLandPrices", "FetchStationRidership", "StationRidership", "StationRidershipResponse", "TradeListSearch", "isLandType", "parseFloat", "parseJapaneseYear", "BuildingYear", "TimeToNearestStation", "StationMinutes", "CalcLandPriceStats", "CompareLandPrice", "LandPriceQuery", "exponential backoff", "都道府県コード", "市区町村コード", "YYYYQ", "lowDataWarning", "ZoningSummary", "calcZoningSummary", "modalString", "UrbanRisk", "UrbanRiskLevel", "detectUrbanRisks", "URBANIZATION_CONTROL_ZONE", "UNZONED_AREA", "MIXED_ZONE_CAUTION", "ridershipEntries", "RidershipDemandScore", "CalcRidershipDemandScore", "RidershipCorrectionFactor"],
-      "updatedAt": "2026-04-18"
+      "topics": ["FetchLandPrices", "FetchStationRidership", "StationRidership", "StationRidershipGeoJSON", "StationRidershipFeature", "StationRidershipProperties", "StationRidershipGeometry", "LatLngToTile", "TradeListSearch", "isLandType", "parseFloat", "parseJapaneseYear", "BuildingYear", "TimeToNearestStation", "StationMinutes", "CalcLandPriceStats", "CompareLandPrice", "LandPriceQuery", "exponential backoff", "都道府県コード", "市区町村コード", "YYYYQ", "lowDataWarning", "ZoningSummary", "calcZoningSummary", "modalString", "UrbanRisk", "UrbanRiskLevel", "detectUrbanRisks", "URBANIZATION_CONTROL_ZONE", "UNZONED_AREA", "MIXED_ZONE_CAUTION", "ridershipEntries", "RidershipDemandScore", "CalcRidershipDemandScore", "RidershipCorrectionFactor", "z", "x", "y", "タイル座標", "GeoJSON", "WebMercator", "S12_001_ja", "S12_003_ja", "S12_009", "S12_057"],
+      "updatedAt": "2026-04-19"
     },
     {
       "id": "usecases",
@@ -86,11 +86,11 @@
       "id": "frontend-components",
       "path": "docs/frontend-components.md",
       "title": "フロントエンドコンポーネント仕様",
-      "description": "Dashboard・InvestmentForm・YieldAnalysis・CostBreakdown・CashFlowChart・DeadCrossChart・LandPriceAnalysis の責務・props・表示ロジック・ストレステストスライダー・breakEvenYear計算・二軸グラフ設計。YieldAnalysisの空室率3シナリオ比較テーブル、CostBreakdownの初期投資・諸経費・年間費用ドーナツグラフ、InvestmentFormの市区町村インクリメンタルサーチ（useMemo・useEffect自動選択）・stationMinutes入力欄、LandPriceAnalysisの用途地域パネル・都市計画リスクパネル（UrbanRisk・RISK_STYLE）・駅別乗降客数パネル（StationRidershipResult・需要スコアA〜E・カラーラベル）・理論価格パネル（TheoreticalPriceResult・乖離率±20%強調表示・築年数補正%・駅距離補正%・需要スコア補正%）含む。",
-      "tags": ["フロントエンド", "コンポーネント", "React", "Recharts", "グラフ", "空室率", "シナリオ", "諸経費", "コスト内訳", "インクリメンタルサーチ", "用途地域", "都市計画リスク", "理論価格", "乖離率", "駅距離", "需要スコア", "乗降客数"],
+      "description": "Dashboard・InvestmentForm・YieldAnalysis・CostBreakdown・CashFlowChart・DeadCrossChart・LandPriceAnalysis の責務・props・表示ロジック・ストレステストスライダー・breakEvenYear計算・二軸グラフ設計。YieldAnalysisの空室率3シナリオ比較テーブル、CostBreakdownの初期投資・諸経費・年間費用ドーナツグラフ、InvestmentFormの市区町村インクリメンタルサーチ（useMemo・useEffect自動選択）・stationMinutes入力欄・緯度経度任意入力（propertyLat/propertyLng）、Dashboard の stationRidership ステート管理・handleFetchLandPrices(area,city,lat?,lng?) によるfetchStationRidership 非同期呼び出し、LandPriceAnalysisの用途地域パネル・都市計画リスクパネル（UrbanRisk・RISK_STYLE）・駅別乗降客数パネル（StationRidershipResult・需要スコアA〜E・カラーラベル）・理論価格パネル（TheoreticalPriceResult・乖離率±20%強調表示・築年数補正%・駅距離補正%・需要スコア補正%）含む。",
+      "tags": ["フロントエンド", "コンポーネント", "React", "Recharts", "グラフ", "空室率", "シナリオ", "諸経費", "コスト内訳", "インクリメンタルサーチ", "用途地域", "都市計画リスク", "理論価格", "乖離率", "駅距離", "需要スコア", "乗降客数", "緯度経度", "タイル座標"],
       "industry": ["不動産", "フィンテック"],
-      "topics": ["Dashboard", "InvestmentForm", "YieldAnalysis", "CostBreakdown", "CashFlowChart", "DeadCrossChart", "LandPriceAnalysis", "Next.js", "Shadcn/UI", "TypeScript", "breakEvenYear", "equityInvested", "DEFAULT_INPUT", "BUILDING_USEFUL_LIFE", "actualVacancyRate", "annualPropertyTax", "シナリオ比較", "満室想定", "現況", "ストレス", "AcquisitionCostBreakdown", "PieChart", "fmt", "muniFilter", "filteredMunicipalities", "インクリメンタルサーチ", "自動選択", "ZoningSummary", "用途地域パネル", "UrbanRisk", "UrbanRiskLevel", "RISK_STYLE", "都市計画リスクパネル", "stationMinutes", "StationRidershipResult", "RidershipDemandScore", "stationRidership", "乗降客数パネル", "需要スコア", "RIDERSHIP_SCORE_LABEL", "TheoreticalPriceResult", "theoreticalPrice", "deviationPct", "ageCorrection", "stationCorrection", "ridershipCorrection", "hasRidershipData", "理論価格パネル", "estimateLandPrice", "fetchStationRidership"],
-      "updatedAt": "2026-04-18"
+      "topics": ["Dashboard", "InvestmentForm", "YieldAnalysis", "CostBreakdown", "CashFlowChart", "DeadCrossChart", "LandPriceAnalysis", "Next.js", "Shadcn/UI", "TypeScript", "breakEvenYear", "equityInvested", "DEFAULT_INPUT", "BUILDING_USEFUL_LIFE", "actualVacancyRate", "annualPropertyTax", "シナリオ比較", "満室想定", "現況", "ストレス", "AcquisitionCostBreakdown", "PieChart", "fmt", "muniFilter", "filteredMunicipalities", "インクリメンタルサーチ", "自動選択", "ZoningSummary", "用途地域パネル", "UrbanRisk", "UrbanRiskLevel", "RISK_STYLE", "都市計画リスクパネル", "stationMinutes", "propertyLat", "propertyLng", "StationRidershipResult", "RidershipDemandScore", "stationRidership", "乗降客数パネル", "需要スコア", "RIDERSHIP_SCORE_LABEL", "TheoreticalPriceResult", "theoreticalPrice", "deviationPct", "ageCorrection", "stationCorrection", "ridershipCorrection", "hasRidershipData", "理論価格パネル", "estimateLandPrice", "fetchStationRidership", "handleFetchLandPrices"],
+      "updatedAt": "2026-04-19"
     }
   ]
 }

--- a/docs/mlit-api-integration.md
+++ b/docs/mlit-api-integration.md
@@ -218,6 +218,63 @@ func (c *Client) FetchMunicipalities(ctx context.Context, area string) ([]Munici
 
 ---
 
+## XKT015 駅別乗降客数API
+
+### エンドポイント（タイル座標形式）
+
+```
+GET /ex-api/external/XKT015?response_format=geojson&z={z}&x={x}&y={y}
+```
+
+| パラメータ | 説明 |
+|-----------|------|
+| `response_format` | `geojson` 固定 |
+| `z` | ズームレベル（11〜15）。z=14 を推奨（約1.7km×1.7km の範囲） |
+| `x` / `y` | WebMercator タイル座標 |
+
+> XIT001/XIT002 の `area`/`city` パラメータ形式とは異なる。PR #101 では誤って `area`/`city` 形式で実装していたが、PR #103 で修正した。
+
+### 緯度経度→タイル座標変換（`LatLngToTile`）
+
+```go
+func LatLngToTile(lat, lng float64, z int) (x, y int) {
+    n := math.Pow(2, float64(z))
+    x = int(math.Floor((lng + 180.0) / 360.0 * n))
+    latRad := lat * math.Pi / 180.0
+    y = int(math.Floor((1.0 - math.Log(math.Tan(latRad)+1.0/math.Cos(latRad))/math.Pi) / 2.0 * n))
+    return x, y
+}
+```
+
+WebMercator（EPSG:3857）標準の変換式。`mlit` パッケージで公開されており、ハンドラ層から呼び出される。
+
+### GeoJSONレスポンス形式
+
+XKT015 は `FeatureCollection` を返す。各フィーチャのフィールド：
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `S12_001_ja` | string | 駅名 |
+| `S12_002_ja` | string | 運営会社名 |
+| `S12_003_ja` | string | 路線名 |
+| `S12_001c` | string | 駅コード |
+| `S12_009` | int | 乗降客数/日（2011年） |
+| `S12_057` | int | 乗降客数/日（2023年・最新） |
+
+年別乗降客数は4フィールド1組の構造（乗降客数+フラグ×3）になっており、`S12_009`=2011年、4ずつ増加して `S12_057`=2023年。`latestPassengers` で2023年を優先し、欠損時は2011年にフォールバックする。
+
+`geometry.type` は `LineString`（線形フィーチャ）で返るため座標は使用しない。
+
+### FetchStationRidership シグネチャ
+
+```go
+func (c *Client) FetchStationRidership(ctx context.Context, z, x, y int) ([]StationRidership, error)
+```
+
+フロントエンドには `GET /api/station-ridership?lat=35.6762&lng=139.6503[&z=14]` として公開されている。ハンドラ内で `LatLngToTile` によりタイル座標に変換してから呼び出す。
+
+---
+
 ## クエリパラメータ仕様
 
 `LandPriceQuery` 構造体にマップされる。
@@ -384,7 +441,7 @@ type cache struct {
     mu               sync.RWMutex
     entries          map[string]cacheEntry          // XIT001 土地価格キャッシュ
     muniEntries      map[string]muniCacheEntry      // XIT002 市区町村キャッシュ（キー: 都道府県コード）
-    ridershipEntries map[string]ridershipCacheEntry // XKT015 乗降客数キャッシュ（キー: "ridership:area:city"）
+    ridershipEntries map[string]ridershipCacheEntry // XKT015 乗降客数キャッシュ（キー: "ridership:z:x:y"）
 }
 ```
 
@@ -394,7 +451,7 @@ type cache struct {
 |---|---|---|
 | 土地価格（XIT001） | `area:city:year:quarter:toYear:toQuarter` | `"13::2024:1:2024:4"` |
 | 市区町村（XIT002） | 都道府県コード | `"13"` |
-| 駅別乗降客数（XKT015） | `ridership:area:city` | `"ridership:13:13113"` |
+| 駅別乗降客数（XKT015） | `ridership:z:x:y` | `"ridership:14:14547:6451"` |
 
 ### 動作フロー
 
@@ -519,6 +576,7 @@ if diffFromMedian > stats.MedianTsubo * 0.10 {
 | `TestFetchMunicipalities_EmptyArea` | area 空文字でエラー（HTTPリクエストなし） |
 | `TestFetchMunicipalities_CacheHit` | 2回目呼び出しがAPIコールなしでキャッシュから返る |
 | `TestFetchMunicipalities_4xxNoRetry` | 4xx でエラー返却（リトライなし） |
+| `TestLatLngToTile` | WebMercator 変換の期待タイル座標（渋谷付近・赤道・東経180度） |
 
 ```bash
 # ユニットテスト（モックサーバ使用・APIキー不要）

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -44,6 +44,7 @@ export function Dashboard() {
   const handleFetchLandPrices = async (area: string, city: string, lat?: number, lng?: number) => {
     setLoading(true);
     setError(null);
+    setStationRidership(null);
     const { year, quarter, toYear, toQuarter } = getCurrentPeriods();
     try {
       const baseParams = {

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -6,8 +6,8 @@ import { CashFlowChart } from "@/components/CashFlowChart";
 import { DeadCrossChart } from "@/components/DeadCrossChart";
 import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
 import CostBreakdown from "@/components/CostBreakdown";
-import type { InvestmentInput, InvestmentResult, LandPriceComparison, TheoreticalPriceResult } from "@/types/investment";
-import { analyze, compareLandPrice, estimateLandPrice } from "@/lib/api";
+import type { InvestmentInput, InvestmentResult, LandPriceComparison, TheoreticalPriceResult, StationRidershipResult } from "@/types/investment";
+import { analyze, compareLandPrice, estimateLandPrice, fetchStationRidership } from "@/lib/api";
 import { ShieldAlert, XOctagon, AlertTriangle } from "lucide-react";
 
 /** 直近2年分の期間（国交省API形式: YYYYQ） */
@@ -25,6 +25,7 @@ export function Dashboard() {
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [lastInput, setLastInput] = useState<InvestmentInput | null>(null);
+  const [stationRidership, setStationRidership] = useState<StationRidershipResult[] | null>(null);
 
   const handleAnalyze = async (input: InvestmentInput) => {
     setLoading(true);
@@ -40,7 +41,7 @@ export function Dashboard() {
     }
   };
 
-  const handleFetchLandPrices = async (area: string, city: string) => {
+  const handleFetchLandPrices = async (area: string, city: string, lat?: number, lng?: number) => {
     setLoading(true);
     setError(null);
     const { year, quarter, toYear, toQuarter } = getCurrentPeriods();
@@ -68,6 +69,14 @@ export function Dashboard() {
           setTheoreticalPrice(est);
         } catch {
           setTheoreticalPrice(null);
+        }
+      }
+      if (lat !== undefined && lng !== undefined) {
+        try {
+          const ridership = await fetchStationRidership({ lat, lng });
+          setStationRidership(ridership);
+        } catch {
+          setStationRidership(null);
         }
       }
     } catch (e) {
@@ -120,7 +129,7 @@ export function Dashboard() {
               </div>
             )}
 
-            {comparison && <LandPriceAnalysis comparison={comparison} input={lastInput} theoreticalPrice={theoreticalPrice} />}
+            {comparison && <LandPriceAnalysis comparison={comparison} input={lastInput} theoreticalPrice={theoreticalPrice} stationRidership={stationRidership} />}
 
             {result && lastInput && (
               <>

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -51,7 +51,7 @@ const BUILDING_TYPES: { value: BuildingType; label: string }[] = [
 
 interface Props {
   onAnalyze: (input: InvestmentInput) => Promise<void>;
-  onFetchLandPrices: (area: string, city: string) => Promise<void>;
+  onFetchLandPrices: (area: string, city: string, lat?: number, lng?: number) => Promise<void>;
   loading: boolean;
 }
 
@@ -96,6 +96,8 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading }: Props)
   const [input, setInput] = useState<InvestmentInput>(DEFAULT_INPUT);
   const [area, setArea] = useState("10");
   const [city, setCity] = useState("");
+  const [propertyLat, setPropertyLat] = useState("");
+  const [propertyLng, setPropertyLng] = useState("");
   const [municipalities, setMunicipalities] = useState<Municipality[]>([]);
   const [muniLoading, setMuniLoading] = useState(false);
   const [muniFilter, setMuniFilter] = useState("");
@@ -216,11 +218,42 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading }: Props)
               )}
             </div>
           </div>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium text-foreground">緯度（任意）</label>
+              <input
+                type="number"
+                placeholder="例: 35.6762"
+                step="0.0001"
+                value={propertyLat}
+                onChange={(e) => setPropertyLat(e.target.value)}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                aria-label="物件の緯度"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium text-foreground">経度（任意）</label>
+              <input
+                type="number"
+                placeholder="例: 139.6503"
+                step="0.0001"
+                value={propertyLng}
+                onChange={(e) => setPropertyLng(e.target.value)}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                aria-label="物件の経度"
+              />
+            </div>
+          </div>
           <p className="text-xs text-muted-foreground">
-            {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します
+            {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します。緯度・経度を入力すると周辺駅の需要スコアも取得します
           </p>
           <Button variant="outline" className="w-full" loading={loading}
-            onClick={() => onFetchLandPrices(area, city)}>
+            onClick={() => {
+              const lat = parseFloat(propertyLat);
+              const lng = parseFloat(propertyLng);
+              const hasCoords = !isNaN(lat) && !isNaN(lng);
+              onFetchLandPrices(area, city, hasCoords ? lat : undefined, hasCoords ? lng : undefined);
+            }}>
             <Search className="h-4 w-4" />相場データを取得
           </Button>
         </CardContent>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -106,13 +106,17 @@ export async function estimateLandPrice(params: {
   return handleResponse<TheoreticalPriceResult>(res);
 }
 
-/** 駅別乗降客数と需要スコアを取得（XKT015） */
+/** 物件の緯度経度から周辺駅の乗降客数と需要スコアを取得（XKT015） */
 export async function fetchStationRidership(params: {
-  area: string;
-  city?: string;
+  lat: number;
+  lng: number;
+  z?: number;
 }): Promise<StationRidershipResult[]> {
-  const q = new URLSearchParams({ area: params.area });
-  if (params.city) q.set("city", params.city);
+  const q = new URLSearchParams({
+    lat: String(params.lat),
+    lng: String(params.lng),
+  });
+  if (params.z !== undefined) q.set("z", String(params.z));
   const res = await fetch(`${BASE}/station-ridership?${q}`);
   return handleResponse<StationRidershipResult[]>(res);
 }


### PR DESCRIPTION
## 概要

PR #101 で実装した XKT015（駅別乗降客数）が、正常系リクエストで以下のエラーを返すことを確認した。

```json
{ "message": "不正なズーム値（z）が指定されたため、検索できませんでした。" }
```

XKT015 の正しい仕様を確認した結果、リクエスト形式・レスポンスフィールドともに実装が仕様と合っていなかった。本PRで全面修正する。

## 変更内容

**バックエンド**
- `mlit/types.go`: `StationRidershipResponse`/`StationRidership`（旧）を削除し、GeoJSON形式の型（`StationRidershipGeoJSON`, `StationRidershipFeature`, `StationRidershipProperties`, `StationRidershipGeometry`）を追加。フィールド名を実仕様（`S12_001_ja`, `S12_003_ja`, `S12_057` 等）に合わせた
- `mlit/client.go`: `FetchStationRidership` のシグネチャを `(area, city string)` → `(z, x, y int)` に変更。URLを `response_format=geojson&z=Z&x=X&y=Y` 形式に修正。`LatLngToTile(lat, lng, z)` ユーティリティを追加
- `api/handler.go`: `GetStationRidership` ハンドラのパラメータを `?area&city` → `?lat&lng[&z]` に変更。バックエンド内でタイル座標に変換して呼び出す。`MLITClient` インターフェースも更新
- `api/handler_test.go`: モックシグネチャ・テストケースを更新。`TestGetStationRidership_InvalidLatLng` を新規追加
- `mlit/client_test.go`: `TestLatLngToTile` を追加

**フロントエンド**
- `lib/api.ts`: `fetchStationRidership` の引数を `{area, city?}` → `{lat, lng, z?}` に変更
- `components/InvestmentForm.tsx`: 「土地相場データ取得」カードに緯度・経度の任意入力フィールドを追加
- `components/Dashboard.tsx`: `fetchStationRidership` を実際に呼び出し、結果を `LandPriceAnalysis` に渡すよう接続（従来は未接続だった）

**Makefile**
- `mlit-station-ridership`: `area=` → `z=` `x=` `y=` に変更
- `api-station-ridership`: `area=` → `lat=` `lng=` に変更

## 仕様差異のまとめ

| 項目 | 旧実装（誤） | 正しい仕様 |
|------|------------|-----------|
| リクエスト形式 | `?area=13&city=13113` | `?response_format=geojson&z=14&x=14547&y=6451` |
| 駅名フィールド | `StationName` | `S12_001_ja` |
| 路線名フィールド | `LineName` | `S12_003_ja` |
| 乗降客数 | `Passengers`（string, 単一値） | `S12_057`（最新年2023）, `S12_009`（2011年フォールバック） |

## 関連Issue

Closes #102

## テスト
- [x] 既存テストが通ること（`go test ./... -race` → 全PASS）
- [x] TypeScript型チェック通過（`tsc --noEmit` → エラーなし）
- [x] `TestLatLngToTile` を追加しWebMercator変換を検証
- [x] `TestGetStationRidership_InvalidLatLng` を追加しバリデーションを検証
- [ ] XKT015実データでのE2E動作確認（APIキーが設定された環境で実施要）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み