### PR TITLE
fix(api): Analyze ハンドラーで input.Validate() を呼び出す

### DIFF
--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -144,6 +144,12 @@ func (h *Handler) Analyze(c *gin.Context) {
 		return
 	}
 
+	input.Defaults()
+	if err := input.Validate(); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
 	result := domain.Analyze(input)
 	telemetry.AnalyzeRequestsTotal.Add(c.Request.Context(), 1)
 	c.JSON(http.StatusOK, result)


### PR DESCRIPTION
## 概要
`Analyze` ハンドラーで `validateInvestmentInput`（範囲チェック）の後に `input.Defaults()` を呼び、続けて `input.Validate()` を呼び出すよう修正した。これにより `VacancyRate + VacancyRateDelta > 0.99` のような不正な組み合わせを HTTP 400 で早期拒否できる。

## 変更内容
- `backend/internal/api/handler.go`: `Analyze` ハンドラーに `input.Defaults()` と `input.Validate()` の呼び出しを追加

## 関連Issue
Closes #147

## テスト
- [x] 既存テストが通ること（`go test -race ./...` 全パッケージ PASS）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み