### PR TITLE
fix(make): make dev でバックエンドプロセスが残留する問題を修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,10 +5,12 @@
 
 ## dev: バックエンド・フロントエンドの開発サーバーを起動
 dev:
-	@echo "==> Starting backend..."
-	cd backend && set -a; . ../.env 2>/dev/null; set +a; go run ./cmd/server &
-	@echo "==> Starting frontend..."
-	cd frontend && npm run dev -- --webpack
+	@trap 'kill 0' INT TERM EXIT; \
+	echo "==> Starting backend..."; \
+	(cd backend && set -a; . ../.env 2>/dev/null; set +a; go run ./cmd/server) & \
+	echo "==> Starting frontend..."; \
+	(cd frontend && npm run dev -- --webpack) & \
+	wait
 
 ## test: 全テストを実行
 test:


### PR DESCRIPTION
## 概要

closes #217

## 変更内容

`make dev` の `dev` ターゲットを `trap 'kill 0' INT TERM EXIT` パターンに書き換え、Ctrl+C 終了時にバックエンド・フロントエンド両プロセスをまとめて終了させる。

**変更前の問題:**
- バックエンドを `&` でバックグラウンド起動し、フロントエンドをフォアグラウンドで起動していた
- Ctrl+C はフロントエンドにしか届かず、バックエンドが `:8080` を占有したまま残留した

**変更後:**
```makefile
dev:
	@trap 'kill 0' INT TERM EXIT; \
	(cd backend && ...) & \
	(cd frontend && npm run dev -- --webpack) & \
	wait
```
- 両プロセスをバックグラウンドで起動し `wait` で待機
- `trap 'kill 0'` によりシェル終了時（INT/TERM/EXIT）にプロセスグループ全体へ SIGTERM を送信

## 動作確認

- [ ] Ctrl+C でバックエンド・フロントエンド両プロセスが終了する
- [ ] `:8080` ポートが解放されている
- [ ] 再度 `make dev` が `bind: address already in use` なしで起動できる