### PR TITLE
fix(frontend): CriticalErrorBanner の role=alert セマンティクス改善

### DIFF
--- a/frontend/src/components/CriticalErrorBanner.tsx
+++ b/frontend/src/components/CriticalErrorBanner.tsx
@@ -9,11 +9,11 @@ export function CriticalErrorBanner({ errors }: CriticalErrorBannerProps) {
   if (!errors || errors.length === 0) return null;
 
   return (
-    <div className="space-y-2">
+    <div role="alert" aria-label="重大なリスク" className="space-y-2">
       {errors.map((err) => (
         <div
           key={err.code}
-          role="alert"
+          role="listitem"
           className={`flex items-start gap-3 rounded-md border-2 p-4 ${
             err.status === "REJECT"
               ? "border-red-500 bg-red-50 text-red-900"

--- a/frontend/src/components/__tests__/CriticalErrorBanner.test.tsx
+++ b/frontend/src/components/__tests__/CriticalErrorBanner.test.tsx
@@ -46,23 +46,24 @@ describe("CriticalErrorBanner", () => {
     expect(screen.getByText(/DEADCROSS_EARLY/)).toBeInTheDocument();
   });
 
-  it("各バナーに role=alert が付与されている", () => {
+  it("外側ラッパーに role=alert が付与され、各アイテムに role=listitem が付与されている", () => {
     render(<CriticalErrorBanner errors={[rejectError, warningError]} />);
-    const alerts = screen.getAllByRole("alert");
-    expect(alerts).toHaveLength(2);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
   });
 
   it("REJECT のとき赤系クラスが適用されている", () => {
     render(<CriticalErrorBanner errors={[rejectError]} />);
-    const alert = screen.getByRole("alert");
-    expect(alert.className).toContain("border-red-500");
-    expect(alert.className).toContain("bg-red-50");
+    const item = screen.getByRole("listitem");
+    expect(item.className).toContain("border-red-500");
+    expect(item.className).toContain("bg-red-50");
   });
 
   it("WARNING のとき黄系クラスが適用されている", () => {
     render(<CriticalErrorBanner errors={[warningError]} />);
-    const alert = screen.getByRole("alert");
-    expect(alert.className).toContain("border-yellow-400");
-    expect(alert.className).toContain("bg-yellow-50");
+    const item = screen.getByRole("listitem");
+    expect(item.className).toContain("border-yellow-400");
+    expect(item.className).toContain("bg-yellow-50");
   });
 });


### PR DESCRIPTION
## 概要
複数のエラーが存在する場合、各バナーアイテムに `role="alert"` を付与していたため、スクリーンリーダーが全アイテムを独立した alert として読み上げていた。外側ラッパーに `role="alert" aria-label="重大なリスク"` を一つ持ち、各アイテムは `role="listitem"` に変更することでセマンティクスを改善する。

## 変更内容
- `CriticalErrorBanner.tsx`: 外側 `<div>` に `role="alert" aria-label="重大なリスク"` を移動
- 各バナーアイテムの `role="alert"` を `role="listitem"` に変更
- `CriticalErrorBanner.test.tsx`: 新しいロール構造に合わせてテストを更新

## 関連Issue
Closes #172

## テスト
- [x] 既存テストが通ること（8/8 PASS）
- [x] `role=alert` が outer ラッパーに1つ、`role=listitem` が各アイテムに付くことをテストで確認

## 確認事項
- [x] コードレビュー観点での自己レビュー済み