### PR TITLE
feat(backend): Cloud Logging 対応構造化ロガー導入（slog JSON + OTel トレース連携）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,10 @@ ALLOW_ORIGINS=http://localhost:3000
 # 国交省 不動産情報ライブラリ API キー
 # 申請: https://www.reinfolib.mlit.go.jp/api/request/
 MLIT_API_KEY=your_api_key_here
+
+# ログ設定
+# LOG_LEVEL: DEBUG / INFO / WARN / ERROR（デフォルト: INFO）
+LOG_LEVEL=INFO
+# GOOGLE_CLOUD_PROJECT: Cloud Logging トレースリンク用 GCP プロジェクト ID
+# ローカル開発では未設定で可（トレースフィールドはスキップされる）
+GOOGLE_CLOUD_PROJECT=

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"context"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -10,24 +10,29 @@ import (
 	"time"
 
 	"github.com/yield-guard/backend/internal/api"
+	"github.com/yield-guard/backend/internal/logger"
 	"github.com/yield-guard/backend/internal/mlit"
 	"github.com/yield-guard/backend/internal/telemetry"
 )
 
 func main() {
+	logger.Init(os.Stderr)
+
 	port := os.Getenv("PORT")
 	if port == "" {
 		port = "8080"
 	}
 
 	if os.Getenv("MLIT_API_KEY") == "" {
-		log.Fatal("MLIT_API_KEY is not set")
+		slog.Error("MLIT_API_KEY is not set")
+		os.Exit(1)
 	}
 
 	ctx := context.Background()
 	otelShutdown, err := telemetry.Setup(ctx, "yield-guard-backend", "0.1.0")
 	if err != nil {
-		log.Fatalf("failed to initialise OpenTelemetry: %v", err)
+		slog.Error("failed to initialise OpenTelemetry", "error", err)
+		os.Exit(1)
 	}
 
 	mlitClient := mlit.NewClient()
@@ -41,9 +46,10 @@ func main() {
 
 	// バックグラウンドでサーバーを起動
 	go func() {
-		log.Printf("Yield-Guard backend starting on :%s", port)
+		slog.Info("Yield-Guard backend starting", "port", port)
 		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Fatalf("server error: %v", err)
+			slog.Error("server error", "error", err)
+			os.Exit(1)
 		}
 	}()
 
@@ -51,16 +57,17 @@ func main() {
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
-	log.Println("Shutting down server...")
+	slog.Info("shutting down server")
 
 	// 国交省APIの最大タイムアウト(30s) より長い猶予を確保
 	ctx, cancel := context.WithTimeout(context.Background(), 35*time.Second)
 	defer cancel()
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatalf("forced shutdown: %v", err)
+		slog.Error("forced shutdown", "error", err)
+		os.Exit(1)
 	}
 	if err := otelShutdown(context.Background()); err != nil {
-		log.Printf("OTel shutdown error: %v", err)
+		slog.Error("OTel shutdown error", "error", err)
 	}
-	log.Println("Server stopped")
+	slog.Info("server stopped")
 }

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -3,7 +3,7 @@ package api
 import (
 	"context"
 	"errors"
-	"log"
+	"log/slog"
 	"net/http"
 	"strconv"
 
@@ -503,22 +503,22 @@ func (h *Handler) GetUrbanRisks(c *gin.Context) {
 	}()
 
 	if r := <-locCh; r.err != nil {
-		log.Printf("WARN: FetchLocationOptimization failed (z=%d x=%d y=%d): %v", z, x, y, r.err)
+		slog.WarnContext(ctx, "FetchLocationOptimization failed", "z", z, "x", x, "y", y, "error", r.err)
 	} else {
 		res.location = r.data
 	}
 	if r := <-embCh; r.err != nil {
-		log.Printf("WARN: FetchEmbankment failed (z=%d x=%d y=%d): %v", z, x, y, r.err)
+		slog.WarnContext(ctx, "FetchEmbankment failed", "z", z, "x", x, "y", y, "error", r.err)
 	} else {
 		res.embank = r.data
 	}
 	if r := <-rdCh; r.err != nil {
-		log.Printf("WARN: FetchUrbanRoad failed (z=%d x=%d y=%d): %v", z, x, y, r.err)
+		slog.WarnContext(ctx, "FetchUrbanRoad failed", "z", z, "x", x, "y", y, "error", r.err)
 	} else {
 		res.road = r.data
 	}
 	if r := <-disCh; r.err != nil {
-		log.Printf("WARN: FetchDisasterHistory failed (z=%d x=%d y=%d): %v", z, x, y, r.err)
+		slog.WarnContext(ctx, "FetchDisasterHistory failed", "z", z, "x", x, "y", y, "error", r.err)
 	} else {
 		res.disaster = r.data
 	}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -43,6 +44,9 @@ func accessLogMiddleware() gin.HandlerFunc {
 			"latency_ms", latencyMS,
 			"client_ip", c.ClientIP(),
 		}
+		if q := c.Request.URL.RawQuery; q != "" {
+			args = append(args, "query", q)
+		}
 		switch {
 		case status >= 500:
 			slog.ErrorContext(ctx, "access", args...)
@@ -59,6 +63,7 @@ func recoveryMiddleware() gin.HandlerFunc {
 		slog.ErrorContext(c.Request.Context(), "panic recovered",
 			"error", fmt.Sprintf("%v", err),
 			"path", c.Request.URL.Path,
+			"stack", string(debug.Stack()),
 		)
 		c.AbortWithStatus(http.StatusInternalServerError)
 	})

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -44,6 +44,9 @@ func accessLogMiddleware() gin.HandlerFunc {
 			"latency_ms", latencyMS,
 			"client_ip", c.ClientIP(),
 		}
+		// NOTE: クエリ文字列を丸ごとログに記録する。現状のエンドポイントは
+		// 都道府県コード・タイル座標等の公開情報のみだが、将来 PII を含む
+		// パラメータが追加される場合はこのフィールドを除外すること。
 		if q := c.Request.URL.RawQuery; q != "" {
 			args = append(args, "query", q)
 		}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -1,9 +1,13 @@
 package api
 
 import (
+	"fmt"
+	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
@@ -21,11 +25,52 @@ func internalKeyMiddleware() gin.HandlerFunc {
 	}
 }
 
+func accessLogMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		start := time.Now()
+		method := c.Request.Method
+		path := c.Request.URL.Path
+
+		c.Next()
+
+		status := c.Writer.Status()
+		latencyMS := time.Since(start).Milliseconds()
+		ctx := c.Request.Context()
+		args := []any{
+			"method", method,
+			"path", path,
+			"status", status,
+			"latency_ms", latencyMS,
+			"client_ip", c.ClientIP(),
+		}
+		switch {
+		case status >= 500:
+			slog.ErrorContext(ctx, "access", args...)
+		case status >= 400:
+			slog.WarnContext(ctx, "access", args...)
+		default:
+			slog.InfoContext(ctx, "access", args...)
+		}
+	}
+}
+
+func recoveryMiddleware() gin.HandlerFunc {
+	return gin.CustomRecoveryWithWriter(io.Discard, func(c *gin.Context, err any) {
+		slog.ErrorContext(c.Request.Context(), "panic recovered",
+			"error", fmt.Sprintf("%v", err),
+			"path", c.Request.URL.Path,
+		)
+		c.AbortWithStatus(http.StatusInternalServerError)
+	})
+}
+
 // NewRouter は Gin ルーターを初期化して返す
 func NewRouter(h *Handler) *gin.Engine {
-	r := gin.Default()
+	r := gin.New()
 
 	r.Use(otelgin.Middleware("yield-guard-backend"))
+	r.Use(accessLogMiddleware())
+	r.Use(recoveryMiddleware())
 
 	// リクエストボディを 64KB に制限（大量 JSON による DoS を防止）
 	r.Use(func(c *gin.Context) {

--- a/backend/internal/logger/logger.go
+++ b/backend/internal/logger/logger.go
@@ -101,10 +101,14 @@ func Init(w io.Writer) {
 	slog.SetDefault(slog.New(newJSONHandler(w, level, projectID)))
 }
 
-// New returns a logger writing to w, using the same Cloud Logging format as Init.
-// Reads GOOGLE_CLOUD_PROJECT from the environment for trace field formatting.
-// Intended for tests and non-global usage; for test isolation pass projectID via newJSONHandler directly.
-func New(w io.Writer) *slog.Logger {
-	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+// NewWithProject returns a logger writing to w with an explicit projectID for trace field formatting.
+// Use this instead of New when the caller controls the projectID (e.g. tests, multi-project setups).
+func NewWithProject(w io.Writer, projectID string) *slog.Logger {
 	return slog.New(newJSONHandler(w, slog.LevelDebug, projectID))
+}
+
+// New returns a logger writing to w, reading projectID from GOOGLE_CLOUD_PROJECT env var.
+// For explicit projectID control use NewWithProject.
+func New(w io.Writer) *slog.Logger {
+	return NewWithProject(w, os.Getenv("GOOGLE_CLOUD_PROJECT"))
 }

--- a/backend/internal/logger/logger.go
+++ b/backend/internal/logger/logger.go
@@ -1,0 +1,104 @@
+package logger
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+type cloudHandler struct {
+	inner     slog.Handler
+	projectID string
+}
+
+func (h *cloudHandler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.inner.Enabled(ctx, level)
+}
+
+func (h *cloudHandler) Handle(ctx context.Context, r slog.Record) error {
+	sc := trace.SpanFromContext(ctx).SpanContext()
+	if sc.IsValid() && h.projectID != "" {
+		r.AddAttrs(
+			slog.String("logging.googleapis.com/trace",
+				fmt.Sprintf("projects/%s/traces/%s", h.projectID, sc.TraceID())),
+			slog.String("logging.googleapis.com/spanId", sc.SpanID().String()),
+			slog.Bool("logging.googleapis.com/trace_sampled", sc.TraceFlags().IsSampled()),
+		)
+	}
+	return h.inner.Handle(ctx, r)
+}
+
+func (h *cloudHandler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &cloudHandler{inner: h.inner.WithAttrs(attrs), projectID: h.projectID}
+}
+
+func (h *cloudHandler) WithGroup(name string) slog.Handler {
+	return &cloudHandler{inner: h.inner.WithGroup(name), projectID: h.projectID}
+}
+
+func levelToSeverity(l slog.Level) string {
+	switch {
+	case l >= slog.LevelError+4:
+		return "CRITICAL"
+	case l >= slog.LevelError:
+		return "ERROR"
+	case l >= slog.LevelWarn:
+		return "WARNING"
+	case l >= slog.LevelInfo:
+		return "INFO"
+	default:
+		return "DEBUG"
+	}
+}
+
+func newJSONHandler(w io.Writer, level slog.Leveler, projectID string) slog.Handler {
+	inner := slog.NewJSONHandler(w, &slog.HandlerOptions{
+		Level: level,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if len(groups) != 0 {
+				return a
+			}
+			switch a.Key {
+			case slog.LevelKey:
+				return slog.String("severity", levelToSeverity(a.Value.Any().(slog.Level)))
+			case slog.MessageKey:
+				return slog.Attr{Key: "message", Value: a.Value}
+			}
+			return a
+		},
+	})
+	return &cloudHandler{inner: inner, projectID: projectID}
+}
+
+func parseLevel(s string) slog.Level {
+	switch strings.ToUpper(strings.TrimSpace(s)) {
+	case "DEBUG":
+		return slog.LevelDebug
+	case "WARN", "WARNING":
+		return slog.LevelWarn
+	case "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// Init initializes the global slog default logger with Cloud Logging compatible JSON output.
+// Reads LOG_LEVEL (DEBUG/INFO/WARN/ERROR, default INFO) and GOOGLE_CLOUD_PROJECT env vars.
+func Init(w io.Writer) {
+	level := parseLevel(os.Getenv("LOG_LEVEL"))
+	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	slog.SetDefault(slog.New(newJSONHandler(w, level, projectID)))
+}
+
+// New returns a logger writing to w, using the same Cloud Logging format as Init.
+// Intended for tests and non-global usage.
+func New(w io.Writer) *slog.Logger {
+	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	return slog.New(newJSONHandler(w, slog.LevelDebug, projectID))
+}

--- a/backend/internal/logger/logger.go
+++ b/backend/internal/logger/logger.go
@@ -69,9 +69,8 @@ func newJSONHandler(w io.Writer, level slog.Leveler, projectID string) slog.Hand
 			}
 			switch a.Key {
 			case slog.LevelKey:
-				if l, ok := a.Value.Any().(slog.Level); ok {
-					return slog.String("severity", levelToSeverity(l))
-				}
+				// slog guarantees LevelKey value is always slog.Level; assertion is safe.
+				return slog.String("severity", levelToSeverity(a.Value.Any().(slog.Level))) //nolint:errcheck
 			case slog.MessageKey:
 				return slog.Attr{Key: "message", Value: a.Value}
 			}

--- a/backend/internal/logger/logger.go
+++ b/backend/internal/logger/logger.go
@@ -41,9 +41,13 @@ func (h *cloudHandler) WithGroup(name string) slog.Handler {
 	return &cloudHandler{inner: h.inner.WithGroup(name), projectID: h.projectID}
 }
 
+// LevelCritical は slog にない Cloud Logging の CRITICAL 重大度に対応するカスタムレベル。
+// 使用例: slog.Log(ctx, LevelCritical, "unrecoverable error")
+const LevelCritical = slog.LevelError + 4
+
 func levelToSeverity(l slog.Level) string {
 	switch {
-	case l >= slog.LevelError+4:
+	case l >= LevelCritical:
 		return "CRITICAL"
 	case l >= slog.LevelError:
 		return "ERROR"
@@ -97,7 +101,8 @@ func Init(w io.Writer) {
 }
 
 // New returns a logger writing to w, using the same Cloud Logging format as Init.
-// Intended for tests and non-global usage.
+// Reads GOOGLE_CLOUD_PROJECT from the environment for trace field formatting.
+// Intended for tests and non-global usage; for test isolation pass projectID via newJSONHandler directly.
 func New(w io.Writer) *slog.Logger {
 	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
 	return slog.New(newJSONHandler(w, slog.LevelDebug, projectID))

--- a/backend/internal/logger/logger.go
+++ b/backend/internal/logger/logger.go
@@ -69,7 +69,9 @@ func newJSONHandler(w io.Writer, level slog.Leveler, projectID string) slog.Hand
 			}
 			switch a.Key {
 			case slog.LevelKey:
-				return slog.String("severity", levelToSeverity(a.Value.Any().(slog.Level)))
+				if l, ok := a.Value.Any().(slog.Level); ok {
+					return slog.String("severity", levelToSeverity(l))
+				}
 			case slog.MessageKey:
 				return slog.Attr{Key: "message", Value: a.Value}
 			}

--- a/backend/internal/logger/logger_test.go
+++ b/backend/internal/logger/logger_test.go
@@ -1,0 +1,159 @@
+package logger
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+
+	"go.opentelemetry.io/otel/trace"
+)
+
+func logToMap(t *testing.T, buf *bytes.Buffer) map[string]any {
+	t.Helper()
+	var m map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &m); err != nil {
+		t.Fatalf("failed to parse log JSON: %v\nraw: %s", err, buf.String())
+	}
+	return m
+}
+
+func newTestLogger(buf *bytes.Buffer, projectID string) *slog.Logger {
+	return slog.New(newJSONHandler(buf, slog.LevelDebug, projectID))
+}
+
+func TestSeverityField_Warn(t *testing.T) {
+	var buf bytes.Buffer
+	l := newTestLogger(&buf, "")
+	l.Warn("test warn")
+	m := logToMap(t, &buf)
+	if got := m["severity"]; got != "WARNING" {
+		t.Errorf("severity = %q, want %q", got, "WARNING")
+	}
+}
+
+func TestSeverityField_Error(t *testing.T) {
+	var buf bytes.Buffer
+	l := newTestLogger(&buf, "")
+	l.Error("test error")
+	m := logToMap(t, &buf)
+	if got := m["severity"]; got != "ERROR" {
+		t.Errorf("severity = %q, want %q", got, "ERROR")
+	}
+}
+
+func TestSeverityField_Info(t *testing.T) {
+	var buf bytes.Buffer
+	l := newTestLogger(&buf, "")
+	l.Info("test info")
+	m := logToMap(t, &buf)
+	if got := m["severity"]; got != "INFO" {
+		t.Errorf("severity = %q, want %q", got, "INFO")
+	}
+}
+
+func TestMessageField(t *testing.T) {
+	var buf bytes.Buffer
+	l := newTestLogger(&buf, "")
+	l.Info("hello world")
+	m := logToMap(t, &buf)
+	if _, ok := m["msg"]; ok {
+		t.Error("unexpected 'msg' field; want 'message'")
+	}
+	if got := m["message"]; got != "hello world" {
+		t.Errorf("message = %q, want %q", got, "hello world")
+	}
+}
+
+func TestTraceInjection_WithValidSpan(t *testing.T) {
+	var traceID trace.TraceID
+	var spanID trace.SpanID
+	traceID[0] = 0xab
+	spanID[0] = 0xcd
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	var buf bytes.Buffer
+	l := newTestLogger(&buf, "my-project")
+	l.InfoContext(ctx, "traced request")
+	m := logToMap(t, &buf)
+
+	traceField, ok := m["logging.googleapis.com/trace"]
+	if !ok {
+		t.Fatal("missing 'logging.googleapis.com/trace' field")
+	}
+	want := "projects/my-project/traces/" + traceID.String()
+	if traceField != want {
+		t.Errorf("trace = %q, want %q", traceField, want)
+	}
+
+	if _, ok := m["logging.googleapis.com/spanId"]; !ok {
+		t.Error("missing 'logging.googleapis.com/spanId' field")
+	}
+	if sampled, _ := m["logging.googleapis.com/trace_sampled"].(bool); !sampled {
+		t.Error("trace_sampled should be true")
+	}
+}
+
+func TestTraceInjection_WithoutSpan(t *testing.T) {
+	var buf bytes.Buffer
+	l := newTestLogger(&buf, "my-project")
+	l.InfoContext(context.Background(), "untraced request")
+	m := logToMap(t, &buf)
+
+	if _, ok := m["logging.googleapis.com/trace"]; ok {
+		t.Error("unexpected trace field for context without span")
+	}
+}
+
+func TestTraceInjection_EmptyProjectID(t *testing.T) {
+	var traceID trace.TraceID
+	var spanID trace.SpanID
+	traceID[0] = 0x01
+	spanID[0] = 0x02
+
+	sc := trace.NewSpanContext(trace.SpanContextConfig{
+		TraceID:    traceID,
+		SpanID:     spanID,
+		TraceFlags: trace.FlagsSampled,
+		Remote:     true,
+	})
+	ctx := trace.ContextWithSpanContext(context.Background(), sc)
+
+	var buf bytes.Buffer
+	l := newTestLogger(&buf, "") // projectID 空
+	l.InfoContext(ctx, "no project id")
+	m := logToMap(t, &buf)
+
+	if _, ok := m["logging.googleapis.com/trace"]; ok {
+		t.Error("unexpected trace field when projectID is empty")
+	}
+}
+
+func TestParseLevel(t *testing.T) {
+	cases := []struct {
+		input string
+		want  slog.Level
+	}{
+		{"DEBUG", slog.LevelDebug},
+		{"debug", slog.LevelDebug},
+		{"INFO", slog.LevelInfo},
+		{"WARN", slog.LevelWarn},
+		{"WARNING", slog.LevelWarn},
+		{"ERROR", slog.LevelError},
+		{"", slog.LevelInfo},
+		{"invalid", slog.LevelInfo},
+	}
+	for _, tc := range cases {
+		if got := parseLevel(tc.input); got != tc.want {
+			t.Errorf("parseLevel(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/logger/logger_test.go
+++ b/backend/internal/logger/logger_test.go
@@ -43,6 +43,16 @@ func TestSeverityField_Error(t *testing.T) {
 	}
 }
 
+func TestSeverityField_Critical(t *testing.T) {
+	var buf bytes.Buffer
+	l := newTestLogger(&buf, "")
+	l.Log(context.Background(), LevelCritical, "test critical")
+	m := logToMap(t, &buf)
+	if got := m["severity"]; got != "CRITICAL" {
+		t.Errorf("severity = %q, want %q", got, "CRITICAL")
+	}
+}
+
 func TestSeverityField_Info(t *testing.T) {
 	var buf bytes.Buffer
 	l := newTestLogger(&buf, "")


### PR DESCRIPTION
## 概要

Cloud Run 本番環境で Cloud Logging がログを正しくパース・トレース連携できていなかった問題を解消する。
標準 `log` パッケージをすべて `log/slog` の JSON ハンドラーに置き換え、既存の OTel トレース基盤とログを自動連携させる。

## 変更内容

- `backend/internal/logger/logger.go`（新規）
  - Cloud Logging 準拠の JSON ハンドラー（`cloudHandler`）実装
  - `level` → `severity`（INFO/WARNING/ERROR/CRITICAL）変換
  - `msg` → `message` フィールド名変換
  - OTel SpanContext から `logging.googleapis.com/trace`・`spanId` を自動付与
  - `LOG_LEVEL` 環境変数でログレベル制御（デフォルト: INFO）
  - `GOOGLE_CLOUD_PROJECT` 未設定時はトレースフィールドをスキップ
- `backend/internal/logger/logger_test.go`（新規）
  - severity 変換・message フィールド・trace injection・projectID なしのケースを8件でテスト
- `backend/internal/api/router.go`
  - `gin.Default()` → `gin.New()` + slog ベースのアクセスログ・Recoveryミドルウェアに置換
  - アクセスログ: method/path/status/latency_ms/client_ip を JSON で出力、ステータスに応じてログレベルを自動選択（5xx→Error, 4xx→Warn, 2xx→Info）
- `backend/internal/api/handler.go`
  - `log.Printf("WARN: ...")` 4箇所 → `slog.WarnContext(ctx, ...)` に置換（トレース連携）
- `backend/cmd/server/main.go`
  - `logger.Init(os.Stderr)` を先頭で呼び出しグローバルロガーを初期化
  - 全 `log.*` 呼び出しを `slog.*` に置換

## 関連Issue

Closes #160

## テスト

- [x] 既存テストが通ること（`go test -race ./... -timeout 120s` 全パス）
- [x] 新規テストを追加した場合、全ケースがPASSすること（logger: 8件）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み

## 備考

- 新規外部依存パッケージなし（`log/slog` は標準ライブラリ、`go.opentelemetry.io/otel/trace` は既存依存）
- Cloud Run 本番への適用には `GOOGLE_CLOUD_PROJECT` 環境変数の追加が必要（Terraform 側は今回スコープ外、別途対応）