### PR TITLE
feat(security): Vercel-Render 間の内部通信保護（APP_INTERNAL_API_KEY）

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ cd yield-guard
 cp .env.example .env
 # .env を編集して MLIT_API_KEY を設定する
 # APIキー申請: https://www.reinfolib.mlit.go.jp/api/request/（審査5営業日）
+# APP_INTERNAL_API_KEY は本番環境（Vercel-Render 間認証）用。ローカルでは未設定でよい
 ```
 
 ### Docker（推奨）

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -730,7 +730,7 @@ func TestInternalKeyMiddleware_CorrectKey(t *testing.T) {
 	req.Header.Set("X-Internal-Key", "secret")
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
-	if w.Code == http.StatusUnauthorized {
-		t.Fatalf("expected non-401 with correct key, got %d", w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 with correct key, got %d", w.Code)
 	}
 }

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -677,3 +677,60 @@ func TestGetLandAppraisals_InvalidDivision(t *testing.T) {
 		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }
+
+func TestInternalKeyMiddleware_NoKeySet(t *testing.T) {
+	t.Setenv("APP_INTERNAL_API_KEY", "")
+	r := newTestRouter(&mockMLITClient{})
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 when key not set, got %d", w.Code)
+	}
+}
+
+func TestInternalKeyMiddleware_HealthSkipped(t *testing.T) {
+	t.Setenv("APP_INTERNAL_API_KEY", "secret")
+	r := newTestRouter(&mockMLITClient{})
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for /health without key, got %d", w.Code)
+	}
+}
+
+func TestInternalKeyMiddleware_Unauthorized(t *testing.T) {
+	t.Setenv("APP_INTERNAL_API_KEY", "secret")
+	r := newTestRouter(&mockMLITClient{})
+	req := httptest.NewRequest(http.MethodGet, "/api/municipalities", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without X-Internal-Key, got %d", w.Code)
+	}
+}
+
+func TestInternalKeyMiddleware_WrongKey(t *testing.T) {
+	t.Setenv("APP_INTERNAL_API_KEY", "secret")
+	r := newTestRouter(&mockMLITClient{})
+	req := httptest.NewRequest(http.MethodGet, "/api/municipalities", nil)
+	req.Header.Set("X-Internal-Key", "wrong")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 with wrong key, got %d", w.Code)
+	}
+}
+
+func TestInternalKeyMiddleware_CorrectKey(t *testing.T) {
+	t.Setenv("APP_INTERNAL_API_KEY", "secret")
+	r := newTestRouter(&mockMLITClient{})
+	req := httptest.NewRequest(http.MethodGet, "/api/municipalities?area=13", nil)
+	req.Header.Set("X-Internal-Key", "secret")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code == http.StatusUnauthorized {
+		t.Fatalf("expected non-401 with correct key, got %d", w.Code)
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -9,6 +9,17 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+func internalKeyMiddleware() gin.HandlerFunc {
+	key := os.Getenv("APP_INTERNAL_API_KEY")
+	return func(c *gin.Context) {
+		if key != "" && c.GetHeader("X-Internal-Key") != key {
+			c.AbortWithStatus(http.StatusUnauthorized)
+			return
+		}
+		c.Next()
+	}
+}
+
 // NewRouter は Gin ルーターを初期化して返す
 func NewRouter(h *Handler) *gin.Engine {
 	r := gin.Default()
@@ -35,6 +46,7 @@ func NewRouter(h *Handler) *gin.Engine {
 	r.GET("/health", h.HealthCheck)
 
 	api := r.Group("/api")
+	api.Use(internalKeyMiddleware())
 	{
 		api.GET("/land-prices/stats", h.GetLandPrices)
 		api.GET("/land-prices/compare", h.CompareLandPrice)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -11,6 +11,18 @@
 | レスポンス形式 | `application/json` |
 | CORS 許可オリジン | 環境変数 `ALLOW_ORIGINS`（カンマ区切り）。未設定時は `http://localhost:3000` のみ |
 
+### 内部通信認証（`/api/*`）
+
+環境変数 `APP_INTERNAL_API_KEY` が設定されている場合、`/api/*` エンドポイントへのすべてのリクエストに `X-Internal-Key` ヘッダーが必要。
+
+| ヘッダー | 説明 |
+|----------|------|
+| `X-Internal-Key` | `APP_INTERNAL_API_KEY` と同一の値。不一致または未送信の場合は `401 Unauthorized` |
+
+- `/health` エンドポイントはこの認証をスキップする
+- `APP_INTERNAL_API_KEY` が未設定（ローカル開発）の場合はヘッダー検証をスキップし、従来通り動作する
+- Vercel フロントエンドは `frontend/src/middleware.ts` で自動的にヘッダーを付与するため、ブラウザからの通常利用では意識不要
+
 ### エラーレスポンス形式
 
 ```json

--- a/docs/metadata.json
+++ b/docs/metadata.json
@@ -1,16 +1,16 @@
 {
   "version": "1.0.0",
-  "lastUpdated": "2026-04-19T12:40:00",
+  "lastUpdated": "2026-04-19T22:05:00",
   "documents": [
     {
       "id": "overview",
       "path": "docs/overview.md",
       "title": "プロジェクト概要とアーキテクチャ",
-      "description": "Yield-Guard の目的・解決する3大リスク（相場判定・デッドクロス・出口戦略）・技術スタック・ディレクトリ構成・起動手順・計算の制約と免責事項",
-      "tags": ["概要", "アーキテクチャ", "セットアップ", "不動産投資"],
+      "description": "Yield-Guard の目的・解決する3大リスク（相場判定・デッドクロス・出口戦略）・技術スタック・ディレクトリ構成・起動手順・計算の制約と免責事項。バックエンド環境変数（PORT/ALLOW_ORIGINS/MLIT_API_KEY/APP_INTERNAL_API_KEY）・フロントエンド環境変数（APP_INTERNAL_API_KEY）の一覧を含む。",
+      "tags": ["概要", "アーキテクチャ", "セットアップ", "不動産投資", "環境変数", "APP_INTERNAL_API_KEY"],
       "industry": ["不動産", "フィンテック"],
-      "topics": ["Go", "Gin", "Next.js", "Tailwind CSS", "Recharts", "Clean Architecture", "国交省API", "起動手順", "テスト"],
-      "updatedAt": "2026-03-28"
+      "topics": ["Go", "Gin", "Next.js", "Tailwind CSS", "Recharts", "Clean Architecture", "国交省API", "起動手順", "テスト", "APP_INTERNAL_API_KEY", "MLIT_API_KEY", "ALLOW_ORIGINS"],
+      "updatedAt": "2026-04-19"
     },
     {
       "id": "domain-investment-calculation",
@@ -56,10 +56,20 @@
       "id": "api-reference",
       "path": "docs/api-reference.md",
       "title": "APIリファレンス",
-      "description": "全エンドポイント（/api/land-prices/stats、/api/land-prices/compare、/api/land-prices/estimate、/api/investment/analyze、/api/municipalities、/api/station-ridership、/api/population-forecast、/api/land-appraisals、/health）の入出力・バリデーション範囲・エラー仕様。CORS設定とALLOW_ORIGINS環境変数。/api/land-appraisals は XCT001 地価公示データを取得し公示価格中央値・変動率・トレンドラベルを返す（AppraisalComparisonResult型）。/api/population-forecast は lat/lng/z パラメータで XKT013 将来推計人口を取得し、30年後変化率・空室率増加推定（×0.5係数）・4段階トレンドを返す。",
-      "tags": ["API", "エンドポイント", "REST", "バリデーション", "CORS", "理論価格", "築年数補正", "駅距離補正", "需要スコア", "乗降客数", "XKT015", "XKT013", "XCT001", "地価公示", "将来推計人口", "人口減少", "ストレステスト", "タイル座標", "lat", "lng"],
+      "description": "全エンドポイント（/api/land-prices/stats、/api/land-prices/compare、/api/land-prices/estimate、/api/investment/analyze、/api/municipalities、/api/station-ridership、/api/population-forecast、/api/land-appraisals、/health）の入出力・バリデーション範囲・エラー仕様。CORS設定とALLOW_ORIGINS環境変数。APP_INTERNAL_API_KEY設定時は/api/*にX-Internal-Keyヘッダーが必要（/healthはスキップ）。/api/land-appraisals は XCT001 地価公示データを取得し公示価格中央値・変動率・トレンドラベルを返す（AppraisalComparisonResult型）。/api/population-forecast は lat/lng/z パラメータで XKT013 将来推計人口を取得し、30年後変化率・空室率増加推定（×0.5係数）・4段階トレンドを返す。",
+      "tags": ["API", "エンドポイント", "REST", "バリデーション", "CORS", "理論価格", "築年数補正", "駅距離補正", "需要スコア", "乗降客数", "XKT015", "XKT013", "XCT001", "地価公示", "将来推計人口", "人口減少", "ストレステスト", "タイル座標", "lat", "lng", "認証", "X-Internal-Key", "APP_INTERNAL_API_KEY"],
       "industry": ["不動産", "フィンテック"],
-      "topics": ["GET /api/land-prices/stats", "GET /api/land-prices/compare", "GET /api/land-prices/estimate", "GET /api/station-ridership", "GET /api/population-forecast", "GET /api/land-appraisals", "POST /api/investment/analyze", "GET /api/municipalities", "GET /health", "AppraisalComparisonResult", "appraisalMedianPerSqm", "appraisalCount", "appraisalTrend", "trendLabel", "InvestmentInput", "InvestmentResult", "LandPriceStats", "TheoreticalPriceResult", "PopulationForecastResult", "changeRate30yr", "vacancyRateDelta", "RidershipDemandScore", "lat", "lng", "z", "division", "エラーレスポンス", "Gin"],
+      "topics": ["GET /api/land-prices/stats", "GET /api/land-prices/compare", "GET /api/land-prices/estimate", "GET /api/station-ridership", "GET /api/population-forecast", "GET /api/land-appraisals", "POST /api/investment/analyze", "GET /api/municipalities", "GET /health", "AppraisalComparisonResult", "appraisalMedianPerSqm", "appraisalCount", "appraisalTrend", "trendLabel", "InvestmentInput", "InvestmentResult", "LandPriceStats", "TheoreticalPriceResult", "PopulationForecastResult", "changeRate30yr", "vacancyRateDelta", "RidershipDemandScore", "lat", "lng", "z", "division", "エラーレスポンス", "Gin", "internalKeyMiddleware", "X-Internal-Key", "APP_INTERNAL_API_KEY"],
+      "updatedAt": "2026-04-19"
+    },
+    {
+      "id": "security",
+      "path": "docs/security.md",
+      "title": "セキュリティ設計",
+      "description": "Vercel-Render 間の内部通信認証（APP_INTERNAL_API_KEY / X-Internal-Key ヘッダー）の設計意図・動作仕様・適用範囲・ローカル開発での挙動・本番キー設定手順。internalKeyMiddleware が /api/* グループに適用され、/health はスキップ。APP_INTERNAL_API_KEY 未設定時はミドルウェアをスキップし後方互換を維持。",
+      "tags": ["セキュリティ", "認証", "ミドルウェア", "X-Internal-Key", "APP_INTERNAL_API_KEY", "Vercel", "Render", "内部通信"],
+      "industry": ["不動産", "フィンテック"],
+      "topics": ["internalKeyMiddleware", "X-Internal-Key", "APP_INTERNAL_API_KEY", "middleware.ts", "router.go", "401 Unauthorized", "/health", "本番環境", "ローカル開発"],
       "updatedAt": "2026-04-19"
     },
     {

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -132,6 +132,7 @@ go run cmd/server/main.go
 | `PORT` | リッスンポート | `8080` |
 | `ALLOW_ORIGINS` | CORS許可オリジン | `http://localhost:3000` |
 | `MLIT_API_KEY` | 不動産情報ライブラリ APIキー（必須） | — |
+| `APP_INTERNAL_API_KEY` | Vercel-Render 間の内部通信認証キー。設定時は `/api/*` に `X-Internal-Key` ヘッダーが必要 | 未設定（ローカル開発時はスキップ） |
 
 **フロントエンド**
 
@@ -140,6 +141,12 @@ cd frontend
 npm install
 npm run dev   # http://localhost:3000
 ```
+
+フロントエンド環境変数（`frontend/.env.local`）:
+
+| 変数名 | 説明 | デフォルト |
+|---|---|---|
+| `APP_INTERNAL_API_KEY` | バックエンドへの内部認証キー（バックエンドと同一値を設定） | 未設定（ローカル開発時はスキップ） |
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,49 @@
+# セキュリティ設計
+
+## 内部通信認証（APP_INTERNAL_API_KEY）
+
+### 背景
+
+Render バックエンドの URL を知っている者が Vercel を経由せずに `/api/*` を直接呼び出せる状態を防ぐため、Vercel-Render 間に共有シークレットによる内部認証を設けている。
+
+### 仕組み
+
+```
+ブラウザ → Vercel (Next.js) → Render (Go/Gin)
+                ↓ middleware.ts が付与
+          X-Internal-Key: <APP_INTERNAL_API_KEY>
+```
+
+1. Vercel の `frontend/src/middleware.ts` が `/api/:path*` へのリクエストに `X-Internal-Key` ヘッダーを自動付与する
+2. Render の `internalKeyMiddleware`（`backend/internal/api/router.go`）が `/api/*` グループでヘッダーを検証する
+3. キーが不一致または未送信の場合は `401 Unauthorized` を返す
+
+### 適用範囲
+
+| エンドポイント | 認証 |
+|---|---|
+| `/api/*` | `APP_INTERNAL_API_KEY` 設定時に必須 |
+| `/health` | スキップ（ヘルスチェックは認証不要） |
+
+### ローカル開発
+
+`APP_INTERNAL_API_KEY` を未設定（空）にするとミドルウェアは検証をスキップする。`docker-compose` / `make dev` での動作は変わらない。
+
+### 本番環境でのキー設定
+
+Vercel と Render の双方に **同一の値** を設定する。
+
+```bash
+# キー生成例
+openssl rand -hex 32
+```
+
+- Vercel: 環境変数 `APP_INTERNAL_API_KEY` に設定
+- Render: 環境変数 `APP_INTERNAL_API_KEY` に設定
+- Terraform (#113) で管理する場合は `app_internal_api_key` 変数として注入する
+
+### 関連ファイル
+
+- `backend/internal/api/router.go` — `internalKeyMiddleware()`
+- `frontend/src/middleware.ts` — ヘッダー付与
+- `backend/internal/api/handler_test.go` — ミドルウェアの単体テスト

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server'
+import type { NextRequest } from 'next/server'
+
+export function middleware(request: NextRequest) {
+  const requestHeaders = new Headers(request.headers)
+  requestHeaders.set('X-Internal-Key', process.env.APP_INTERNAL_API_KEY ?? '')
+  return NextResponse.next({ request: { headers: requestHeaders } })
+}
+
+export const config = { matcher: '/api/:path*' }

--- a/frontend/src/middleware.ts
+++ b/frontend/src/middleware.ts
@@ -2,8 +2,12 @@ import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
+  const internalKey = process.env.APP_INTERNAL_API_KEY
+  if (!internalKey) {
+    return NextResponse.next()
+  }
   const requestHeaders = new Headers(request.headers)
-  requestHeaders.set('X-Internal-Key', process.env.APP_INTERNAL_API_KEY ?? '')
+  requestHeaders.set('X-Internal-Key', internalKey)
   return NextResponse.next({ request: { headers: requestHeaders } })
 }
 


### PR DESCRIPTION
## 概要
Render バックエンドの `/api/*` エンドポイントへの直接アクセスを防ぐため、`X-Internal-Key` ヘッダーを検証するミドルウェアを実装。Vercel フロントエンド側では Next.js middleware で自動的にヘッダーを付与する。

## 変更内容
- `backend/internal/api/router.go`: `internalKeyMiddleware()` を追加し `/api/*` グループに適用（`/health` は対象外）
- `frontend/src/middleware.ts`: 新規作成。`/api/:path*` へのリクエストに `X-Internal-Key` を付与
- `backend/internal/api/handler_test.go`: ミドルウェアの単体テスト5ケースを追加（キー未設定・`/health`スキップ・未送信・誤キー・正しいキー）

## 関連Issue
Closes #115

## テスト
- [x] 既存テストが通ること
- [x] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み