### PR TITLE
fix(backend): クエリパラメータのパース失敗時に HTTP 400 を返すよう修正

### DIFF
--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -72,7 +72,11 @@ func (h *Handler) CompareLandPrice(c *gin.Context) {
 
 	areaSqm := 0.0
 	if areaSqmStr != "" {
-		areaSqm, _ = strconv.ParseFloat(areaSqmStr, 64)
+		areaSqm, err = strconv.ParseFloat(areaSqmStr, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "area_sqm は数値で指定してください"})
+			return
+		}
 	}
 
 	transactions, err := h.mlitClient.FetchLandPrices(c.Request.Context(), q)
@@ -204,7 +208,11 @@ func (h *Handler) EstimateLandPrice(c *gin.Context) {
 
 	areaSqm := 0.0
 	if areaSqmStr != "" {
-		areaSqm, _ = strconv.ParseFloat(areaSqmStr, 64)
+		areaSqm, err = strconv.ParseFloat(areaSqmStr, 64)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "area_sqm は数値で指定してください"})
+			return
+		}
 	}
 	if areaSqm <= 0 {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "area_sqm は正の数値で指定してください"})
@@ -213,12 +221,20 @@ func (h *Handler) EstimateLandPrice(c *gin.Context) {
 
 	buildingAge := 0
 	if buildingAgeStr != "" {
-		buildingAge, _ = strconv.Atoi(buildingAgeStr)
+		buildingAge, err = strconv.Atoi(buildingAgeStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "building_age は整数で指定してください"})
+			return
+		}
 	}
 
 	stationMinutes := 0
 	if sm := c.Query("station_minutes"); sm != "" {
-		stationMinutes, _ = strconv.Atoi(sm)
+		stationMinutes, err = strconv.Atoi(sm)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "station_minutes は整数で指定してください"})
+			return
+		}
 	}
 
 	var ridershipScore domain.RidershipDemandScore


### PR DESCRIPTION
## 概要
`backend/internal/api/handler.go` 内で `strconv.ParseFloat` / `strconv.Atoi` のエラーを `_` で無視していた箇所を修正しました。無効な入力値（数値以外の文字列など）が渡された場合、暗黙的に `0.0` / `0` に変換されていたため、HTTP 400 Bad Request を返すように変更しました。

## 変更内容
- `CompareLandPrice`: `area_sqm` のパースエラーを HTTP 400 で返すよう修正
- `EstimateLandPrice`: `area_sqm` / `building_age` / `station_minutes` のパースエラーをそれぞれ HTTP 400 で返すよう修正

## 関連Issue
Closes #129

## テスト
- [x] 既存テストが通ること（`go test -race ./internal/api/...` PASS）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み