### PR TITLE
feat(api): add IP-based rate limiting

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -14,6 +14,8 @@ require (
 	go.opentelemetry.io/otel/metric v1.43.0
 	go.opentelemetry.io/otel/sdk v1.43.0
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
+	go.opentelemetry.io/otel/trace v1.43.0
+	golang.org/x/time v0.13.0
 )
 
 require (
@@ -57,7 +59,6 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
-	go.opentelemetry.io/otel/trace v1.43.0 // indirect
 	golang.org/x/arch v0.25.0 // indirect
 	golang.org/x/crypto v0.49.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
@@ -65,7 +66,6 @@ require (
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	golang.org/x/text v0.35.0 // indirect
-	golang.org/x/time v0.13.0 // indirect
 	google.golang.org/api v0.249.0 // indirect
 	google.golang.org/genproto v0.0.0-20250922171735-9219d122eba9 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260401024825-9d38bb4040a9 // indirect

--- a/backend/internal/api/ratelimit.go
+++ b/backend/internal/api/ratelimit.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+	"strconv"
 	"sync"
 	"time"
 
@@ -19,6 +20,7 @@ type rateLimiter struct {
 	limiters map[string]*ipLimiter
 	r        rate.Limit
 	burst    int
+	stop     chan struct{}
 }
 
 func newRateLimiter(r rate.Limit, burst int) *rateLimiter {
@@ -26,9 +28,26 @@ func newRateLimiter(r rate.Limit, burst int) *rateLimiter {
 		limiters: make(map[string]*ipLimiter),
 		r:        r,
 		burst:    burst,
+		stop:     make(chan struct{}),
 	}
-	go rl.cleanup()
+	t := time.NewTicker(5 * time.Minute)
+	go func() {
+		for {
+			select {
+			case <-t.C:
+				rl.purge()
+			case <-rl.stop:
+				t.Stop()
+				return
+			}
+		}
+	}()
 	return rl
+}
+
+// shutdown stops the background cleanup goroutine.
+func (rl *rateLimiter) shutdown() {
+	close(rl.stop)
 }
 
 func (rl *rateLimiter) get(ip string) *rate.Limiter {
@@ -43,23 +62,23 @@ func (rl *rateLimiter) get(ip string) *rate.Limiter {
 	return entry.limiter
 }
 
-// cleanup removes entries not seen for 10 minutes.
-func (rl *rateLimiter) cleanup() {
-	for range time.Tick(5 * time.Minute) {
-		rl.mu.Lock()
-		for ip, entry := range rl.limiters {
-			if time.Since(entry.lastSeen) > 10*time.Minute {
-				delete(rl.limiters, ip)
-			}
+func (rl *rateLimiter) purge() {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	for ip, entry := range rl.limiters {
+		if time.Since(entry.lastSeen) > 10*time.Minute {
+			delete(rl.limiters, ip)
 		}
-		rl.mu.Unlock()
 	}
 }
 
 func (rl *rateLimiter) middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		if !rl.get(c.ClientIP()).Allow() {
-			c.Header("Retry-After", "60")
+		res := rl.get(c.ClientIP()).Reserve()
+		if d := res.Delay(); d > 0 {
+			res.Cancel()
+			waitSec := int(d.Seconds()) + 1
+			c.Header("Retry-After", strconv.Itoa(waitSec))
 			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "リクエスト数が上限を超えました。しばらく待ってから再試行してください。"})
 			return
 		}

--- a/backend/internal/api/ratelimit.go
+++ b/backend/internal/api/ratelimit.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+type ipLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+type rateLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*ipLimiter
+	r        rate.Limit
+	burst    int
+}
+
+func newRateLimiter(r rate.Limit, burst int) *rateLimiter {
+	rl := &rateLimiter{
+		limiters: make(map[string]*ipLimiter),
+		r:        r,
+		burst:    burst,
+	}
+	go rl.cleanup()
+	return rl
+}
+
+func (rl *rateLimiter) get(ip string) *rate.Limiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+	entry, ok := rl.limiters[ip]
+	if !ok {
+		entry = &ipLimiter{limiter: rate.NewLimiter(rl.r, rl.burst)}
+		rl.limiters[ip] = entry
+	}
+	entry.lastSeen = time.Now()
+	return entry.limiter
+}
+
+// cleanup removes entries not seen for 10 minutes.
+func (rl *rateLimiter) cleanup() {
+	for range time.Tick(5 * time.Minute) {
+		rl.mu.Lock()
+		for ip, entry := range rl.limiters {
+			if time.Since(entry.lastSeen) > 10*time.Minute {
+				delete(rl.limiters, ip)
+			}
+		}
+		rl.mu.Unlock()
+	}
+}
+
+func (rl *rateLimiter) middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !rl.get(c.ClientIP()).Allow() {
+			c.Header("Retry-After", "60")
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "リクエスト数が上限を超えました。しばらく待ってから再試行してください。"})
+			return
+		}
+		c.Next()
+	}
+}

--- a/backend/internal/api/ratelimit.go
+++ b/backend/internal/api/ratelimit.go
@@ -1,8 +1,10 @@
 package api
 
 import (
+	"net"
 	"net/http"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -72,9 +74,26 @@ func (rl *rateLimiter) purge() {
 	}
 }
 
+// realIP は Cloud Run (Google LB) 環境でも実クライアント IP を返す。
+// Google LB は X-Forwarded-For の末尾に実 IP を追記するため、最後のエントリが信頼できる。
+// ヘッダー未設定時（ローカル開発）は RemoteAddr を使用する。
+func realIP(c *gin.Context) string {
+	if xff := c.GetHeader("X-Forwarded-For"); xff != "" {
+		parts := strings.Split(xff, ",")
+		if ip := strings.TrimSpace(parts[len(parts)-1]); ip != "" {
+			return ip
+		}
+	}
+	ip, _, err := net.SplitHostPort(c.Request.RemoteAddr)
+	if err != nil {
+		return c.Request.RemoteAddr
+	}
+	return ip
+}
+
 func (rl *rateLimiter) middleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		res := rl.get(c.ClientIP()).Reserve()
+		res := rl.get(realIP(c)).Reserve()
 		if d := res.Delay(); d > 0 {
 			res.Cancel()
 			waitSec := int(d.Seconds()) + 1

--- a/backend/internal/api/ratelimit_test.go
+++ b/backend/internal/api/ratelimit_test.go
@@ -121,3 +121,52 @@ func TestRateLimiter_IsolatesPerIP(t *testing.T) {
 		t.Fatalf("IP B first request: want 200, got %d", got)
 	}
 }
+
+func TestRealIP(t *testing.T) {
+	cases := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		want       string
+	}{
+		{
+			name:       "no XFF — use RemoteAddr",
+			remoteAddr: "1.2.3.4:5678",
+			xff:        "",
+			want:       "1.2.3.4",
+		},
+		{
+			name:       "single XFF entry",
+			remoteAddr: "10.0.0.1:1234",
+			xff:        "203.0.113.1",
+			want:       "203.0.113.1",
+		},
+		{
+			name:       "Cloud Run: client spoofs XFF, LB appends real IP at end",
+			remoteAddr: "10.0.0.1:1234",
+			xff:        "spoofed-ip, 203.0.113.99",
+			want:       "203.0.113.99",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gin.SetMode(gin.TestMode)
+			var got string
+			r := gin.New()
+			r.GET("/", func(c *gin.Context) {
+				got = realIP(c)
+				c.Status(http.StatusOK)
+			})
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			req.RemoteAddr = tc.remoteAddr
+			if tc.xff != "" {
+				req.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			r.ServeHTTP(httptest.NewRecorder(), req)
+			if got != tc.want {
+				t.Errorf("realIP = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/backend/internal/api/ratelimit_test.go
+++ b/backend/internal/api/ratelimit_test.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 func TestRateLimiter_AllowsUnderLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rl := newRateLimiter(rate.Every(time.Second), 5)
+	t.Cleanup(rl.shutdown)
 
 	r := gin.New()
 	r.GET("/test", rl.middleware(), func(c *gin.Context) {
@@ -32,8 +34,9 @@ func TestRateLimiter_AllowsUnderLimit(t *testing.T) {
 
 func TestRateLimiter_BlocksOverLimit(t *testing.T) {
 	gin.SetMode(gin.TestMode)
-	// burst=2: 3 requests should trigger 429
+	// burst=2: 3rd request should trigger 429
 	rl := newRateLimiter(rate.Every(time.Hour), 2)
+	t.Cleanup(rl.shutdown)
 
 	r := gin.New()
 	r.GET("/test", rl.middleware(), func(c *gin.Context) {
@@ -61,7 +64,9 @@ func TestRateLimiter_BlocksOverLimit(t *testing.T) {
 
 func TestRateLimiter_RetryAfterHeader(t *testing.T) {
 	gin.SetMode(gin.TestMode)
+	// 1 token per hour, burst=1: 2nd request must wait ~3600s
 	rl := newRateLimiter(rate.Every(time.Hour), 1)
+	t.Cleanup(rl.shutdown)
 
 	r := gin.New()
 	r.GET("/test", rl.middleware(), func(c *gin.Context) {
@@ -81,14 +86,17 @@ func TestRateLimiter_RetryAfterHeader(t *testing.T) {
 	if w.Code != http.StatusTooManyRequests {
 		t.Fatalf("want 429, got %d", w.Code)
 	}
-	if w.Header().Get("Retry-After") != "60" {
-		t.Fatalf("want Retry-After: 60, got %q", w.Header().Get("Retry-After"))
+	retryAfter := w.Header().Get("Retry-After")
+	secs, err := strconv.Atoi(retryAfter)
+	if err != nil || secs <= 0 {
+		t.Fatalf("Retry-After must be a positive integer, got %q", retryAfter)
 	}
 }
 
 func TestRateLimiter_IsolatesPerIP(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	rl := newRateLimiter(rate.Every(time.Hour), 1)
+	t.Cleanup(rl.shutdown)
 
 	r := gin.New()
 	r.GET("/test", rl.middleware(), func(c *gin.Context) {

--- a/backend/internal/api/ratelimit_test.go
+++ b/backend/internal/api/ratelimit_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+func TestRateLimiter_AllowsUnderLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rl := newRateLimiter(rate.Every(time.Second), 5)
+
+	r := gin.New()
+	r.GET("/test", rl.middleware(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	for i := range 5 {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusOK {
+			t.Fatalf("request %d: want 200, got %d", i+1, w.Code)
+		}
+	}
+}
+
+func TestRateLimiter_BlocksOverLimit(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	// burst=2: 3 requests should trigger 429
+	rl := newRateLimiter(rate.Every(time.Hour), 2)
+
+	r := gin.New()
+	r.GET("/test", rl.middleware(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	send := func() int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "1.2.3.4:1234"
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if got := send(); got != http.StatusOK {
+		t.Fatalf("request 1: want 200, got %d", got)
+	}
+	if got := send(); got != http.StatusOK {
+		t.Fatalf("request 2: want 200, got %d", got)
+	}
+	if got := send(); got != http.StatusTooManyRequests {
+		t.Fatalf("request 3: want 429, got %d", got)
+	}
+}
+
+func TestRateLimiter_RetryAfterHeader(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rl := newRateLimiter(rate.Every(time.Hour), 1)
+
+	r := gin.New()
+	r.GET("/test", rl.middleware(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	send := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = "5.6.7.8:1234"
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+
+	send() // consume burst
+	w := send()
+	if w.Code != http.StatusTooManyRequests {
+		t.Fatalf("want 429, got %d", w.Code)
+	}
+	if w.Header().Get("Retry-After") != "60" {
+		t.Fatalf("want Retry-After: 60, got %q", w.Header().Get("Retry-After"))
+	}
+}
+
+func TestRateLimiter_IsolatesPerIP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	rl := newRateLimiter(rate.Every(time.Hour), 1)
+
+	r := gin.New()
+	r.GET("/test", rl.middleware(), func(c *gin.Context) {
+		c.Status(http.StatusOK)
+	})
+
+	sendFrom := func(ip string) int {
+		req := httptest.NewRequest(http.MethodGet, "/test", nil)
+		req.RemoteAddr = ip + ":1234"
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	// exhaust IP A
+	sendFrom("10.0.0.1")
+	if got := sendFrom("10.0.0.1"); got != http.StatusTooManyRequests {
+		t.Fatalf("IP A second request: want 429, got %d", got)
+	}
+	// IP B should still be allowed
+	if got := sendFrom("10.0.0.2"); got != http.StatusOK {
+		t.Fatalf("IP B first request: want 200, got %d", got)
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -76,6 +76,11 @@ func recoveryMiddleware() gin.HandlerFunc {
 // NewRouter は Gin ルーターを初期化して返す
 func NewRouter(h *Handler) *gin.Engine {
 	r := gin.New()
+	// X-Forwarded-For を信頼しない: TCP 接続元 IP のみを ClientIP() として使用し
+	// ヘッダー偽装によるレートリミット回避を防ぐ。
+	if err := r.SetTrustedProxies(nil); err != nil {
+		panic(err)
+	}
 
 	r.Use(otelgin.Middleware("yield-guard-backend"))
 	r.Use(accessLogMiddleware())
@@ -100,9 +105,9 @@ func NewRouter(h *Handler) *gin.Engine {
 		AllowCredentials: false,
 	}))
 
-	// IP ベースレートリミッター: 一般 API 60 req/min、analyze 10 req/min
-	generalRL := newRateLimiter(rate.Every(time.Minute/60), 20)
-	analyzeRL := newRateLimiter(rate.Every(time.Minute/10), 5)
+	// IP ベースレートリミッター: 一般 API 60 req/min (1 token/s)、analyze 10 req/min (1 token/6s)
+	generalRL := newRateLimiter(rate.Every(time.Second), 20)
+	analyzeRL := newRateLimiter(rate.Every(6*time.Second), 5)
 
 	r.GET("/health", h.HealthCheck)
 
@@ -113,6 +118,7 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/land-prices/stats", h.GetLandPrices)
 		api.GET("/land-prices/compare", h.CompareLandPrice)
 		api.GET("/land-prices/estimate", h.EstimateLandPrice)
+		// analyze は generalRL + analyzeRL の両方でトークンを消費する（意図的な二重制限）
 		api.POST("/investment/analyze", analyzeRL.middleware(), h.Analyze)
 		api.GET("/municipalities", h.GetMunicipalities)
 		api.GET("/station-ridership", h.GetStationRidership)

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -76,11 +76,6 @@ func recoveryMiddleware() gin.HandlerFunc {
 // NewRouter は Gin ルーターを初期化して返す
 func NewRouter(h *Handler) *gin.Engine {
 	r := gin.New()
-	// X-Forwarded-For を信頼しない: TCP 接続元 IP のみを ClientIP() として使用し
-	// ヘッダー偽装によるレートリミット回避を防ぐ。
-	if err := r.SetTrustedProxies(nil); err != nil {
-		panic(err)
-	}
 
 	r.Use(otelgin.Middleware("yield-guard-backend"))
 	r.Use(accessLogMiddleware())

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gin-contrib/cors"
 	"github.com/gin-gonic/gin"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin"
+	"golang.org/x/time/rate"
 )
 
 func internalKeyMiddleware() gin.HandlerFunc {
@@ -99,15 +100,20 @@ func NewRouter(h *Handler) *gin.Engine {
 		AllowCredentials: false,
 	}))
 
+	// IP ベースレートリミッター: 一般 API 60 req/min、analyze 10 req/min
+	generalRL := newRateLimiter(rate.Every(time.Minute/60), 20)
+	analyzeRL := newRateLimiter(rate.Every(time.Minute/10), 5)
+
 	r.GET("/health", h.HealthCheck)
 
 	api := r.Group("/api")
 	api.Use(internalKeyMiddleware())
+	api.Use(generalRL.middleware())
 	{
 		api.GET("/land-prices/stats", h.GetLandPrices)
 		api.GET("/land-prices/compare", h.CompareLandPrice)
 		api.GET("/land-prices/estimate", h.EstimateLandPrice)
-		api.POST("/investment/analyze", h.Analyze)
+		api.POST("/investment/analyze", analyzeRL.middleware(), h.Analyze)
 		api.GET("/municipalities", h.GetMunicipalities)
 		api.GET("/station-ridership", h.GetStationRidership)
 		api.GET("/population-forecast", h.GetPopulationForecast)


### PR DESCRIPTION
## 概要

- すべての `/api/*` エンドポイントに IP ベースのレートリミットを追加
- `POST /investment/analyze` にはより厳しい制限を個別適用

## 背景

`APP_INTERNAL_API_KEY` が漏洩した場合でも、スクレイピングや大量リクエストによる悪用コストを高めるため。

## 変更内容

### レート制限値

| エンドポイント | 上限 | バースト |
|---|---|---|
| `/api/*`（全般） | 60 req/min | 20 |
| `/api/investment/analyze` | 10 req/min | 5 |

- 上限超過時: `429 Too Many Requests` + `Retry-After: 60` ヘッダー
- IP ごとに独立したトークンバケット（`golang.org/x/time/rate`）
- 10 分間アクセスがない IP のエントリは自動削除

### 実装

| ファイル | 変更 |
|---|---|
| `backend/internal/api/ratelimit.go` | 新規：`rateLimiter` 構造体、ミドルウェア、GC ゴルーチン |
| `backend/internal/api/router.go` | `generalRL` / `analyzeRL` をルーターに組み込み |
| `backend/internal/api/ratelimit_test.go` | 新規：4 ケース（許可・ブロック・ヘッダー・IP 分離） |

## テスト

- [x] `go test -race ./internal/api/...` 全パス
- [x] `go test -race ./...` 全パス
- [x] `go build ./...` 成功

## 依存関係

`golang.org/x/time` は既存の indirect dep（追加パッケージなし）。