### PR TITLE
fix(terraform): deployer SA に artifactregistry.admin を付与し terraform apply の権限エラーを修正

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -67,9 +67,10 @@ resource "google_project_iam_member" "deployer_sa_admin" {
 }
 
 resource "google_project_iam_member" "deployer_ar_repo_admin" {
-  # Required to set IAM policies on Artifact Registry repositories.
+  # artifactregistry.admin is required to update repository metadata (cleanup_policies etc.)
+  # via terraform apply. repoAdmin does not include artifactregistry.repositories.update.
   project = var.project_id
-  role    = "roles/artifactregistry.repoAdmin"
+  role    = "roles/artifactregistry.admin"
   member  = "serviceAccount:${google_service_account.deployer.email}"
 }
 


### PR DESCRIPTION
## 概要

`terraform apply` で Artifact Registry リポジトリの更新（cleanup_policies 等）を行う際に発生していた 403 権限エラーを修正する。

## 問題

```
Error 403: Permission 'artifactregistry.repositories.update' denied
on resource '.../repositories/yield-guard'
```

deployer SA に付与していた `roles/artifactregistry.repoAdmin` は artifacts（イメージ）の管理権限が主体であり、**リポジトリメタデータの更新**（`artifactregistry.repositories.update`）を含まない。

| ロール | artifacts 操作 | repositories.update |
|--------|:--------------:|:-------------------:|
| `artifactregistry.repoAdmin` | ✓ | ✗ |
| `artifactregistry.admin` | ✓ | ✓ |

## 変更内容

`deployer_ar_repo_admin` の role を `repoAdmin` → `artifactregistry.admin` に変更。

```hcl
# 変更前
role = "roles/artifactregistry.repoAdmin"

# 変更後
role = "roles/artifactregistry.admin"
```

## 影響範囲

- deployer SA（CI/CD 専用）のみに影響
- runtime SA（Cloud Run 実行用）の権限は変更なし
- `artifactregistry.admin` はプロジェクト内の全 AR リポジトリに対する管理権限を付与するが、deployer SA の用途（Terraform による infra 管理）上は適切なスコープ

## 動作確認

- [ ] `terraform plan` でロール変更（`~`）のみ確認
- [ ] `terraform apply` 後に `artifactregistry.repositories.update` エラーが解消される
- [ ] cleanup_policies の更新が正常に適用される