### PR TITLE
fix(pwa): @react-pdf/renderer の React 19.2.x クラッシュを修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@
 ## dev: バックエンド・フロントエンドの開発サーバーを起動
 dev:
 	@echo "==> Starting backend..."
-	cd backend && go run ./cmd/server &
+	cd backend && set -a; . ../.env 2>/dev/null; set +a; go run ./cmd/server &
 	@echo "==> Starting frontend..."
-	cd frontend && npm run dev
+	cd frontend && npm run dev -- --webpack
 
 ## test: 全テストを実行
 test:

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3993,9 +3993,9 @@
       }
     },
     "node_modules/@react-pdf/reconciler/node_modules/scheduler": {
-      "version": "0.25.0-rc-603e6108-20241029",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0-rc-603e6108-20241029.tgz",
-      "integrity": "sha512-pFwF6H1XrSdYYNLfOcGlM28/j8CGLu8IvdrxqhjWULe2bPcKiKW4CV+OWqR/9fT52mywx65l7ysNkjLKBda7eA==",
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.25.0.tgz",
+      "integrity": "sha512-xFVuu11jh+xcO7JOAGJNOXld8/TcEHK/4CituBUeUb5hqxJLj9YuemAEuvm9gQ/+pgXYfbQuqAkiYu+u7YEsNA==",
       "license": "MIT"
     },
     "node_modules/@react-pdf/render": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,11 @@
     "recharts": "^2.12.7",
     "tailwind-merge": "^2.4.0"
   },
+  "overrides": {
+    "@react-pdf/reconciler": {
+      "scheduler": "0.25.0"
+    }
+  },
   "devDependencies": {
     "@emnapi/core": "^1.10.0",
     "@emnapi/runtime": "^1.10.0",

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -10,7 +10,17 @@ class PdfErrorBoundary extends Component<
     return { failed: true };
   }
   render() {
-    if (this.state.failed) return null;
+    if (this.state.failed)
+      return (
+        <button
+          disabled
+          className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white shadow-sm opacity-50 cursor-not-allowed"
+          title="PDF生成ライブラリが現在のReactバージョンに未対応です"
+        >
+          <FileDown className="h-3.5 w-3.5" />
+          PDF生成に失敗しました
+        </button>
+      );
     return this.props.children;
   }
 }
@@ -57,6 +67,7 @@ export function Dashboard() {
   const [externalUrbanRisks, setExternalUrbanRisks] = useState<UrbanRisk[] | null>(null);
   const [simulationMode, setSimulationMode] = useState<SimulationMode>("quick");
   const [modeNotice, setModeNotice] = useState(false);
+  const [pdfRequested, setPdfRequested] = useState(false);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
@@ -78,6 +89,7 @@ export function Dashboard() {
   const handleAnalyze = async (input: InvestmentInput) => {
     setLoading(true);
     setError(null);
+    setPdfRequested(false);
     try {
       const res = await analyze(input);
       setResult(res);
@@ -156,22 +168,32 @@ export function Dashboard() {
           </div>
           <div className="ml-auto flex items-center gap-3">
             {result && lastInput && (
-              <PdfErrorBoundary>
-                <PDFDownloadLink
-                  document={<ReportPDF input={lastInput} result={result} />}
-                  fileName={`yield-guard-report-${new Date().toISOString().slice(0, 10).replace(/-/g, "")}.pdf`}
+              pdfRequested ? (
+                <PdfErrorBoundary>
+                  <PDFDownloadLink
+                    document={<ReportPDF input={lastInput} result={result} />}
+                    fileName={`yield-guard-report-${new Date().toISOString().slice(0, 10).replace(/-/g, "")}.pdf`}
+                  >
+                    {({ loading: pdfLoading }) => (
+                      <button
+                        disabled={pdfLoading}
+                        className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-primary/90 disabled:opacity-60"
+                      >
+                        <FileDown className="h-3.5 w-3.5" />
+                        {pdfLoading ? "生成中..." : "PDFレポート出力"}
+                      </button>
+                    )}
+                  </PDFDownloadLink>
+                </PdfErrorBoundary>
+              ) : (
+                <button
+                  onClick={() => setPdfRequested(true)}
+                  className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-primary/90"
                 >
-                  {({ loading: pdfLoading }) => (
-                    <button
-                      disabled={pdfLoading}
-                      className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-primary/90 disabled:opacity-60"
-                    >
-                      <FileDown className="h-3.5 w-3.5" />
-                      {pdfLoading ? "生成中..." : "PDFレポート出力"}
-                    </button>
-                  )}
-                </PDFDownloadLink>
-              </PdfErrorBoundary>
+                  <FileDown className="h-3.5 w-3.5" />
+                  PDFレポート出力
+                </button>
+              )
             )}
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <span className="h-2 w-2 rounded-full bg-green-400" />

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,5 +1,19 @@
 "use client";
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, Component } from "react";
+
+class PdfErrorBoundary extends Component<
+  { children: React.ReactNode },
+  { failed: boolean }
+> {
+  state = { failed: false };
+  static getDerivedStateFromError() {
+    return { failed: true };
+  }
+  render() {
+    if (this.state.failed) return null;
+    return this.props.children;
+  }
+}
 import { InvestmentForm } from "@/components/InvestmentForm";
 import { YieldAnalysis } from "@/components/YieldAnalysis";
 import { CashFlowChart } from "@/components/CashFlowChart";
@@ -142,20 +156,22 @@ export function Dashboard() {
           </div>
           <div className="ml-auto flex items-center gap-3">
             {result && lastInput && (
-              <PDFDownloadLink
-                document={<ReportPDF input={lastInput} result={result} />}
-                fileName={`yield-guard-report-${new Date().toISOString().slice(0, 10).replace(/-/g, "")}.pdf`}
-              >
-                {({ loading: pdfLoading }) => (
-                  <button
-                    disabled={pdfLoading}
-                    className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-primary/90 disabled:opacity-60"
-                  >
-                    <FileDown className="h-3.5 w-3.5" />
-                    {pdfLoading ? "生成中..." : "PDFレポート出力"}
-                  </button>
-                )}
-              </PDFDownloadLink>
+              <PdfErrorBoundary>
+                <PDFDownloadLink
+                  document={<ReportPDF input={lastInput} result={result} />}
+                  fileName={`yield-guard-report-${new Date().toISOString().slice(0, 10).replace(/-/g, "")}.pdf`}
+                >
+                  {({ loading: pdfLoading }) => (
+                    <button
+                      disabled={pdfLoading}
+                      className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-primary/90 disabled:opacity-60"
+                    >
+                      <FileDown className="h-3.5 w-3.5" />
+                      {pdfLoading ? "生成中..." : "PDFレポート出力"}
+                    </button>
+                  )}
+                </PDFDownloadLink>
+              </PdfErrorBoundary>
             )}
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <span className="h-2 w-2 rounded-full bg-green-400" />


### PR DESCRIPTION
## 概要

analyze 実行後に「このページを読み込めませんでした」が表示される問題を修正。

## 根本原因

```
@react-pdf/reconciler@2.0.0
  └─ scheduler@0.25.0-rc-603e6108-20241029  ← React 19 RC版スケジューラ
react@19.2.5  ← 安定版（reconciler 内部 API 変更により非互換）
→ Uncaught TypeError: re is not a function
→ Reactツリー全体がアンマウント → 「このページを読み込めませんでした」
```

`@react-pdf/reconciler v2.0.0` が React 19.2.x に未対応のため、ライブラリ側の修正待ち。

## 変更内容

### 1. `package.json` — scheduler を安定版に上書き（部分的緩和）

RC 版スケジューラを `scheduler@0.25.0` に差し替え。根本解決には至らないが、将来の修正に備えた対応として残す。

### 2. `Dashboard.tsx` — PDF をクリック時のみ初期化 + ErrorBoundary

- analyze 完了時に `PDFDownloadLink` を即レンダーするのをやめ、ユーザーがボタンをクリックしたときだけ初期化する（`pdfRequested` state）
- `PdfErrorBoundary` でクラッシュを捕捉し、ページ全体への伝播を防止
- クラッシュ時は「PDF生成に失敗しました」と表示（黙って消えない）

### 3. `Makefile` — dev 起動の修正

- `.env` を読み込んでからバックエンドを起動（`MLIT_API_KEY` が未設定になる問題を修正）
- `npm run dev` に `--webpack` フラグを追加（Next.js 16 の Turbopack デフォルト化への対応）

## 動作確認結果

| 機能 | 修正前 | 修正後 |
|------|--------|--------|
| analyze 実行 | ページクラッシュ | ✅ 正常動作 |
| PDF ボタン | クラッシュで消滅 | ✅ 表示される |
| PDF 出力 | 機能なし | ⚠️ ライブラリ未対応のため「PDF生成に失敗しました」と表示 |

## 確認方法

- [ ] analyze 実行後にページがクラッシュしないことを確認
- [ ] 「PDFレポート出力」ボタンが表示されることを確認
- [ ] クリック時に「PDF生成に失敗しました」と表示されることを確認（ページはクラッシュしない）
- [ ] `@react-pdf/renderer` が React 19.2.x に対応した際は `overrides` を削除して再テスト