### PR TITLE
fix(ci): golangci-lint SHAピン固定 & デプロイを Backend CI 成功後のみ発火

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -37,7 +37,7 @@ jobs:
           cache-dependency-path: backend/go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa  # v7.0.1
         with:
           working-directory: backend
           version: v2.11.4

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -1,11 +1,10 @@
 name: Deploy Backend to Cloud Run
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Backend CI"]
+    types: [completed]
     branches: [main]
-    paths:
-      - "backend/**"
-      - ".github/workflows/deploy-backend.yml"
   workflow_dispatch:
 
 permissions:
@@ -20,9 +19,11 @@ jobs:
   deploy:
     name: Build & Deploy
     runs-on: ubuntu-24.04
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
 
     env:
       IMAGE: asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/yield-guard/backend
+      DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     steps:
       - name: Checkout
@@ -43,10 +44,10 @@ jobs:
       - name: Build and push Docker image
         run: |
           docker build \
-            --tag "${{ env.IMAGE }}:${{ github.sha }}" \
+            --tag "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}" \
             --tag "${{ env.IMAGE }}:latest" \
             ./backend
-          docker push "${{ env.IMAGE }}:${{ github.sha }}"
+          docker push "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}"
           docker push "${{ env.IMAGE }}:latest"
 
       - name: Deploy to Cloud Run
@@ -56,4 +57,4 @@ jobs:
           # stg 環境用には deploy-backend-stg.yml を別途作成し service 名を変更する。
           service: yield-guard-prod-backend
           region: asia-northeast1
-          image: ${{ env.IMAGE }}:${{ github.sha }}
+          image: ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
 
       - name: Authenticate to Google Cloud (OIDC)
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0


### PR DESCRIPTION
## 概要

- closes #215
- closes #216

## 変更内容

### fix(ci): golangci-lint-action を SHA ピンに統一 (#215)

- `golangci/golangci-lint-action@v7`（ミュータブルなタグ参照）を `@9fae48ac # v7.0.1` に変更
- 他のアクションと同様の SHA ピン形式に統一し、サプライチェーンリスクを排除

### fix(ci): デプロイを Backend CI 成功後のみ発火 (#216)

- `deploy-backend.yml` のトリガーを `push` → `workflow_run` に変更
- `if: github.event.workflow_run.conclusion == 'success'` で CI 失敗時のデプロイを防止
- `workflow_dispatch` は引き続き利用可能（手動デプロイ用）
- `DEPLOY_SHA` 環境変数でイメージタグを統一（`workflow_run` 時は `head_sha`、`workflow_dispatch` 時は `github.sha` にフォールバック）

## 動作確認

- [ ] Backend CI 失敗時にデプロイが発火しないこと
- [ ] Backend CI 成功後に正常デプロイされること
- [ ] `workflow_dispatch` による手動デプロイが機能すること

## レビューポイント

`workflow_run` トリガーの `branches: [main]` フィルタにより、PR ブランチでの CI 完了時はデプロイが起動しないことを確認済み（PR の head branch は feature/* となるため）。