### PR TITLE
feat: 利回り目標（8%）をユーザー設定可能なパラメータに変更

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -9,8 +9,7 @@ import (
 
 const (
 	// SqmPerTsubo は 1坪あたりの平方メートル数（mlit パッケージからも参照）
-	SqmPerTsubo     = 3.30578
-	targetYield8pct = 0.08 // 8%境界線
+	SqmPerTsubo = 3.30578
 )
 
 // Analyze は投資入力値から収支シミュレーション結果を算出する
@@ -36,8 +35,8 @@ func Analyze(input InvestmentInput) InvestmentResult {
 		netYield = (annualRent - annualExpenses) / totalInvestment
 	}
 
-	// 8%逆算
-	requiredRent, landDrop := calcRequired8pct(input, totalInvestment)
+	// 目標利回り逆算
+	requiredRent, landDrop := calcRequiredForTarget(input, totalInvestment)
 
 	// ローン月次計算
 	monthlyPayment := calcMonthlyPayment(input.LoanAmount, effectiveRate, input.LoanYears)
@@ -178,7 +177,8 @@ func Analyze(input InvestmentInput) InvestmentResult {
 		MiscExpenses:          miscExpenses,
 		GrossYield:            grossYield,
 		NetYield:              netYield,
-		IsAbove8Percent:       grossYield >= targetYield8pct,
+		IsAboveYieldTarget:    grossYield >= input.YieldTarget,
+		YieldTarget:           input.YieldTarget,
 		RequiredCostReduction: landDrop,
 		RequiredMonthlyRent:   requiredRent,
 		DeadCrossYear:         deadCrossYear,
@@ -349,18 +349,16 @@ func calcYearlyLoanComponents(balance, annualRate, monthlyPayment float64) (inte
 	return interest, principal
 }
 
-// calcRequired8pct は表面利回り8%達成に必要な値を逆算する
+// calcRequiredForTarget は目標利回り達成に必要な値を逆算する
 // costReduction は「土地価格または建築費のいずれか一方」を削減すべき金額を表す
-func calcRequired8pct(input InvestmentInput, totalInvestment float64) (requiredRent, costReduction float64) {
-	// 目標利回り8%達成に必要な月額賃料
-	requiredAnnualRent := totalInvestment * targetYield8pct
+func calcRequiredForTarget(input InvestmentInput, totalInvestment float64) (requiredRent, costReduction float64) {
+	target := input.YieldTarget
+	requiredAnnualRent := totalInvestment * target
 	requiredRent = requiredAnnualRent / 12
 
-	// 現在の賃料で8%達成に必要な総投資額
 	currentAnnualRent := input.MonthlyRent * 12
-	requiredTotalInvestment := currentAnnualRent / targetYield8pct
+	requiredTotalInvestment := currentAnnualRent / target
 
-	// 過剰投資額 = 土地 or 建築費いずれかを削減すべき額
 	excess := totalInvestment - requiredTotalInvestment
 	if excess > 0 {
 		costReduction = excess

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -97,8 +97,8 @@ func TestAnalyze_Above8Percent(t *testing.T) {
 	}
 	highRent.Defaults()
 	r1 := Analyze(highRent)
-	if !r1.IsAbove8Percent {
-		t.Errorf("高賃料ケース: IsAbove8Percent = false, want true (yield=%.2f%%)", r1.GrossYield*100)
+	if !r1.IsAboveYieldTarget {
+		t.Errorf("高賃料ケース: IsAboveYieldTarget = false, want true (yield=%.2f%%)", r1.GrossYield*100)
 	}
 
 	// 低賃料 → 8%未満
@@ -109,8 +109,8 @@ func TestAnalyze_Above8Percent(t *testing.T) {
 	}
 	lowRent.Defaults()
 	r2 := Analyze(lowRent)
-	if r2.IsAbove8Percent {
-		t.Errorf("低賃料ケース: IsAbove8Percent = true, want false (yield=%.2f%%)", r2.GrossYield*100)
+	if r2.IsAboveYieldTarget {
+		t.Errorf("低賃料ケース: IsAboveYieldTarget = true, want false (yield=%.2f%%)", r2.GrossYield*100)
 	}
 }
 

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -86,6 +86,9 @@ type InvestmentInput struct {
 
 	// 賃料下落率: 毎年この割合だけ実効賃料が低下する（例: 0.01 = 年1%下落）
 	RentDeclineRate float64 `json:"rentDeclineRate"`
+
+	// 目標表面利回り（例: 0.08 = 8%）。0 の場合は Defaults() で 0.08 にセットされる。
+	YieldTarget float64 `json:"yieldTarget"`
 }
 
 // Validate は入力値のバリデーションを行い、不正な組み合わせはエラーを返す。
@@ -117,6 +120,9 @@ func (i *InvestmentInput) Defaults() {
 	}
 	if i.ExitYieldTarget == 0 {
 		i.ExitYieldTarget = 0.06
+	}
+	if i.YieldTarget == 0 {
+		i.YieldTarget = 0.08
 	}
 	if i.LoanYears == 0 {
 		i.LoanYears = 35
@@ -177,9 +183,10 @@ type InvestmentResult struct {
 	MiscExpenses    float64 `json:"miscExpenses"`
 	GrossYield      float64 `json:"grossYield"`      // 表面利回り（満室想定年収/総投資額）
 	NetYield        float64 `json:"netYield"`        // 実質利回り（実効収入-経費)/総投資額）
-	IsAbove8Percent bool    `json:"isAbove8Percent"`
+	IsAboveYieldTarget bool    `json:"isAboveYieldTarget"`
+	YieldTarget        float64 `json:"yieldTarget"` // 目標表面利回り（例: 0.08）
 
-	// 8%達成に必要な改善額（土地・建築費いずれか一方を削減する額）
+	// 目標利回り達成に必要な改善額（土地・建築費いずれか一方を削減する額）
 	RequiredCostReduction float64 `json:"requiredCostReduction"`
 	RequiredMonthlyRent   float64 `json:"requiredMonthlyRent"` // または必要月額賃料
 

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -96,6 +96,8 @@ function validateFull(input: InvestmentInput): FormErrors {
     e.incomeTaxRate = "0〜60%の範囲で入力してください";
   if (input.exitYieldTarget <= 0 || input.exitYieldTarget > 0.5)
     e.exitYieldTarget = "0%超〜50%の範囲で入力してください";
+  if (input.yieldTarget <= 0 || input.yieldTarget > 0.5)
+    e.yieldTarget = "0%超〜50%の範囲で入力してください";
   if (input.holdingYears < 0 || input.holdingYears > 50)
     e.holdingYears = "0〜50年の範囲で入力してください";
   return e;
@@ -355,6 +357,10 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   value={toMan(input.loanAmount)}
                   onChange={(e) => setNum("loanAmount", fromMan(e.target.value))}
                   error={fieldError("loanAmount")} />
+                <Input label="目標利回り" type="number" suffix="%" step="0.5"
+                  value={toPct(input.yieldTarget, 1)}
+                  onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
+                  error={fieldError("yieldTarget")} />
               </div>
 
               <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 space-y-0.5">
@@ -668,6 +674,10 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                     value={toPct(input.exitYieldTarget, 1)}
                     onChange={(e) => setNum("exitYieldTarget", fromPct(e.target.value))}
                     error={fieldError("exitYieldTarget")} />
+                  <Input label="目標表面利回り" type="number" suffix="%" step="0.5"
+                    value={toPct(input.yieldTarget, 1)}
+                    onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
+                    error={fieldError("yieldTarget")} />
                   <Input label="所得税率（実効）" type="number" suffix="%" step="1"
                     value={toPct(input.incomeTaxRate, 0)}
                     onChange={(e) => setNum("incomeTaxRate", fromPct(e.target.value))}

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -12,21 +12,20 @@ interface Props {
   populationForecast?: PopulationForecastResult | null;
 }
 
-const MAX_YIELD_PCT = 16; // ゲージ上限（8%が中央に来る設計）
-const TARGET_PCT = 8;
-
 export function YieldAnalysis({ result, input, populationForecast }: Props) {
   const yieldPct = result.grossYield * 100;
   const netYieldPct = result.netYield * 100;
-  const isGood = result.isAbove8Percent;
+  const isGood = result.isAboveYieldTarget;
+  const targetPct = result.yieldTarget * 100;
+  const maxYieldPct = targetPct * 2; // ゲージ上限: 目標の2倍（目標が中央）
 
   // 人口シナリオ用（populationForecast表示のために残す）
   const actualV = input.actualVacancyRate > 0 ? input.actualVacancyRate : input.vacancyRate;
 
   const stressScenarios: StressScenarioResult[] = result.stressScenarios ?? [];
 
-  const gaugePosition = Math.min(yieldPct / MAX_YIELD_PCT, 1) * 100;
-  const targetPosition = (TARGET_PCT / MAX_YIELD_PCT) * 100; // = 50%
+  const gaugePosition = Math.min(yieldPct / maxYieldPct, 1) * 100;
+  const targetPosition = 50; // 目標は常にゲージ中央
 
   return (
     <div className="space-y-4">
@@ -50,23 +49,23 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
               {isGood ? (
                 <>
                   <CheckCircle className="h-12 w-12 text-green-500" />
-                  <Badge variant="success">8%超え ✓</Badge>
+                  <Badge variant="success">{targetPct}%超え ✓</Badge>
                 </>
               ) : (
                 <>
                   <AlertTriangle className="h-12 w-12 text-red-500" />
-                  <Badge variant="danger">8%未満 ✗</Badge>
+                  <Badge variant="danger">{targetPct}%未満 ✗</Badge>
                 </>
               )}
             </div>
           </div>
 
-          {/* 8%境界線ゲージ（上限16%、8%が中央） */}
+          {/* 目標利回り境界線ゲージ（目標が中央） */}
           <div className="mt-4">
             <div className="flex justify-between text-xs text-muted-foreground mb-1">
               <span>0%</span>
-              <span className="font-semibold text-orange-500">目標 {TARGET_PCT}%</span>
-              <span>{MAX_YIELD_PCT}%+</span>
+              <span className="font-semibold text-orange-500">目標 {targetPct}%</span>
+              <span>{maxYieldPct}%+</span>
             </div>
             <div className="relative h-3 rounded-full bg-muted overflow-hidden">
               <div className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-red-400 via-yellow-400 to-green-400 w-full" />
@@ -193,13 +192,13 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
         </CardContent>
       </Card>
 
-      {/* 8%未達の場合: 逆算カード（ISSUE-16: either-or を明示） */}
+      {/* 目標利回り未達の場合: 逆算カード（ISSUE-16: either-or を明示） */}
       {!isGood && (
         <Card className="border-orange-200 bg-orange-50">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base text-orange-800">
               <TrendingDown className="h-5 w-5" />
-              8%達成のために必要な改善（いずれか一方）
+              {targetPct}%達成のために必要な改善（いずれか一方）
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -221,23 +220,23 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
         </Card>
       )}
 
-      {/* 8%以上の場合: 余裕度 */}
+      {/* 目標利回り以上の場合: 余裕度 */}
       {isGood && (
         <Card className="border-green-200 bg-green-50">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base text-green-800">
               <TrendingUp className="h-5 w-5" />
-              8%超え達成！余裕度
+              {targetPct}%超え達成！余裕度
             </CardTitle>
           </CardHeader>
           <CardContent>
             <p className="text-sm text-green-700">
-              目標の8%に対して{" "}
-              <span className="font-bold">+{formatPct(result.grossYield - 0.08)}</span>{" "}
+              目標の{targetPct}%に対して{" "}
+              <span className="font-bold">+{formatPct(result.grossYield - result.yieldTarget)}</span>{" "}
               の余裕があります。
             </p>
             <p className="mt-2 text-xs text-muted-foreground">
-              ※満室想定賃料が{formatPct((result.grossYield - 0.08) / result.grossYield)}下落すると8%を下回ります
+              ※満室想定賃料が{formatPct((result.grossYield - result.yieldTarget) / result.grossYield)}下落すると{targetPct}%を下回ります
               （空室変動の影響は別途考慮してください）
             </p>
           </CardContent>

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -27,7 +27,7 @@ describe("Dashboard", () => {
   });
 
   it("analyzeAPIの応答後にYieldAnalysisが表示される（クイックモード）", async () => {
-    const mockResult = makeResult({ grossYield: 0.09, isAbove8Percent: true });
+    const mockResult = makeResult({ grossYield: 0.09, isAboveYieldTarget: true });
     vi.mocked(api.analyze).mockResolvedValue(mockResult);
 
     render(<Dashboard />);
@@ -45,7 +45,7 @@ describe("Dashboard", () => {
   });
 
   it("詳細モードでanalyzeAPIの応答後にCashFlowChartが表示される", async () => {
-    const mockResult = makeResult({ grossYield: 0.09, isAbove8Percent: true });
+    const mockResult = makeResult({ grossYield: 0.09, isAboveYieldTarget: true });
     vi.mocked(api.analyze).mockResolvedValue(mockResult);
 
     render(<Dashboard />);

--- a/frontend/src/components/__tests__/YieldAnalysis.test.tsx
+++ b/frontend/src/components/__tests__/YieldAnalysis.test.tsx
@@ -11,20 +11,20 @@ describe("YieldAnalysis", () => {
   });
 
   it("8%超えのとき緑のバッジと成功アイコンを表示する", () => {
-    const result = makeResult({ isAbove8Percent: true, grossYield: 0.09 });
+    const result = makeResult({ isAboveYieldTarget: true, grossYield: 0.09 });
     render(<YieldAnalysis result={result} input={makeInput()} />);
     expect(screen.getByText("8%超え ✓")).toBeInTheDocument();
   });
 
   it("8%未満のとき赤のバッジを表示する", () => {
-    const result = makeResult({ isAbove8Percent: false, grossYield: 0.07 });
+    const result = makeResult({ isAboveYieldTarget: false, grossYield: 0.07 });
     render(<YieldAnalysis result={result} input={makeInput()} />);
     expect(screen.getByText("8%未満 ✗")).toBeInTheDocument();
   });
 
   it("8%未満のとき改善カードを表示し、余裕度カードを非表示にする", () => {
     const result = makeResult({
-      isAbove8Percent: false,
+      isAboveYieldTarget: false,
       grossYield: 0.07,
       requiredCostReduction: 500_000,
       requiredMonthlyRent: 140_000,
@@ -35,7 +35,7 @@ describe("YieldAnalysis", () => {
   });
 
   it("8%以上のとき余裕度カードを表示し、改善カードを非表示にする", () => {
-    const result = makeResult({ isAbove8Percent: true, grossYield: 0.09 });
+    const result = makeResult({ isAboveYieldTarget: true, grossYield: 0.09 });
     render(<YieldAnalysis result={result} input={makeInput()} />);
     expect(screen.getByText("8%超え達成！余裕度")).toBeInTheDocument();
     expect(screen.queryByText("8%達成のために必要な改善（いずれか一方）")).not.toBeInTheDocument();

--- a/frontend/src/components/__tests__/helpers.ts
+++ b/frontend/src/components/__tests__/helpers.ts
@@ -23,6 +23,7 @@ export function makeInput(overrides: Partial<InvestmentInput> = {}): InvestmentI
     loanRateDelta: 0,
     annualPropertyTax: 0,
     rentDeclineRate: 0,
+    yieldTarget: 0.08,
     ...overrides,
   };
 }
@@ -86,7 +87,8 @@ export function makeResult(overrides: Partial<InvestmentResult> = {}): Investmen
     miscExpenses: 1_050_000,
     grossYield: 0.09,
     netYield: 0.065,
-    isAbove8Percent: true,
+    isAboveYieldTarget: true,
+    yieldTarget: 0.08,
     requiredCostReduction: 0,
     requiredMonthlyRent: 120_000,
     deadCrossYear: 0,

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -67,6 +67,7 @@ export interface InvestmentInput {
   loanRateDelta: number;
   annualPropertyTax: number;  // 固定資産税・都市計画税（年間）。0 = ExpenseRateに含む。
   rentDeclineRate: number;    // 年間賃料下落率（例: 0.01 = 1%/年）
+  yieldTarget: number;        // 目標表面利回り（例: 0.08 = 8%）
 }
 
 export interface YearlyResult {
@@ -102,7 +103,8 @@ export interface InvestmentResult {
   miscExpenses: number;
   grossYield: number;
   netYield: number;
-  isAbove8Percent: boolean;
+  isAboveYieldTarget: boolean;
+  yieldTarget: number;
   requiredCostReduction: number;
   requiredMonthlyRent: number;
   deadCrossYear: number;
@@ -208,6 +210,7 @@ export const DEFAULT_INPUT: InvestmentInput = {
   loanRateDelta: 0,
   annualPropertyTax: 0,
   rentDeclineRate: 0,
+  yieldTarget: 0.08,
 };
 
 export const BUILDING_USEFUL_LIFE: Record<BuildingType, number> = {
@@ -237,4 +240,5 @@ export const QUICK_MODE_DEFAULTS: Partial<InvestmentInput> = {
   buildingType:      "木造" as BuildingType,
   annualLoanRate:    0.015,
   rentDeclineRate:   0.01,
+  yieldTarget:       0.08,
 };


### PR DESCRIPTION
## 概要
フロントエンド・バックエンド双方にハードコードされていた表面利回り目標 8% を、ユーザーが任意に設定できるパラメータ（`yieldTarget`）に変更する。デフォルト値は従来通り 8%。

## 変更内容

### バックエンド
- `types.go`: `InvestmentInput` に `YieldTarget float64`（`Defaults()` でデフォルト 0.08）を追加
- `types.go`: `InvestmentResult` の `IsAbove8Percent` → `IsAboveYieldTarget`、`YieldTarget float64` を追加
- `investment.go`: `targetYield8pct = 0.08` 定数を削除し、`input.YieldTarget` を参照するよう変更
- `investment_test.go`: `IsAbove8Percent` → `IsAboveYieldTarget` に更新

### フロントエンド
- `types/investment.ts`: `InvestmentInput` に `yieldTarget` 追加、`InvestmentResult` の `isAbove8Percent` → `isAboveYieldTarget` + `yieldTarget`
- `InvestmentForm.tsx`: クイック・詳細モード両方に「目標利回り（%）」入力フィールドを追加、バリデーション追加
- `YieldAnalysis.tsx`: `TARGET_PCT = 8` 定数を廃止し `result.yieldTarget` を参照、ゲージ上限を `target×2` に動的化
- テストヘルパー・各テストファイルを新フィールド名に更新

## 関連Issue
Closes #136

## テスト
- [x] バックエンド: `go test ./internal/domain/...` PASS
- [x] フロントエンド: vitest 71/71 PASS

## 確認事項
- [x] デフォルト値 8% により既存の動作は変わらない（後方互換）
- [x] コードレビュー観点での自己レビュー済み