### PR TITLE
fix(pwa): POSTリクエストをService Workerのキャッシュ対象から除外

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -10,7 +10,8 @@ const withPWA = withPWAInit({
     disableDevLogs: true,
     runtimeCaching: [
       {
-        urlPattern: /\/api\/.*/i,
+        urlPattern: ({ url, request }) =>
+          /\/api\/.*/i.test(url.pathname) && request.method === "GET",
         handler: "NetworkFirst",
         options: {
           cacheName: "api-cache",


### PR DESCRIPTION
## 概要

- PWA の Service Worker が `/api/*` に一致する**全リクエスト**をインターセプトしていた
- Workbox の `NetworkFirst` 戦略は GET 専用であり、POST リクエストを処理しようとするとエラーが発生する
- `POST /api/investment/analyze` 実行直後に「このページを読み込めませんでした」が表示される原因となっていた

## 変更内容

`urlPattern` を正規表現から関数形式に変更し、**GET リクエストのみ**を SW のキャッシュ対象とした。

```js
// 修正前
urlPattern: /\/api\/.*/i,

// 修正後
urlPattern: ({ url, request }) =>
  /\/api\/.*/i.test(url.pathname) && request.method === "GET",
```

## 影響範囲

- `frontend/next.config.mjs` のみ
- POST / PUT / DELETE リクエストは SW を素通りしてサーバーに直接届く（本来あるべき挙動）
- GET リクエストのキャッシュ動作は変わらない

## 確認方法

- [ ] Vercel プレビューで `/api/investment/analyze` を実行し「このページを読み込めませんでした」が出ないことを確認
- [ ] DevTools > Application > Service Workers でエラーが出ていないことを確認