### PR TITLE
fix(pdf): virtualfs に base64 文字列ではなく Uint8Array を渡す

### DIFF
--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -43,22 +43,14 @@ const FONTS = {
 } as const;
 
 type FontKey = keyof typeof FONTS;
-const fontCache: Partial<Record<FontKey, string>> = {};
+const fontCache: Partial<Record<FontKey, Uint8Array>> = {};
 
-async function loadFont(key: FontKey): Promise<string> {
+async function loadFont(key: FontKey): Promise<Uint8Array> {
   if (fontCache[key]) return fontCache[key]!;
   const url = FONTS[key];
   const res = await fetch(url);
   if (!res.ok) throw new Error(`Font fetch failed: ${res.status}`);
-  const buf = await res.arrayBuffer();
-  const bytes = new Uint8Array(buf);
-  // Chunk-based btoa to avoid call-stack overflow on large font files
-  const CHUNK = 8192;
-  let binary = "";
-  for (let i = 0; i < bytes.length; i += CHUNK) {
-    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
-  }
-  fontCache[key] = btoa(binary);
+  fontCache[key] = new Uint8Array(await res.arrayBuffer());
   return fontCache[key]!;
 }
 
@@ -117,27 +109,27 @@ export async function downloadReportPDF(
   input: InvestmentInput,
   result: InvestmentResult
 ): Promise<void> {
-  const [pdfMakeModule, regularB64, boldB64] = await Promise.all([
+  const [pdfMakeModule, regularBytes, boldBytes] = await Promise.all([
     import("pdfmake/build/pdfmake"),
     loadFont("regular"),
     loadFont("bold"),
   ]);
 
   const pdfMake = ((pdfMakeModule as Record<string, unknown>).default ?? pdfMakeModule) as {
-    virtualfs: { writeFileSync: (name: string, data: string) => void };
+    virtualfs: { writeFileSync: (name: string, data: Uint8Array) => void };
     fonts: Record<string, unknown>;
     createPdf: (def: unknown) => { download: (name: string) => void };
   };
 
-  // pdfmake 0.3.x uses virtualfs.writeFileSync (not pdfMake.vfs)
-  pdfMake.virtualfs.writeFileSync("NotoSansJP-Regular.woff2", regularB64);
-  pdfMake.virtualfs.writeFileSync("NotoSansJP-Bold.woff2", boldB64);
+  // Pass raw binary (Uint8Array) — base64 strings are stored as ASCII bytes and fail font parsing
+  pdfMake.virtualfs.writeFileSync("NotoSansJP-Regular.ttf", regularBytes);
+  pdfMake.virtualfs.writeFileSync("NotoSansJP-Bold.ttf", boldBytes);
   pdfMake.fonts = {
     NotoSansJP: {
-      normal: "NotoSansJP-Regular.woff2",
-      bold: "NotoSansJP-Bold.woff2",
-      italics: "NotoSansJP-Regular.woff2",
-      bolditalics: "NotoSansJP-Bold.woff2",
+      normal: "NotoSansJP-Regular.ttf",
+      bold: "NotoSansJP-Bold.ttf",
+      italics: "NotoSansJP-Regular.ttf",
+      bolditalics: "NotoSansJP-Bold.ttf",
     },
   };
 


### PR DESCRIPTION
## 概要

PR #227 で TTF に切り替えたが、引き続き `Unknown font format` が発生していた問題を修正する。

## 原因

`loadFont` がフォントデータを **base64 文字列**に変換してから `virtualfs.writeFileSync` に渡していたため、pdfkit はフォントファイルの生バイナリではなく base64 文字列の ASCII バイト列を読んでいた。

```
fetch TTF → ArrayBuffer → btoa() → base64文字列
→ writeFileSync("font.ttf", "AAEAAAD...") ← ASCII bytes として格納
→ pdfkit readFileSync → TTF ヘッダではなく ASCII → "Unknown font format"
```

## 修正

`loadFont` を `Uint8Array` を返すよう変更し、生バイナリを直接 `writeFileSync` に渡す。

```ts
// before: base64変換して渡す → 文字列のASCIIバイトが格納される
fontCache[key] = btoa(binary);
pdfMake.virtualfs.writeFileSync("NotoSansJP-Regular.ttf", regularB64);

// after: Uint8Array をそのまま渡す → 正しいフォントバイナリが格納される
fontCache[key] = new Uint8Array(await res.arrayBuffer());
pdfMake.virtualfs.writeFileSync("NotoSansJP-Regular.ttf", regularBytes);
```

## テスト

- [x] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み