### PR TITLE
fix(domain): exit NOI に保有年数時点の賃料下落を反映する

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -83,7 +83,8 @@ func Analyze(input InvestmentInput) InvestmentResult {
 			}
 		}
 
-		yearAnnualRent := annualRent
+		declineFactor := math.Pow(1-input.RentDeclineRate, float64(y))
+		yearAnnualRent := annualRent * declineFactor
 		yearExpenses := yearAnnualRent*input.ExpenseRate + input.AnnualPropertyTax
 
 		// 減価償却は耐用年数内のみ

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -428,6 +428,71 @@ func TestCalcCriticalErrors_LandValueGuard(t *testing.T) {
 	}
 }
 
+// TestAnalyze_ExitNOI_UsesHoldingYearValues は出口NOIが保有年数時点の賃料下落を反映することを検証する
+func TestAnalyze_ExitNOI_UsesHoldingYearValues(t *testing.T) {
+	const (
+		monthlyRent     = 120_000.0
+		vacancyRate     = 0.05
+		expenseRate     = 0.20
+		rentDeclineRate = 0.01  // 年1%下落
+		holdingYears    = 10
+		exitYieldTarget = 0.06
+	)
+
+	input := InvestmentInput{
+		LandPrice:       5_000_000,
+		BuildingCost:    10_000_000,
+		MiscExpenseRate: 0.07,
+		MonthlyRent:     monthlyRent,
+		VacancyRate:     vacancyRate,
+		LoanAmount:      13_000_000,
+		AnnualLoanRate:  0.015,
+		LoanYears:       35,
+		BuildingType:    BuildingTypeRC,
+		ExpenseRate:     expenseRate,
+		IncomeTaxRate:   0.33,
+		HoldingYears:    holdingYears,
+		ExitYieldTarget: exitYieldTarget,
+		RentDeclineRate: rentDeclineRate,
+	}
+
+	result := Analyze(input)
+
+	// 保有10年目(インデックス9)の賃料下落係数: (1-0.01)^9 = 0.99^9
+	declineFactor := math.Pow(1-rentDeclineRate, float64(holdingYears-1))
+	baseAnnualRent := monthlyRent * 12 * (1 - vacancyRate)
+	expectedRent := baseAnnualRent * declineFactor
+	expectedNOI := expectedRent * (1 - expenseRate)
+	expectedSalePrice := expectedNOI / exitYieldTarget
+
+	if len(result.YearlyResults) < holdingYears {
+		t.Fatalf("YearlyResults too short: got %d, want >= %d", len(result.YearlyResults), holdingYears)
+	}
+
+	// 保有年次の賃料が下落を反映していること
+	yearRent := result.YearlyResults[holdingYears-1].AnnualRent
+	if !approxEqual(yearRent, expectedRent, 1.0) {
+		t.Errorf("YearlyResults[%d].AnnualRent = %.2f, want ≈ %.2f", holdingYears-1, yearRent, expectedRent)
+	}
+
+	// 売却価格が保有年次の下落後NOIから算出されること
+	if !approxEqual(result.ExitSalePrice, expectedSalePrice, 1000) {
+		t.Errorf("ExitSalePrice = %.0f, want ≈ %.0f (decline-adjusted NOI)", result.ExitSalePrice, expectedSalePrice)
+	}
+
+	// RentDeclineRate=0のケースより売却価格が低いことを確認
+	inputNoDecline := input
+	inputNoDecline.RentDeclineRate = 0
+	resultNoDecline := Analyze(inputNoDecline)
+	if result.ExitSalePrice >= resultNoDecline.ExitSalePrice {
+		t.Errorf("ExitSalePrice with decline (%.0f) should be < without decline (%.0f)",
+			result.ExitSalePrice, resultNoDecline.ExitSalePrice)
+	}
+
+	t.Logf("declineFactor=%.6f, expectedRent=%.0f, ExitSalePrice=%.0f (vs no-decline=%.0f)",
+		declineFactor, expectedRent, result.ExitSalePrice, resultNoDecline.ExitSalePrice)
+}
+
 func makeTx(cityPlanning string) LandTransaction {
 	return LandTransaction{
 		CityPlanning:     cityPlanning,

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -81,6 +81,9 @@ type InvestmentInput struct {
 
 	// 固定資産税・都市計画税（年間合計）。0 の場合は ExpenseRate に含まれる想定。
 	AnnualPropertyTax float64 `json:"annualPropertyTax"`
+
+	// 賃料下落率: 毎年この割合だけ実効賃料が低下する（例: 0.01 = 年1%下落）
+	RentDeclineRate float64 `json:"rentDeclineRate"`
 }
 
 // Defaults は構造的デフォルト（省略可能なフィールド）にのみ適用する。


### PR DESCRIPTION
## 概要

出口戦略の売却価格（NOI/目標利回り）を算出する際、従来は初年度の実効賃料をそのまま使用していたため、保有期間中の賃料下落が反映されていなかった。`RentDeclineRate` フィールドを追加し、各年の賃料に `(1 - rentDeclineRate)^y` を乗じることで、保有年数時点の正確な NOI から売却価格を算出するよう修正した。

## 変更内容

- `types.go`: `InvestmentInput` に `RentDeclineRate float64 \`json:"rentDeclineRate"\`` を追加
- `investment.go`: 年次ループ内で `declineFactor := math.Pow(1-input.RentDeclineRate, float64(y))` を計算し `yearAnnualRent` に乗算
- `investment_test.go`: `TestAnalyze_ExitNOI_UsesHoldingYearValues` を追加し、下落後 NOI から算出した期待売却価格と一致することを検証

## 関連Issue

Closes #133

## テスト

- [x] 既存テストが通ること
- [x] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み