### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -29,9 +29,9 @@ jobs:
         working-directory: backend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
         with:
           go-version-file: backend/go.mod
           cache-dependency-path: backend/go.sum

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -26,16 +26,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Authenticate to Google Cloud (OIDC)
-        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f  # v2.1.7
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.SA_EMAIL }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@6189d56e4096ee891640bb02ac264be376592d6a  # v2.1.4
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
 
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
@@ -50,7 +50,7 @@ jobs:
           docker push "${{ env.IMAGE }}:latest"
 
       - name: Deploy to Cloud Run
-        uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522  # v2.7.6
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d  # v3.0.1
         with:
           # このワークフローは main ブランチ → prod 環境専用。
           # stg 環境用には deploy-backend-stg.yml を別途作成し service 名を変更する。

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -32,9 +32,9 @@ jobs:
         working-directory: frontend
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "22.22.2"
           cache: npm
@@ -64,9 +64,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: "22.22.2"
 

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85  # v4.0.0
@@ -50,7 +50,7 @@ jobs:
         working-directory: terraform
 
       - name: Authenticate to Google Cloud (OIDC)
-        uses: google-github-actions/auth@6fc4af4b145ae7821d527454aa9bd537d1f2dc5f  # v2.1.7
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.SA_EMAIL }}


### PR DESCRIPTION
## 概要

GitHub Actions の Node.js 20 deprecation 警告に対応し、全ワークフローの actions を最新版（Node.js 24 対応）に更新。併せてタグ参照（`@v4` 等）を SHA ピン留めに統一。

## 背景

2026年6月2日より GitHub Actions ランナーが Node.js 24 をデフォルトに移行予定。Terraform CI ワークフローのログに以下の警告が出ていた:

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20
and may not work as expected: actions/checkout, google-github-actions/auth.
```

## 変更内容

| Action | 変更前 | 変更後 |
|---|---|---|
| `actions/checkout` | `@v4` / v4.2.2 | v6.0.2（SHA固定） |
| `actions/setup-go` | `@v5` | v6.4.0（SHA固定） |
| `actions/setup-node` | `@v4` | v6.4.0（SHA固定） |
| `google-github-actions/auth` | v2.1.7 | v3.0.0（SHA固定） |
| `google-github-actions/setup-gcloud` | v2.1.4 | v3.0.1（SHA固定） |
| `google-github-actions/deploy-cloudrun` | v2.7.6 | v3.0.1（SHA固定） |

## SHA ピン留めについて

タグ（`@v4`）はリポジトリオーナーが後から書き換え可能なため、サプライチェーン攻撃のリスクがある。コミット SHA に固定することで同一コードの実行を保証する。