### PR TITLE
fix(chart): 散布図ツールチップの単位重複表示を修正

### DIFF
--- a/frontend/src/components/LandPriceAnalysis.tsx
+++ b/frontend/src/components/LandPriceAnalysis.tsx
@@ -295,6 +295,7 @@ export function LandPriceAnalysis({ comparison, input, theoreticalPrice, station
                 <YAxis
                   dataKey="tsubo"
                   name="坪単価"
+                  tickFormatter={(v) => `${v}万`}
                   tick={{ fontSize: 10 }}
                   width={50}
                 />

--- a/frontend/src/components/LandPriceAnalysis.tsx
+++ b/frontend/src/components/LandPriceAnalysis.tsx
@@ -289,14 +289,12 @@ export function LandPriceAnalysis({ comparison, input, theoreticalPrice, station
                 <XAxis
                   dataKey="area"
                   name="面積"
-                  unit="m²"
                   tick={{ fontSize: 10 }}
                   label={{ value: "面積(m²)", position: "insideBottom", offset: -4, fontSize: 10 }}
                 />
                 <YAxis
                   dataKey="tsubo"
                   name="坪単価"
-                  unit="万円"
                   tick={{ fontSize: 10 }}
                   width={50}
                 />


### PR DESCRIPTION
## 概要
Recharts の `ScatterChart` で `XAxis`/`YAxis` の `unit` プロパティと `Tooltip` の `formatter` が両方単位を付加するため、「135m²m²」「100万円/坪万円」のような二重表示が発生していた問題を修正。

## 変更内容
- `LandPriceAnalysis.tsx`: `XAxis` から `unit="m²"`、`YAxis` から `unit="万円"` を削除
  - Recharts は `unit` プロパティの値をツールチップに自動追記する仕様のため、`formatter` で単位を付加していると二重表示になる
  - `formatter` 側で単位を一元管理する形に統一
- `YAxis` に `tickFormatter` を追加し、軸目盛りに単位（万）を表示

## 関連Issue

## テスト
- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み