### PR TITLE
fix(ux): クイックモード切替時に結果が消えることをユーザーに通知

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState, useRef } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { InvestmentForm } from "@/components/InvestmentForm";
 import { YieldAnalysis } from "@/components/YieldAnalysis";
 import { CashFlowChart } from "@/components/CashFlowChart";
@@ -8,7 +8,7 @@ import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
 import CostBreakdown from "@/components/CostBreakdown";
 import type { InvestmentInput, InvestmentResult, LandPriceComparison, TheoreticalPriceResult, StationRidershipResult, PopulationForecastResult, AppraisalComparisonResult, UrbanRisk, SimulationMode } from "@/types/investment";
 import { analyze, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks } from "@/lib/api";
-import { ShieldAlert } from "lucide-react";
+import { ShieldAlert, Info } from "lucide-react";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 
 /** 直近2年分の期間（国交省API形式: YYYYQ） */
@@ -33,6 +33,12 @@ export function Dashboard() {
   const [simulationMode, setSimulationMode] = useState<SimulationMode>("quick");
   const [modeNotice, setModeNotice] = useState(false);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (noticeTimer.current) clearTimeout(noticeTimer.current);
+    };
+  }, []);
 
   const handleModeChange = (mode: SimulationMode) => {
     if (result) {
@@ -138,8 +144,9 @@ export function Dashboard() {
         )}
 
         {modeNotice && (
-          <div className="mb-4 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
-            ℹ モードを切り替えたため、結果をクリアしました。再度シミュレーションを実行してください。
+          <div className="mb-4 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+            <Info className="h-4 w-4 shrink-0" />
+            モードを切り替えたため、結果をクリアしました。再度シミュレーションを実行してください。
           </div>
         )}
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import { InvestmentForm } from "@/components/InvestmentForm";
 import { YieldAnalysis } from "@/components/YieldAnalysis";
 import { CashFlowChart } from "@/components/CashFlowChart";
@@ -31,8 +31,15 @@ export function Dashboard() {
   const [landAppraisal, setLandAppraisal] = useState<AppraisalComparisonResult | null>(null);
   const [externalUrbanRisks, setExternalUrbanRisks] = useState<UrbanRisk[] | null>(null);
   const [simulationMode, setSimulationMode] = useState<SimulationMode>("quick");
+  const [modeNotice, setModeNotice] = useState(false);
+  const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleModeChange = (mode: SimulationMode) => {
+    if (result) {
+      if (noticeTimer.current) clearTimeout(noticeTimer.current);
+      setModeNotice(true);
+      noticeTimer.current = setTimeout(() => setModeNotice(false), 4000);
+    }
     setSimulationMode(mode);
     setResult(null);
   };
@@ -127,6 +134,12 @@ export function Dashboard() {
         {error && (
           <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
             ⚠ {error}
+          </div>
+        )}
+
+        {modeNotice && (
+          <div className="mb-4 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+            ℹ モードを切り替えたため、結果をクリアしました。再度シミュレーションを実行してください。
           </div>
         )}
 


### PR DESCRIPTION
## 概要
クイック↔詳細モード切替時に `setResult(null)` で結果が黙って消える問題を解消する。結果が存在する状態でモードを切り替えた場合に、4秒間のインラインバナーで「結果をクリアしました。再度シミュレーションを実行してください」と通知する。

## 変更内容
- `Dashboard.tsx`: `modeNotice` state と `useRef` タイマーを追加
- 結果が存在する状態での切替時のみバナーを表示（結果がない状態での切替は通知しない）
- 4秒後に自動消去（連続切替時はタイマーをリセット）

## 関連Issue
Closes #154

## テスト
- [x] 既存テストが通ること（71/71 PASS）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み