### PR TITLE
feat(フロントエンド): クイックモード入力の最小化とローン80%自動計算・履歴復元

### DIFF
--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -12,6 +12,38 @@ import { fetchMunicipalities, type Municipality } from "@/lib/api";
 import { Search, Calculator, Info, AlertTriangle, ShieldCheck, Zap, SlidersHorizontal, ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
 import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
 
+const QUICK_HISTORY_KEY = "yield-guard:quick-history";
+const QUICK_HISTORY_MAX = 5;
+
+interface QuickHistoryEntry {
+  totalPriceMan: string;
+  monthlyRentMan: string;
+  ts: number;
+}
+
+function loadQuickHistory(): QuickHistoryEntry[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(QUICK_HISTORY_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed as QuickHistoryEntry[];
+  } catch {
+    return [];
+  }
+}
+
+function saveQuickHistory(entry: QuickHistoryEntry): void {
+  try {
+    const history = loadQuickHistory();
+    const next = [entry, ...history].slice(0, QUICK_HISTORY_MAX);
+    localStorage.setItem(QUICK_HISTORY_KEY, JSON.stringify(next));
+  } catch {
+    // ignore storage errors
+  }
+}
+
 const PREFECTURES = [
   { value: "01", label: "北海道" }, { value: "02", label: "青森県" },
   { value: "03", label: "岩手県" }, { value: "04", label: "宮城県" },
@@ -136,6 +168,10 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   // 現金購入前のローン値を保存（チェックを外したときに復元）
   const [savedLoanAmount, setSavedLoanAmount] = useState(DEFAULT_INPUT.loanAmount);
   const [savedLoanYears, setSavedLoanYears] = useState(DEFAULT_INPUT.loanYears);
+  // クイックモード: ローン自動計算（80%）の展開フラグ
+  const [showCustomLoan, setShowCustomLoan] = useState(false);
+  // クイックモード: 入力履歴
+  const [quickHistory, setQuickHistory] = useState<QuickHistoryEntry[]>([]);
 
   // 変動金利スケジュール
   const [rateScheduleEnabled, setRateScheduleEnabled] = useState(false);
@@ -225,6 +261,11 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
     }
   }, [filteredMunicipalities]);
 
+  // クイックモード入力履歴をlocalStorageから読み込む
+  useEffect(() => {
+    setQuickHistory(loadQuickHistory());
+  }, []);
+
   const handleAreaChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const code = e.target.value;
     setArea(code);
@@ -299,16 +340,32 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
     if (hasErrors) return;
     if (isQuick) {
       const total = (parseFloat(quickTotalPriceMan) || 0) * 10_000;
+      const autoLoanAmount = !isCashPurchase && !showCustomLoan ? total * 0.8 : input.loanAmount;
       const payload: InvestmentInput = sortedInput({
         ...input,
         ...QUICK_MODE_DEFAULTS,
         landPrice: total * 0.7,
         buildingCost: total * 0.3,
+        loanAmount: isCashPurchase ? 0 : autoLoanAmount,
       });
+      const entry: QuickHistoryEntry = {
+        totalPriceMan: quickTotalPriceMan,
+        monthlyRentMan: String(input.monthlyRent),
+        ts: Date.now(),
+      };
+      saveQuickHistory(entry);
+      setQuickHistory(loadQuickHistory());
       onAnalyze(payload);
     } else {
       onAnalyze(sortedInput(input));
     }
+  };
+
+  const handleRestoreLastInput = () => {
+    if (quickHistory.length === 0) return;
+    const last = quickHistory[0];
+    setQuickTotalPriceMan(last.totalPriceMan);
+    setNum("monthlyRent", parseFloat(last.monthlyRentMan) || 0);
   };
 
   return (
@@ -412,7 +469,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
             )}
           </div>
 
-          {/* 3項目フォーム */}
+          {/* クイックモード入力フォーム */}
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
@@ -421,6 +478,15 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
+              {quickHistory.length > 0 && (
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 min-h-[44px] text-sm font-medium text-primary hover:bg-primary/10 transition-colors"
+                  onClick={handleRestoreLastInput}
+                >
+                  前回の入力から開始
+                </button>
+              )}
               <div className="space-y-3">
                 <div>
                   <Input
@@ -441,7 +507,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
                   error={fieldError("monthlyRent")} />
                 <div className="space-y-2">
-                  <label className="flex items-center gap-2 cursor-pointer select-none">
+                  <label className="flex items-center gap-2 cursor-pointer select-none min-h-[44px]">
                     <input
                       type="checkbox"
                       checked={isCashPurchase}
@@ -451,11 +517,37 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                     />
                     <span className="text-sm font-medium">現金購入（ローンなし）</span>
                   </label>
-                  <Input label="ローン金額" type="number" suffix="万円"
-                    value={toMan(input.loanAmount)}
-                    onChange={(e) => { if (!isCashPurchase) setNum("loanAmount", fromMan(e.target.value)); }}
-                    error={fieldError("loanAmount")}
-                    disabled={isCashPurchase} />
+                  {!isCashPurchase && (
+                    <>
+                      {!showCustomLoan && (
+                        <p className="text-xs text-muted-foreground">
+                          ローン 80% 自動適用中 —{" "}
+                          <button
+                            type="button"
+                            className="underline underline-offset-2 hover:text-foreground"
+                            onClick={() => setShowCustomLoan(true)}
+                          >
+                            カスタム設定
+                          </button>
+                        </p>
+                      )}
+                      {showCustomLoan && (
+                        <div className="space-y-1">
+                          <Input label="ローン金額" type="number" suffix="万円"
+                            value={toMan(input.loanAmount)}
+                            onChange={(e) => setNum("loanAmount", fromMan(e.target.value))}
+                            error={fieldError("loanAmount")} />
+                          <button
+                            type="button"
+                            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                            onClick={() => setShowCustomLoan(false)}
+                          >
+                            80% 自動計算に戻す
+                          </button>
+                        </div>
+                      )}
+                    </>
+                  )}
                 </div>
                 <Input label="目標利回り" type="number" suffix="%" step="0.5"
                   value={toPct(input.yieldTarget, 1)}
@@ -465,7 +557,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
 
               <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 space-y-0.5">
                 <p className="font-semibold">自動設定されるデフォルト値</p>
-                <p>空室率 5%・運営経費率 20%・建物構造: 木造・{isCashPurchase ? "現金購入（ローンなし）" : "年利 1.5%・返済期間 35年"}・10年後売却・所得税率 33%</p>
+                <p>空室率 5%・運営経費率 20%・建物構造: 木造・{isCashPurchase ? "現金購入（ローンなし）" : !showCustomLoan ? "ローン 80%・年利 1.5%・返済期間 35年" : "年利 1.5%・返済期間 35年"}・10年後売却・所得税率 33%</p>
               </div>
 
               <Button className="w-full" size="lg" loading={loading} disabled={hasErrors || loading} onClick={handleAnalyze}>

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -558,14 +558,13 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
 
               <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 space-y-0.5">
                 <p className="font-semibold">自動設定されるデフォルト値</p>
-                {(() => {
-                  const loanBannerText = isCashPurchase
+                <p>空室率 5%・運営経費率 20%・建物構造: 木造・{
+                  isCashPurchase
                     ? "現金購入（ローンなし）"
                     : !showCustomLoan
                       ? "ローン 80%・年利 1.5%・返済期間 35年"
-                      : "年利 1.5%・返済期間 35年";
-                  return <p>空室率 5%・運営経費率 20%・建物構造: 木造・{loanBannerText}・10年後売却・所得税率 33%</p>;
-                })()}
+                      : "年利 1.5%・返済期間 35年"
+                }・10年後売却・所得税率 33%</p>
               </div>
 
               <Button className="w-full" size="lg" loading={loading} disabled={hasErrors || loading} onClick={handleAnalyze}>

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -34,13 +34,14 @@ function loadQuickHistory(): QuickHistoryEntry[] {
   }
 }
 
-function saveQuickHistory(entry: QuickHistoryEntry): void {
+function saveQuickHistory(entry: QuickHistoryEntry): QuickHistoryEntry[] {
   try {
     const history = loadQuickHistory();
     const next = [entry, ...history].slice(0, QUICK_HISTORY_MAX);
     localStorage.setItem(QUICK_HISTORY_KEY, JSON.stringify(next));
+    return next;
   } catch {
-    // ignore storage errors
+    return loadQuickHistory();
   }
 }
 
@@ -285,6 +286,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
       setSavedLoanAmount(input.loanAmount);
       setSavedLoanYears(input.loanYears);
       setInput((prev) => ({ ...prev, loanAmount: 0, loanYears: 0 }));
+      setShowCustomLoan(false);
     } else {
       setInput((prev) => ({ ...prev, loanAmount: savedLoanAmount, loanYears: savedLoanYears }));
     }
@@ -353,8 +355,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
         monthlyRentYen: String(input.monthlyRent),
         ts: Date.now(),
       };
-      saveQuickHistory(entry);
-      setQuickHistory(loadQuickHistory());
+      setQuickHistory(saveQuickHistory(entry));
       onAnalyze(payload);
     } else {
       onAnalyze(sortedInput(input));
@@ -557,7 +558,14 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
 
               <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 space-y-0.5">
                 <p className="font-semibold">自動設定されるデフォルト値</p>
-                <p>空室率 5%・運営経費率 20%・建物構造: 木造・{isCashPurchase ? "現金購入（ローンなし）" : !showCustomLoan ? "ローン 80%・年利 1.5%・返済期間 35年" : "年利 1.5%・返済期間 35年"}・10年後売却・所得税率 33%</p>
+                {(() => {
+                  const loanBannerText = isCashPurchase
+                    ? "現金購入（ローンなし）"
+                    : !showCustomLoan
+                      ? "ローン 80%・年利 1.5%・返済期間 35年"
+                      : "年利 1.5%・返済期間 35年";
+                  return <p>空室率 5%・運営経費率 20%・建物構造: 木造・{loanBannerText}・10年後売却・所得税率 33%</p>;
+                })()}
               </div>
 
               <Button className="w-full" size="lg" loading={loading} disabled={hasErrors || loading} onClick={handleAnalyze}>

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -17,7 +17,7 @@ const QUICK_HISTORY_MAX = 5;
 
 interface QuickHistoryEntry {
   totalPriceMan: string;
-  monthlyRentMan: string;
+  monthlyRentYen: string;
   ts: number;
 }
 
@@ -350,7 +350,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
       });
       const entry: QuickHistoryEntry = {
         totalPriceMan: quickTotalPriceMan,
-        monthlyRentMan: String(input.monthlyRent),
+        monthlyRentYen: String(input.monthlyRent),
         ts: Date.now(),
       };
       saveQuickHistory(entry);
@@ -365,7 +365,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
     if (quickHistory.length === 0) return;
     const last = quickHistory[0];
     setQuickTotalPriceMan(last.totalPriceMan);
-    setNum("monthlyRent", parseFloat(last.monthlyRentMan) || 0);
+    setNum("monthlyRent", parseFloat(last.monthlyRentYen) || 0);
   };
 
   return (

--- a/frontend/src/components/__tests__/InvestmentForm.test.tsx
+++ b/frontend/src/components/__tests__/InvestmentForm.test.tsx
@@ -203,26 +203,27 @@ describe("InvestmentForm", () => {
       expect(screen.getByLabelText(/返済期間/)).toBeDisabled();
     });
 
-    it("現金購入チェックを入れるとローン金額入力欄が無効化される", async () => {
+    it("現金購入チェックを入れるとローン80%自動適用メッセージが非表示になる", async () => {
       renderForm("quick");
+      expect(screen.getByText(/ローン 80% 自動適用中/)).toBeInTheDocument();
       const checkbox = screen.getByLabelText(/現金購入（ローンなし）/);
       await userEvent.click(checkbox);
-      expect(screen.getByLabelText(/ローン金額/)).toBeDisabled();
+      expect(screen.queryByText(/ローン 80% 自動適用中/)).not.toBeInTheDocument();
     });
 
-    it("現金購入チェックを入れるとローン金額が0になる", async () => {
+    it("カスタム設定リンクをクリックするとローン金額入力欄が表示される", async () => {
       renderForm("quick");
-      const checkbox = screen.getByLabelText(/現金購入（ローンなし）/);
-      await userEvent.click(checkbox);
-      expect(screen.getByLabelText(/ローン金額/)).toHaveValue(0);
+      expect(screen.queryByLabelText(/ローン金額/)).not.toBeInTheDocument();
+      await userEvent.click(screen.getByText(/カスタム設定/));
+      expect(screen.getByLabelText(/ローン金額/)).toBeInTheDocument();
     });
 
-    it("現金購入チェックを外すとローン金額入力欄が有効になる", async () => {
+    it("カスタム設定後に80%自動計算に戻すリンクをクリックするとローン金額入力欄が非表示になる", async () => {
       renderForm("quick");
-      const checkbox = screen.getByLabelText(/現金購入（ローンなし）/);
-      await userEvent.click(checkbox);
-      await userEvent.click(checkbox);
-      expect(screen.getByLabelText(/ローン金額/)).not.toBeDisabled();
+      await userEvent.click(screen.getByText(/カスタム設定/));
+      expect(screen.getByLabelText(/ローン金額/)).toBeInTheDocument();
+      await userEvent.click(screen.getByText(/80% 自動計算に戻す/));
+      expect(screen.queryByLabelText(/ローン金額/)).not.toBeInTheDocument();
     });
 
     it("現金購入チェック時にシミュレーションを実行するとloanAmountが0で送信される", async () => {

--- a/frontend/src/components/__tests__/InvestmentForm.test.tsx
+++ b/frontend/src/components/__tests__/InvestmentForm.test.tsx
@@ -243,5 +243,34 @@ describe("InvestmentForm", () => {
       await userEvent.click(checkbox);
       expect(screen.getAllByText(/現金購入（ローンなし）/).length).toBeGreaterThan(0);
     });
+
+    it("現金購入チェックオン時に showCustomLoan がリセットされる", async () => {
+      renderForm("quick");
+      await userEvent.click(screen.getByText(/カスタム設定/));
+      expect(screen.getByLabelText(/ローン金額/)).toBeInTheDocument();
+      await userEvent.click(screen.getByLabelText(/現金購入（ローンなし）/));
+      await userEvent.click(screen.getByLabelText(/現金購入（ローンなし）/));
+      expect(screen.queryByLabelText(/ローン金額/)).not.toBeInTheDocument();
+      expect(screen.getByText(/ローン 80% 自動適用中/)).toBeInTheDocument();
+    });
+
+    it("前回の入力から開始ボタンで直前の入力が復元される", async () => {
+      const store: Record<string, string> = {
+        "yield-guard:quick-history": JSON.stringify([
+          { totalPriceMan: "3000", monthlyRentYen: "150000", ts: Date.now() },
+        ]),
+      };
+      vi.stubGlobal("localStorage", {
+        getItem: (key: string) => store[key] ?? null,
+        setItem: (key: string, value: string) => { store[key] = value; },
+        removeItem: (key: string) => { delete store[key]; },
+        clear: () => { Object.keys(store).forEach((k) => delete store[k]); },
+      });
+      renderForm("quick");
+      await userEvent.click(screen.getByText(/前回の入力から開始/));
+      expect(screen.getByLabelText(/物件価格（土地＋建物の総額）/)).toHaveValue(3000);
+      expect(screen.getByLabelText(/想定月額賃料/)).toHaveValue(150000);
+      vi.unstubAllGlobals();
+    });
   });
 });


### PR DESCRIPTION
## 概要

内覧現場での「30秒で判定」を実現するため、クイックモードの入力項目を最小化し、前回入力の再利用を可能にしました。

## 変更内容

- **ローン金額を任意化（80% 自動計算）**
  - ローン金額フィールドをデフォルト非表示に変更
  - 物件価格 × 80% を自動適用（`handleAnalyze` 時に上書き）
  - 「カスタム設定」トグルリンクで展開可能、「80% 自動計算に戻す」で折りたたみ可能
  - 現金購入チェック時は自動計算メッセージごと非表示

- **入力履歴（localStorage）**
  - `yield-guard:quick-history` キーに最大 5 件保存
  - `handleAnalyze` 呼び出し時に `{ totalPriceMan, monthlyRentYen, ts }` を push
  - 履歴が 1 件以上ある場合のみ「前回の入力から開始」ボタンを表示

- **UI 改善**
  - 現金購入チェックボックスラベルに `min-h-[44px]` を追加（タッチターゲット）
  - デフォルト値バナーをローン自動計算の状態に応じて更新

- **テスト更新**
  - ローンフィールドの disabled 状態テストを削除（フィールドが非表示のため）
  - 新規テスト: auto-loan メッセージの表示/非表示、カスタムトグルの動作を検証

## 関連Issue

Closes #207

## テスト

- [x] 既存テストが通ること（97 tests passed）
- [x] 新規テストを追加した場合、全ケースがPASSすること
- [x] `npm run build` でビルド通過

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] フルモードの動作は一切変更していない
- [x] `InvestmentForm.tsx` のみ変更（`Dashboard.tsx` は未変更）