### PR TITLE
fix(backend): ヘルスプローブログの抑制と OTel シャットダウンエラーの WARN 格下げ

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -66,8 +66,13 @@ func main() {
 		slog.Error("forced shutdown", "error", err)
 		os.Exit(1)
 	}
-	if err := otelShutdown(context.Background()); err != nil {
-		slog.Error("OTel shutdown error", "error", err)
+	// OTel フラッシュに 5s のタイムアウトを設定。
+	// ローリングデプロイ時に新旧インスタンスのメトリクス時系列が重複し
+	// "Points must be written in order" エラーが発生するのは既知の挙動のため WARN に留める。
+	otelCtx, otelCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer otelCancel()
+	if err := otelShutdown(otelCtx); err != nil {
+		slog.Warn("OTel shutdown error", "error", err)
 	}
 	slog.Info("server stopped")
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -29,6 +29,12 @@ func internalKeyMiddleware() gin.HandlerFunc {
 
 func accessLogMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
+		// liveness probe のログノイズを抑制
+		if c.Request.URL.Path == "/health" {
+			c.Next()
+			return
+		}
+
 		start := time.Now()
 		method := c.Request.Method
 		path := c.Request.URL.Path


### PR DESCRIPTION
## 概要

Cloud Run ログの2つのノイズ問題を修正。

## 変更内容

### 1. `/health` アクセスログを抑制

liveness probe が30秒ごとにアクセスログを出力していた。`accessLogMiddleware` でスキップするよう修正。

```
変更前: INFO access path=/health status=200 ... (2行/分、常時出力)
変更後: ログなし
```

### 2. OTel シャットダウンエラーを WARN に格下げ + タイムアウト追加

ローリングデプロイ時に旧インスタンスのシャットダウンで以下のエラーが ERROR として記録されていた:

```
Points must be written in order. One or more of the points specified
had an older start time than the most recent point.
```

新旧インスタンスが重複して動く際、Cloud Monitoring の累積メトリクス時系列が競合するため発生する既知の挙動。デプロイのたびに必ず発生するため ERROR は不適切。

- `context.Background()`（タイムアウトなし）→ 5秒タイムアウトに変更
- `slog.Error` → `slog.Warn` に格下げ

## テスト

- `go test -race ./...` 全パス
- `go build ./...` 成功