### PR TITLE
fix(terraform): Artifact Registry delete-old policy に older_than 条件を追加

### DIFF
--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -4,6 +4,8 @@ resource "google_artifact_registry_repository" "backend" {
   format        = "DOCKER"
   description   = "yield-guard backend Docker images"
 
+  # 評価順序: KEEP が優先され、最新5件は保護される。
+  # それ以外のタグ付きイメージは older_than を超えた時点で DELETE 対象となる。
   cleanup_policies {
     id     = "keep-5-most-recent"
     action = "KEEP"
@@ -16,7 +18,8 @@ resource "google_artifact_registry_repository" "backend" {
     id     = "delete-old"
     action = "DELETE"
     condition {
-      tag_state = "TAGGED"
+      tag_state  = "TAGGED"
+      older_than = "2592000s" # 30日
     }
   }
 }


### PR DESCRIPTION
## 概要

closes #224

## 変更内容

`terraform/artifact_registry.tf` の `delete-old` cleanup policy に `older_than = "2592000s"`（30日）を追加。

**変更前の問題:**
- ポリシー名が `delete-old` なのに「古い」の時間定義がなく意図が不明瞭だった
- `KEEP 5件 + 時間条件なし DELETE` の組み合わせはレビュー時に誤解を招きやすかった

**変更後:**
```hcl
# 評価順序: KEEP が優先され、最新5件は保護される。
# それ以外のタグ付きイメージは older_than を超えた時点で DELETE 対象となる。
cleanup_policies {
  id     = "delete-old"
  action = "DELETE"
  condition {
    tag_state  = "TAGGED"
    older_than = "2592000s" # 30日
  }
}
```

- 最新5件は `keep-5-most-recent` KEEP ポリシーで保護される
- それ以外のタグ付きイメージは作成から30日経過後に削除対象となる
- KEEP → DELETE の評価順序をコメントで明文化

## 動作確認

- [ ] `terraform validate` が通る
- [ ] `terraform plan` で意図しないリソース再作成が発生しない（インプレース更新のみ）