### PR TITLE
enhancement(frontend): MLIT データ未収録とAPIエラーを区別して表示

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -100,7 +100,7 @@ export function Dashboard() {
         setExternalUrbanRisks(urbanRisks.status === "fulfilled" ? urbanRisks.value : null);
       }
     } catch (e) {
-      setError(e instanceof Error ? e.message : "相場データの取得に失敗しました");
+      setError(e instanceof Error ? e.message : "相場データの取得に失敗しました。しばらく後に再試行してください");
     } finally {
       setLoading(false);
     }

--- a/frontend/src/components/LandPriceAnalysis.tsx
+++ b/frontend/src/components/LandPriceAnalysis.tsx
@@ -106,11 +106,11 @@ export function LandPriceAnalysis({ comparison, input, theoreticalPrice, station
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex items-start gap-3 rounded-md border border-red-200 bg-red-50 p-4 text-red-800">
+          <div className="flex items-start gap-3 rounded-md border border-amber-200 bg-amber-50 p-4 text-amber-800">
             <SearchX className="h-5 w-5 mt-0.5 shrink-0" />
             <div>
-              <p className="text-sm font-semibold">取引データが見つかりませんでした</p>
-              <p className="text-xs mt-1">エリア・取得期間の条件を変更して再取得してください。</p>
+              <p className="text-sm font-semibold">このエリアの取引データは未収録です</p>
+              <p className="text-xs mt-1">国交省データベースに該当期間の宅地取引実績がありません。都道府県・市区町村・取得期間を変更してお試しください。</p>
             </div>
           </div>
         </CardContent>

--- a/frontend/src/components/__tests__/LandPriceAnalysis.test.tsx
+++ b/frontend/src/components/__tests__/LandPriceAnalysis.test.tsx
@@ -5,9 +5,9 @@ import { makeComparison, makeInput, ZERO_STATS } from "./helpers";
 
 describe("LandPriceAnalysis", () => {
   describe("count === 0 のとき", () => {
-    it("「取引データが見つかりませんでした」を表示する", () => {
+    it("「このエリアの取引データは未収録です」を表示する", () => {
       render(<LandPriceAnalysis comparison={makeComparison({ stats: ZERO_STATS })} />);
-      expect(screen.getByText("取引データが見つかりませんでした")).toBeInTheDocument();
+      expect(screen.getByText("このエリアの取引データは未収録です")).toBeInTheDocument();
     });
 
     it("判定バッジを表示しない", () => {
@@ -101,9 +101,9 @@ describe("LandPriceAnalysis", () => {
       expect(screen.queryByText("統計データが不足しています")).not.toBeInTheDocument();
     });
 
-    it("「取引データが見つかりませんでした」を表示しない", () => {
+    it("「このエリアの取引データは未収録です」を表示しない", () => {
       render(<LandPriceAnalysis comparison={makeComparison()} />);
-      expect(screen.queryByText("取引データが見つかりませんでした")).not.toBeInTheDocument();
+      expect(screen.queryByText("このエリアの取引データは未収録です")).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## 概要

MLIT API が「対象エリアのデータなし」の場合と「APIエラー」の場合でフロントエンドの表示が混在していた問題を改善する。

## 変更内容

### LandPriceAnalysis.tsx
- `stats.count === 0` 時のメッセージを「取引データが見つかりませんでした」→「このエリアの取引データは未収録です」に変更
- 色を赤（border-red）→ 黄土色（border-amber）に変更（エラーではなく「未収録」の情報表示であるため）
- 補足文を「国交省データベースに該当期間の宅地取引実績がありません。都道府県・市区町村・取得期間を変更してお試しください。」に変更

### Dashboard.tsx
- 相場データ取得失敗時のフォールバックメッセージに「しばらく後に再試行してください」を追記

## バックエンド変更なし

バックエンドはすでに API エラー時 502・データなし時 200（count=0）と別ステータスで返しているため変更不要。

## 関連Issue

Closes #135

## テスト
- [x] tsc --noEmit エラーなし
- [x] vitest 全件パス

## 確認事項
- [x] コードレビュー観点での自己レビュー済み