### PR TITLE
feat(frontend): CriticalErrorBanner コンポーネント実装

### DIFF
--- a/frontend/src/components/CriticalErrorBanner.tsx
+++ b/frontend/src/components/CriticalErrorBanner.tsx
@@ -1,0 +1,38 @@
+import { XOctagon, AlertTriangle } from "lucide-react";
+import type { CriticalError } from "@/types/investment";
+
+interface Props {
+  errors: CriticalError[];
+}
+
+export function CriticalErrorBanner({ errors }: Props) {
+  if (errors.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      {errors.map((err) => (
+        <div
+          key={err.code}
+          role="alert"
+          className={`flex items-start gap-3 rounded-md border-2 p-4 ${
+            err.status === "REJECT"
+              ? "border-red-500 bg-red-50 text-red-900"
+              : "border-yellow-400 bg-yellow-50 text-yellow-900"
+          }`}
+        >
+          {err.status === "REJECT" ? (
+            <XOctagon className="mt-0.5 h-5 w-5 shrink-0 text-red-600" />
+          ) : (
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-yellow-600" />
+          )}
+          <div>
+            <p className="text-sm font-bold">
+              {err.status === "REJECT" ? "⛔ 一発退場" : "⚠ 警告"}: {err.code}
+            </p>
+            <p className="mt-0.5 text-sm">{err.message}</p>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/CriticalErrorBanner.tsx
+++ b/frontend/src/components/CriticalErrorBanner.tsx
@@ -1,12 +1,12 @@
 import { XOctagon, AlertTriangle } from "lucide-react";
 import type { CriticalError } from "@/types/investment";
 
-interface Props {
+interface CriticalErrorBannerProps {
   errors: CriticalError[];
 }
 
-export function CriticalErrorBanner({ errors }: Props) {
-  if (errors.length === 0) return null;
+export function CriticalErrorBanner({ errors }: CriticalErrorBannerProps) {
+  if (!errors || errors.length === 0) return null;
 
   return (
     <div className="space-y-2">

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -8,7 +8,8 @@ import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
 import CostBreakdown from "@/components/CostBreakdown";
 import type { InvestmentInput, InvestmentResult, LandPriceComparison, TheoreticalPriceResult, StationRidershipResult, PopulationForecastResult, AppraisalComparisonResult, UrbanRisk, SimulationMode } from "@/types/investment";
 import { analyze, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks } from "@/lib/api";
-import { ShieldAlert, XOctagon, AlertTriangle } from "lucide-react";
+import { ShieldAlert } from "lucide-react";
+import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 
 /** 直近2年分の期間（国交省API形式: YYYYQ） */
 function getCurrentPeriods(): { year: number; quarter: number; toYear: number; toQuarter: number } {
@@ -155,31 +156,7 @@ export function Dashboard() {
 
             {result && lastInput && (
               <>
-                {result.criticalErrors.length > 0 && (
-                  <div className="space-y-2">
-                    {result.criticalErrors.map((err) => (
-                      <div
-                        key={err.code}
-                        className={`flex items-start gap-3 rounded-md border-2 p-4 ${
-                          err.status === "REJECT"
-                            ? "border-red-500 bg-red-50 text-red-900"
-                            : "border-yellow-400 bg-yellow-50 text-yellow-900"
-                        }`}
-                      >
-                        {err.status === "REJECT"
-                          ? <XOctagon className="h-5 w-5 shrink-0 mt-0.5 text-red-600" />
-                          : <AlertTriangle className="h-5 w-5 shrink-0 mt-0.5 text-yellow-600" />
-                        }
-                        <div>
-                          <p className="text-sm font-bold">
-                            {err.status === "REJECT" ? "⛔ 一発退場" : "⚠ 警告"}: {err.code}
-                          </p>
-                          <p className="text-sm mt-0.5">{err.message}</p>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                )}
+                <CriticalErrorBanner errors={result.criticalErrors} />
                 <YieldAnalysis result={result} input={lastInput} populationForecast={populationForecast} />
                 {simulationMode === "full" && (
                   <>

--- a/frontend/src/components/__tests__/CriticalErrorBanner.test.tsx
+++ b/frontend/src/components/__tests__/CriticalErrorBanner.test.tsx
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
+import type { CriticalError } from "@/types/investment";
+
+const rejectError: CriticalError = {
+  code: "LAND_VALUE_GUARD",
+  status: "REJECT",
+  message: "積算評価額が購入総額の50%未満です",
+};
+
+const warningError: CriticalError = {
+  code: "DEADCROSS_EARLY",
+  status: "WARNING",
+  message: "10年以内にデッドクロスが発生します",
+};
+
+describe("CriticalErrorBanner", () => {
+  it("errors が空配列のとき何もレンダリングしない", () => {
+    const { container } = render(<CriticalErrorBanner errors={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("errors が undefined のとき何もレンダリングしない", () => {
+    const { container } = render(
+      <CriticalErrorBanner errors={undefined as unknown as CriticalError[]} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("REJECT エラーのとき「⛔ 一発退場」ラベルとエラーコードを表示する", () => {
+    render(<CriticalErrorBanner errors={[rejectError]} />);
+    expect(screen.getByText(/⛔ 一発退場.*LAND_VALUE_GUARD/)).toBeInTheDocument();
+    expect(screen.getByText("積算評価額が購入総額の50%未満です")).toBeInTheDocument();
+  });
+
+  it("WARNING エラーのとき「⚠ 警告」ラベルとエラーコードを表示する", () => {
+    render(<CriticalErrorBanner errors={[warningError]} />);
+    expect(screen.getByText(/⚠ 警告.*DEADCROSS_EARLY/)).toBeInTheDocument();
+    expect(screen.getByText("10年以内にデッドクロスが発生します")).toBeInTheDocument();
+  });
+
+  it("複数エラーがあるとき全件表示する", () => {
+    render(<CriticalErrorBanner errors={[rejectError, warningError]} />);
+    expect(screen.getByText(/LAND_VALUE_GUARD/)).toBeInTheDocument();
+    expect(screen.getByText(/DEADCROSS_EARLY/)).toBeInTheDocument();
+  });
+
+  it("各バナーに role=alert が付与されている", () => {
+    render(<CriticalErrorBanner errors={[rejectError, warningError]} />);
+    const alerts = screen.getAllByRole("alert");
+    expect(alerts).toHaveLength(2);
+  });
+
+  it("REJECT のとき赤系クラスが適用されている", () => {
+    render(<CriticalErrorBanner errors={[rejectError]} />);
+    const alert = screen.getByRole("alert");
+    expect(alert.className).toContain("border-red-500");
+    expect(alert.className).toContain("bg-red-50");
+  });
+
+  it("WARNING のとき黄系クラスが適用されている", () => {
+    render(<CriticalErrorBanner errors={[warningError]} />);
+    const alert = screen.getByRole("alert");
+    expect(alert.className).toContain("border-yellow-400");
+    expect(alert.className).toContain("bg-yellow-50");
+  });
+});


### PR DESCRIPTION
## 概要
バックエンドが返す `criticalErrors` をフロントエンドで表示するための専用コンポーネントを実装。
`Dashboard.tsx` に散在していたインライン実装を独立コンポーネントに分離し、可読性・再利用性を向上させた。

## 変更内容
- `frontend/src/components/CriticalErrorBanner.tsx` 新規作成
  - `CriticalError[]` を受け取り REJECT（赤）/ WARNING（黄）バナーを表示
  - `errors` が空配列の場合は何もレンダリングしない（`null` return）
  - `role="alert"` を付与してアクセシビリティに対応
- `frontend/src/components/Dashboard.tsx` 修正
  - インライン criticalErrors 表示ロジックを `<CriticalErrorBanner errors={result.criticalErrors} />` に置換
  - 不要になった `XOctagon`, `AlertTriangle` の import を削除

## 関連Issue
Closes #131

## テスト
- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [ ] コードレビュー観点での自己レビュー済み