### PR TITLE
docs: OTel 観測基盤・セキュリティドキュメント追加

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -74,3 +74,98 @@ graph TD
 | Frontend CI | `frontend/**`, `frontend-ci.yml` | `lint` / `tsc --noEmit` / `vitest run` / `build` |
 
 Dependabot により Go modules・npm の依存パッケージが毎週月曜（JST）に自動更新される（エコシステムごとに1PR）。
+
+---
+
+## 観測基盤（OpenTelemetry + 構造化ロギング）
+
+### スタック概要
+
+| レイヤー | 実装 | パッケージ |
+|---|---|---|
+| トレース / メトリクス | OpenTelemetry Go SDK | `backend/internal/telemetry/setup.go` |
+| HTTP スパン自動計装 | `otelgin` ミドルウェア | `go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin` |
+| 構造化ログ | `slog` JSON ハンドラー（Cloud Logging 準拠） | `backend/internal/logger/logger.go` |
+| ログ ↔ トレース相関 | slog ハンドラーが OTel SpanContext からトレースフィールドを注入 | 同上 |
+
+### OTel シグナルフロー
+
+```mermaid
+flowchart LR
+    subgraph Request
+        Gin["Gin ルーター"]
+        OtelGin["otelgin ミドルウェア\n（スパン開始・Context注入）"]
+        Handler["ハンドラー\n（MLITクライアント等）"]
+    end
+
+    subgraph Telemetry["internal/telemetry"]
+        TP["TracerProvider\n（sdktrace）"]
+        MP["MeterProvider\n（sdkmetric）"]
+    end
+
+    subgraph Export["エクスポーター"]
+        Stdout["stdout\n（ローカル開発）"]
+        OTLP["OTLP gRPC\n（本番: Cloud Trace / Monitoring）"]
+    end
+
+    subgraph Logging["internal/logger"]
+        SlogHandler["cloudHandler\n（slog.NewJSONHandler ラップ）"]
+        CloudLog["Cloud Logging\n（stderr JSON）"]
+    end
+
+    Gin --> OtelGin --> Handler
+    Handler --> TP
+    Handler --> MP
+    TP --> Stdout
+    TP --> OTLP
+    MP --> Stdout
+    MP --> OTLP
+    OtelGin -.-> |SpanContext| SlogHandler
+    SlogHandler --> CloudLog
+```
+
+### エクスポーター切り替え
+
+`OTEL_EXPORTER_OTLP_ENDPOINT` 環境変数の有無で自動切り替えする。
+
+| 環境 | `OTEL_EXPORTER_OTLP_ENDPOINT` | トレース出力先 | メトリクス出力先 |
+|---|---|---|---|
+| ローカル開発 | 未設定 | stdout（整形JSON） | stdout |
+| Cloud Run 本番 | `https://...` (OTLP エンドポイント) | Cloud Trace（OTLP gRPC） | Cloud Monitoring（OTLP gRPC） |
+
+### 構造化ログフォーマット（Cloud Logging 準拠）
+
+`logger.Init(os.Stderr)` を `main()` 先頭で呼ぶことでグローバル `slog` デフォルトロガーを設定する。
+
+```json
+{
+  "severity": "INFO",
+  "message": "access",
+  "method": "GET",
+  "path": "/api/land-prices/stats",
+  "status": 200,
+  "latency_ms": 42,
+  "logging.googleapis.com/trace": "projects/my-project/traces/abc123...",
+  "logging.googleapis.com/spanId": "def456...",
+  "logging.googleapis.com/trace_sampled": true
+}
+```
+
+- `severity` / `message` フィールド名は Cloud Logging が自動パースする予約名
+- `logging.googleapis.com/trace` を付与することで Cloud Logging UI でトレースと相関表示できる
+- `GOOGLE_CLOUD_PROJECT` が未設定（ローカル）の場合、トレースフィールドはスキップされる
+
+### メトリクス計装
+
+`telemetry.Setup()` 後、以下のグローバル計測器が有効になる。
+
+| 計測器名 | 種別 | 説明 |
+|---|---|---|
+| `analyze.requests.total` | Counter | 投資分析リクエスト数 |
+| `mlit.api.request.duration` | Histogram | MLIT API リクエストレイテンシ（秒） |
+| `mlit.cache.hits` | Counter | MLIT インメモリキャッシュ ヒット数 |
+| `mlit.cache.misses` | Counter | MLIT インメモリキャッシュ ミス数 |
+
+### ログレベル制御
+
+`LOG_LEVEL` 環境変数（`DEBUG` / `INFO` / `WARN` / `ERROR`、デフォルト `INFO`）で動的に変更できる。`LevelCritical`（`slog.LevelError + 4`）は Cloud Logging の `CRITICAL` 重大度に対応するカスタムレベルとして `logger` パッケージで公開している。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,7 +131,7 @@ flowchart LR
 | 環境 | `OTEL_EXPORTER_OTLP_ENDPOINT` | トレース出力先 | メトリクス出力先 |
 |---|---|---|---|
 | ローカル開発 | 未設定 | stdout（整形JSON） | stdout |
-| Cloud Run 本番 | `https://...` (OTLP エンドポイント) | Cloud Trace（OTLP gRPC） | Cloud Monitoring（OTLP gRPC） |
+| Cloud Run 本番 | `host:port`（例: `otel-collector:4317`） | Cloud Trace（OTLP gRPC） | Cloud Monitoring（OTLP gRPC） |
 
 ### 構造化ログフォーマット（Cloud Logging 準拠）
 

--- a/docs/metadata.json
+++ b/docs/metadata.json
@@ -13,6 +13,16 @@
       "updatedAt": "2026-04-21"
     },
     {
+      "id": "architecture",
+      "path": "docs/architecture.md",
+      "title": "アーキテクチャ詳細",
+      "description": "投資計算フロー（InvestmentInput→年次ループ→InvestmentResult）の Mermaid 図と計算式サマリー（表面利回り・元利均等返済・デッドクロス・長期譲渡税率・法定耐用年数）。デプロイフロー（GitHub Actions CI → Docker ビルド → Cloud Run / Vercel → Terraform）。観測基盤（OpenTelemetry + 構造化ロギング）: OTel シグナルフロー（Gin → otelgin → TracerProvider/MeterProvider → stdout/OTLP gRPC）・OTEL_EXPORTER_OTLP_ENDPOINT によるエクスポーター切り替え・Cloud Logging 準拠 JSON ログフォーマット（severity/message/logging.googleapis.com/trace フィールド）・メトリクス計装一覧（analyze.requests.total/mlit.api.request.duration/mlit.cache.hits/mlit.cache.misses）・LOG_LEVEL 環境変数と LevelCritical カスタムレベル。",
+      "tags": ["アーキテクチャ", "投資計算", "デプロイ", "CI/CD", "OpenTelemetry", "OTel", "構造化ロギング", "slog", "Cloud Logging", "Cloud Run", "Vercel", "GitHub Actions", "Terraform", "メトリクス", "トレース", "観測基盤"],
+      "industry": ["不動産", "フィンテック"],
+      "topics": ["InvestmentInput", "InvestmentResult", "YearlyResult", "表面利回り", "元利均等返済", "デッドクロス", "長期譲渡税率", "法定耐用年数", "Docker", "Dependabot", "otelgin", "TracerProvider", "MeterProvider", "stdouttrace", "stdoutmetric", "otlptracegrpc", "otlpmetricgrpc", "OTEL_EXPORTER_OTLP_ENDPOINT", "cloudHandler", "slog.NewJSONHandler", "severity", "logging.googleapis.com/trace", "logging.googleapis.com/spanId", "logging.googleapis.com/trace_sampled", "GOOGLE_CLOUD_PROJECT", "LOG_LEVEL", "LevelCritical", "analyze.requests.total", "mlit.api.request.duration", "mlit.cache.hits", "mlit.cache.misses", "telemetry/setup.go", "logger/logger.go", "backend-ci.yml", "frontend-ci.yml"],
+      "updatedAt": "2026-04-22"
+    },
+    {
       "id": "domain-investment-calculation",
       "path": "docs/domain-investment-calculation.md",
       "title": "投資計算ロジック詳細仕様",
@@ -70,16 +80,6 @@
       "tags": ["セキュリティ", "認証", "ミドルウェア", "X-Internal-Key", "APP_INTERNAL_API_KEY", "Vercel", "Cloud Run", "内部通信", "WIF", "OIDC", "Secret Manager", "SHA固定", "VERCEL_TOKEN", "GitHub Actions", "OpenTelemetry", "OTel", "OTEL_EXPORTER_OTLP_ENDPOINT", "GOOGLE_CLOUD_PROJECT", "スパン属性", "PII", "Cloud Logging"],
       "industry": ["不動産", "フィンテック"],
       "topics": ["internalKeyMiddleware", "X-Internal-Key", "APP_INTERNAL_API_KEY", "middleware.ts", "router.go", "401 Unauthorized", "/health", "本番環境", "ローカル開発", "Workload Identity Federation", "WIF_PROVIDER", "SA_EMAIL", "deploy-cloudrun", "SHA固定", "Secret Manager", "Artifact Registry", "クリーンアップポリシー", "VERCEL_TOKEN", "VERCEL_ORG_ID", "VERCEL_PROJECT_ID", "frontend-ci.yml", "vercel deploy", "OTEL_EXPORTER_OTLP_ENDPOINT", "GOOGLE_CLOUD_PROJECT", "mlit.query.*", "mlit.endpoint", "mlit.cache.hit", "mlit.retry.count", "stdout exporter", "Cloud Logging", "setup.go", "logger.go"],
-      "updatedAt": "2026-04-22"
-    },
-    {
-      "id": "architecture",
-      "path": "docs/architecture.md",
-      "title": "アーキテクチャ詳細",
-      "description": "投資計算フロー（InvestmentInput→年次ループ→InvestmentResult）の Mermaid 図と計算式サマリー（表面利回り・元利均等返済・デッドクロス・長期譲渡税率・法定耐用年数）。デプロイフロー（GitHub Actions CI → Docker ビルド → Cloud Run / Vercel → Terraform）。観測基盤（OpenTelemetry + 構造化ロギング）: OTel シグナルフロー（Gin → otelgin → TracerProvider/MeterProvider → stdout/OTLP gRPC）・OTEL_EXPORTER_OTLP_ENDPOINT によるエクスポーター切り替え・Cloud Logging 準拠 JSON ログフォーマット（severity/message/logging.googleapis.com/trace フィールド）・メトリクス計装一覧（analyze.requests.total/mlit.api.request.duration/mlit.cache.hits/mlit.cache.misses）・LOG_LEVEL 環境変数と LevelCritical カスタムレベル。",
-      "tags": ["アーキテクチャ", "投資計算", "デプロイ", "CI/CD", "OpenTelemetry", "OTel", "構造化ロギング", "slog", "Cloud Logging", "Cloud Run", "Vercel", "GitHub Actions", "Terraform", "メトリクス", "トレース", "観測基盤"],
-      "industry": ["不動産", "フィンテック"],
-      "topics": ["InvestmentInput", "InvestmentResult", "YearlyResult", "表面利回り", "元利均等返済", "デッドクロス", "長期譲渡税率", "法定耐用年数", "Docker", "Dependabot", "otelgin", "TracerProvider", "MeterProvider", "stdouttrace", "stdoutmetric", "otlptracegrpc", "otlpmetricgrpc", "OTEL_EXPORTER_OTLP_ENDPOINT", "cloudHandler", "slog.NewJSONHandler", "severity", "logging.googleapis.com/trace", "logging.googleapis.com/spanId", "logging.googleapis.com/trace_sampled", "GOOGLE_CLOUD_PROJECT", "LOG_LEVEL", "LevelCritical", "analyze.requests.total", "mlit.api.request.duration", "mlit.cache.hits", "mlit.cache.misses", "telemetry/setup.go", "logger/logger.go", "backend-ci.yml", "frontend-ci.yml"],
       "updatedAt": "2026-04-22"
     },
     {

--- a/docs/metadata.json
+++ b/docs/metadata.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "lastUpdated": "2026-04-22T02:15:00",
+  "lastUpdated": "2026-04-22T15:30:00",
   "documents": [
     {
       "id": "overview",
@@ -66,11 +66,21 @@
       "id": "security",
       "path": "docs/security.md",
       "title": "セキュリティ設計",
-      "description": "Vercel-Cloud Run 間の内部通信認証（APP_INTERNAL_API_KEY / X-Internal-Key ヘッダー）の設計意図・動作仕様・適用範囲・ローカル開発での挙動・本番キー設定手順。internalKeyMiddleware が /api/* グループに適用され、/health はスキップ。APP_INTERNAL_API_KEY 未設定時はミドルウェアをスキップし後方互換を維持。Workload Identity Federation（OIDC パスワードレスデプロイ）・SHA固定 GitHub Actions・Secret Manager・Artifact Registry クリーンアップポリシーを含む。フロントエンド GitHub Actions デプロイ（VERCEL_TOKEN env渡し・vercel CLI バージョン固定・最小権限）も記載。",
-      "tags": ["セキュリティ", "認証", "ミドルウェア", "X-Internal-Key", "APP_INTERNAL_API_KEY", "Vercel", "Cloud Run", "内部通信", "WIF", "OIDC", "Secret Manager", "SHA固定", "VERCEL_TOKEN", "GitHub Actions"],
+      "description": "Vercel-Cloud Run 間の内部通信認証（APP_INTERNAL_API_KEY / X-Internal-Key ヘッダー）の設計意図・動作仕様・適用範囲・ローカル開発での挙動・本番キー設定手順。internalKeyMiddleware が /api/* グループに適用され、/health はスキップ。APP_INTERNAL_API_KEY 未設定時はミドルウェアをスキップし後方互換を維持。Workload Identity Federation（OIDC パスワードレスデプロイ）・SHA固定 GitHub Actions・Secret Manager・Artifact Registry クリーンアップポリシーを含む。フロントエンド GitHub Actions デプロイ（VERCEL_TOKEN env渡し・vercel CLI バージョン固定・最小権限）も記載。OpenTelemetry 観測基盤のセキュリティ考慮: OTEL_EXPORTER_OTLP_ENDPOINT の管理方針（非シークレット・Cloud Run 環境変数）・stdout エクスポーターのデータスコープ（ローカル開発時の出力内容）・スパン属性ポリシー（mlit.query.* 属性に PII を含まない設計）・GOOGLE_CLOUD_PROJECT と Cloud Logging トレース相関の説明。",
+      "tags": ["セキュリティ", "認証", "ミドルウェア", "X-Internal-Key", "APP_INTERNAL_API_KEY", "Vercel", "Cloud Run", "内部通信", "WIF", "OIDC", "Secret Manager", "SHA固定", "VERCEL_TOKEN", "GitHub Actions", "OpenTelemetry", "OTel", "OTEL_EXPORTER_OTLP_ENDPOINT", "GOOGLE_CLOUD_PROJECT", "スパン属性", "PII", "Cloud Logging"],
       "industry": ["不動産", "フィンテック"],
-      "topics": ["internalKeyMiddleware", "X-Internal-Key", "APP_INTERNAL_API_KEY", "middleware.ts", "router.go", "401 Unauthorized", "/health", "本番環境", "ローカル開発", "Workload Identity Federation", "WIF_PROVIDER", "SA_EMAIL", "deploy-cloudrun", "SHA固定", "Secret Manager", "Artifact Registry", "クリーンアップポリシー", "VERCEL_TOKEN", "VERCEL_ORG_ID", "VERCEL_PROJECT_ID", "frontend-ci.yml", "vercel deploy"],
-      "updatedAt": "2026-04-21"
+      "topics": ["internalKeyMiddleware", "X-Internal-Key", "APP_INTERNAL_API_KEY", "middleware.ts", "router.go", "401 Unauthorized", "/health", "本番環境", "ローカル開発", "Workload Identity Federation", "WIF_PROVIDER", "SA_EMAIL", "deploy-cloudrun", "SHA固定", "Secret Manager", "Artifact Registry", "クリーンアップポリシー", "VERCEL_TOKEN", "VERCEL_ORG_ID", "VERCEL_PROJECT_ID", "frontend-ci.yml", "vercel deploy", "OTEL_EXPORTER_OTLP_ENDPOINT", "GOOGLE_CLOUD_PROJECT", "mlit.query.*", "mlit.endpoint", "mlit.cache.hit", "mlit.retry.count", "stdout exporter", "Cloud Logging", "setup.go", "logger.go"],
+      "updatedAt": "2026-04-22"
+    },
+    {
+      "id": "architecture",
+      "path": "docs/architecture.md",
+      "title": "アーキテクチャ詳細",
+      "description": "投資計算フロー（InvestmentInput→年次ループ→InvestmentResult）の Mermaid 図と計算式サマリー（表面利回り・元利均等返済・デッドクロス・長期譲渡税率・法定耐用年数）。デプロイフロー（GitHub Actions CI → Docker ビルド → Cloud Run / Vercel → Terraform）。観測基盤（OpenTelemetry + 構造化ロギング）: OTel シグナルフロー（Gin → otelgin → TracerProvider/MeterProvider → stdout/OTLP gRPC）・OTEL_EXPORTER_OTLP_ENDPOINT によるエクスポーター切り替え・Cloud Logging 準拠 JSON ログフォーマット（severity/message/logging.googleapis.com/trace フィールド）・メトリクス計装一覧（analyze.requests.total/mlit.api.request.duration/mlit.cache.hits/mlit.cache.misses）・LOG_LEVEL 環境変数と LevelCritical カスタムレベル。",
+      "tags": ["アーキテクチャ", "投資計算", "デプロイ", "CI/CD", "OpenTelemetry", "OTel", "構造化ロギング", "slog", "Cloud Logging", "Cloud Run", "Vercel", "GitHub Actions", "Terraform", "メトリクス", "トレース", "観測基盤"],
+      "industry": ["不動産", "フィンテック"],
+      "topics": ["InvestmentInput", "InvestmentResult", "YearlyResult", "表面利回り", "元利均等返済", "デッドクロス", "長期譲渡税率", "法定耐用年数", "Docker", "Dependabot", "otelgin", "TracerProvider", "MeterProvider", "stdouttrace", "stdoutmetric", "otlptracegrpc", "otlpmetricgrpc", "OTEL_EXPORTER_OTLP_ENDPOINT", "cloudHandler", "slog.NewJSONHandler", "severity", "logging.googleapis.com/trace", "logging.googleapis.com/spanId", "logging.googleapis.com/trace_sampled", "GOOGLE_CLOUD_PROJECT", "LOG_LEVEL", "LevelCritical", "analyze.requests.total", "mlit.api.request.duration", "mlit.cache.hits", "mlit.cache.misses", "telemetry/setup.go", "logger/logger.go", "backend-ci.yml", "frontend-ci.yml"],
+      "updatedAt": "2026-04-22"
     },
     {
       "id": "mlit-api-integration",

--- a/docs/security.md
+++ b/docs/security.md
@@ -135,6 +135,47 @@ Artifact Registry の無料枠（0.5 GB/月）を超えないよう、最新 5 �
 
 ---
 
+## OpenTelemetry 観測基盤のセキュリティ考慮
+
+### OTEL_EXPORTER_OTLP_ENDPOINT
+
+`OTEL_EXPORTER_OTLP_ENDPOINT` はシークレットではなく、通常の環境変数として Cloud Run に設定する（Secret Manager 管理不要）。ただし、エンドポイント URL 自体がインフラ構成情報を含む場合は適宜アクセス制御を検討すること。
+
+| 環境 | 値 | 管理方法 |
+|---|---|---|
+| ローカル開発 | 未設定（stdout 出力） | 不要 |
+| Cloud Run 本番 | OTLP gRPC エンドポイント | Cloud Run 環境変数（Terraform） |
+
+### stdout エクスポーターのデータスコープ（ローカル開発）
+
+`OTEL_EXPORTER_OTLP_ENDPOINT` が未設定の場合、トレース・メトリクスは **stdout（コンソール）** に出力される。出力される情報は以下の通り。
+
+- スパン名・開始/終了時刻・ステータス
+- スパン属性（下記「スパン属性ポリシー」参照）
+- メトリクス計測値（カウンター・ヒストグラム）
+
+ログイン資格情報・APIキー・個人情報はスパン属性に含まれない設計としている。
+
+### スパン属性ポリシー（mlit.query.* 属性）
+
+MLIT API クライアント（`backend/internal/mlit/client.go`）は以下の属性をスパンに付与する。
+
+| 属性名 | 例 | 分類 |
+|---|---|---|
+| `mlit.endpoint` | `"XIT001"` | API エンドポイント識別子（非機密） |
+| `mlit.query.area` | `"13"` | 都道府県コード（非機密） |
+| `mlit.cache.hit` | `true` / `false` | キャッシュ状態（非機密） |
+| `mlit.retry.count` | `1` | リトライ回数（非機密） |
+| `server.address` | `"www.reinfolib.mlit.go.jp"` | OTel セマンティクス準拠 |
+
+**注意:** クエリパラメータに含まれる値（都道府県コード・タイル座標等）は公開情報のみであり、個人を特定できる情報（PII）はスパン属性として記録しない。
+
+### GOOGLE_CLOUD_PROJECT と Cloud Logging トレース相関
+
+`GOOGLE_CLOUD_PROJECT` はシークレットではなく、GCP プロジェクト ID（公開情報）を設定する。この値は Cloud Logging のトレースリンク URL 生成（`projects/<id>/traces/<traceId>`）にのみ使用される。未設定の場合、トレースフィールドは JSON ログに含まれず、Cloud Logging との相関表示が無効になる（ローカル開発では意図的に未設定とする）。
+
+---
+
 ## 関連ファイル
 
 - `backend/internal/api/router.go` — `internalKeyMiddleware()`
@@ -145,3 +186,5 @@ Artifact Registry の無料枠（0.5 GB/月）を超えないよう、最新 5 �
 - `terraform/cloud_run.tf` — Cloud Run v2 サービス定義
 - `.github/workflows/deploy-backend.yml` — バックエンドデプロイワークフロー（SHA 固定）
 - `.github/workflows/frontend-ci.yml` — フロントエンド CI + Vercel デプロイワークフロー
+- `backend/internal/telemetry/setup.go` — OTel TracerProvider / MeterProvider 初期化
+- `backend/internal/logger/logger.go` — Cloud Logging 準拠 slog ハンドラー


### PR DESCRIPTION
## 概要

Issue #152 対応。OpenTelemetry 観測基盤と構造化ロギング（slog）の導入に伴い、アーキテクチャ・セキュリティ・メタデータのドキュメントを更新する。

## 変更内容

- `docs/architecture.md`: 「観測基盤（OpenTelemetry + 構造化ロギング）」セクションを追加
  - OTel シグナルフロー図（Mermaid）
  - エクスポーター切り替え（`OTEL_EXPORTER_OTLP_ENDPOINT` による stdout ↔ OTLP gRPC）
  - Cloud Logging 準拠 JSON ログフォーマットの説明
  - メトリクス計装一覧（`analyze.requests.total` / `mlit.api.*`）
  - ログレベル制御（`LOG_LEVEL` 環境変数・`LevelCritical`）
- `docs/security.md`: 「OpenTelemetry 観測基盤のセキュリティ考慮」セクションを追加
  - `OTEL_EXPORTER_OTLP_ENDPOINT` の管理方針（非シークレット）
  - stdout エクスポーターのデータスコープ（ローカル開発）
  - スパン属性ポリシー（`mlit.query.*` 属性に PII を含まない設計）
  - `GOOGLE_CLOUD_PROJECT` と Cloud Logging トレース相関の説明
- `docs/metadata.json`: `architecture` エントリ新規追加・`security` エントリの description/tags/topics を OTel 内容で更新

## 関連Issue

Closes #152

## テスト

- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み