### PR TITLE
fix(pdf): pdfmake 0.3.x のフォント登録を virtualfs.writeFileSync に修正

### DIFF
--- a/frontend/src/lib/__tests__/generatePdf.test.ts
+++ b/frontend/src/lib/__tests__/generatePdf.test.ts
@@ -9,7 +9,7 @@ const mockCreatePdf = vi.fn(() => ({ download: mockDownload }));
 vi.mock("pdfmake/build/pdfmake", () => ({
   default: {
     createPdf: mockCreatePdf,
-    vfs: {},
+    virtualfs: { writeFileSync: vi.fn() },
     fonts: {},
   },
 }));

--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -124,16 +124,14 @@ export async function downloadReportPDF(
   ]);
 
   const pdfMake = ((pdfMakeModule as Record<string, unknown>).default ?? pdfMakeModule) as {
-    vfs: Record<string, string>;
+    virtualfs: { writeFileSync: (name: string, data: string) => void };
     fonts: Record<string, unknown>;
     createPdf: (def: unknown) => { download: (name: string) => void };
   };
 
-  // Font registration is hardcoded; user input never reaches vfs paths
-  pdfMake.vfs = {
-    "NotoSansJP-Regular.woff2": regularB64,
-    "NotoSansJP-Bold.woff2": boldB64,
-  };
+  // pdfmake 0.3.x uses virtualfs.writeFileSync (not pdfMake.vfs)
+  pdfMake.virtualfs.writeFileSync("NotoSansJP-Regular.woff2", regularB64);
+  pdfMake.virtualfs.writeFileSync("NotoSansJP-Bold.woff2", boldB64);
   pdfMake.fonts = {
     NotoSansJP: {
       normal: "NotoSansJP-Regular.woff2",


### PR DESCRIPTION
## 概要

PDF 出力時に以下のエラーが発生していた問題を修正する。

```
Error: File 'NotoSansJP-Bold.woff2' not found in virtual file system
```

## 原因

pdfmake 0.3.x で VFS の API が変更された。

| バージョン | プロパティ | 登録方法 |
|---|---|---|
| 0.2.x | `pdfMake.vfs` | オブジェクト代入 |
| **0.3.x** | `pdfMake.virtualfs` | `writeFileSync()` メソッド |

`generatePdf.ts` では旧 API（`pdfMake.vfs = {...}`）を使っていたため、フォントが VFS に登録されず pdfkit がフォントを見つけられなかった。

## 変更内容

```ts
// before
pdfMake.vfs = {
  "NotoSansJP-Regular.woff2": regularB64,
  "NotoSansJP-Bold.woff2": boldB64,
};

// after
pdfMake.virtualfs.writeFileSync("NotoSansJP-Regular.woff2", regularB64);
pdfMake.virtualfs.writeFileSync("NotoSansJP-Bold.woff2", boldB64);
```

## テスト

- [x] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み