### PR TITLE
feat(ci): フロントエンドのVercel本番デプロイをGitHub Actionsで管理

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -53,3 +53,26 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  deploy:
+    name: Deploy to Vercel
+    runs-on: ubuntu-24.04
+    needs: ci
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.22.2"
+
+      - name: Install Vercel CLI
+        run: npm install -g vercel@latest
+
+      - name: Deploy to Vercel
+        run: vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
+        working-directory: frontend
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -59,6 +59,8 @@ jobs:
     runs-on: ubuntu-24.04
     needs: ci
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -68,11 +70,12 @@ jobs:
           node-version: "22.22.2"
 
       - name: Install Vercel CLI
-        run: npm install -g vercel@latest
+        run: npm install -g vercel@51.8.0
 
       - name: Deploy to Vercel
-        run: vercel deploy --prod --yes --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel deploy --prod --yes
         working-directory: frontend
         env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/docs/metadata.json
+++ b/docs/metadata.json
@@ -6,10 +6,10 @@
       "id": "overview",
       "path": "docs/overview.md",
       "title": "プロジェクト概要とアーキテクチャ",
-      "description": "Yield-Guard の目的・解決する3大リスク（相場判定・デッドクロス・出口戦略）・技術スタック・ディレクトリ構成・起動手順・計算の制約と免責事項。バックエンド環境変数（PORT/ALLOW_ORIGINS/MLIT_API_KEY/APP_INTERNAL_API_KEY）・フロントエンド環境変数（APP_INTERNAL_API_KEY）の一覧を含む。PWA対応（@ducanh2912/next-pwa・manifest.ts）を含む。",
-      "tags": ["概要", "アーキテクチャ", "セットアップ", "不動産投資", "環境変数", "APP_INTERNAL_API_KEY", "PWA"],
+      "description": "Yield-Guard の目的・解決する3大リスク（相場判定・デッドクロス・出口戦略）・技術スタック・ディレクトリ構成・起動手順・計算の制約と免責事項。バックエンド環境変数（PORT/ALLOW_ORIGINS/MLIT_API_KEY/APP_INTERNAL_API_KEY）・フロントエンド環境変数（APP_INTERNAL_API_KEY）の一覧を含む。PWA対応（@ducanh2912/next-pwa・manifest.ts）を含む。フロントエンド（Vercel）・バックエンド（Cloud Run）のデプロイフローも記載。",
+      "tags": ["概要", "アーキテクチャ", "セットアップ", "不動産投資", "環境変数", "APP_INTERNAL_API_KEY", "PWA", "デプロイ", "Vercel", "Cloud Run"],
       "industry": ["不動産", "フィンテック"],
-      "topics": ["Go", "Gin", "Next.js", "Tailwind CSS", "Recharts", "Clean Architecture", "国交省API", "起動手順", "テスト", "APP_INTERNAL_API_KEY", "MLIT_API_KEY", "ALLOW_ORIGINS", "@ducanh2912/next-pwa", "manifest.ts", "PWA", "Service Worker"],
+      "topics": ["Go", "Gin", "Next.js", "Tailwind CSS", "Recharts", "Clean Architecture", "国交省API", "起動手順", "テスト", "APP_INTERNAL_API_KEY", "MLIT_API_KEY", "ALLOW_ORIGINS", "@ducanh2912/next-pwa", "manifest.ts", "PWA", "Service Worker", "Vercel", "vercel deploy", "VERCEL_TOKEN", "frontend-ci.yml", "deploy-backend.yml"],
       "updatedAt": "2026-04-21"
     },
     {
@@ -66,10 +66,10 @@
       "id": "security",
       "path": "docs/security.md",
       "title": "セキュリティ設計",
-      "description": "Vercel-Cloud Run 間の内部通信認証（APP_INTERNAL_API_KEY / X-Internal-Key ヘッダー）の設計意図・動作仕様・適用範囲・ローカル開発での挙動・本番キー設定手順。internalKeyMiddleware が /api/* グループに適用され、/health はスキップ。APP_INTERNAL_API_KEY 未設定時はミドルウェアをスキップし後方互換を維持。Workload Identity Federation（OIDC パスワードレスデプロイ）・SHA固定 GitHub Actions・Secret Manager・Artifact Registry クリーンアップポリシーを含む。",
-      "tags": ["セキュリティ", "認証", "ミドルウェア", "X-Internal-Key", "APP_INTERNAL_API_KEY", "Vercel", "Cloud Run", "内部通信", "WIF", "OIDC", "Secret Manager", "SHA固定"],
+      "description": "Vercel-Cloud Run 間の内部通信認証（APP_INTERNAL_API_KEY / X-Internal-Key ヘッダー）の設計意図・動作仕様・適用範囲・ローカル開発での挙動・本番キー設定手順。internalKeyMiddleware が /api/* グループに適用され、/health はスキップ。APP_INTERNAL_API_KEY 未設定時はミドルウェアをスキップし後方互換を維持。Workload Identity Federation（OIDC パスワードレスデプロイ）・SHA固定 GitHub Actions・Secret Manager・Artifact Registry クリーンアップポリシーを含む。フロントエンド GitHub Actions デプロイ（VERCEL_TOKEN env渡し・vercel CLI バージョン固定・最小権限）も記載。",
+      "tags": ["セキュリティ", "認証", "ミドルウェア", "X-Internal-Key", "APP_INTERNAL_API_KEY", "Vercel", "Cloud Run", "内部通信", "WIF", "OIDC", "Secret Manager", "SHA固定", "VERCEL_TOKEN", "GitHub Actions"],
       "industry": ["不動産", "フィンテック"],
-      "topics": ["internalKeyMiddleware", "X-Internal-Key", "APP_INTERNAL_API_KEY", "middleware.ts", "router.go", "401 Unauthorized", "/health", "本番環境", "ローカル開発", "Workload Identity Federation", "WIF_PROVIDER", "SA_EMAIL", "deploy-cloudrun", "SHA固定", "Secret Manager", "Artifact Registry", "クリーンアップポリシー"],
+      "topics": ["internalKeyMiddleware", "X-Internal-Key", "APP_INTERNAL_API_KEY", "middleware.ts", "router.go", "401 Unauthorized", "/health", "本番環境", "ローカル開発", "Workload Identity Federation", "WIF_PROVIDER", "SA_EMAIL", "deploy-cloudrun", "SHA固定", "Secret Manager", "Artifact Registry", "クリーンアップポリシー", "VERCEL_TOKEN", "VERCEL_ORG_ID", "VERCEL_PROJECT_ID", "frontend-ci.yml", "vercel deploy"],
       "updatedAt": "2026-04-21"
     },
     {

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -152,6 +152,41 @@ npm run dev   # http://localhost:3000
 
 ---
 
+## デプロイフロー
+
+### フロントエンド（Vercel）
+
+```
+main ブランチへの push
+    ↓
+[GitHub Actions: frontend-ci.yml]
+    ci ジョブ: Lint → 型チェック → テスト → ビルド（next build --webpack）
+    ↓ 成功時のみ
+    deploy ジョブ: vercel deploy --prod
+    ↓
+https://yield-guard-alpha.vercel.app
+```
+
+- CI が失敗した場合はデプロイしない（`needs: ci`）
+- PR 時はデプロイしない（main push 時のみ）
+- Vercel 環境変数: `BACKEND_URL`・`APP_INTERNAL_API_KEY`（Vercel ダッシュボードで設定済み）
+- GitHub Secrets: `VERCEL_TOKEN`・`VERCEL_ORG_ID`・`VERCEL_PROJECT_ID`
+
+### バックエンド（Cloud Run）
+
+```
+main ブランチへの push（backend/** 変更時）
+    ↓
+[GitHub Actions: deploy-backend.yml]
+    OIDC 認証（Workload Identity Federation）
+    ↓
+    Docker ビルド → Artifact Registry push → Cloud Run デプロイ
+```
+
+詳細は `docs/security.md` を参照。
+
+---
+
 ## 国交省API 開発用リクエスト（Makefile）
 
 `.env` の `MLIT_API_KEY` を使って国交省APIへ直接リクエストできる開発者向けターゲット。`jq` が必要。

--- a/docs/security.md
+++ b/docs/security.md
@@ -113,6 +113,28 @@ Artifact Registry の無料枠（0.5 GB/月）を超えないよう、最新 5 �
 
 ---
 
+## フロントエンド GitHub Actions デプロイ
+
+`.github/workflows/frontend-ci.yml` の `deploy` ジョブは以下のセキュリティ設計を採用している。
+
+| 項目 | 設計 |
+|---|---|
+| トークン渡し方 | `VERCEL_TOKEN` を `env:` 経由で渡す（`--token=` 引数は使用しない。プロセス一覧への露出を防ぐため） |
+| Vercel CLI バージョン | `vercel@51.8.0` に固定（`latest` 不使用） |
+| 実行条件 | `needs: ci` により CI 全通過後のみ実行 |
+| 実行タイミング | `github.ref == 'refs/heads/main' && github.event_name == 'push'` により main マージ時のみ |
+| 権限 | `permissions: contents: read`（最小権限） |
+
+### GitHub Secrets
+
+| Secret 名 | 用途 |
+|---|---|
+| `VERCEL_TOKEN` | Vercel API 認証トークン（Vercel ダッシュボードで発行） |
+| `VERCEL_ORG_ID` | Vercel 組織 ID（`.vercel/project.json` の `orgId`） |
+| `VERCEL_PROJECT_ID` | Vercel プロジェクト ID（`.vercel/project.json` の `projectId`） |
+
+---
+
 ## 関連ファイル
 
 - `backend/internal/api/router.go` — `internalKeyMiddleware()`
@@ -121,4 +143,5 @@ Artifact Registry の無料枠（0.5 GB/月）を超えないよう、最新 5 �
 - `terraform/iam.tf` — Workload Identity Federation + SA 最小権限
 - `terraform/secret_manager.tf` — Secret Manager リソース
 - `terraform/cloud_run.tf` — Cloud Run v2 サービス定義
-- `.github/workflows/deploy-backend.yml` — デプロイワークフロー（SHA 固定）
+- `.github/workflows/deploy-backend.yml` — バックエンドデプロイワークフロー（SHA 固定）
+- `.github/workflows/frontend-ci.yml` — フロントエンド CI + Vercel デプロイワークフロー


### PR DESCRIPTION
## 概要
フロントエンドの Vercel デプロイを GitHub Actions で明示的に管理する。これまでは Vercel の GitHub インテグレーション任せだったが、CI 通過後にのみデプロイされる仕組みに変更する。

## 変更内容
- `frontend-ci.yml` に `deploy` ジョブを追加
  - `needs: ci` により Lint・型チェック・テスト・ビルドがすべて成功した場合のみ実行
  - `github.ref == 'refs/heads/main' && github.event_name == 'push'` により main へのマージ時のみデプロイ（PR 時はスキップ）
  - `vercel deploy --prod --yes` で本番環境へデプロイ
  - `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` は GitHub Secrets から注入

## 関連Issue
なし（PWA対応 PR #122 で発覚したデプロイ管理の問題を解消）

## 事前準備
以下の GitHub Secrets を登録済み：
- `VERCEL_TOKEN`
- `VERCEL_ORG_ID`
- `VERCEL_PROJECT_ID`

## テスト
- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [ ] コードレビュー観点での自己レビュー済み