### PR TITLE
feat(frontend): クイック/詳細モードのUXを抜本的に再設計する

### DIFF
--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -95,17 +95,33 @@ const equityInvested = result.totalInvestment - input.loanAmount
 
 `propertyLat`, `propertyLng`（コンポーネント内ローカル状態、`InvestmentInput` には含まれない）。都道府県・市区町村セレクトの下に2カラムグリッドで配置。「相場データを取得」押下時に有効な数値が入力されていれば `Dashboard.handleFetchLandPrices` に渡され、`GET /api/station-ridership?lat=&lng=` の呼び出しに使用される。未入力または不正値（`parseFloat` → `NaN`）の場合は undefined として渡され、駅別乗降客数の取得はスキップされる。
 
-**詳細設定トグル（showAdvanced）**:
-`expenseRate`, `incomeTaxRate`, `buildingAge`, `buildingType`, `exitYieldTarget` は
-詳細設定パネルに格納されており、デフォルトでは非表示。
+**クイック / 詳細モード（`simulationMode`）**:
+
+`SimulationMode = "quick" | "full"` で切り替える2モード設計。モード切替ボタンにサブタイトル（「内覧でサッと試す」／「じっくり分析する」）を表示。
+
+| | クイックモード | 詳細モード |
+|---|---|---|
+| 入力項目 | 3項目（物件価格総額・月額賃料・ローン金額） | 全フィールド（16項目+） |
+| 土地相場データ | 折りたたみ（初期非表示・任意） | 常時展開 |
+| フォーム構造 | フラット | 4セクション（物件情報/収益条件/ローン条件/出口戦略） |
+| ストレステスト | 非表示 | 常時表示 |
+| デフォルト値バナー | 表示（空室率5%・経費率20%等を明示） | なし |
+
+クイックモード送信時は「物件価格総額」（`quickTotalPriceMan`）を `landPrice = total × 0.7`・`buildingCost = total × 0.3` に自動分割し、`QUICK_MODE_DEFAULTS` とマージして API へ送信する。
+
+旧来の「詳細設定トグル（`showAdvanced`）」は廃止済み。`expenseRate`・`incomeTaxRate`・`buildingAge`・`buildingType`・`exitYieldTarget`・`rentDeclineRate` は詳細モードの各セクションにフラット配置。
 
 **レスポンシブグリッド**:
 
 すべての入力グリッドは `grid-cols-1 sm:grid-cols-2`（または `sm:grid-cols-3`）で実装されており、モバイル（`sm` ブレークポイント未満）では縦1列に、タブレット以上では2〜3列に切り替わる。
 
-**クライアントサイドバリデーション（`validate`）**:
-「シミュレーション実行」押下時に `validate()` を実行し、エラーがあれば API を呼ばずフィールド直下にエラーメッセージを表示する。
-検証ルールはバックエンドの `validateInvestmentInput()` と同一。フィールドの値を変更するとそのフィールドのエラーをクリアする。
+**クライアントサイドバリデーション**:
+「シミュレーション実行」押下時に `validateQuick` または `validateFull` を実行し、エラーがあれば API を呼ばずフィールド直下にエラーメッセージを表示する。フィールドの値を変更するとそのフィールドのエラーをクリアする。
+
+| モード | バリデーション対象 |
+|---|---|
+| クイック | 物件価格総額・月額賃料・ローン金額（3項目） |
+| 詳細 | 全フィールド（バックエンドの `validateInvestmentInput()` と同一） |
 
 | フィールド | 条件 |
 |-----------|------|

--- a/docs/metadata.json
+++ b/docs/metadata.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "lastUpdated": "2026-04-19T22:05:00",
+  "lastUpdated": "2026-04-22T02:15:00",
   "documents": [
     {
       "id": "overview",
@@ -96,11 +96,11 @@
       "id": "frontend-components",
       "path": "docs/frontend-components.md",
       "title": "フロントエンドコンポーネント仕様",
-      "description": "Dashboard・InvestmentForm・YieldAnalysis・CostBreakdown・CashFlowChart・DeadCrossChart・LandPriceAnalysis の責務・props・表示ロジック。LandPriceAnalysis に地価公示2軸比較セクション追加（XCT001）: 公示価格中央値・取引価格中央値・取引/公示比率・前年比トレンドバッジ（上昇/安定/下落）。Dashboard に landAppraisal・externalUrbanRisks ステートを追加。YieldAnalysisに人口減少シナリオ（4シナリオ目）追加。Dashboard の populationForecast・stationRidership・externalUrbanRisks を Promise.allSettled で並行呼び出し。LandPriceAnalysis で stats.urbanRisks（XIT001）と externalUrbanRisks（XKT003/020/030/XST001）を allUrbanRisks にマージして表示。InvestmentForm のグリッドは grid-cols-1 sm:grid-cols-2/3 でモバイルレスポンシブ対応。",
-      "tags": ["フロントエンド", "コンポーネント", "React", "Recharts", "グラフ", "空室率", "シナリオ", "人口減少", "ストレステスト", "XKT013", "XCT001", "XKT003", "XKT020", "XKT030", "XST001", "地価公示", "2軸比較", "将来推計人口", "諸経費", "コスト内訳", "用途地域", "都市計画リスク", "立地適正化計画", "大規模盛土", "都市計画道路", "災害履歴", "理論価格", "乖離率", "駅距離", "需要スコア", "乗降客数", "レスポンシブ", "モバイル対応"],
+      "description": "Dashboard・InvestmentForm・YieldAnalysis・CostBreakdown・CashFlowChart・DeadCrossChart・LandPriceAnalysis の責務・props・表示ロジック。LandPriceAnalysis に地価公示2軸比較セクション追加（XCT001）: 公示価格中央値・取引価格中央値・取引/公示比率・前年比トレンドバッジ（上昇/安定/下落）。Dashboard に landAppraisal・externalUrbanRisks ステートを追加。YieldAnalysisに人口減少シナリオ（4シナリオ目）追加。Dashboard の populationForecast・stationRidership・externalUrbanRisks を Promise.allSettled で並行呼び出し。InvestmentForm はクイック（3項目入力・土地相場データ折りたたみ・総額70:30自動按分）と詳細（4セクションフラット: 物件情報/収益条件/ローン条件/出口戦略）の2モード。旧showAdvancedトグルは廃止。validateQuick（3項目）とvalidateFull（全フィールド）をモード別に呼び分け。QUICK_MODE_DEFAULTSにrentDeclineRate追加。",
+      "tags": ["フロントエンド", "コンポーネント", "React", "Recharts", "グラフ", "空室率", "シナリオ", "人口減少", "ストレステスト", "XKT013", "XCT001", "XKT003", "XKT020", "XKT030", "XST001", "地価公示", "2軸比較", "将来推計人口", "諸経費", "コスト内訳", "用途地域", "都市計画リスク", "立地適正化計画", "大規模盛土", "都市計画道路", "災害履歴", "理論価格", "乖離率", "駅距離", "需要スコア", "乗降客数", "レスポンシブ", "モバイル対応", "クイックモード", "詳細モード", "UX"],
       "industry": ["不動産", "フィンテック"],
-      "topics": ["Dashboard", "InvestmentForm", "YieldAnalysis", "CostBreakdown", "CashFlowChart", "DeadCrossChart", "LandPriceAnalysis", "Next.js", "Shadcn/UI", "TypeScript", "landAppraisal", "externalUrbanRisks", "allUrbanRisks", "fetchUrbanRisks", "UrbanRisk", "OUTSIDE_RESIDENTIAL_GUIDANCE", "LARGE_EMBANKMENT", "URBAN_PLANNING_ROAD", "DISASTER_HISTORY", "AppraisalComparisonResult", "fetchLandAppraisals", "appraisalMedianPerSqm", "appraisalTrend", "trendLabel", "取引/公示比率", "populationForecast", "fetchPopulationForecast", "Promise.allSettled", "stationRidership", "POPULATION_TREND_STYLE", "RISK_STYLE", "StationRidershipResult", "RidershipDemandScore", "RIDERSHIP_SCORE_LABEL", "TheoreticalPriceResult", "handleFetchLandPrices", "grid-cols-1", "sm:grid-cols-2", "sm:grid-cols-3", "レスポンシブグリッド"],
-      "updatedAt": "2026-04-21"
+      "topics": ["Dashboard", "InvestmentForm", "YieldAnalysis", "CostBreakdown", "CashFlowChart", "DeadCrossChart", "LandPriceAnalysis", "Next.js", "Shadcn/UI", "TypeScript", "landAppraisal", "externalUrbanRisks", "allUrbanRisks", "fetchUrbanRisks", "UrbanRisk", "OUTSIDE_RESIDENTIAL_GUIDANCE", "LARGE_EMBANKMENT", "URBAN_PLANNING_ROAD", "DISASTER_HISTORY", "AppraisalComparisonResult", "fetchLandAppraisals", "appraisalMedianPerSqm", "appraisalTrend", "trendLabel", "取引/公示比率", "populationForecast", "fetchPopulationForecast", "Promise.allSettled", "stationRidership", "POPULATION_TREND_STYLE", "RISK_STYLE", "StationRidershipResult", "RidershipDemandScore", "RIDERSHIP_SCORE_LABEL", "TheoreticalPriceResult", "handleFetchLandPrices", "grid-cols-1", "sm:grid-cols-2", "sm:grid-cols-3", "レスポンシブグリッド", "SimulationMode", "quickTotalPriceMan", "showLandSection", "validateQuick", "validateFull", "QUICK_MODE_DEFAULTS", "物件情報", "収益条件", "ローン条件", "出口戦略", "showAdvanced"],
+      "updatedAt": "2026-04-22"
     }
   ]
 }

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -9,10 +9,9 @@ import type { InvestmentInput, BuildingType, SimulationMode } from "@/types/inve
 import { DEFAULT_INPUT, QUICK_MODE_DEFAULTS } from "@/types/investment";
 import { formatPct } from "@/lib/utils";
 import { fetchMunicipalities, type Municipality } from "@/lib/api";
-import { Search, Calculator, Info, AlertTriangle, ShieldCheck, Zap, SlidersHorizontal } from "lucide-react";
+import { Search, Calculator, Info, AlertTriangle, ShieldCheck, Zap, SlidersHorizontal, ChevronDown, ChevronUp } from "lucide-react";
 import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
 
-// 全47都道府県（法的に変容しない静的データ）
 const PREFECTURES = [
   { value: "01", label: "北海道" }, { value: "02", label: "青森県" },
   { value: "03", label: "岩手県" }, { value: "04", label: "宮城県" },
@@ -66,13 +65,12 @@ interface Props {
   onModeChange: (mode: SimulationMode) => void;
 }
 
-/** 現在の直近2年分の期間ラベルを生成 */
 function getPeriodLabel(): string {
   const year = new Date().getFullYear();
   return `${year - 2}〜${year - 1}年`;
 }
 
-type FormErrors = Partial<Record<keyof InvestmentInput, string>>;
+type FormErrors = Partial<Record<keyof InvestmentInput | "quickTotalPrice", string>>;
 
 function validateFull(input: InvestmentInput): FormErrors {
   const e: FormErrors = {};
@@ -103,20 +101,15 @@ function validateFull(input: InvestmentInput): FormErrors {
   return e;
 }
 
-function validateQuick(input: InvestmentInput): FormErrors {
+function validateQuick(quickTotalPriceMan: string, input: InvestmentInput): FormErrors {
   const e: FormErrors = {};
-  if (input.landPrice <= 0 || input.landPrice > 10_000_000_000)
-    e.landPrice = "1〜100億円の範囲で入力してください";
-  if (input.buildingCost <= 0 || input.buildingCost > 10_000_000_000)
-    e.buildingCost = "1〜100億円の範囲で入力してください";
+  const total = parseFloat(quickTotalPriceMan) || 0;
+  if (total <= 0 || total * 10_000 > 10_000_000_000)
+    e.quickTotalPrice = "1〜100億円の範囲で入力してください";
   if (input.monthlyRent <= 0)
     e.monthlyRent = "正の値を入力してください";
   if (input.loanAmount < 0)
     e.loanAmount = "0以上の値を入力してください";
-  if (input.loanYears < 0 || input.loanYears > 50)
-    e.loanYears = "0〜50年の範囲で入力してください";
-  if (input.holdingYears < 0 || input.holdingYears > 50)
-    e.holdingYears = "0〜50年の範囲で入力してください";
   return e;
 }
 
@@ -129,9 +122,13 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   const [municipalities, setMunicipalities] = useState<Municipality[]>([]);
   const [muniLoading, setMuniLoading] = useState(false);
   const [muniFilter, setMuniFilter] = useState("");
-  const [showAdvanced, setShowAdvanced] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
   const [zoningType, setZoningType] = useState<ZoningType>("");
+
+  // クイックモード専用: 物件価格（総額）
+  const [quickTotalPriceMan, setQuickTotalPriceMan] = useState("");
+  // クイックモード: 相場データ取得セクションの開閉
+  const [showLandSection, setShowLandSection] = useState(false);
 
   // 按分ヘルパーの状態
   const [showBuildingHelper, setShowBuildingHelper] = useState(false);
@@ -140,7 +137,6 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   const [buildingAssess, setBuildingAssess] = useState("");
   const [totalPrice, setTotalPrice] = useState("");
 
-  // 按分計算ユーティリティ
   const calcFromTax = (taxMan: number) => taxMan / 0.1;
   const calcFromAssessment = (totalMan: number, landA: number, buildingA: number) =>
     landA + buildingA > 0 ? totalMan * (buildingA / (landA + buildingA)) : 0;
@@ -169,12 +165,10 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
     }
   }, []);
 
-  // 初回マウント時に初期都道府県の市区町村を取得
   useEffect(() => {
     loadMunicipalities("10");
   }, [loadMunicipalities]);
 
-  // フィルタ結果が1件になったら自動選択
   useEffect(() => {
     if (filteredMunicipalities.length === 1) {
       setCity(filteredMunicipalities[0].id);
@@ -187,7 +181,6 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
     loadMunicipalities(code);
   };
 
-  // 制御コンポーネント用ヘルパー
   const setNum = (key: keyof InvestmentInput, value: number) => {
     setInput((prev) => ({ ...prev, [key]: value }));
     setErrors((prev) => {
@@ -206,13 +199,24 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   const fromPct = (s: string) => (parseFloat(s) || 0) / 100;
 
   const handleAnalyze = () => {
-    const errs = isQuick ? validateQuick(input) : validateFull(input);
-    setErrors(errs);
-    if (Object.keys(errs).length > 0) return;
-    const payload: InvestmentInput = isQuick
-      ? { ...input, ...QUICK_MODE_DEFAULTS } as InvestmentInput
-      : input;
-    onAnalyze(payload);
+    if (isQuick) {
+      const errs = validateQuick(quickTotalPriceMan, input);
+      setErrors(errs);
+      if (Object.keys(errs).length > 0) return;
+      const total = (parseFloat(quickTotalPriceMan) || 0) * 10_000;
+      const payload: InvestmentInput = {
+        ...input,
+        ...QUICK_MODE_DEFAULTS,
+        landPrice: total * 0.7,
+        buildingCost: total * 0.3,
+      };
+      onAnalyze(payload);
+    } else {
+      const errs = validateFull(input);
+      setErrors(errs);
+      if (Object.keys(errs).length > 0) return;
+      onAnalyze(input);
+    }
   };
 
   return (
@@ -224,428 +228,484 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
           role="radio"
           aria-checked={simulationMode === "quick"}
           onClick={() => onModeChange("quick")}
-          className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+          className={`flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
             simulationMode === "quick"
               ? "bg-primary text-white shadow-sm"
               : "text-muted-foreground hover:text-foreground"
           }`}
         >
-          <Zap className="h-3.5 w-3.5" />
-          クイック
+          <span className="flex items-center gap-1.5">
+            <Zap className="h-3.5 w-3.5" />
+            クイック
+          </span>
+          <span className="text-xs font-normal opacity-75">内覧でサッと試す</span>
         </button>
         <button
           type="button"
           role="radio"
           aria-checked={simulationMode === "full"}
           onClick={() => onModeChange("full")}
-          className={`flex flex-1 items-center justify-center gap-1.5 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
+          className={`flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
             simulationMode === "full"
               ? "bg-primary text-white shadow-sm"
               : "text-muted-foreground hover:text-foreground"
           }`}
         >
-          <SlidersHorizontal className="h-3.5 w-3.5" />
-          詳細
+          <span className="flex items-center gap-1.5">
+            <SlidersHorizontal className="h-3.5 w-3.5" />
+            詳細
+          </span>
+          <span className="text-xs font-normal opacity-75">じっくり分析する</span>
         </button>
       </div>
 
+      {/* ─── クイックモード ─── */}
       {isQuick && (
-        <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800">
-          <span className="font-semibold">クイックモード:</span>{" "}
-          6項目のみ入力してください。空室率5%・運営経費率20%・建物構造:木造・年利1.5% をデフォルトとして計算します。
-        </div>
+        <>
+          {/* 土地相場データ取得（折りたたみ） */}
+          <div className="rounded-lg border">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground"
+              onClick={() => setShowLandSection((p) => !p)}
+            >
+              <span className="flex items-center gap-2">
+                <Search className="h-4 w-4" />
+                土地相場データを取得（任意）
+              </span>
+              {showLandSection
+                ? <ChevronUp className="h-4 w-4" />
+                : <ChevronDown className="h-4 w-4" />
+              }
+            </button>
+            {showLandSection && (
+              <div className="border-t px-4 pb-4 pt-3 space-y-3">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <Select label="都道府県" value={area} onChange={handleAreaChange} options={PREFECTURES} />
+                  <div className="flex flex-col gap-1">
+                    <label className="text-sm font-medium text-foreground">市区町村</label>
+                    <input
+                      type="text"
+                      placeholder="例: 前橋市"
+                      value={muniFilter}
+                      onChange={(e) => setMuniFilter(e.target.value)}
+                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                    />
+                    <select
+                      value={city}
+                      onChange={(e) => setCity(e.target.value)}
+                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    >
+                      <option value="">（全市区町村）</option>
+                      {muniLoading
+                        ? <option disabled>読み込み中...</option>
+                        : filteredMunicipalities.map((m) => <option key={m.id} value={m.id}>{m.name}</option>)
+                      }
+                    </select>
+                  </div>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します
+                </p>
+                <Button variant="outline" className="w-full" loading={loading}
+                  onClick={() => {
+                    const lat = parseFloat(propertyLat);
+                    const lng = parseFloat(propertyLng);
+                    const hasCoords = !isNaN(lat) && !isNaN(lng);
+                    onFetchLandPrices(area, city, hasCoords ? lat : undefined, hasCoords ? lng : undefined);
+                  }}>
+                  <Search className="h-4 w-4" />相場データを取得
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {/* 3項目フォーム */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Calculator className="h-5 w-5 text-primary" />
+                物件・投資条件
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="space-y-3">
+                <div>
+                  <Input
+                    label="物件価格（土地＋建物の総額）"
+                    type="number"
+                    suffix="万円"
+                    value={quickTotalPriceMan}
+                    onChange={(e) => {
+                      setQuickTotalPriceMan(e.target.value);
+                      setErrors((prev) => { const n = { ...prev }; delete n.quickTotalPrice; return n; });
+                    }}
+                    error={errors.quickTotalPrice}
+                  />
+                  <p className="text-xs text-muted-foreground mt-1">内部で土地70%・建物30%に按分して計算します</p>
+                </div>
+                <Input label="想定月額賃料" type="number" suffix="円"
+                  value={String(input.monthlyRent)}
+                  onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
+                  error={errors.monthlyRent} />
+                <Input label="ローン金額" type="number" suffix="万円"
+                  value={toMan(input.loanAmount)}
+                  onChange={(e) => setNum("loanAmount", fromMan(e.target.value))}
+                  error={errors.loanAmount} />
+              </div>
+
+              <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 space-y-0.5">
+                <p className="font-semibold">自動設定されるデフォルト値</p>
+                <p>空室率 5%・運営経費率 20%・建物構造: 木造・年利 1.5%・返済期間 35年・10年後売却・所得税率 33%</p>
+              </div>
+
+              <Button className="w-full" size="lg" loading={loading} onClick={handleAnalyze}>
+                <Calculator className="h-5 w-5" />
+                シミュレーション実行
+              </Button>
+
+              <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-xs text-yellow-800 space-y-1">
+                <p className="flex items-center gap-1 font-semibold">
+                  <Info className="h-3 w-3" />免責事項
+                </p>
+                <ul className="list-disc list-inside space-y-0.5">
+                  <li>計算結果は参考値であり、税務上の助言ではありません</li>
+                  <li>消費税・損益通算・各種特例（3000万控除等）は考慮していません</li>
+                  <li>実際の投資判断は税理士・不動産の専門家にご相談ください</li>
+                </ul>
+              </div>
+            </CardContent>
+          </Card>
+        </>
       )}
 
-      {/* 相場データ取得 */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Search className="h-5 w-5 text-primary" />
-            土地相場データ取得
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <Select
-              label="都道府県"
-              value={area}
-              onChange={handleAreaChange}
-              options={PREFECTURES}
-            />
-            <div className="flex flex-col gap-1">
-              <label className="text-sm font-medium text-foreground">市区町村</label>
-              <input
-                type="text"
-                placeholder="例: 前橋市"
-                value={muniFilter}
-                onChange={(e) => setMuniFilter(e.target.value)}
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                aria-label="市区町村を検索"
-              />
-              <select
-                value={city}
-                onChange={(e) => setCity(e.target.value)}
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <option value="">（全市区町村）</option>
-                {muniLoading
-                  ? <option disabled>読み込み中...</option>
-                  : filteredMunicipalities.length === 0 && muniFilter.trim()
-                  ? <option disabled>該当なし</option>
-                  : filteredMunicipalities.map((m) => (
-                      <option key={m.id} value={m.id}>{m.name}</option>
-                    ))
-                }
-              </select>
-              {muniFilter.trim() && filteredMunicipalities.length > 0 && (
-                <p className="text-xs text-muted-foreground">{filteredMunicipalities.length}件該当</p>
-              )}
-            </div>
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div className="flex flex-col gap-1">
-              <label className="text-sm font-medium text-foreground">緯度（任意）</label>
-              <input
-                type="number"
-                placeholder="例: 35.6762"
-                step="0.0001"
-                value={propertyLat}
-                onChange={(e) => setPropertyLat(e.target.value)}
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                aria-label="物件の緯度"
-              />
-            </div>
-            <div className="flex flex-col gap-1">
-              <label className="text-sm font-medium text-foreground">経度（任意）</label>
-              <input
-                type="number"
-                placeholder="例: 139.6503"
-                step="0.0001"
-                value={propertyLng}
-                onChange={(e) => setPropertyLng(e.target.value)}
-                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                aria-label="物件の経度"
-              />
-            </div>
-          </div>
-          <p className="text-xs text-muted-foreground">
-            {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します。緯度・経度を入力すると周辺駅の需要スコアも取得します
-          </p>
-          <Button variant="outline" className="w-full" loading={loading}
-            onClick={() => {
-              const lat = parseFloat(propertyLat);
-              const lng = parseFloat(propertyLng);
-              const hasCoords = !isNaN(lat) && !isNaN(lng);
-              onFetchLandPrices(area, city, hasCoords ? lat : undefined, hasCoords ? lng : undefined);
-            }}>
-            <Search className="h-4 w-4" />相場データを取得
-          </Button>
-        </CardContent>
-      </Card>
+      {/* ─── 詳細モード ─── */}
+      {!isQuick && (
+        <>
+          {/* 相場データ取得（常時表示） */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Search className="h-5 w-5 text-primary" />
+                土地相場データ取得
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <Select label="都道府県" value={area} onChange={handleAreaChange} options={PREFECTURES} />
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm font-medium text-foreground">市区町村</label>
+                  <input
+                    type="text"
+                    placeholder="例: 前橋市"
+                    value={muniFilter}
+                    onChange={(e) => setMuniFilter(e.target.value)}
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                    aria-label="市区町村を検索"
+                  />
+                  <select
+                    value={city}
+                    onChange={(e) => setCity(e.target.value)}
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  >
+                    <option value="">（全市区町村）</option>
+                    {muniLoading
+                      ? <option disabled>読み込み中...</option>
+                      : filteredMunicipalities.length === 0 && muniFilter.trim()
+                      ? <option disabled>該当なし</option>
+                      : filteredMunicipalities.map((m) => (
+                          <option key={m.id} value={m.id}>{m.name}</option>
+                        ))
+                    }
+                  </select>
+                  {muniFilter.trim() && filteredMunicipalities.length > 0 && (
+                    <p className="text-xs text-muted-foreground">{filteredMunicipalities.length}件該当</p>
+                  )}
+                </div>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm font-medium text-foreground">緯度（任意）</label>
+                  <input
+                    type="number"
+                    placeholder="例: 35.6762"
+                    step="0.0001"
+                    value={propertyLat}
+                    onChange={(e) => setPropertyLat(e.target.value)}
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                    aria-label="物件の緯度"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm font-medium text-foreground">経度（任意）</label>
+                  <input
+                    type="number"
+                    placeholder="例: 139.6503"
+                    step="0.0001"
+                    value={propertyLng}
+                    onChange={(e) => setPropertyLng(e.target.value)}
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                    aria-label="物件の経度"
+                  />
+                </div>
+              </div>
+              <p className="text-xs text-muted-foreground">
+                {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します。緯度・経度を入力すると周辺駅の需要スコアも取得します
+              </p>
+              <Button variant="outline" className="w-full" loading={loading}
+                onClick={() => {
+                  const lat = parseFloat(propertyLat);
+                  const lng = parseFloat(propertyLng);
+                  const hasCoords = !isNaN(lat) && !isNaN(lng);
+                  onFetchLandPrices(area, city, hasCoords ? lat : undefined, hasCoords ? lng : undefined);
+                }}>
+                <Search className="h-4 w-4" />相場データを取得
+              </Button>
+            </CardContent>
+          </Card>
 
-      {/* 物件情報 */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Calculator className="h-5 w-5 text-primary" />
-            物件・投資条件
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <Input label="土地取得価格" type="number" suffix="万円"
-              value={toMan(input.landPrice)}
-              onChange={(e) => setNum("landPrice", fromMan(e.target.value))}
-              error={errors.landPrice} />
-            {!isQuick && (
-              <Input label="土地面積" type="number" suffix="m²"
-                value={String(input.landArea)}
-                onChange={(e) => setNum("landArea", parseFloat(e.target.value) || 0)} />
-            )}
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <div>
-              <Input label="建物価格" type="number" suffix="万円"
-                value={toMan(input.buildingCost)}
-                onChange={(e) => setNum("buildingCost", fromMan(e.target.value))}
-                error={errors.buildingCost} />
-              <p className="text-xs text-muted-foreground mt-1">新築は建設費、中古は売買契約書記載の建物価格（消費税の課税対象部分）を入力</p>
+          {/* 物件・投資条件（フラット） */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Calculator className="h-5 w-5 text-primary" />
+                物件・投資条件
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-6">
 
-              {/* 按分ヘルパー */}
-              <button
-                type="button"
-                className="mt-2 text-xs text-primary underline-offset-2 hover:underline"
-                onClick={() => setShowBuildingHelper((p) => !p)}
-              >
-                {showBuildingHelper ? "▲ 按分ヘルパーを閉じる" : "▼ 建物価格がわからない場合（按分ヘルパー）"}
-              </button>
+              {/* 物件情報 */}
+              <div>
+                <p className="text-sm font-semibold text-foreground mb-3">物件情報</p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <Input label="土地取得価格" type="number" suffix="万円"
+                    value={toMan(input.landPrice)}
+                    onChange={(e) => setNum("landPrice", fromMan(e.target.value))}
+                    error={errors.landPrice} />
+                  <Input label="土地面積" type="number" suffix="m²"
+                    value={String(input.landArea)}
+                    onChange={(e) => setNum("landArea", parseFloat(e.target.value) || 0)} />
+                  <div className="sm:col-span-2">
+                    <Input label="建物価格" type="number" suffix="万円"
+                      value={toMan(input.buildingCost)}
+                      onChange={(e) => setNum("buildingCost", fromMan(e.target.value))}
+                      error={errors.buildingCost} />
+                    <p className="text-xs text-muted-foreground mt-1">新築は建設費、中古は売買契約書記載の建物価格（消費税の課税対象部分）を入力</p>
 
-              {showBuildingHelper && (
-                <div className="mt-2 rounded-md bg-muted/50 p-3 space-y-3 text-sm">
-                  {/* 方法1: 消費税から計算 */}
-                  <div>
-                    <p className="font-medium text-xs mb-1">① 消費税額から計算（最も確実）</p>
-                    <div className="flex gap-2 items-end">
-                      <div className="flex-1">
-                        <Input
-                          label="消費税額"
-                          type="number"
-                          suffix="万円"
-                          value={taxAmount}
-                          onChange={(e) => setTaxAmount(e.target.value)}
-                        />
-                      </div>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="mb-0 shrink-0"
-                        onClick={() => {
-                          const tax = parseFloat(taxAmount) || 0;
-                          const result = calcFromTax(tax);
-                          if (result > 0) setNum("buildingCost", result * 10_000);
-                        }}
-                      >
-                        適用
-                      </Button>
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-1">建物価格 = 消費税額 ÷ 0.1</p>
-                  </div>
-
-                  {/* 方法2: 固定資産税評価額から計算 */}
-                  <div>
-                    <p className="font-medium text-xs mb-1">② 固定資産税評価額の比率で按分</p>
-                    <div className="grid grid-cols-3 gap-2">
-                      <Input
-                        label="土地評価額"
-                        type="number"
-                        suffix="万円"
-                        value={landAssess}
-                        onChange={(e) => setLandAssess(e.target.value)}
-                      />
-                      <Input
-                        label="建物評価額"
-                        type="number"
-                        suffix="万円"
-                        value={buildingAssess}
-                        onChange={(e) => setBuildingAssess(e.target.value)}
-                      />
-                      <Input
-                        label="購入総額"
-                        type="number"
-                        suffix="万円"
-                        value={totalPrice}
-                        onChange={(e) => setTotalPrice(e.target.value)}
-                      />
-                    </div>
-                    <Button
+                    <button
                       type="button"
-                      variant="outline"
-                      size="sm"
-                      className="mt-2"
-                      onClick={() => {
-                        const total = parseFloat(totalPrice) || 0;
-                        const land = parseFloat(landAssess) || 0;
-                        const building = parseFloat(buildingAssess) || 0;
-                        const result = calcFromAssessment(total, land, building);
-                        if (result > 0) setNum("buildingCost", result * 10_000);
-                      }}
+                      className="mt-2 text-xs text-primary underline-offset-2 hover:underline"
+                      onClick={() => setShowBuildingHelper((p) => !p)}
                     >
-                      按分して適用
-                    </Button>
-                    <p className="text-xs text-muted-foreground mt-1">建物価格 = 総額 × 建物評価 ÷（土地+建物評価）</p>
+                      {showBuildingHelper ? "▲ 按分ヘルパーを閉じる" : "▼ 建物価格がわからない場合（按分ヘルパー）"}
+                    </button>
+
+                    {showBuildingHelper && (
+                      <div className="mt-2 rounded-md bg-muted/50 p-3 space-y-3 text-sm">
+                        <div>
+                          <p className="font-medium text-xs mb-1">① 消費税額から計算（最も確実）</p>
+                          <div className="flex gap-2 items-end">
+                            <div className="flex-1">
+                              <Input label="消費税額" type="number" suffix="万円"
+                                value={taxAmount} onChange={(e) => setTaxAmount(e.target.value)} />
+                            </div>
+                            <Button type="button" variant="outline" size="sm" className="mb-0 shrink-0"
+                              onClick={() => {
+                                const tax = parseFloat(taxAmount) || 0;
+                                const result = calcFromTax(tax);
+                                if (result > 0) setNum("buildingCost", result * 10_000);
+                              }}>
+                              適用
+                            </Button>
+                          </div>
+                          <p className="text-xs text-muted-foreground mt-1">建物価格 = 消費税額 ÷ 0.1</p>
+                        </div>
+                        <div>
+                          <p className="font-medium text-xs mb-1">② 固定資産税評価額の比率で按分</p>
+                          <div className="grid grid-cols-3 gap-2">
+                            <Input label="土地評価額" type="number" suffix="万円"
+                              value={landAssess} onChange={(e) => setLandAssess(e.target.value)} />
+                            <Input label="建物評価額" type="number" suffix="万円"
+                              value={buildingAssess} onChange={(e) => setBuildingAssess(e.target.value)} />
+                            <Input label="購入総額" type="number" suffix="万円"
+                              value={totalPrice} onChange={(e) => setTotalPrice(e.target.value)} />
+                          </div>
+                          <Button type="button" variant="outline" size="sm" className="mt-2"
+                            onClick={() => {
+                              const total = parseFloat(totalPrice) || 0;
+                              const land = parseFloat(landAssess) || 0;
+                              const building = parseFloat(buildingAssess) || 0;
+                              const result = calcFromAssessment(total, land, building);
+                              if (result > 0) setNum("buildingCost", result * 10_000);
+                            }}>
+                            按分して適用
+                          </Button>
+                          <p className="text-xs text-muted-foreground mt-1">建物価格 = 総額 × 建物評価 ÷（土地+建物評価）</p>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                  <Input label="築年数" type="number" suffix="年（0=新築）"
+                    value={String(input.buildingAge)}
+                    onChange={(e) => setNum("buildingAge", parseInt(e.target.value) || 0)} />
+                  <Input label="最寄り駅徒歩" type="number" suffix="分（0=未入力）"
+                    value={String(input.stationMinutes)}
+                    onChange={(e) => setNum("stationMinutes", parseInt(e.target.value) || 0)} />
+                  <Select label="建物構造" value={input.buildingType}
+                    onChange={(e) => {
+                      const bt = e.target.value as BuildingType;
+                      setStr("buildingType", bt);
+                      setNum("rentDeclineRate", RENT_DECLINE_DEFAULTS[bt]);
+                    }}
+                    options={BUILDING_TYPES} />
+                  <div>
+                    <Input label="年間賃料下落率" type="number" suffix="%" step="0.1"
+                      value={toPct(input.rentDeclineRate, 1)}
+                      onChange={(e) => setNum("rentDeclineRate", fromPct(e.target.value))} />
+                    <p className="text-xs text-muted-foreground mt-1">
+                      建物構造から自動設定（例: 木造1%/年）
+                    </p>
                   </div>
                 </div>
-              )}
-            </div>
-            {!isQuick && (
-              <Input label="築年数" type="number" suffix="年（0=新築）"
-                value={String(input.buildingAge)}
-                onChange={(e) => setNum("buildingAge", parseInt(e.target.value) || 0)} />
-            )}
-            {!isQuick && (
-              <Input label="最寄り駅徒歩" type="number" suffix="分（0=未入力）"
-                value={String(input.stationMinutes)}
-                onChange={(e) => setNum("stationMinutes", parseInt(e.target.value) || 0)} />
-            )}
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <Input label="想定月額賃料" type="number" suffix="円"
-              value={String(input.monthlyRent)}
-              onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
-              error={errors.monthlyRent} />
-            {!isQuick && (
-              <Select label="建物構造" value={input.buildingType}
-                onChange={(e) => {
-                  const bt = e.target.value as BuildingType;
-                  setStr("buildingType", bt);
-                  setNum("rentDeclineRate", RENT_DECLINE_DEFAULTS[bt]);
-                }}
-                options={BUILDING_TYPES} />
-            )}
-          </div>
+              </div>
 
-          {/* ローン条件 */}
-          <div className="border-t pt-3">
-            <p className="mb-3 text-sm font-medium text-muted-foreground">ローン条件</p>
-            <div className={`grid grid-cols-1 ${isQuick ? "sm:grid-cols-2" : "sm:grid-cols-3"} gap-3`}>
-              <Input label="ローン金額" type="number" suffix="万円"
-                value={toMan(input.loanAmount)}
-                onChange={(e) => setNum("loanAmount", fromMan(e.target.value))}
-                error={errors.loanAmount} />
-              {!isQuick && (
-                <Input label="年利" type="number" suffix="%" step="0.01"
-                  value={toPct(input.annualLoanRate)}
-                  onChange={(e) => setNum("annualLoanRate", fromPct(e.target.value))}
-                  error={errors.annualLoanRate} />
-              )}
-              <Input label="返済期間" type="number" suffix="年"
-                value={String(input.loanYears)}
-                onChange={(e) => setNum("loanYears", parseInt(e.target.value) || 35)}
-                error={errors.loanYears} />
-            </div>
-          </div>
-
-          {/* 出口戦略 */}
-          <div className="border-t pt-3">
-            <p className="mb-3 text-sm font-medium text-muted-foreground">出口戦略</p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <Input label="売却予定年数" type="number" suffix="年後"
-                value={String(input.holdingYears)}
-                onChange={(e) => setNum("holdingYears", parseInt(e.target.value) || 10)}
-                error={errors.holdingYears} />
-              {!isQuick && (
-                <Input label="売却時目標利回り（実質）" type="number" suffix="%" step="0.5"
-                  value={toPct(input.exitYieldTarget, 1)}
-                  onChange={(e) => setNum("exitYieldTarget", fromPct(e.target.value))}
-                  error={errors.exitYieldTarget} />
-              )}
-            </div>
-          </div>
-
-          {/* 用途地域 */}
-          {!isQuick && (
-            <div className="border-t pt-3 space-y-2">
-              <Select
-                label="用途地域（任意）"
-                value={zoningType}
-                onChange={(e) => setZoningType(e.target.value as ZoningType)}
-                options={[
-                  { value: "", label: "（未選択）" },
-                  ...ZONING_TYPES.map((z) => ({ value: z, label: z })),
-                ]}
-              />
-              {zoningType && (() => {
-                const meta = ZONING_META[zoningType];
-                if (!meta) return null;
-                if (meta.riskLevel === 0) return (
-                  <div className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-2 text-green-800 text-xs">
-                    <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5" />
-                    <span>良好な住環境です</span>
-                  </div>
-                );
-                const styles: Record<number, string> = {
-                  1: "border-blue-200 bg-blue-50 text-blue-800",
-                  2: "border-yellow-300 bg-yellow-50 text-yellow-800",
-                  3: "border-red-300 bg-red-50 text-red-800",
-                };
-                const labels: Record<number, string> = { 1: "低リスク", 2: "中リスク", 3: "高リスク" };
-                return (
-                  <div className={`flex items-start gap-2 rounded-md border p-2 text-xs ${styles[meta.riskLevel]}`}>
-                    <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
-                    <div>
-                      <span className="font-semibold">{labels[meta.riskLevel]}: </span>
-                      <span>{meta.riskMessage}</span>
-                    </div>
-                  </div>
-                );
-              })()}
-            </div>
-          )}
-
-          {/* 詳細設定 */}
-          {!isQuick && (
-            <>
-              <button className="text-xs text-primary underline-offset-2 hover:underline"
-                onClick={() => setShowAdvanced((p) => !p)}>
-                {showAdvanced ? "▲ 詳細設定を閉じる" : "▼ 詳細設定（諸経費率・空室率など）"}
-              </button>
-
-              {showAdvanced && (
-                <div className="space-y-3 rounded-md bg-muted/50 p-3">
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    <Input label="諸経費率" type="number" suffix="%" step="0.5"
-                      value={toPct(input.miscExpenseRate, 1)}
-                      onChange={(e) => setNum("miscExpenseRate", fromPct(e.target.value))}
-                      error={errors.miscExpenseRate} />
-                    <Input label="現況空室率" type="number" suffix="%" step="1"
-                      value={toPct(input.actualVacancyRate, 0)}
-                      onChange={(e) => setNum("actualVacancyRate", fromPct(e.target.value))} />
-                    <Input label="想定空室率（長期）" type="number" suffix="%" step="1"
-                      value={toPct(input.vacancyRate, 0)}
-                      onChange={(e) => setNum("vacancyRate", fromPct(e.target.value))}
-                      error={errors.vacancyRate} />
-                    <Input label="運営経費率※" type="number" suffix="%" step="1"
-                      value={toPct(input.expenseRate, 0)}
-                      onChange={(e) => setNum("expenseRate", fromPct(e.target.value))}
-                      error={errors.expenseRate} />
-                    <Input label="所得税率（実効）" type="number" suffix="%" step="1"
-                      value={toPct(input.incomeTaxRate, 0)}
-                      onChange={(e) => setNum("incomeTaxRate", fromPct(e.target.value))}
-                      error={errors.incomeTaxRate} />
-                    <div>
-                      <Input label="年間賃料下落率" type="number" suffix="%" step="0.1"
-                        value={toPct(input.rentDeclineRate, 1)}
-                        onChange={(e) => setNum("rentDeclineRate", fromPct(e.target.value))} />
-                      <p className="text-xs text-muted-foreground mt-1">
-                        建物構造から自動設定。経年による賃料低下を考慮する場合に使用（例: 木造1%/年）
-                      </p>
-                    </div>
-                  </div>
-                  <p className="text-xs text-muted-foreground">
-                    ※運営経費率はローン利息を含みません（管理費・修繕費・固定資産税・保険等）
-                  </p>
+              {/* 収益条件 */}
+              <div className="border-t pt-4">
+                <p className="text-sm font-semibold text-foreground mb-3">収益条件</p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                  <Input label="想定月額賃料" type="number" suffix="円"
+                    value={String(input.monthlyRent)}
+                    onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
+                    error={errors.monthlyRent} />
+                  <Input label="現況空室率" type="number" suffix="%" step="1"
+                    value={toPct(input.actualVacancyRate, 0)}
+                    onChange={(e) => setNum("actualVacancyRate", fromPct(e.target.value))} />
+                  <Input label="想定空室率（長期）" type="number" suffix="%" step="1"
+                    value={toPct(input.vacancyRate, 0)}
+                    onChange={(e) => setNum("vacancyRate", fromPct(e.target.value))}
+                    error={errors.vacancyRate} />
+                  <Input label="運営経費率※" type="number" suffix="%" step="1"
+                    value={toPct(input.expenseRate, 0)}
+                    onChange={(e) => setNum("expenseRate", fromPct(e.target.value))}
+                    error={errors.expenseRate} />
+                  <Input label="諸経費率" type="number" suffix="%" step="0.5"
+                    value={toPct(input.miscExpenseRate, 1)}
+                    onChange={(e) => setNum("miscExpenseRate", fromPct(e.target.value))}
+                    error={errors.miscExpenseRate} />
                 </div>
-              )}
-            </>
-          )}
+                <p className="text-xs text-muted-foreground mt-2">
+                  ※運営経費率はローン利息を含みません（管理費・修繕費・固定資産税・保険等）
+                </p>
+                <div className="mt-3 space-y-2">
+                  <Select
+                    label="用途地域（任意）"
+                    value={zoningType}
+                    onChange={(e) => setZoningType(e.target.value as ZoningType)}
+                    options={[
+                      { value: "", label: "（未選択）" },
+                      ...ZONING_TYPES.map((z) => ({ value: z, label: z })),
+                    ]}
+                  />
+                  {zoningType && (() => {
+                    const meta = ZONING_META[zoningType];
+                    if (!meta) return null;
+                    if (meta.riskLevel === 0) return (
+                      <div className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-2 text-green-800 text-xs">
+                        <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5" />
+                        <span>良好な住環境です</span>
+                      </div>
+                    );
+                    const styles: Record<number, string> = {
+                      1: "border-blue-200 bg-blue-50 text-blue-800",
+                      2: "border-yellow-300 bg-yellow-50 text-yellow-800",
+                      3: "border-red-300 bg-red-50 text-red-800",
+                    };
+                    const labels: Record<number, string> = { 1: "低リスク", 2: "中リスク", 3: "高リスク" };
+                    return (
+                      <div className={`flex items-start gap-2 rounded-md border p-2 text-xs ${styles[meta.riskLevel]}`}>
+                        <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                        <div>
+                          <span className="font-semibold">{labels[meta.riskLevel]}: </span>
+                          <span>{meta.riskMessage}</span>
+                        </div>
+                      </div>
+                    );
+                  })()}
+                </div>
+              </div>
 
-          {/* ストレステスト */}
-          {!isQuick && (
-            <div className="border-t pt-3 space-y-4">
-              <p className="text-sm font-medium text-muted-foreground">ストレステスト</p>
-              <Slider label="空室率の上昇" value={input.vacancyRateDelta}
-                min={0} max={0.3} step={0.01}
-                onChange={(v) => setNum("vacancyRateDelta", v)}
-                formatValue={(v) => `+${formatPct(v)}`} />
-              <Slider label="金利の上昇" value={input.loanRateDelta}
-                min={0} max={0.03} step={0.001}
-                onChange={(v) => setNum("loanRateDelta", v)}
-                formatValue={(v) => `+${formatPct(v)}`} />
-            </div>
-          )}
+              {/* ローン条件 */}
+              <div className="border-t pt-4">
+                <p className="text-sm font-semibold text-foreground mb-3">ローン条件</p>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                  <Input label="ローン金額" type="number" suffix="万円"
+                    value={toMan(input.loanAmount)}
+                    onChange={(e) => setNum("loanAmount", fromMan(e.target.value))}
+                    error={errors.loanAmount} />
+                  <Input label="年利" type="number" suffix="%" step="0.01"
+                    value={toPct(input.annualLoanRate)}
+                    onChange={(e) => setNum("annualLoanRate", fromPct(e.target.value))}
+                    error={errors.annualLoanRate} />
+                  <Input label="返済期間" type="number" suffix="年"
+                    value={String(input.loanYears)}
+                    onChange={(e) => setNum("loanYears", parseInt(e.target.value) || 35)}
+                    error={errors.loanYears} />
+                </div>
+              </div>
 
-          <Button className="w-full" size="lg" loading={loading}
-            onClick={handleAnalyze}>
-            <Calculator className="h-5 w-5" />
-            シミュレーション実行
-          </Button>
+              {/* 出口戦略 */}
+              <div className="border-t pt-4">
+                <p className="text-sm font-semibold text-foreground mb-3">出口戦略</p>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                  <Input label="売却予定年数" type="number" suffix="年後"
+                    value={String(input.holdingYears)}
+                    onChange={(e) => setNum("holdingYears", parseInt(e.target.value) || 10)}
+                    error={errors.holdingYears} />
+                  <Input label="売却時目標利回り（実質）" type="number" suffix="%" step="0.5"
+                    value={toPct(input.exitYieldTarget, 1)}
+                    onChange={(e) => setNum("exitYieldTarget", fromPct(e.target.value))}
+                    error={errors.exitYieldTarget} />
+                  <Input label="所得税率（実効）" type="number" suffix="%" step="1"
+                    value={toPct(input.incomeTaxRate, 0)}
+                    onChange={(e) => setNum("incomeTaxRate", fromPct(e.target.value))}
+                    error={errors.incomeTaxRate} />
+                </div>
+              </div>
 
-          {/* 免責事項 */}
-          <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-xs text-yellow-800 space-y-1">
-            <p className="flex items-center gap-1 font-semibold">
-              <Info className="h-3 w-3" />免責事項
-            </p>
-            <ul className="list-disc list-inside space-y-0.5">
-              <li>計算結果は参考値であり、税務上の助言ではありません</li>
-              <li>消費税・損益通算・各種特例（3000万控除等）は考慮していません</li>
-              <li>所得税率は給与所得との合算後の実効税率を入力してください</li>
-              <li>中古物件の耐用年数は「築年数」から簡便法で算出しています</li>
-              <li>実際の投資判断は税理士・不動産の専門家にご相談ください</li>
-            </ul>
-          </div>
-        </CardContent>
-      </Card>
+              {/* ストレステスト */}
+              <div className="border-t pt-4 space-y-4">
+                <p className="text-sm font-semibold text-foreground">ストレステスト</p>
+                <Slider label="空室率の上昇" value={input.vacancyRateDelta}
+                  min={0} max={0.3} step={0.01}
+                  onChange={(v) => setNum("vacancyRateDelta", v)}
+                  formatValue={(v) => `+${formatPct(v)}`} />
+                <Slider label="金利の上昇" value={input.loanRateDelta}
+                  min={0} max={0.03} step={0.001}
+                  onChange={(v) => setNum("loanRateDelta", v)}
+                  formatValue={(v) => `+${formatPct(v)}`} />
+              </div>
+
+              <Button className="w-full" size="lg" loading={loading} onClick={handleAnalyze}>
+                <Calculator className="h-5 w-5" />
+                シミュレーション実行
+              </Button>
+
+              <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-xs text-yellow-800 space-y-1">
+                <p className="flex items-center gap-1 font-semibold">
+                  <Info className="h-3 w-3" />免責事項
+                </p>
+                <ul className="list-disc list-inside space-y-0.5">
+                  <li>計算結果は参考値であり、税務上の助言ではありません</li>
+                  <li>消費税・損益通算・各種特例（3000万控除等）は考慮していません</li>
+                  <li>所得税率は給与所得との合算後の実効税率を入力してください</li>
+                  <li>中古物件の耐用年数は「築年数」から簡便法で算出しています</li>
+                  <li>実際の投資判断は税理士・不動産の専門家にご相談ください</li>
+                </ul>
+              </div>
+            </CardContent>
+          </Card>
+        </>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -32,6 +32,7 @@ describe("Dashboard", () => {
 
     render(<Dashboard />);
 
+    await userEvent.type(screen.getByLabelText(/物件価格（土地＋建物の総額）/), "1500");
     await userEvent.click(screen.getByRole("button", { name: /シミュレーション実行/ }));
 
     await waitFor(() => {
@@ -70,6 +71,7 @@ describe("Dashboard", () => {
 
     render(<Dashboard />);
 
+    await userEvent.type(screen.getByLabelText(/物件価格（土地＋建物の総額）/), "1500");
     await userEvent.click(screen.getByRole("button", { name: /シミュレーション実行/ }));
 
     // ボタンが無効化されていること
@@ -84,6 +86,7 @@ describe("Dashboard", () => {
 
     render(<Dashboard />);
 
+    await userEvent.type(screen.getByLabelText(/物件価格（土地＋建物の総額）/), "1500");
     await userEvent.click(screen.getByRole("button", { name: /シミュレーション実行/ }));
 
     await waitFor(() => {
@@ -96,6 +99,7 @@ describe("Dashboard", () => {
 
     render(<Dashboard />);
 
+    await userEvent.type(screen.getByLabelText(/物件価格（土地＋建物の総額）/), "1500");
     await userEvent.click(screen.getByRole("button", { name: /シミュレーション実行/ }));
 
     await waitFor(() => {

--- a/frontend/src/components/__tests__/InvestmentForm.test.tsx
+++ b/frontend/src/components/__tests__/InvestmentForm.test.tsx
@@ -112,15 +112,11 @@ describe("InvestmentForm", () => {
     });
   });
 
-  it("詳細設定を開く/閉じるトグルが機能する", async () => {
+  it("詳細モードでは諸経費率フィールドが常時表示される", () => {
     render(
       <InvestmentForm onAnalyze={vi.fn()} onFetchLandPrices={vi.fn()} loading={false} simulationMode="full" onModeChange={vi.fn()} />
     );
-    expect(screen.queryByText("諸経費率")).not.toBeInTheDocument();
-    await userEvent.click(screen.getByText(/詳細設定（諸経費率・空室率など）/));
-    expect(screen.getByText(/諸経費率/)).toBeInTheDocument();
-    await userEvent.click(screen.getByText(/詳細設定を閉じる/));
-    expect(screen.queryByText("諸経費率")).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/諸経費率/)).toBeInTheDocument();
   });
 
   describe("クイックシミュレーションモード", () => {
@@ -156,6 +152,7 @@ describe("InvestmentForm", () => {
 
     it("クイックモードでシミュレーション実行すると QUICK_MODE_DEFAULTS がマージされる", async () => {
       const { onAnalyze } = renderForm("quick");
+      await userEvent.type(screen.getByLabelText(/物件価格（土地＋建物の総額）/), "1500");
       await userEvent.click(screen.getByRole("button", { name: /シミュレーション実行/ }));
       expect(onAnalyze).toHaveBeenCalledTimes(1);
       expect(onAnalyze).toHaveBeenCalledWith(expect.objectContaining({
@@ -178,7 +175,7 @@ describe("InvestmentForm", () => {
 
     it("クイックモードではインフォバナーが表示される", () => {
       renderForm("quick");
-      expect(screen.getByText(/クイックモード:/)).toBeInTheDocument();
+      expect(screen.getByText(/自動設定されるデフォルト値/)).toBeInTheDocument();
     });
 
     it("詳細モードではクイックモードのインフォバナーが非表示", () => {

--- a/frontend/src/components/__tests__/helpers.ts
+++ b/frontend/src/components/__tests__/helpers.ts
@@ -22,6 +22,7 @@ export function makeInput(overrides: Partial<InvestmentInput> = {}): InvestmentI
     vacancyRateDelta: 0,
     loanRateDelta: 0,
     annualPropertyTax: 0,
+    rentDeclineRate: 0,
     ...overrides,
   };
 }

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -236,4 +236,5 @@ export const QUICK_MODE_DEFAULTS: Partial<InvestmentInput> = {
   annualPropertyTax: 0,
   buildingType:      "木造" as BuildingType,
   annualLoanRate:    0.015,
+  rentDeclineRate:   0.01,
 };


### PR DESCRIPTION
## 概要

クイック/詳細モードの体験差が「表示項目を減らすだけ」だった問題を解消し、ユーザー像に応じた明確な体験設計に再構築する。

## 変更内容

### クイックモード
- 入力項目を3つに絞る（物件価格総額・月額賃料・ローン金額）
- 「土地相場データ取得」セクションを初期折りたたみにし、任意扱いに変更
- 物件価格は土地70%・建物30%で内部自動按分
- デフォルト値（空室率5%・経費率20%・木造・年利1.5%・35年・10年後売却）をUI上に明示
- モード切替ボタンに「内覧でサッと試す」のサブタイトルを追加

### 詳細モード
- 「詳細モードの中に詳細設定」という入れ子3層構造を廃止
- 全フィールドを4つのセクションにフラット化：物件情報 / 収益条件 / ローン条件 / 出口戦略
- ストレステストを詳細モードで常時表示（従来と変わらず）
- モード切替ボタンに「じっくり分析する」のサブタイトルを追加

### その他
- `QUICK_MODE_DEFAULTS` に `rentDeclineRate: 0.01` を追加（木造デフォルト）
- テスト用 `makeInput` ヘルパーに `rentDeclineRate: 0` を追加

## 関連Issue

Closes #159

## テスト
- [x] 既存テストが通ること（tsc --noEmit エラーなし）
- [x] クイックモード: 3項目入力→実行で正常にシミュレーション送信
- [x] 詳細モード: 全フィールドが折りたたみなしで表示される

## 確認事項
- [x] コードレビュー観点での自己レビュー済み