### PR TITLE
fix(infra): SA を deployer / runtime に分離して最小権限を実現

### DIFF
--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -90,8 +90,8 @@ resource "google_cloud_run_v2_service" "backend" {
     google_project_service.apis,
     google_secret_manager_secret_iam_member.mlit_accessor,
     google_secret_manager_secret_iam_member.internal_key_accessor,
-    google_project_iam_member.sa_trace_agent,
-    google_project_iam_member.sa_metric_writer,
+    google_project_iam_member.backend_trace_agent,
+    google_project_iam_member.backend_metric_writer,
   ]
 }
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -1,6 +1,13 @@
+# --- Service Accounts ---
+
 resource "google_service_account" "backend" {
   account_id   = local.sa_name
-  display_name = "yield-guard ${var.env} backend"
+  display_name = "yield-guard ${var.env} backend (runtime)"
+}
+
+resource "google_service_account" "deployer" {
+  account_id   = local.deployer_sa_name
+  display_name = "yield-guard ${var.env} deployer (CI/CD)"
 }
 
 # --- Workload Identity Federation ---
@@ -26,12 +33,11 @@ resource "google_iam_workload_identity_pool_provider" "github" {
     "attribute.repository" = "assertion.repository"
   }
 
-  # Restrict token exchange to this specific repository
   attribute_condition = "attribute.repository == 'glkt3912/yield-guard'"
 }
 
 resource "google_service_account_iam_binding" "wif_impersonation" {
-  service_account_id = google_service_account.backend.name
+  service_account_id = google_service_account.deployer.name
   role               = "roles/iam.workloadIdentityUser"
 
   members = [
@@ -39,43 +45,48 @@ resource "google_service_account_iam_binding" "wif_impersonation" {
   ]
 }
 
-# --- Minimal permissions for the Service Account ---
+# --- Deployer SA permissions (CI/CD only) ---
 
-resource "google_artifact_registry_repository_iam_member" "sa_push" {
+resource "google_project_iam_member" "deployer_viewer" {
+  project = var.project_id
+  role    = "roles/viewer"
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_project_iam_member" "deployer_project_iam_admin" {
+  project = var.project_id
+  role    = "roles/resourcemanager.projectIamAdmin"
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_project_iam_member" "deployer_run_developer" {
+  project = var.project_id
+  role    = "roles/run.developer"
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_artifact_registry_repository_iam_member" "deployer_push" {
   repository = google_artifact_registry_repository.backend.name
   location   = var.region
   role       = "roles/artifactregistry.writer"
-  member     = "serviceAccount:${google_service_account.backend.email}"
+  member     = "serviceAccount:${google_service_account.deployer.email}"
 }
 
-resource "google_project_iam_member" "sa_run_developer" {
-  project = var.project_id
-  role    = "roles/run.developer"
-  member  = "serviceAccount:${google_service_account.backend.email}"
-}
-
-resource "google_project_iam_member" "sa_viewer" {
-  # terraform plan reads current state of all managed resources.
-  project = var.project_id
-  role    = "roles/viewer"
-  member  = "serviceAccount:${google_service_account.backend.email}"
-}
-
-resource "google_project_iam_member" "sa_project_iam_admin" {
-  # terraform apply sets project-level IAM bindings; requires setIamPolicy.
-  project = var.project_id
-  role    = "roles/resourcemanager.projectIamAdmin"
-  member  = "serviceAccount:${google_service_account.backend.email}"
-}
-
-resource "google_service_account_iam_member" "sa_act_as" {
-  # deploy-cloudrun Action が SA impersonation に必要。
-  # GitHub Actions SA と Cloud Run ランタイム SA を統一しているための自己参照。
-  # SA を分離する場合は GitHub Actions 側 SA → Cloud Run SA への付与に変更する。
+resource "google_service_account_iam_member" "deployer_act_as_backend" {
+  # deployer SA impersonates runtime SA when deploying Cloud Run.
   service_account_id = google_service_account.backend.name
   role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${google_service_account.backend.email}"
+  member             = "serviceAccount:${google_service_account.deployer.email}"
 }
+
+resource "google_storage_bucket_iam_member" "deployer_tfstate_admin" {
+  # storage.admin includes getIamPolicy/setIamPolicy needed for terraform apply.
+  bucket = "yield-guard-tfstate"
+  role   = "roles/storage.admin"
+  member = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+# --- Runtime SA permissions (Cloud Run only) ---
 
 resource "google_secret_manager_secret_iam_member" "mlit_accessor" {
   secret_id = google_secret_manager_secret.mlit_api_key.secret_id
@@ -89,25 +100,14 @@ resource "google_secret_manager_secret_iam_member" "internal_key_accessor" {
   member    = "serviceAccount:${google_service_account.backend.email}"
 }
 
-# --- Observability permissions ---
-
-resource "google_project_iam_member" "sa_trace_agent" {
+resource "google_project_iam_member" "backend_trace_agent" {
   project = var.project_id
   role    = "roles/cloudtrace.agent"
   member  = "serviceAccount:${google_service_account.backend.email}"
 }
 
-resource "google_project_iam_member" "sa_metric_writer" {
+resource "google_project_iam_member" "backend_metric_writer" {
   project = var.project_id
   role    = "roles/monitoring.metricWriter"
   member  = "serviceAccount:${google_service_account.backend.email}"
-}
-
-# --- Terraform state backend permissions ---
-
-resource "google_storage_bucket_iam_member" "sa_tfstate_admin" {
-  # storage.admin includes getIamPolicy/setIamPolicy needed for terraform apply.
-  bucket = "yield-guard-tfstate"
-  role   = "roles/storage.admin"
-  member = "serviceAccount:${google_service_account.backend.email}"
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,6 +19,7 @@ provider "google" {
 }
 
 locals {
-  service_name = "yield-guard-${var.env}-backend"
-  sa_name      = "sa-yield-guard-${var.env}"
+  service_name     = "yield-guard-${var.env}-backend"
+  sa_name          = "sa-yield-guard-${var.env}"
+  deployer_sa_name = "sa-yield-guard-${var.env}-deployer"
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -8,7 +8,12 @@ output "wif_provider" {
   value       = google_iam_workload_identity_pool_provider.github.name
 }
 
-output "sa_email" {
-  description = "Service account email (set as SA_EMAIL GitHub Secret)"
+output "deployer_sa_email" {
+  description = "Deployer SA email (set as SA_EMAIL GitHub Secret)"
+  value       = google_service_account.deployer.email
+}
+
+output "runtime_sa_email" {
+  description = "Runtime SA email (used by Cloud Run)"
   value       = google_service_account.backend.email
 }


### PR DESCRIPTION
## 概要

Issue #188 対応。GitHub Actions（Terraform/deploy）と Cloud Run ランタイムで同一 SA を使用していた設計を分離し、権限昇格リスクを解消する。

## 変更内容

### SA 構成の変更

| SA | 用途 | 主な権限 |
|---|---|---|
| `sa-yield-guard-prod-deployer`（新規） | GitHub Actions / Terraform | `projectIamAdmin`, `storage.admin`（tfstate のみ）, `viewer`, `run.developer`, `artifactregistry.writer`, `serviceAccountUser`（→runtime SA） |
| `sa-yield-guard-prod`（既存） | Cloud Run ランタイム | `secretmanager.secretAccessor`, `cloudtrace.agent`, `monitoring.metricWriter` |

### ファイル変更

- `terraform/iam.tf` — deployer SA 新規作成、WIF impersonation を deployer SA に変更、runtime SA から CI/CD 権限を削除
- `terraform/main.tf` — `deployer_sa_name` local 追加
- `terraform/outputs.tf` — `sa_email` → `deployer_sa_email` / `runtime_sa_email` に分離

## マージ後の作業

`terraform apply` 完了後、GitHub Secrets の `SA_EMAIL` を deployer SA のメールアドレスに更新する必要がある。

```
terraform output deployer_sa_email
# → sa-yield-guard-prod-deployer@yield-guard.iam.gserviceaccount.com
```

Settings → Secrets → `SA_EMAIL` をこの値に更新する。

## セキュリティ改善点

- Cloud Run ランタイムから `projectIamAdmin` / `storage.admin` / `viewer` / `run.developer` を削除
- アプリ脆弱性経由の権限昇格経路を遮断
- ランタイム SA は Secret 読み取りと OTel 送信のみに限定

Closes #188