### PR TITLE
feat: 変動金利シミュレーション対応

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -12,13 +12,25 @@ const (
 	SqmPerTsubo = 3.30578
 )
 
+// resolveRateForYear はスケジュールと基準金利から指定年の適用金利を返す。
+// schedule が空の場合は baseRate + rateDelta を返す（固定金利）。
+// rateDelta はストレステスト用の追加オフセット。
+func resolveRateForYear(baseRate, rateDelta float64, schedule []RateAdjustment, year int) float64 {
+	rate := baseRate
+	for _, adj := range schedule {
+		if year >= adj.AfterYear {
+			rate = adj.Rate
+		}
+	}
+	return rate + rateDelta
+}
+
 // Analyze は投資入力値から収支シミュレーション結果を算出する
 func Analyze(input InvestmentInput) InvestmentResult {
 	input.Defaults()
 
 	// ストレステスト値を適用（空室率は99%上限でキャップ）
 	effectiveVacancy := math.Min(input.VacancyRate+input.VacancyRateDelta, 0.99)
-	effectiveRate := input.AnnualLoanRate + input.LoanRateDelta
 
 	miscExpenses := (input.LandPrice + input.BuildingCost) * input.MiscExpenseRate
 	totalInvestment := input.LandPrice + input.BuildingCost + miscExpenses
@@ -38,8 +50,9 @@ func Analyze(input InvestmentInput) InvestmentResult {
 	// 目標利回り逆算
 	requiredRent, landDrop := calcRequiredForTarget(input, totalInvestment)
 
-	// ローン月次計算
-	monthlyPayment := calcMonthlyPayment(input.LoanAmount, effectiveRate, input.LoanYears)
+	// 変動金利: 初年度の実効金利でローン返済額を計算
+	currentRate := resolveRateForYear(input.AnnualLoanRate, input.LoanRateDelta, input.RateAdjustmentSchedule, 1)
+	monthlyPayment := calcMonthlyPayment(input.LoanAmount, currentRate, input.LoanYears)
 
 	// 減価償却 (定額法)
 	// 中古物件は簡便法耐用年数を使用（新築は法定耐用年数）
@@ -67,13 +80,24 @@ func Analyze(input InvestmentInput) InvestmentResult {
 
 	for y := 0; y < years; y++ {
 		year := y + 1
+
+		// 変動金利: スケジュールで金利が変化したら返済額を残高・残期間で再計算
+		if year > 1 && len(input.RateAdjustmentSchedule) > 0 {
+			newRate := resolveRateForYear(input.AnnualLoanRate, input.LoanRateDelta, input.RateAdjustmentSchedule, year)
+			if newRate != currentRate && remainingBalance > 0 && year <= input.LoanYears {
+				remainingYears := input.LoanYears - y
+				monthlyPayment = calcMonthlyPayment(remainingBalance, newRate, remainingYears)
+				currentRate = newRate
+			}
+		}
+
 		annualInterest := 0.0
 		annualPrincipal := 0.0
 		annualLoanPayment := 0.0
 
 		if remainingBalance > 0 && year <= input.LoanYears {
 			annualInterest, annualPrincipal = calcYearlyLoanComponents(
-				remainingBalance, effectiveRate, monthlyPayment,
+				remainingBalance, currentRate, monthlyPayment,
 			)
 			annualLoanPayment = monthlyPayment * 12
 			remainingBalance -= annualPrincipal
@@ -130,6 +154,7 @@ func Analyze(input InvestmentInput) InvestmentResult {
 			CumulativeCashFlow:   cumulativeCF,
 			IsDeadCrossYear:      isDeadCrossYear,
 			IsInDeadCrossZone:    inDeadCrossZone,
+			EffectiveRate:        currentRate,
 		}
 	}
 
@@ -231,16 +256,17 @@ func calcStressScenario(base InvestmentInput, label string, rateDelta, vacDelta 
 	if effectiveVacancy > 1 {
 		effectiveVacancy = 1
 	}
-	effectiveRate := in.AnnualLoanRate + rateDelta
 
 	annualRent := in.MonthlyRent * 12 * (1 - effectiveVacancy)
 	annualExpenses := annualRent*in.ExpenseRate + in.AnnualPropertyTax
 	noi := annualRent - annualExpenses
 
-	monthlyPayment := calcMonthlyPayment(in.LoanAmount, effectiveRate, in.LoanYears)
+	// 初年度の実効金利（スケジュール+ストレスdelta）
+	initRate := resolveRateForYear(in.AnnualLoanRate, rateDelta, in.RateAdjustmentSchedule, 1)
+	monthlyPayment := calcMonthlyPayment(in.LoanAmount, initRate, in.LoanYears)
 	annualLoanPayment := monthlyPayment * 12
 
-	// DSCR = NOI / 年間ローン返済額
+	// DSCR = NOI / 初年度年間ローン返済額
 	dscr := 0.0
 	if annualLoanPayment > 0 {
 		dscr = noi / annualLoanPayment
@@ -255,8 +281,20 @@ func calcStressScenario(base InvestmentInput, label string, rateDelta, vacDelta 
 	breakEvenYear := -1
 	cumCF := 0.0
 	remainingBalance := in.LoanAmount
+	currentRate := initRate
+	curMonthlyPayment := monthlyPayment
 	for y := 1; y <= holdingYears; y++ {
-		yearLoan := annualLoanPayment
+		// 変動金利スケジュール適用
+		if y > 1 && len(in.RateAdjustmentSchedule) > 0 {
+			newRate := resolveRateForYear(in.AnnualLoanRate, rateDelta, in.RateAdjustmentSchedule, y)
+			if newRate != currentRate && remainingBalance > 0 && y <= in.LoanYears {
+				remainingYears := in.LoanYears - (y - 1)
+				curMonthlyPayment = calcMonthlyPayment(remainingBalance, newRate, remainingYears)
+				currentRate = newRate
+			}
+		}
+
+		yearLoan := curMonthlyPayment * 12
 		if remainingBalance <= 0 || y > in.LoanYears {
 			yearLoan = 0
 		}
@@ -266,10 +304,8 @@ func calcStressScenario(base InvestmentInput, label string, rateDelta, vacDelta 
 		if breakEvenYear == -1 && cumCF > 0 {
 			breakEvenYear = y
 		}
-		// 残高更新（簡略: 元金返済=返済額-利息）
 		if remainingBalance > 0 && y <= in.LoanYears {
-			annInterest, annPrincipal := calcYearlyLoanComponents(remainingBalance, effectiveRate, monthlyPayment)
-			_ = annInterest
+			_, annPrincipal := calcYearlyLoanComponents(remainingBalance, currentRate, curMonthlyPayment)
 			remainingBalance -= annPrincipal
 			if remainingBalance < 0 {
 				remainingBalance = 0

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -1333,3 +1333,210 @@ func TestAnalyze_UltraLowInterestRate(t *testing.T) {
 		t.Errorf("GrossYield is NaN or Inf: %v", result.GrossYield)
 	}
 }
+
+// ── 変動金利テスト ────────────────────────────────────────────────
+
+// TestResolveRateForYear はスケジュールに基づく年別金利解決を検証する
+func TestResolveRateForYear(t *testing.T) {
+	schedule := []RateAdjustment{
+		{AfterYear: 6, Rate: 0.02},
+		{AfterYear: 11, Rate: 0.03},
+	}
+
+	cases := []struct {
+		year int
+		want float64
+	}{
+		{1, 0.015},  // スケジュール前: baseRate
+		{5, 0.015},  // スケジュール前: baseRate
+		{6, 0.02},   // 第1ステップ適用
+		{10, 0.02},  // 第1ステップ継続
+		{11, 0.03},  // 第2ステップ適用
+		{35, 0.03},  // 第2ステップ継続
+	}
+
+	for _, c := range cases {
+		got := resolveRateForYear(0.015, 0, schedule, c.year)
+		if math.Abs(got-c.want) > 1e-9 {
+			t.Errorf("year=%d: got %.4f, want %.4f", c.year, got, c.want)
+		}
+	}
+
+	// rateDelta が全ステップに上乗せされること
+	got := resolveRateForYear(0.015, 0.01, schedule, 6)
+	if math.Abs(got-0.03) > 1e-9 {
+		t.Errorf("rateDelta: got %.4f, want 0.03", got)
+	}
+
+	// 空スケジュールは baseRate + rateDelta を返す
+	got = resolveRateForYear(0.015, 0.005, nil, 10)
+	if math.Abs(got-0.02) > 1e-9 {
+		t.Errorf("empty schedule: got %.4f, want 0.02", got)
+	}
+}
+
+// TestValidateRateAdjustmentSchedule はスケジュールのバリデーションを検証する
+func TestValidateRateAdjustmentSchedule(t *testing.T) {
+	base := InvestmentInput{
+		VacancyRate:  0.05,
+		LoanYears:    35,
+		RentDeclineRate: 0,
+	}
+
+	t.Run("valid single step", func(t *testing.T) {
+		in := base
+		in.RateAdjustmentSchedule = []RateAdjustment{{AfterYear: 6, Rate: 0.02}}
+		if err := in.Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("valid multi step ascending", func(t *testing.T) {
+		in := base
+		in.RateAdjustmentSchedule = []RateAdjustment{
+			{AfterYear: 6, Rate: 0.02},
+			{AfterYear: 11, Rate: 0.025},
+		}
+		if err := in.Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("AfterYear < 2", func(t *testing.T) {
+		in := base
+		in.RateAdjustmentSchedule = []RateAdjustment{{AfterYear: 1, Rate: 0.02}}
+		if err := in.Validate(); err == nil {
+			t.Error("expected error for AfterYear < 2")
+		}
+	})
+
+	t.Run("AfterYear > LoanYears", func(t *testing.T) {
+		in := base
+		in.RateAdjustmentSchedule = []RateAdjustment{{AfterYear: 36, Rate: 0.02}}
+		if err := in.Validate(); err == nil {
+			t.Error("expected error for AfterYear > LoanYears")
+		}
+	})
+
+	t.Run("Rate out of range", func(t *testing.T) {
+		in := base
+		in.RateAdjustmentSchedule = []RateAdjustment{{AfterYear: 6, Rate: 0.35}}
+		if err := in.Validate(); err == nil {
+			t.Error("expected error for Rate > 0.3")
+		}
+	})
+
+	t.Run("unsorted AfterYear", func(t *testing.T) {
+		in := base
+		in.RateAdjustmentSchedule = []RateAdjustment{
+			{AfterYear: 11, Rate: 0.02},
+			{AfterYear: 6, Rate: 0.025},
+		}
+		if err := in.Validate(); err == nil {
+			t.Error("expected error for unsorted schedule")
+		}
+	})
+
+	t.Run("duplicate AfterYear", func(t *testing.T) {
+		in := base
+		in.RateAdjustmentSchedule = []RateAdjustment{
+			{AfterYear: 6, Rate: 0.02},
+			{AfterYear: 6, Rate: 0.025},
+		}
+		if err := in.Validate(); err == nil {
+			t.Error("expected error for duplicate AfterYear")
+		}
+	})
+}
+
+// TestAnalyzeWithRateSchedule は変動金利スケジュール適用後の動作を検証する
+func TestAnalyzeWithRateSchedule(t *testing.T) {
+	base := InvestmentInput{
+		LandPrice:    5_000_000,
+		BuildingCost: 10_000_000,
+		MonthlyRent:  120_000,
+		VacancyRate:  0.05,
+		LoanAmount:   13_000_000,
+		AnnualLoanRate: 0.015,
+		LoanYears:    35,
+		BuildingType: BuildingTypeWood,
+		ExpenseRate:  0.20,
+		IncomeTaxRate: 0.33,
+		HoldingYears: 15,
+		ExitYieldTarget: 0.06,
+		YieldTarget:  0.08,
+	}
+
+	t.Run("fixed rate: all years same EffectiveRate", func(t *testing.T) {
+		result := Analyze(base)
+		for _, y := range result.YearlyResults {
+			if math.Abs(y.EffectiveRate-0.015) > 1e-9 {
+				t.Errorf("year=%d: EffectiveRate=%.4f, want 0.015", y.Year, y.EffectiveRate)
+			}
+		}
+	})
+
+	t.Run("rate steps up at year 6 and 11", func(t *testing.T) {
+		in := base
+		in.RateAdjustmentSchedule = []RateAdjustment{
+			{AfterYear: 6, Rate: 0.02},
+			{AfterYear: 11, Rate: 0.03},
+		}
+		result := Analyze(in)
+
+		for _, y := range result.YearlyResults {
+			var wantRate float64
+			switch {
+			case y.Year >= 11:
+				wantRate = 0.03
+			case y.Year >= 6:
+				wantRate = 0.02
+			default:
+				wantRate = 0.015
+			}
+			if math.Abs(y.EffectiveRate-wantRate) > 1e-9 {
+				t.Errorf("year=%d: EffectiveRate=%.4f, want %.4f", y.Year, y.EffectiveRate, wantRate)
+			}
+		}
+
+		// 金利変化年に月次返済額が増加することを確認
+		// 年5→年6: 金利0.015→0.02なので返済額が増えるはず
+		y5 := result.YearlyResults[4]
+		y6 := result.YearlyResults[5]
+		if y6.AnnualLoanPayment <= y5.AnnualLoanPayment {
+			t.Errorf("year6 payment(%.0f) should be > year5 payment(%.0f) after rate increase",
+				y6.AnnualLoanPayment, y5.AnnualLoanPayment)
+		}
+	})
+
+	t.Run("variable rate total interest > fixed rate total interest", func(t *testing.T) {
+		// 金利が途中から上がれば総支払利息は増える
+		fixed := Analyze(base)
+		variable := base
+		variable.RateAdjustmentSchedule = []RateAdjustment{{AfterYear: 6, Rate: 0.03}}
+		varResult := Analyze(variable)
+
+		fixedInterest := 0.0
+		varInterest := 0.0
+		for i := range fixed.YearlyResults {
+			fixedInterest += fixed.YearlyResults[i].AnnualInterest
+			varInterest += varResult.YearlyResults[i].AnnualInterest
+		}
+		if varInterest <= fixedInterest {
+			t.Errorf("variable rate total interest(%.0f) should be > fixed(%.0f)", varInterest, fixedInterest)
+		}
+	})
+
+	t.Run("LoanRateDelta stacks on top of schedule", func(t *testing.T) {
+		in := base
+		in.RateAdjustmentSchedule = []RateAdjustment{{AfterYear: 6, Rate: 0.02}}
+		in.LoanRateDelta = 0.005
+		result := Analyze(in)
+
+		// 年6以降: 0.02 + 0.005 = 0.025
+		y6 := result.YearlyResults[5]
+		if math.Abs(y6.EffectiveRate-0.025) > 1e-9 {
+			t.Errorf("year6 EffectiveRate=%.4f, want 0.025 (schedule+delta)", y6.EffectiveRate)
+		}
+	})
+}

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -54,6 +54,14 @@ func CalcResidualUsefulLife(buildingType BuildingType, buildingAge int) int {
 	return residual
 }
 
+// RateAdjustment は変動金利スケジュールの1ステップ
+type RateAdjustment struct {
+	// AfterYear: この年（1始まり）以降に Rate を適用（例: 6 = 6年目から）
+	AfterYear int `json:"afterYear"`
+	// Rate: 絶対値の年利（例: 0.02 = 2%）
+	Rate float64 `json:"rate"`
+}
+
 // InvestmentInput は収支シミュレーションの入力値
 type InvestmentInput struct {
 	LandPrice       float64      `json:"landPrice"`       // 土地取得費 (円)
@@ -89,6 +97,10 @@ type InvestmentInput struct {
 
 	// 目標表面利回り（例: 0.08 = 8%）。0 の場合は Defaults() で 0.08 にセットされる。
 	YieldTarget float64 `json:"yieldTarget"`
+
+	// 変動金利スケジュール: 指定年以降に適用する金利ステップ（空=固定金利）
+	// LoanRateDelta はスケジュール後の金利にも加算される。
+	RateAdjustmentSchedule []RateAdjustment `json:"rateAdjustmentSchedule"`
 }
 
 // Validate は入力値のバリデーションを行い、不正な組み合わせはエラーを返す。
@@ -105,6 +117,20 @@ func (i *InvestmentInput) Validate() error {
 			"RentDeclineRate(%.3f) must be between 0.0 and 0.2",
 			i.RentDeclineRate,
 		)
+	}
+	for idx, adj := range i.RateAdjustmentSchedule {
+		if adj.AfterYear < 2 {
+			return fmt.Errorf(
+				"RateAdjustmentSchedule[%d].AfterYear(%d) must be >= 2",
+				idx, adj.AfterYear,
+			)
+		}
+		if adj.Rate <= 0 || adj.Rate > 0.3 {
+			return fmt.Errorf(
+				"RateAdjustmentSchedule[%d].Rate(%.4f) must be between 0 and 0.3",
+				idx, adj.Rate,
+			)
+		}
 	}
 	return nil
 }
@@ -149,6 +175,7 @@ type YearlyResult struct {
 	CumulativeCashFlow   float64 `json:"cumulativeCashFlow"`
 	IsDeadCrossYear      bool    `json:"isDeadCrossYear"`   // デッドクロス初年度
 	IsInDeadCrossZone    bool    `json:"isInDeadCrossZone"` // デッドクロス継続中
+	EffectiveRate        float64 `json:"effectiveRate"`     // その年の適用金利（年利）
 }
 
 // CriticalErrorStatus は重大エラーの深刻度

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -118,6 +118,10 @@ func (i *InvestmentInput) Validate() error {
 			i.RentDeclineRate,
 		)
 	}
+	loanYears := i.LoanYears
+	if loanYears == 0 {
+		loanYears = 35 // Defaults() 適用前に呼ばれる場合の保護
+	}
 	for idx, adj := range i.RateAdjustmentSchedule {
 		if adj.AfterYear < 2 {
 			return fmt.Errorf(
@@ -125,10 +129,22 @@ func (i *InvestmentInput) Validate() error {
 				idx, adj.AfterYear,
 			)
 		}
+		if adj.AfterYear > loanYears {
+			return fmt.Errorf(
+				"RateAdjustmentSchedule[%d].AfterYear(%d) exceeds LoanYears(%d)",
+				idx, adj.AfterYear, loanYears,
+			)
+		}
 		if adj.Rate <= 0 || adj.Rate > 0.3 {
 			return fmt.Errorf(
 				"RateAdjustmentSchedule[%d].Rate(%.4f) must be between 0 and 0.3",
 				idx, adj.Rate,
+			)
+		}
+		if idx > 0 && adj.AfterYear <= i.RateAdjustmentSchedule[idx-1].AfterYear {
+			return fmt.Errorf(
+				"RateAdjustmentSchedule must be sorted in ascending order by afterYear: [%d].AfterYear(%d) <= [%d].AfterYear(%d)",
+				idx, adj.AfterYear, idx-1, i.RateAdjustmentSchedule[idx-1].AfterYear,
 			)
 		}
 	}

--- a/frontend/src/components/CashFlowChart.tsx
+++ b/frontend/src/components/CashFlowChart.tsx
@@ -24,12 +24,24 @@ export function CashFlowChart({ result, equityInvested }: Props) {
     // 自己資金を初期コストとして加算した累積CF（ISSUE-22）
     累積CF: Math.round((y.cumulativeCashFlow - equityInvested) / 10_000),
     isDeadCrossZone: y.isInDeadCrossZone,
+    effectiveRate: y.effectiveRate,
   }));
 
   // 自己資金を回収した年（累積CF - 自己資金 >= 0）
   const breakEvenYear = yearlyResults.find(
     (y) => y.cumulativeCashFlow - equityInvested >= 0
   )?.year ?? null;
+
+  // 金利が変化した年のリスト（2年目以降で前年から変化した年）
+  const rateChangeYears: { year: string; rate: number }[] = [];
+  for (let i = 1; i < Math.min(yearlyResults.length, 35); i++) {
+    if (yearlyResults[i].effectiveRate !== yearlyResults[i - 1].effectiveRate) {
+      rateChangeYears.push({
+        year: `${yearlyResults[i].year}年`,
+        rate: yearlyResults[i].effectiveRate,
+      });
+    }
+  }
 
   return (
     <Card>
@@ -60,6 +72,16 @@ export function CashFlowChart({ result, equityInvested }: Props) {
               <ReferenceLine yAxisId="right" x={`${breakEvenYear}年`} stroke="#22c55e" strokeDasharray="4 4"
                 label={{ value: "回収", position: "top", fontSize: 10, fill: "#22c55e" }} />
             )}
+            {rateChangeYears.map(({ year, rate }) => (
+              <ReferenceLine
+                key={year}
+                yAxisId="left"
+                x={year}
+                stroke="#f97316"
+                strokeDasharray="4 3"
+                label={{ value: `${(rate * 100).toFixed(2)}%`, position: "insideTopRight", fontSize: 9, fill: "#f97316" }}
+              />
+            ))}
             <Bar yAxisId="left" dataKey="税引後CF" maxBarSize={20} radius={[2, 2, 0, 0]}>
               {data.map((entry, index) => (
                 <Cell key={index} fill={entry.isDeadCrossZone ? "#fca5a5" : "#60a5fa"} />
@@ -70,6 +92,7 @@ export function CashFlowChart({ result, equityInvested }: Props) {
         </ResponsiveContainer>
         <p className="mt-1 text-xs text-muted-foreground text-right">
           ※赤色の棒はデッドクロスゾーン（元金返済 &gt; 減価償却費）
+          {rateChangeYears.length > 0 && "　※橙色の縦線は金利変更年"}
         </p>
 
         {/* 出口戦略サマリー */}

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -5,11 +5,11 @@ import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
-import type { InvestmentInput, BuildingType, SimulationMode } from "@/types/investment";
+import type { InvestmentInput, BuildingType, SimulationMode, RateAdjustment } from "@/types/investment";
 import { DEFAULT_INPUT, QUICK_MODE_DEFAULTS } from "@/types/investment";
 import { formatPct } from "@/lib/utils";
 import { fetchMunicipalities, type Municipality } from "@/lib/api";
-import { Search, Calculator, Info, AlertTriangle, ShieldCheck, Zap, SlidersHorizontal, ChevronDown, ChevronUp } from "lucide-react";
+import { Search, Calculator, Info, AlertTriangle, ShieldCheck, Zap, SlidersHorizontal, ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
 import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
 
 const PREFECTURES = [
@@ -137,6 +137,9 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   const [savedLoanAmount, setSavedLoanAmount] = useState(DEFAULT_INPUT.loanAmount);
   const [savedLoanYears, setSavedLoanYears] = useState(DEFAULT_INPUT.loanYears);
 
+  // 変動金利スケジュール
+  const [rateScheduleEnabled, setRateScheduleEnabled] = useState(false);
+
   // 按分ヘルパーの状態
   const [showBuildingHelper, setShowBuildingHelper] = useState(false);
   const [taxAmount, setTaxAmount] = useState("");
@@ -232,6 +235,37 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   const fromMan = (s: string) => (parseFloat(s) || 0) * 10_000;
   const toPct = (rate: number, digits = 2) => (rate * 100).toFixed(digits);
   const fromPct = (s: string) => (parseFloat(s) || 0) / 100;
+
+  const addRateStep = () => {
+    const schedule = input.rateAdjustmentSchedule;
+    const lastYear = schedule.length > 0 ? schedule[schedule.length - 1].afterYear : 1;
+    const nextYear = Math.min(lastYear + 5, input.loanYears || 35);
+    const newStep: RateAdjustment = { afterYear: nextYear, rate: input.annualLoanRate + 0.005 };
+    setInput((prev) => ({ ...prev, rateAdjustmentSchedule: [...prev.rateAdjustmentSchedule, newStep] }));
+  };
+
+  const removeRateStep = (index: number) => {
+    setInput((prev) => ({
+      ...prev,
+      rateAdjustmentSchedule: prev.rateAdjustmentSchedule.filter((_, i) => i !== index),
+    }));
+  };
+
+  const updateRateStep = (index: number, field: keyof RateAdjustment, value: number) => {
+    setInput((prev) => ({
+      ...prev,
+      rateAdjustmentSchedule: prev.rateAdjustmentSchedule.map((s, i) =>
+        i === index ? { ...s, [field]: value } : s
+      ),
+    }));
+  };
+
+  const handleRateScheduleToggle = (enabled: boolean) => {
+    setRateScheduleEnabled(enabled);
+    if (!enabled) {
+      setInput((prev) => ({ ...prev, rateAdjustmentSchedule: [] }));
+    }
+  };
 
   const handleAnalyze = () => {
     if (hasErrors) return;
@@ -736,6 +770,71 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                     onChange={(e) => setNum("incomeTaxRate", fromPct(e.target.value))}
                     error={fieldError("incomeTaxRate")} />
                 </div>
+              </div>
+
+              {/* 変動金利スケジュール */}
+              <div className="border-t pt-4 space-y-3">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-semibold text-foreground">変動金利シミュレーション</p>
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={rateScheduleEnabled}
+                      onChange={(e) => handleRateScheduleToggle(e.target.checked)}
+                      className="h-4 w-4 rounded border-gray-300"
+                    />
+                    <span className="text-xs text-muted-foreground">有効にする</span>
+                  </label>
+                </div>
+                {rateScheduleEnabled && (
+                  <div className="space-y-2">
+                    <p className="text-xs text-muted-foreground">
+                      指定年以降の適用金利（絶対値）を設定します。最大3ステップ。
+                    </p>
+                    {input.rateAdjustmentSchedule.map((step, i) => (
+                      <div key={i} className="flex items-center gap-2">
+                        <Input
+                          label={i === 0 ? "開始年" : ""}
+                          type="number"
+                          suffix="年目〜"
+                          min="2"
+                          max={String(input.loanYears || 35)}
+                          step="1"
+                          value={String(step.afterYear)}
+                          onChange={(e) => updateRateStep(i, "afterYear", parseInt(e.target.value) || 2)}
+                        />
+                        <Input
+                          label={i === 0 ? "適用金利" : ""}
+                          type="number"
+                          suffix="%"
+                          min="0.1"
+                          max="30"
+                          step="0.1"
+                          value={(step.rate * 100).toFixed(2)}
+                          onChange={(e) => updateRateStep(i, "rate", (parseFloat(e.target.value) || 0) / 100)}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => removeRateStep(i)}
+                          className={`text-muted-foreground hover:text-destructive flex-shrink-0 ${i === 0 ? "mt-5" : ""}`}
+                          aria-label="削除"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    ))}
+                    {input.rateAdjustmentSchedule.length < 3 && (
+                      <button
+                        type="button"
+                        onClick={addRateStep}
+                        className="flex items-center gap-1 text-xs text-primary hover:underline"
+                      >
+                        <Plus className="h-3 w-3" />
+                        金利ステップを追加
+                      </button>
+                    )}
+                  </div>
+                )}
               </div>
 
               {/* ストレステスト */}

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -267,19 +267,27 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
     }
   };
 
+  // 送信前にスケジュールを afterYear 昇順にソートする
+  const sortedInput = (src: InvestmentInput): InvestmentInput => ({
+    ...src,
+    rateAdjustmentSchedule: [...src.rateAdjustmentSchedule].sort(
+      (a, b) => a.afterYear - b.afterYear
+    ),
+  });
+
   const handleAnalyze = () => {
     if (hasErrors) return;
     if (isQuick) {
       const total = (parseFloat(quickTotalPriceMan) || 0) * 10_000;
-      const payload: InvestmentInput = {
+      const payload: InvestmentInput = sortedInput({
         ...input,
         ...QUICK_MODE_DEFAULTS,
         landPrice: total * 0.7,
         buildingCost: total * 0.3,
-      };
+      });
       onAnalyze(payload);
     } else {
-      onAnalyze(input);
+      onAnalyze(sortedInput(input));
     }
   };
 
@@ -791,38 +799,54 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                     <p className="text-xs text-muted-foreground">
                       指定年以降の適用金利（絶対値）を設定します。最大3ステップ。
                     </p>
-                    {input.rateAdjustmentSchedule.map((step, i) => (
-                      <div key={i} className="flex items-center gap-2">
-                        <Input
-                          label={i === 0 ? "開始年" : ""}
-                          type="number"
-                          suffix="年目〜"
-                          min="2"
-                          max={String(input.loanYears || 35)}
-                          step="1"
-                          value={String(step.afterYear)}
-                          onChange={(e) => updateRateStep(i, "afterYear", parseInt(e.target.value) || 2)}
-                        />
-                        <Input
-                          label={i === 0 ? "適用金利" : ""}
-                          type="number"
-                          suffix="%"
-                          min="0.1"
-                          max="30"
-                          step="0.1"
-                          value={(step.rate * 100).toFixed(2)}
-                          onChange={(e) => updateRateStep(i, "rate", (parseFloat(e.target.value) || 0) / 100)}
-                        />
-                        <button
-                          type="button"
-                          onClick={() => removeRateStep(i)}
-                          className={`text-muted-foreground hover:text-destructive flex-shrink-0 ${i === 0 ? "mt-5" : ""}`}
-                          aria-label="削除"
-                        >
-                          <Trash2 className="h-4 w-4" />
-                        </button>
-                      </div>
-                    ))}
+                    {input.rateAdjustmentSchedule.map((step, i) => {
+                      const maxYear = input.loanYears || 35;
+                      const prevYear = i > 0 ? input.rateAdjustmentSchedule[i - 1].afterYear : 1;
+                      const yearError = step.afterYear < 2
+                        ? "2年目以降を指定してください"
+                        : step.afterYear > maxYear
+                        ? `${maxYear}年以内を指定してください`
+                        : step.afterYear <= prevYear
+                        ? `前のステップより後の年を指定してください`
+                        : undefined;
+                      const rateError = step.rate <= 0 || step.rate > 0.3
+                        ? "0%超〜30%の範囲で入力してください"
+                        : undefined;
+                      return (
+                        <div key={i} className="flex items-center gap-2">
+                          <Input
+                            label={i === 0 ? "開始年" : ""}
+                            type="number"
+                            suffix="年目〜"
+                            min="2"
+                            max={String(maxYear)}
+                            step="1"
+                            value={String(step.afterYear)}
+                            onChange={(e) => updateRateStep(i, "afterYear", parseInt(e.target.value) || 2)}
+                            error={yearError}
+                          />
+                          <Input
+                            label={i === 0 ? "適用金利" : ""}
+                            type="number"
+                            suffix="%"
+                            min="0.1"
+                            max="30"
+                            step="0.1"
+                            value={(step.rate * 100).toFixed(2)}
+                            onChange={(e) => updateRateStep(i, "rate", (parseFloat(e.target.value) || 0) / 100)}
+                            error={rateError}
+                          />
+                          <button
+                            type="button"
+                            onClick={() => removeRateStep(i)}
+                            className={`text-muted-foreground hover:text-destructive flex-shrink-0 ${i === 0 ? "mt-5" : ""}`}
+                            aria-label="削除"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </button>
+                        </div>
+                      );
+                    })}
                     {input.rateAdjustmentSchedule.length < 3 && (
                       <button
                         type="button"

--- a/frontend/src/components/__tests__/helpers.ts
+++ b/frontend/src/components/__tests__/helpers.ts
@@ -24,6 +24,7 @@ export function makeInput(overrides: Partial<InvestmentInput> = {}): InvestmentI
     annualPropertyTax: 0,
     rentDeclineRate: 0,
     yieldTarget: 0.08,
+    rateAdjustmentSchedule: [],
     ...overrides,
   };
 }
@@ -76,6 +77,7 @@ export function makeYearlyResult(year: number, overrides: Partial<YearlyResult> 
     cumulativeCashFlow: 274_200 * year,
     isDeadCrossYear: false,
     isInDeadCrossZone: false,
+    effectiveRate: 0.015,
     ...overrides,
   };
 }

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -45,6 +45,11 @@ export interface StationRidershipResult {
   correction: number;
 }
 
+export interface RateAdjustment {
+  afterYear: number; // この年（1始まり）以降に適用（例: 6 = 6年目から）
+  rate: number;      // 絶対値の年利（例: 0.02 = 2%）
+}
+
 export interface InvestmentInput {
   landPrice: number;
   landArea: number;       // 土地面積 (m²)
@@ -68,6 +73,7 @@ export interface InvestmentInput {
   annualPropertyTax: number;  // 固定資産税・都市計画税（年間）。0 = ExpenseRateに含む。
   rentDeclineRate: number;    // 年間賃料下落率（例: 0.01 = 1%/年）
   yieldTarget: number;        // 目標表面利回り（例: 0.08 = 8%）
+  rateAdjustmentSchedule: RateAdjustment[]; // 変動金利スケジュール（空=固定金利）
 }
 
 export interface YearlyResult {
@@ -86,6 +92,7 @@ export interface YearlyResult {
   cumulativeCashFlow: number;
   isDeadCrossYear: boolean;
   isInDeadCrossZone: boolean;   // デッドクロス継続ゾーン
+  effectiveRate: number;        // その年の適用金利（年利）
 }
 
 export interface StressScenarioResult {
@@ -223,6 +230,7 @@ export const DEFAULT_INPUT: InvestmentInput = {
   annualPropertyTax: 0,
   rentDeclineRate: 0,
   yieldTarget: 0.08,
+  rateAdjustmentSchedule: [],
 };
 
 export const BUILDING_USEFUL_LIFE: Record<BuildingType, number> = {
@@ -250,7 +258,8 @@ export const QUICK_MODE_DEFAULTS: Partial<InvestmentInput> = {
   loanRateDelta:     0,
   annualPropertyTax: 0,
   buildingType:      "木造" as BuildingType,
-  annualLoanRate:    0.015,
-  rentDeclineRate:   0.01,
-  yieldTarget:       0.08,
+  annualLoanRate:           0.015,
+  rentDeclineRate:          0.01,
+  yieldTarget:              0.08,
+  rateAdjustmentSchedule:  [],
 };


### PR DESCRIPTION
## 概要

issue #4 「変動金利シミュレーションへの対応」を実装しました。

## 変更内容

### バックエンド (`backend/internal/domain/`)

- **`types.go`**
  - `RateAdjustment` 構造体を追加（`afterYear: int`, `rate: float64`）
  - `InvestmentInput` に `RateAdjustmentSchedule []RateAdjustment` フィールドを追加
  - `YearlyResult` に `EffectiveRate float64` フィールドを追加
  - `Validate()` にスケジュールのバリデーション追加（`AfterYear >= 2`、`Rate` in `(0, 0.3]`）

- **`investment.go`**
  - `resolveRateForYear()` ヘルパーを追加（スケジュール + ストレスdelta → 年別実効金利）
  - `Analyze()` の年次ループを変動金利対応に改修：金利変化年で残高・残期間から月次返済額を再計算
  - `calcStressScenario()` もスケジュールを考慮した年次ループに改修

### フロントエンド (`frontend/src/`)

- **`types/investment.ts`**
  - `RateAdjustment` インターフェース追加
  - `InvestmentInput` に `rateAdjustmentSchedule: RateAdjustment[]` 追加
  - `YearlyResult` に `effectiveRate: number` 追加
  - `DEFAULT_INPUT` / `QUICK_MODE_DEFAULTS` / テストヘルパー更新

- **`components/InvestmentForm.tsx`**
  - 「変動金利シミュレーション」セクションを追加（ストレステストの上）
  - チェックボックスでON/OFF切替
  - 最大3ステップの金利変更設定（開始年 + 適用金利%）を追加/削除可能

- **`components/CashFlowChart.tsx`**
  - `yearlyResults` の `effectiveRate` 変化を検出して、金利変更年に橙色の縦線（年利ラベル付き）を表示

## 動作仕様

- 変動金利が未設定（空スケジュール）の場合は従来の固定金利動作と完全互換
- 金利変化時は**残ローン残高と残期間で月次返済額を再計算**（元利均等返済の再設定を模倣）
- ストレスdelta（`loanRateDelta`）はスケジュール後の金利にも上乗せされる

## テスト

- `go test -race ./...` — 全パス
- `vitest run` (84テスト) — 全パス
- `tsc --noEmit` — エラーなし

closes #4