### PR TITLE
fix(frontend): ES2023 の findLast() をブラウザ互換の reverse().find() に置き換え

### DIFF
--- a/frontend/src/components/DeadCrossChart.tsx
+++ b/frontend/src/components/DeadCrossChart.tsx
@@ -28,7 +28,7 @@ export function DeadCrossChart({ result }: Props) {
 
   // デッドクロスゾーンの終了年（ローン完済またはデータ終端）
   const deadCrossEndYear = hasDeadCross
-    ? (yearlyResults.slice(0, 35).findLast((y) => y.isInDeadCrossZone)?.year ?? deadCrossYear)
+    ? ([...yearlyResults.slice(0, 35)].reverse().find((y) => y.isInDeadCrossZone)?.year ?? deadCrossYear)
     : null;
 
   return (


### PR DESCRIPTION
## 概要

`Array.prototype.findLast()` はES2023で導入されたメソッドであり、古いブラウザや一部の環境（Node.js 18未満など）では動作しない。`DeadCrossChart.tsx` 内の `findLast()` 呼び出しを、より広い環境で動作する `[...arr].reverse().find()` に置き換えた。

## 変更内容

- `frontend/src/components/DeadCrossChart.tsx`: `yearlyResults.slice(0, 35).findLast(...)` → `[...yearlyResults.slice(0, 35)].reverse().find(...)` に変更

## 関連Issue

Closes #134

## テスト

- [x] 既存テストが通ること（vitest 38/38 PASS）
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み