### PR TITLE
docs: rentDeclineRateフィールドをAPIリファレンスとドメイン計算ドキュメントに追記

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -337,7 +337,8 @@ DeviationPct         = (price - TheoreticalPrice) / TheoreticalPrice × 100
   "holdingYears": 10,
   "exitYieldTarget": 0.06,
   "vacancyRateDelta": 0,
-  "loanRateDelta": 0
+  "loanRateDelta": 0,
+  "rentDeclineRate": 0.01
 }
 ```
 
@@ -346,7 +347,8 @@ DeviationPct         = (price - TheoreticalPrice) / TheoreticalPrice × 100
 | フィールド | 制約 |
 |-----------|------|
 | `landPrice` | 1〜100億円 |
-| `buildingCost` | 1〜100億円 |
+| `buildingCost` | 1〜100億円（新築は建設費、中古は建物に帰属する取得費） |
+| `rentDeclineRate` | 0.0〜0.2（年間賃料下落率。省略時は 0 = 下落なし） |
 | `monthlyRent` | 正の値 |
 | `vacancyRate` | 0.0〜0.99 |
 | `loanAmount` | 0以上 |

--- a/docs/domain-investment-calculation.md
+++ b/docs/domain-investment-calculation.md
@@ -162,11 +162,33 @@ years := max(LoanYears, HoldingYears, 35)
 
 ---
 
+## 年次賃料下落（`RentDeclineRate`）
+
+毎年の実効賃料に下落係数を乗じることで経年劣化による賃料低下を表現する。
+
+```
+yearAnnualRent = baseAnnualRent × (1 - RentDeclineRate)^y
+  baseAnnualRent : MonthlyRent × 12 × (1 - effectiveVacancy)
+  y              : 経過年数（0始まり。1年目は y=0 で係数 1.0）
+```
+
+`RentDeclineRate = 0`（デフォルト）の場合は毎年同一賃料。
+
+**構造別推奨値（経験則）**
+
+| 建物構造 | 推奨下落率 |
+|---------|-----------|
+| 木造 | 1.0%/年 |
+| 軽量鉄骨・重量鉄骨 | 0.8%/年 |
+| RC造・SRC造 | 0.5%/年 |
+
+---
+
 ## 各年次ループの計算順序
 
 ```
 ① ローン返済内訳（利息・元金）の計算
-② 実効賃料収入・運営経費の計算
+② 実効賃料収入・運営経費の計算（RentDeclineRate を適用）
 ③ 当年の減価償却費（耐用年数内のみ）
 ④ 課税所得 = 収入 - 利息 - 減価償却 - 経費
 ⑤ 所得税 = 課税所得 × IncomeTaxRate（課税所得 ≤ 0 なら 0）


### PR DESCRIPTION
## 概要
賃料下落率フィールド `rentDeclineRate` のドキュメントが未記載だったため追記する（Issue #151 関連）。

## 変更内容
- `docs/api-reference.md`: リクエストサンプルに `rentDeclineRate: 0.01` を追加、バリデーション制約表に説明行を追加
- `docs/domain-investment-calculation.md`: 年次賃料下落の計算式・推奨値表・ループ順序への言及を追加

## 関連Issue
<!-- Closes #151 -->

## テスト
- [ ] 既存テストが通ること

## 確認事項
- [ ] コードレビュー観点での自己レビュー済み