### PR TITLE
fix(frontend): rate schedule step validation and addRateStep stuck state

### DIFF
--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -158,7 +158,17 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
     () => isQuick ? validateQuick(quickTotalPriceMan, input) : validateFull(input),
     [isQuick, quickTotalPriceMan, input]
   );
-  const hasErrors = Object.keys(currentErrors).length > 0;
+  const scheduleHasErrors = useMemo(() => {
+    if (!rateScheduleEnabled) return false;
+    return input.rateAdjustmentSchedule.some((step, i) => {
+      const maxYear = input.loanYears || 35;
+      const prevYear = i > 0 ? input.rateAdjustmentSchedule[i - 1].afterYear : 1;
+      return step.afterYear < 2 || step.afterYear > maxYear || step.afterYear <= prevYear
+        || step.rate <= 0 || step.rate > 0.3;
+    });
+  }, [rateScheduleEnabled, input.rateAdjustmentSchedule, input.loanYears]);
+
+  const hasErrors = Object.keys(currentErrors).length > 0 || scheduleHasErrors;
 
   // touched フィールドにのみエラーを表示する
   const fieldError = (key: string) => touched.has(key) ? currentErrors[key as keyof FormErrors] : undefined;
@@ -238,8 +248,10 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
 
   const addRateStep = () => {
     const schedule = input.rateAdjustmentSchedule;
+    const maxYear = input.loanYears || 35;
     const lastYear = schedule.length > 0 ? schedule[schedule.length - 1].afterYear : 1;
-    const nextYear = Math.min(lastYear + 5, input.loanYears || 35);
+    if (lastYear >= maxYear) return;
+    const nextYear = Math.min(lastYear + 5, maxYear);
     const newStep: RateAdjustment = { afterYear: nextYear, rate: input.annualLoanRate + 0.005 };
     setInput((prev) => ({ ...prev, rateAdjustmentSchedule: [...prev.rateAdjustmentSchedule, newStep] }));
   };
@@ -847,7 +859,9 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                         </div>
                       );
                     })}
-                    {input.rateAdjustmentSchedule.length < 3 && (
+                    {input.rateAdjustmentSchedule.length < 3 &&
+                      (input.rateAdjustmentSchedule.length === 0 ||
+                        input.rateAdjustmentSchedule[input.rateAdjustmentSchedule.length - 1].afterYear < (input.loanYears || 35)) && (
                       <button
                         type="button"
                         onClick={addRateStep}

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -170,6 +170,14 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
 
   const hasErrors = Object.keys(currentErrors).length > 0 || scheduleHasErrors;
 
+  const canAddRateStep = useMemo(() => {
+    const schedule = input.rateAdjustmentSchedule;
+    if (schedule.length >= 3) return false;
+    const maxYear = input.loanYears || 35;
+    const lastYear = schedule.length > 0 ? schedule[schedule.length - 1].afterYear : 1;
+    return lastYear < maxYear;
+  }, [input.rateAdjustmentSchedule, input.loanYears]);
+
   // touched フィールドにのみエラーを表示する
   const fieldError = (key: string) => touched.has(key) ? currentErrors[key as keyof FormErrors] : undefined;
 
@@ -859,9 +867,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                         </div>
                       );
                     })}
-                    {input.rateAdjustmentSchedule.length < 3 &&
-                      (input.rateAdjustmentSchedule.length === 0 ||
-                        input.rateAdjustmentSchedule[input.rateAdjustmentSchedule.length - 1].afterYear < (input.loanYears || 35)) && (
+                    {canAddRateStep && (
                       <button
                         type="button"
                         onClick={addRateStep}


### PR DESCRIPTION
## 概要

PR #194（変動金利シミュレーション）で残存した2件の軽微なバグを修正。

## 変更内容

- **#197**: スケジュールステップの `yearError` / `rateError` を `hasErrors` に含める
  - `scheduleHasErrors` を `useMemo` で導出し、`hasErrors` に OR 結合
  - エラーがある状態でシミュレーション実行ボタンが押せていた問題を解消
- **#199**: `addRateStep` が `lastYear >= loanYears` のとき stuck なステップを追加する問題を修正
  - `addRateStep` 内で早期 return するガードを追加
  - 「金利ステップを追加」ボタンも `lastYear < maxYear` の場合のみ表示

## テスト

- `tsc --noEmit`: エラーなし
- `vitest run`: 84件 全パス

## 関連 Issue

Closes #197
Closes #199