### PR TITLE
feat(frontend): 現金購入（ローンなし）モードを追加

### DIFF
--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -131,7 +131,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   const [quickTotalPriceMan, setQuickTotalPriceMan] = useState("");
   // クイックモード: 相場データ取得セクションの開閉
   const [showLandSection, setShowLandSection] = useState(false);
-  // 現金購入フラグ（クイックモード専用）
+  // 現金購入フラグ（クイック・詳細モード共用）
   const [isCashPurchase, setIsCashPurchase] = useState(false);
   // 現金購入前のローン値を保存（チェックを外したときに復元）
   const [savedLoanAmount, setSavedLoanAmount] = useState(DEFAULT_INPUT.loanAmount);
@@ -191,7 +191,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
 
   // モード切替時に現金購入フラグをリセットし、ローン値を復元する
   useEffect(() => {
-    if (!isQuick && isCashPurchase) {
+    if (isCashPurchase) {
       setIsCashPurchase(false);
       setInput((prev) => ({ ...prev, loanAmount: savedLoanAmount, loanYears: savedLoanYears }));
     }

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -131,6 +131,11 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   const [quickTotalPriceMan, setQuickTotalPriceMan] = useState("");
   // クイックモード: 相場データ取得セクションの開閉
   const [showLandSection, setShowLandSection] = useState(false);
+  // 現金購入フラグ（クイックモード専用）
+  const [isCashPurchase, setIsCashPurchase] = useState(false);
+  // 現金購入前のローン値を保存（チェックを外したときに復元）
+  const [savedLoanAmount, setSavedLoanAmount] = useState(DEFAULT_INPUT.loanAmount);
+  const [savedLoanYears, setSavedLoanYears] = useState(DEFAULT_INPUT.loanYears);
 
   // 按分ヘルパーの状態
   const [showBuildingHelper, setShowBuildingHelper] = useState(false);
@@ -184,6 +189,15 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
     loadMunicipalities("10");
   }, [loadMunicipalities]);
 
+  // モード切替時に現金購入フラグをリセットし、ローン値を復元する
+  useEffect(() => {
+    if (!isQuick && isCashPurchase) {
+      setIsCashPurchase(false);
+      setInput((prev) => ({ ...prev, loanAmount: savedLoanAmount, loanYears: savedLoanYears }));
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isQuick]);
+
   useEffect(() => {
     if (filteredMunicipalities.length === 1) {
       setCity(filteredMunicipalities[0].id);
@@ -202,6 +216,17 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   };
   const setStr = (key: keyof InvestmentInput, value: string) =>
     setInput((prev) => ({ ...prev, [key]: value }));
+
+  const handleCashPurchaseToggle = (checked: boolean) => {
+    setIsCashPurchase(checked);
+    if (checked) {
+      setSavedLoanAmount(input.loanAmount);
+      setSavedLoanYears(input.loanYears);
+      setInput((prev) => ({ ...prev, loanAmount: 0, loanYears: 0 }));
+    } else {
+      setInput((prev) => ({ ...prev, loanAmount: savedLoanAmount, loanYears: savedLoanYears }));
+    }
+  };
 
   const toMan = (yen: number) => String(Math.round(yen / 10_000));
   const fromMan = (s: string) => (parseFloat(s) || 0) * 10_000;
@@ -353,10 +378,23 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   value={String(input.monthlyRent)}
                   onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
                   error={fieldError("monthlyRent")} />
-                <Input label="ローン金額" type="number" suffix="万円"
-                  value={toMan(input.loanAmount)}
-                  onChange={(e) => setNum("loanAmount", fromMan(e.target.value))}
-                  error={fieldError("loanAmount")} />
+                <div className="space-y-2">
+                  <label className="flex items-center gap-2 cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      checked={isCashPurchase}
+                      onChange={(e) => handleCashPurchaseToggle(e.target.checked)}
+                      className="h-4 w-4 rounded border-input accent-primary"
+                      aria-label="現金購入（ローンなし）"
+                    />
+                    <span className="text-sm font-medium">現金購入（ローンなし）</span>
+                  </label>
+                  <Input label="ローン金額" type="number" suffix="万円"
+                    value={toMan(input.loanAmount)}
+                    onChange={(e) => { if (!isCashPurchase) setNum("loanAmount", fromMan(e.target.value)); }}
+                    error={fieldError("loanAmount")}
+                    disabled={isCashPurchase} />
+                </div>
                 <Input label="目標利回り" type="number" suffix="%" step="0.5"
                   value={toPct(input.yieldTarget, 1)}
                   onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
@@ -365,7 +403,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
 
               <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 space-y-0.5">
                 <p className="font-semibold">自動設定されるデフォルト値</p>
-                <p>空室率 5%・運営経費率 20%・建物構造: 木造・年利 1.5%・返済期間 35年・10年後売却・所得税率 33%</p>
+                <p>空室率 5%・運営経費率 20%・建物構造: 木造・{isCashPurchase ? "現金購入（ローンなし）" : "年利 1.5%・返済期間 35年"}・10年後売却・所得税率 33%</p>
               </div>
 
               <Button className="w-full" size="lg" loading={loading} disabled={hasErrors || loading} onClick={handleAnalyze}>
@@ -645,20 +683,35 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
 
               {/* ローン条件 */}
               <div className="border-t pt-4">
-                <p className="text-sm font-semibold text-foreground mb-3">ローン条件</p>
+                <div className="flex items-center justify-between mb-3">
+                  <p className="text-sm font-semibold text-foreground">ローン条件</p>
+                  <label className="flex items-center gap-2 cursor-pointer select-none">
+                    <input
+                      type="checkbox"
+                      checked={isCashPurchase}
+                      onChange={(e) => handleCashPurchaseToggle(e.target.checked)}
+                      className="h-4 w-4 rounded border-input accent-primary"
+                      aria-label="現金購入（ローンなし）"
+                    />
+                    <span className="text-sm font-medium">現金購入（ローンなし）</span>
+                  </label>
+                </div>
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
                   <Input label="ローン金額" type="number" suffix="万円"
                     value={toMan(input.loanAmount)}
-                    onChange={(e) => setNum("loanAmount", fromMan(e.target.value))}
-                    error={fieldError("loanAmount")} />
+                    onChange={(e) => { if (!isCashPurchase) setNum("loanAmount", fromMan(e.target.value)); }}
+                    error={fieldError("loanAmount")}
+                    disabled={isCashPurchase} />
                   <Input label="年利" type="number" suffix="%" step="0.01"
                     value={toPct(input.annualLoanRate)}
-                    onChange={(e) => setNum("annualLoanRate", fromPct(e.target.value))}
-                    error={fieldError("annualLoanRate")} />
+                    onChange={(e) => { if (!isCashPurchase) setNum("annualLoanRate", fromPct(e.target.value)); }}
+                    error={fieldError("annualLoanRate")}
+                    disabled={isCashPurchase} />
                   <Input label="返済期間" type="number" suffix="年"
                     value={String(input.loanYears)}
-                    onChange={(e) => setNum("loanYears", parseInt(e.target.value) || 35)}
-                    error={fieldError("loanYears")} />
+                    onChange={(e) => { if (!isCashPurchase) setNum("loanYears", parseInt(e.target.value) || 0); }}
+                    error={fieldError("loanYears")}
+                    disabled={isCashPurchase} />
                 </div>
               </div>
 

--- a/frontend/src/components/__tests__/InvestmentForm.test.tsx
+++ b/frontend/src/components/__tests__/InvestmentForm.test.tsx
@@ -183,4 +183,64 @@ describe("InvestmentForm", () => {
       expect(screen.queryByText(/クイックモード:/)).not.toBeInTheDocument();
     });
   });
+
+  describe("現金購入チェックボックス（クイックモード）", () => {
+    it("クイックモードでは現金購入チェックボックスが表示される", () => {
+      renderForm("quick");
+      expect(screen.getByLabelText(/現金購入（ローンなし）/)).toBeInTheDocument();
+    });
+
+    it("詳細モードでも現金購入チェックボックスが表示される", () => {
+      renderForm("full");
+      expect(screen.getByLabelText(/現金購入（ローンなし）/)).toBeInTheDocument();
+    });
+
+    it("詳細モードで現金購入チェックを入れるとローン関連フィールドが無効化される", async () => {
+      renderForm("full");
+      const checkbox = screen.getByLabelText(/現金購入（ローンなし）/);
+      await userEvent.click(checkbox);
+      expect(screen.getByLabelText(/ローン金額/)).toBeDisabled();
+      expect(screen.getByLabelText(/返済期間/)).toBeDisabled();
+    });
+
+    it("現金購入チェックを入れるとローン金額入力欄が無効化される", async () => {
+      renderForm("quick");
+      const checkbox = screen.getByLabelText(/現金購入（ローンなし）/);
+      await userEvent.click(checkbox);
+      expect(screen.getByLabelText(/ローン金額/)).toBeDisabled();
+    });
+
+    it("現金購入チェックを入れるとローン金額が0になる", async () => {
+      renderForm("quick");
+      const checkbox = screen.getByLabelText(/現金購入（ローンなし）/);
+      await userEvent.click(checkbox);
+      expect(screen.getByLabelText(/ローン金額/)).toHaveValue(0);
+    });
+
+    it("現金購入チェックを外すとローン金額入力欄が有効になる", async () => {
+      renderForm("quick");
+      const checkbox = screen.getByLabelText(/現金購入（ローンなし）/);
+      await userEvent.click(checkbox);
+      await userEvent.click(checkbox);
+      expect(screen.getByLabelText(/ローン金額/)).not.toBeDisabled();
+    });
+
+    it("現金購入チェック時にシミュレーションを実行するとloanAmountが0で送信される", async () => {
+      const { onAnalyze } = renderForm("quick");
+      await userEvent.type(screen.getByLabelText(/物件価格（土地＋建物の総額）/), "1500");
+      await userEvent.click(screen.getByLabelText(/現金購入（ローンなし）/));
+      await userEvent.click(screen.getByRole("button", { name: /シミュレーション実行/ }));
+      expect(onAnalyze).toHaveBeenCalledWith(expect.objectContaining({
+        loanAmount: 0,
+        loanYears: 0,
+      }));
+    });
+
+    it("現金購入チェック時にインフォバナーが「現金購入（ローンなし）」に変わる", async () => {
+      renderForm("quick");
+      const checkbox = screen.getByLabelText(/現金購入（ローンなし）/);
+      await userEvent.click(checkbox);
+      expect(screen.getAllByText(/現金購入（ローンなし）/).length).toBeGreaterThan(0);
+    });
+  });
 });


### PR DESCRIPTION
## 概要

現金購入（ローンなし）チェックボックスを追加し、チェック時にローン関連入力欄を無効化する機能を実装しました。クイックモードに加え、詳細モードのローン条件セクションにも対応しています。

## 変更内容

- **詳細モード**: ローン条件セクションのヘッダー右側に「現金購入（ローンなし）」チェックボックスを追加
- チェックON時: `loanAmount=0`・`loanYears=0` をセットし、ローン金額・年利・返済期間の3フィールドをグレーアウト＋無効化
- チェックOFF時: チェック前の値を復元してフィールドを再有効化
- `loanYears` の onChange に `!isCashPurchase` ガードを追加し、現金購入中は値を上書きしないよう修正
- クイックモードの既存実装（`isCashPurchase` state・`handleCashPurchaseToggle`）をそのまま共用
- バックエンド `calcMonthlyPayment` は `years <= 0` で 0 を返すガードがすでに存在するため変更不要

## テスト

- [ ] 詳細モードで「現金購入（ローンなし）」チェックボックスが表示されることを確認
- [ ] チェックON時にローン金額・年利・返済期間が無効化されることを確認
- [ ] チェックON時に `loanAmount=0`, `loanYears=0` でシミュレーション送信されることを確認
- [ ] チェックOFF時に元の値が復元されることを確認
- [ ] `npm test` で全79テストがパスすることを確認
- [ ] クイックモードの既存動作（現金購入チェック）に影響がないことを確認

Closes #155