### PR TITLE
feat(frontend): 年間賃料下落率の入力欄追加と建物構造別デフォルト自動補完

### DIFF
--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -49,6 +49,15 @@ const BUILDING_TYPES: { value: BuildingType; label: string }[] = [
   { value: "SRC造", label: "SRC造（耐用47年）" },
 ];
 
+const RENT_DECLINE_DEFAULTS: Record<BuildingType, number> = {
+  "木造": 0.01,
+  "軽量鉄骨(3mm以下)": 0.008,
+  "軽量鉄骨(4mm以下)": 0.008,
+  "重量鉄骨": 0.008,
+  "RC造": 0.005,
+  "SRC造": 0.005,
+};
+
 interface Props {
   onAnalyze: (input: InvestmentInput) => Promise<void>;
   onFetchLandPrices: (area: string, city: string, lat?: number, lng?: number) => Promise<void>;
@@ -368,7 +377,11 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
               error={errors.monthlyRent} />
             {!isQuick && (
               <Select label="建物構造" value={input.buildingType}
-                onChange={(e) => setStr("buildingType", e.target.value as BuildingType)}
+                onChange={(e) => {
+                  const bt = e.target.value as BuildingType;
+                  setStr("buildingType", bt);
+                  setNum("rentDeclineRate", RENT_DECLINE_DEFAULTS[bt]);
+                }}
                 options={BUILDING_TYPES} />
             )}
           </div>
@@ -481,6 +494,14 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                       value={toPct(input.incomeTaxRate, 0)}
                       onChange={(e) => setNum("incomeTaxRate", fromPct(e.target.value))}
                       error={errors.incomeTaxRate} />
+                    <div>
+                      <Input label="年間賃料下落率" type="number" suffix="%" step="0.1"
+                        value={toPct(input.rentDeclineRate, 1)}
+                        onChange={(e) => setNum("rentDeclineRate", fromPct(e.target.value))} />
+                      <p className="text-xs text-muted-foreground mt-1">
+                        建物構造から自動設定。経年による賃料低下を考慮する場合に使用（例: 木造1%/年）
+                      </p>
+                    </div>
                   </div>
                   <p className="text-xs text-muted-foreground">
                     ※運営経費率はローン利息を含みません（管理費・修繕費・固定資産税・保険等）

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -66,6 +66,7 @@ export interface InvestmentInput {
   vacancyRateDelta: number;
   loanRateDelta: number;
   annualPropertyTax: number;  // 固定資産税・都市計画税（年間）。0 = ExpenseRateに含む。
+  rentDeclineRate: number;    // 年間賃料下落率（例: 0.01 = 1%/年）
 }
 
 export interface YearlyResult {
@@ -206,6 +207,7 @@ export const DEFAULT_INPUT: InvestmentInput = {
   vacancyRateDelta: 0,
   loanRateDelta: 0,
   annualPropertyTax: 0,
+  rentDeclineRate: 0,
 };
 
 export const BUILDING_USEFUL_LIFE: Record<BuildingType, number> = {


### PR DESCRIPTION
## 概要

年間賃料下落率（`rentDeclineRate`）のフォーム入力欄が存在せず、常に0で送信されていた問題（#148）を修正。あわせて建物構造選択時に構造別の推奨デフォルト値を自動補完する機能（#149）を追加した。

## 変更内容

- `frontend/src/types/investment.ts`
  - `InvestmentInput` インターフェースに `rentDeclineRate: number` フィールドを追加
  - `DEFAULT_INPUT` に `rentDeclineRate: 0` を追加

- `frontend/src/components/InvestmentForm.tsx`
  - `RENT_DECLINE_DEFAULTS` マップを追加（木造1%・軽量鉄骨0.8%・重量鉄骨0.8%・RC/SRC 0.5%）
  - 建物構造ドロップダウンの `onChange` を拡張し、構造変更時に `rentDeclineRate` を自動セット
  - 詳細設定セクションに「年間賃料下落率」入力欄とヒントテキストを追加

## 関連Issue

Closes #148, Closes #149

## テスト

- [x] 既存テストが通ること（63 tests passed）
- [x] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み