### PR TITLE
fix(pdf): PDF出力のバグ修正 (#230 #231 #232 #235)

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -149,7 +149,8 @@ func Analyze(input InvestmentInput) InvestmentResult {
 		// デッドクロス判定: 元金返済額 > 減価償却費 となるゾーン
 		// 耐用年数経過後は減価償却=0のため、元金返済が残っていれば即デッドクロス
 		// ローン完済後（annualPrincipal==0）はデッドクロスゾーンから脱出
-		inDeadCrossZone := annualPrincipal > 0 && annualPrincipal > yearDepreciation
+		// 建物費用=0の場合は減価償却対象資産がなくデッドクロスの概念が適用されないため除外
+		inDeadCrossZone := input.BuildingCost > 0 && annualPrincipal > 0 && annualPrincipal > yearDepreciation
 		isDeadCrossYear := false
 		if deadCrossYear == -1 && inDeadCrossZone {
 			deadCrossYear = year

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -1817,3 +1817,55 @@ func TestAnalyzeWithRateSchedule(t *testing.T) {
 		}
 	})
 }
+
+// TestAnalyze_DeadCross_ZeroBuildingCost は建物費用=0のときデッドクロスが発生しないことを確認する
+func TestAnalyze_DeadCross_ZeroBuildingCost(t *testing.T) {
+	in := InvestmentInput{
+		LandPrice:     10_000_000,
+		BuildingCost:  0, // 土地のみ投資 → 減価償却資産なし
+		BuildingAge:   0,
+		BuildingType:  "木造",
+		MiscExpenseRate: 0.07,
+		MonthlyRent:   80_000,
+		VacancyRate:   0.05,
+		LoanAmount:    8_000_000,
+		AnnualLoanRate: 0.015,
+		LoanYears:     35,
+		HoldingYears:  10,
+		ExpenseRate:   0.20,
+		IncomeTaxRate: 0.33,
+		ExitYieldTarget: 0.06,
+		YieldTarget:   0.08,
+	}
+	result := Analyze(in)
+	if result.DeadCrossYear != -1 {
+		t.Errorf("DeadCrossYear = %d, want -1 (none) when BuildingCost=0", result.DeadCrossYear)
+	}
+}
+
+// TestAnalyze_DeadCross_NewWoodFrame は新築木造・35年ローン・1.5%のときデッドクロスが早期に発生しないことを確認する
+func TestAnalyze_DeadCross_NewWoodFrame(t *testing.T) {
+	in := InvestmentInput{
+		LandPrice:     5_000_000,
+		BuildingCost:  10_000_000, // 耐用年数22年: 減価償却≒454,545円/年
+		BuildingAge:   0,
+		BuildingType:  "木造",
+		MiscExpenseRate: 0.07,
+		MonthlyRent:   120_000,
+		VacancyRate:   0.05,
+		LoanAmount:    13_000_000,
+		AnnualLoanRate: 0.015,
+		LoanYears:     35,
+		HoldingYears:  10,
+		ExpenseRate:   0.20,
+		IncomeTaxRate: 0.33,
+		ExitYieldTarget: 0.06,
+		YieldTarget:   0.08,
+	}
+	result := Analyze(in)
+	// 新築木造35年1.5%では1年目の元金返済≒285,000円 < 減価償却≒454,545円
+	// デッドクロスは10年以降（または発生しない場合もある）
+	if result.DeadCrossYear > 0 && result.DeadCrossYear <= 5 {
+		t.Errorf("DeadCrossYear = %d: 新築木造35年1.5%%ではデッドクロスは6年以降のはず", result.DeadCrossYear)
+	}
+}

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -1864,8 +1864,8 @@ func TestAnalyze_DeadCross_NewWoodFrame(t *testing.T) {
 	}
 	result := Analyze(in)
 	// 新築木造35年1.5%では1年目の元金返済≒285,000円 < 減価償却≒454,545円
-	// デッドクロスは10年以降（または発生しない場合もある）
-	if result.DeadCrossYear > 0 && result.DeadCrossYear <= 5 {
-		t.Errorf("DeadCrossYear = %d: 新築木造35年1.5%%ではデッドクロスは6年以降のはず", result.DeadCrossYear)
+	// 両者が逆転するのは23年目（実計算値）
+	if result.DeadCrossYear != 23 {
+		t.Errorf("DeadCrossYear = %d, want 23", result.DeadCrossYear)
 	}
 }

--- a/frontend/src/lib/__tests__/generatePdf.test.ts
+++ b/frontend/src/lib/__tests__/generatePdf.test.ts
@@ -123,4 +123,37 @@ describe("downloadReportPDF", () => {
     const fileName = ((mockDownload.mock.calls as unknown[][][])[0]?.[0] as unknown) as string;
     expect(fileName).toMatch(/^yield-guard-report-\d{8}\.pdf$/);
   });
+
+  it("sets PDF metadata title", async () => {
+    global.fetch = makeFontFetchMock();
+    await downloadReportPDF(makeInput(), makeResult());
+
+    const docDef = (mockCreatePdf.mock.calls as unknown[][][])[0]?.[0] as Record<string, unknown>;
+    const info = docDef?.info as Record<string, string> | undefined;
+    expect(info?.title).toBe("不動産投資分析レポート");
+    expect(info?.author).toBe("yield-guard");
+  });
+
+  it("sets header function that returns null on page 1", async () => {
+    global.fetch = makeFontFetchMock();
+    await downloadReportPDF(makeInput(), makeResult());
+
+    const docDef = (mockCreatePdf.mock.calls as unknown[][][])[0]?.[0] as Record<string, unknown>;
+    const header = docDef?.header as ((page: number) => unknown) | undefined;
+    expect(typeof header).toBe("function");
+    expect(header?.(1)).toBeNull();
+    expect(header?.(2)).not.toBeNull();
+  });
+
+  it("sets footer function with page number columns", async () => {
+    global.fetch = makeFontFetchMock();
+    await downloadReportPDF(makeInput(), makeResult());
+
+    const docDef = (mockCreatePdf.mock.calls as unknown[][][])[0]?.[0] as Record<string, unknown>;
+    const footer = docDef?.footer as ((page: number, count: number) => unknown) | undefined;
+    expect(typeof footer).toBe("function");
+    const result = footer?.(2, 5) as Record<string, unknown>;
+    const json = JSON.stringify(result);
+    expect(json).toContain("2 / 5");
+  });
 });

--- a/frontend/src/lib/__tests__/pdfFormat.test.ts
+++ b/frontend/src/lib/__tests__/pdfFormat.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { fmtYen, fmtPct, fmtPct1, sanitize } from "../pdf/format";
+
+describe("fmtYen", () => {
+  it("formats zero as 0円", () => {
+    expect(fmtYen(0)).toBe("0円");
+  });
+
+  it("rounds fractional yen", () => {
+    expect(fmtYen(587_874.124)).toBe("587,874円");
+  });
+
+  it("formats values under 1,000,000 in yen", () => {
+    expect(fmtYen(9_999)).toBe("9,999円");
+  });
+
+  it("formats 999,999 in yen", () => {
+    expect(fmtYen(999_999)).toBe("999,999円");
+  });
+
+  it("formats 150,000 in yen", () => {
+    expect(fmtYen(150_000)).toBe("150,000円");
+  });
+
+  it("formats 1,000,000 as 1.0百万円", () => {
+    expect(fmtYen(1_000_000)).toBe("1.0百万円");
+  });
+
+  it("formats values in 百万円", () => {
+    expect(fmtYen(1_500_000)).toBe("1.5百万円");
+  });
+
+  it("formats 99,999,999 in 百万円", () => {
+    expect(fmtYen(99_999_999)).toBe("100.0百万円");
+  });
+
+  it("formats 100,000,000 as 1.0億円", () => {
+    expect(fmtYen(100_000_000)).toBe("1.0億円");
+  });
+
+  it("formats negative values", () => {
+    expect(fmtYen(-2_000_000)).toBe("-2.0百万円");
+  });
+
+  it("formats negative under 10,000", () => {
+    expect(fmtYen(-5_000)).toBe("-5,000円");
+  });
+});
+
+describe("fmtPct", () => {
+  it("formats 0 as 0.00%", () => {
+    expect(fmtPct(0)).toBe("0.00%");
+  });
+
+  it("formats 0.08 as 8.00%", () => {
+    expect(fmtPct(0.08)).toBe("8.00%");
+  });
+
+  it("formats 0.0825 as 8.25%", () => {
+    expect(fmtPct(0.0825)).toBe("8.25%");
+  });
+
+  it("formats 0.015 as 1.50%", () => {
+    expect(fmtPct(0.015)).toBe("1.50%");
+  });
+});
+
+describe("fmtPct1", () => {
+  it("formats 0.083 as 8.3%", () => {
+    expect(fmtPct1(0.083)).toBe("8.3%");
+  });
+});
+
+describe("sanitize", () => {
+  it("removes < and >", () => {
+    expect(sanitize("<script>")).toBe("script");
+  });
+
+  it("removes &", () => {
+    expect(sanitize("A&B")).toBe("AB");
+  });
+
+  it("returns empty string for undefined", () => {
+    expect(sanitize(undefined)).toBe("");
+  });
+
+  it("converts number to string", () => {
+    expect(sanitize(123)).toBe("123");
+  });
+
+  it("passes through normal Japanese text", () => {
+    expect(sanitize("木造")).toBe("木造");
+  });
+});

--- a/frontend/src/lib/__tests__/pdfFormat.test.ts
+++ b/frontend/src/lib/__tests__/pdfFormat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fmtYen, fmtPct, fmtPct1, sanitize } from "../pdf/format";
+import { fmtYen, fmtPct, sanitize } from "../pdf/format";
 
 describe("fmtYen", () => {
   it("formats zero as 0円", () => {
@@ -62,12 +62,6 @@ describe("fmtPct", () => {
 
   it("formats 0.015 as 1.50%", () => {
     expect(fmtPct(0.015)).toBe("1.50%");
-  });
-});
-
-describe("fmtPct1", () => {
-  it("formats 0.083 as 8.3%", () => {
-    expect(fmtPct1(0.083)).toBe("8.3%");
   });
 });
 

--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -153,14 +153,39 @@ export async function downloadReportPDF(
 
   const docDef = {
     pageSize: "A4",
-    pageMargins: [36, 36, 36, 48],
+    pageMargins: [36, 52, 36, 48],
     defaultStyle: { font: "NotoSansJP", fontSize: 9, color: C.text },
-    footer: () => ({
-      text: "本資料は yield-guard による試算です。実際の投資判断は専門家にご相談ください。",
-      fontSize: 7,
-      color: C.muted,
-      alignment: "center",
-      margin: [36, 4],
+    info: {
+      title: "不動産投資分析レポート",
+      author: "yield-guard",
+      subject: `物件分析 ${date}`,
+      creator: "yield-guard",
+    },
+    header: (currentPage: number) => {
+      if (currentPage === 1) return null;
+      return {
+        columns: [
+          { text: "yield-guard 不動産投資分析レポート", fontSize: 7, color: C.muted, margin: [36, 16, 0, 0] },
+          { text: date, fontSize: 7, color: C.muted, alignment: "right" as const, margin: [0, 16, 36, 0] },
+        ],
+      };
+    },
+    footer: (currentPage: number, pageCount: number) => ({
+      columns: [
+        {
+          text: "本資料は yield-guard による試算です。実際の投資判断は専門家にご相談ください。",
+          fontSize: 7,
+          color: C.muted,
+          margin: [36, 4, 0, 0],
+        },
+        {
+          text: `${currentPage} / ${pageCount}`,
+          fontSize: 7,
+          color: C.muted,
+          alignment: "right" as const,
+          margin: [0, 4, 36, 0],
+        },
+      ],
     }),
     content: [
       // ── Page 1: Cover ──────────────────────────────────────────────

--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -219,16 +219,16 @@ export async function downloadReportPDF(
       sectionTitle("P1 - 投資サマリー", true),
       {
         columns: [
-          kpiBlock("表面利回り", `${(result.grossYield * 100).toFixed(2)}%`),
-          kpiBlock("実質利回り", `${(result.netYield * 100).toFixed(2)}%`),
+          kpiBlock("表面利回り", fmtPct(result.grossYield)),
+          kpiBlock("実質利回り", fmtPct(result.netYield)),
           kpiBlock("DSCR 1年目", dscr.toFixed(2), dscr >= 1.0 ? C.safe : C.danger),
-          kpiBlock("LTV", `${(ltv * 100).toFixed(1)}%`, ltv <= 0.8 ? C.safe : C.danger),
+          kpiBlock("LTV", fmtPct(ltv), ltv <= 0.8 ? C.safe : C.danger),
         ],
         marginBottom: 6,
       },
       {
         columns: [
-          kpiBlock("総投資額", `${(result.totalInvestment / 1_000_000).toFixed(1)}百万円`),
+          kpiBlock("総投資額", fmtYen(result.totalInvestment)),
           kpiBlock("月額賃料", `${(input.monthlyRent / 10_000).toFixed(0)}万円/月`),
           kpiBlock(
             "デッドクロス年",

--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -38,7 +38,7 @@ async function loadFont(key: FontKey): Promise<Uint8Array> {
 function infoRow(label: string, value: string) {
   return {
     columns: [
-      { text: label, width: "40%", color: C.muted, fontSize: 9 },
+      { text: label, width: "40%", color: C.muted, fontSize: 9, noWrap: true },
       { text: sanitize(value), width: "60%", bold: true, fontSize: 9, alignment: "right" as const },
     ],
     marginBottom: 3,
@@ -82,7 +82,7 @@ function hLineTable(body: unknown[][]) {
 
 function twoCol(label: string, value: string, bold = false, color?: string) {
   return [
-    { text: label, fontSize: 8, bold, color: color ? undefined : C.text },
+    { text: label, fontSize: 8, bold, color: color ? undefined : C.text, noWrap: true },
     { text: sanitize(value), fontSize: 8, bold, color: color ?? C.text, alignment: "right" as const },
   ];
 }

--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -48,8 +48,9 @@ function infoRow(label: string, value: string) {
 function kpiBlock(label: string, value: string, color?: string) {
   return {
     stack: [
-      { text: label, fontSize: 7, color: C.muted, marginBottom: 2 },
-      { text: value, fontSize: 15, bold: true, color: color ?? C.primary },
+      // lineHeight: 1 + noWrap prevent pdfmake from splitting CJK glyphs with spurious spaces
+      { text: label, fontSize: 7, color: C.muted, marginBottom: 2, lineHeight: 1, noWrap: true },
+      { text: value, fontSize: 15, bold: true, color: color ?? C.primary, noWrap: true },
     ],
     margin: [0, 0, 6, 6],
   };
@@ -194,8 +195,8 @@ export async function downloadReportPDF(
       {
         columns: [
           kpiBlock("表面利回り", `${(result.grossYield * 100).toFixed(2)}%`),
-          kpiBlock("実効利回り（税引後）", `${(result.netYield * 100).toFixed(2)}%`),
-          kpiBlock("DSCR（1年目）", dscr.toFixed(2), dscr >= 1.0 ? C.safe : C.danger),
+          kpiBlock("実質利回り", `${(result.netYield * 100).toFixed(2)}%`),
+          kpiBlock("DSCR 1年目", dscr.toFixed(2), dscr >= 1.0 ? C.safe : C.danger),
           kpiBlock("LTV", `${(ltv * 100).toFixed(1)}%`, ltv <= 0.8 ? C.safe : C.danger),
         ],
         marginBottom: 6,
@@ -224,7 +225,7 @@ export async function downloadReportPDF(
         twoCol("譲渡所得税", fmtYen(result.exitTransferTax)),
         twoCol("売却手取り", fmtYen(result.exitNetProceeds)),
         twoCol(
-          "トータルエクイティ（CF累積＋売却益）",
+          "トータルエクイティ",
           fmtYen(result.exitTotalEquity),
           true,
           result.exitTotalEquity >= 0 ? C.safe : C.danger

--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -3,6 +3,7 @@ import type {
   InvestmentResult,
   YearlyResult,
 } from "@/types/investment";
+import { fmtYen, fmtPct, fmtDate, sanitize } from "./pdf/format";
 
 const C = {
   primary: "#1a56db",
@@ -15,26 +16,6 @@ const C = {
   muted: "#64748b",
   white: "#ffffff",
 } as const;
-
-// Sanitize string values before embedding in PDF content to prevent injection
-function s(v: string | number | undefined): string {
-  if (v === undefined || v === null) return "";
-  return String(v).replace(/[<>&"'\\]/g, "");
-}
-
-function fmt(v: number): string {
-  if (Math.abs(v) >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}百万円`;
-  return `${v.toLocaleString("ja-JP")}円`;
-}
-
-function pct(v: number): string {
-  return `${(v * 100).toFixed(2)}%`;
-}
-
-function today(): string {
-  const d = new Date();
-  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
-}
 
 // TTF subset served from our own domain — pdfmake's pdfkit does not support woff2
 const FONTS = {
@@ -58,7 +39,7 @@ function infoRow(label: string, value: string) {
   return {
     columns: [
       { text: label, width: "40%", color: C.muted, fontSize: 9 },
-      { text: s(value), width: "60%", bold: true, fontSize: 9, alignment: "right" as const },
+      { text: sanitize(value), width: "60%", bold: true, fontSize: 9, alignment: "right" as const },
     ],
     marginBottom: 3,
   };
@@ -101,7 +82,7 @@ function hLineTable(body: unknown[][]) {
 function twoCol(label: string, value: string, bold = false, color?: string) {
   return [
     { text: label, fontSize: 8, bold, color: color ? undefined : C.text },
-    { text: s(value), fontSize: 8, bold, color: color ?? C.text, alignment: "right" as const },
+    { text: sanitize(value), fontSize: 8, bold, color: color ?? C.text, alignment: "right" as const },
   ];
 }
 
@@ -133,7 +114,7 @@ export async function downloadReportPDF(
     },
   };
 
-  const date = today();
+  const date = fmtDate();
   const year1 = result.yearlyResults[0];
   const dscr =
     year1?.annualLoanPayment > 0 ? year1.annualRent / year1.annualLoanPayment : 0;
@@ -192,21 +173,21 @@ export async function downloadReportPDF(
       { text: "Real Estate Investment Analysis Report", fontSize: 12, color: C.muted, marginBottom: 24 },
 
       { text: "物件概要", fontSize: 9, bold: true, color: C.muted, marginBottom: 8 },
-      infoRow("物件価格（土地）", fmt(input.landPrice)),
-      infoRow("建物費用", fmt(input.buildingCost)),
+      infoRow("物件価格（土地）", fmtYen(input.landPrice)),
+      infoRow("建物費用", fmtYen(input.buildingCost)),
       infoRow("築年数", input.buildingAge === 0 ? "新築" : `${input.buildingAge}年`),
-      infoRow("構造", s(input.buildingType)),
+      infoRow("構造", sanitize(input.buildingType)),
       ...(input.stationMinutes > 0 ? [infoRow("最寄り駅徒歩", `${input.stationMinutes}分`)] : []),
-      infoRow("月額賃料", fmt(input.monthlyRent)),
-      infoRow("想定空室率", pct(input.vacancyRate)),
-      infoRow("ローン金額", fmt(input.loanAmount)),
-      infoRow("ローン金利", pct(input.annualLoanRate)),
+      infoRow("月額賃料", fmtYen(input.monthlyRent)),
+      infoRow("想定空室率", fmtPct(input.vacancyRate)),
+      infoRow("ローン金額", fmtYen(input.loanAmount)),
+      infoRow("ローン金利", fmtPct(input.annualLoanRate)),
       infoRow("ローン期間", `${input.loanYears}年`),
 
       { text: "分析情報", fontSize: 9, bold: true, color: C.muted, marginBottom: 8, marginTop: 16 },
       infoRow("分析実施日", date),
-      infoRow("総投資額", fmt(result.totalInvestment)),
-      infoRow("表面利回り", pct(result.grossYield)),
+      infoRow("総投資額", fmtYen(result.totalInvestment)),
+      infoRow("表面利回り", fmtPct(result.grossYield)),
 
       // ── Page 2: Summary ────────────────────────────────────────────
       sectionTitle("P1 - 投資サマリー", true),
@@ -239,12 +220,12 @@ export async function downloadReportPDF(
 
       subTitle(`出口戦略（${input.holdingYears}年後売却）`),
       hLineTable([
-        twoCol("想定売却価格", fmt(result.exitSalePrice)),
-        twoCol("譲渡所得税", fmt(result.exitTransferTax)),
-        twoCol("売却手取り", fmt(result.exitNetProceeds)),
+        twoCol("想定売却価格", fmtYen(result.exitSalePrice)),
+        twoCol("譲渡所得税", fmtYen(result.exitTransferTax)),
+        twoCol("売却手取り", fmtYen(result.exitNetProceeds)),
         twoCol(
           "トータルエクイティ（CF累積＋売却益）",
-          fmt(result.exitTotalEquity),
+          fmtYen(result.exitTotalEquity),
           true,
           result.exitTotalEquity >= 0 ? C.safe : C.danger
         ),
@@ -269,13 +250,13 @@ export async function downloadReportPDF(
             ],
             ...cfRows.map((r, idx) => [
               tdCell(`${r.year}年`, idx, { align: "left" }),
-              tdCell(fmt(r.annualRent), idx),
-              tdCell(fmt(r.annualLoanPayment), idx),
-              tdCell(fmt(r.annualExpenses), idx),
-              tdCell(fmt(r.cashFlow), idx, { color: r.cashFlow < 0 ? C.danger : C.text }),
-              tdCell(fmt(r.afterTaxCashFlow), idx, { color: r.afterTaxCashFlow < 0 ? C.danger : C.text }),
-              tdCell(fmt(r.cumulativeCashFlow), idx, { color: r.cumulativeCashFlow < 0 ? C.danger : C.text }),
-              tdCell(fmt(r.remainingLoanBalance), idx),
+              tdCell(fmtYen(r.annualRent), idx),
+              tdCell(fmtYen(r.annualLoanPayment), idx),
+              tdCell(fmtYen(r.annualExpenses), idx),
+              tdCell(fmtYen(r.cashFlow), idx, { color: r.cashFlow < 0 ? C.danger : C.text }),
+              tdCell(fmtYen(r.afterTaxCashFlow), idx, { color: r.afterTaxCashFlow < 0 ? C.danger : C.text }),
+              tdCell(fmtYen(r.cumulativeCashFlow), idx, { color: r.cumulativeCashFlow < 0 ? C.danger : C.text }),
+              tdCell(fmtYen(r.remainingLoanBalance), idx),
             ]),
           ],
         },
@@ -299,8 +280,8 @@ export async function downloadReportPDF(
                     thCell("判定", "center"),
                   ],
                   ...result.stressScenarios.map((sc, idx) => [
-                    tdCell(s(sc.label), idx, { align: "left" }),
-                    tdCell(fmt(sc.totalCashFlow), idx, {
+                    tdCell(sanitize(sc.label), idx, { align: "left" }),
+                    tdCell(fmtYen(sc.totalCashFlow), idx, {
                       color: sc.totalCashFlow < 0 ? C.danger : C.text,
                     }),
                     tdCell(sc.dscr.toFixed(2), idx, {
@@ -329,36 +310,36 @@ export async function downloadReportPDF(
             sectionTitle("P4 - 取得コスト内訳", true),
             subTitle("初期投資内訳"),
             hLineTable([
-              twoCol("土地価格", fmt(input.landPrice)),
-              twoCol("建物費用", fmt(input.buildingCost)),
-              twoCol("諸経費合計", fmt(result.miscExpenses)),
-              twoCol("総投資額", fmt(result.totalInvestment), true, C.primary),
+              twoCol("土地価格", fmtYen(input.landPrice)),
+              twoCol("建物費用", fmtYen(input.buildingCost)),
+              twoCol("諸経費合計", fmtYen(result.miscExpenses)),
+              twoCol("総投資額", fmtYen(result.totalInvestment), true, C.primary),
             ]),
             subTitle("取得時諸経費の明細"),
             hLineTable([
-              twoCol("仲介手数料（税込）", fmt(result.acquisitionCosts.brokerageFee)),
-              twoCol("印紙税", fmt(result.acquisitionCosts.stampDuty)),
-              twoCol("登録免許税", fmt(result.acquisitionCosts.registrationTax)),
-              twoCol("不動産取得税（概算）", fmt(result.acquisitionCosts.realEstateAcquisitionTax)),
+              twoCol("仲介手数料（税込）", fmtYen(result.acquisitionCosts.brokerageFee)),
+              twoCol("印紙税", fmtYen(result.acquisitionCosts.stampDuty)),
+              twoCol("登録免許税", fmtYen(result.acquisitionCosts.registrationTax)),
+              twoCol("不動産取得税（概算）", fmtYen(result.acquisitionCosts.realEstateAcquisitionTax)),
               ...(result.acquisitionCosts.propertyTaxProration > 0
-                ? [twoCol("固定資産税日割り精算", fmt(result.acquisitionCosts.propertyTaxProration))]
+                ? [twoCol("固定資産税日割り精算", fmtYen(result.acquisitionCosts.propertyTaxProration))]
                 : []),
-              twoCol("諸経費合計", fmt(result.acquisitionCosts.total), true, C.primary),
+              twoCol("諸経費合計", fmtYen(result.acquisitionCosts.total), true, C.primary),
             ]),
             ...(result.yearlyResults.length > 0
               ? [
                   subTitle("年間費用の内訳（1年目）"),
                   hLineTable([
                     ...(result.yearlyResults[0].annualLoanPayment > 0
-                      ? [twoCol("ローン返済", fmt(result.yearlyResults[0].annualLoanPayment))]
+                      ? [twoCol("ローン返済", fmtYen(result.yearlyResults[0].annualLoanPayment))]
                       : []),
-                    twoCol("運営経費", fmt(result.yearlyResults[0].annualExpenses)),
+                    twoCol("運営経費", fmtYen(result.yearlyResults[0].annualExpenses)),
                     ...(result.yearlyResults[0].incomeTax > 0
-                      ? [twoCol("所得税", fmt(result.yearlyResults[0].incomeTax))]
+                      ? [twoCol("所得税", fmtYen(result.yearlyResults[0].incomeTax))]
                       : []),
                     twoCol(
-                      "税引後キャッシュフロー（1年目）",
-                      fmt(result.yearlyResults[0].afterTaxCashFlow),
+                      "税引後CF（1年目）",
+                      fmtYen(result.yearlyResults[0].afterTaxCashFlow),
                       true,
                       result.yearlyResults[0].afterTaxCashFlow >= 0 ? C.safe : C.danger
                     ),

--- a/frontend/src/lib/pdf/format.ts
+++ b/frontend/src/lib/pdf/format.ts
@@ -1,0 +1,31 @@
+/** 金額を億/百万/円の3段階で表示。Math.round済みなので小数は出ない。
+ * ルール: 100万円未満は円、1億円未満は百万円、1億円以上は億円 */
+export function fmtYen(v: number): string {
+  const rounded = Math.round(v);
+  const abs = Math.abs(rounded);
+  if (abs >= 100_000_000) return `${(rounded / 100_000_000).toFixed(1)}億円`;
+  if (abs >= 1_000_000) return `${(rounded / 1_000_000).toFixed(1)}百万円`;
+  return `${rounded.toLocaleString("ja-JP")}円`;
+}
+
+/** 小数第2位パーセント表示（例: 8.25%） */
+export function fmtPct(v: number): string {
+  return `${(v * 100).toFixed(2)}%`;
+}
+
+/** 小数第1位パーセント表示（KPI用、例: 8.3%） */
+export function fmtPct1(v: number): string {
+  return `${(v * 100).toFixed(1)}%`;
+}
+
+/** 今日の日付を日本語形式で返す（例: 2026年4月23日） */
+export function fmtDate(): string {
+  const d = new Date();
+  return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
+}
+
+/** PDFに埋め込む前の文字列サニタイズ（< > & " ' \ を除去） */
+export function sanitize(v: string | number | undefined): string {
+  if (v === undefined || v === null) return "";
+  return String(v).replace(/[<>&"'\\]/g, "");
+}

--- a/frontend/src/lib/pdf/format.ts
+++ b/frontend/src/lib/pdf/format.ts
@@ -13,11 +13,6 @@ export function fmtPct(v: number): string {
   return `${(v * 100).toFixed(2)}%`;
 }
 
-/** 小数第1位パーセント表示（KPI用、例: 8.3%） */
-export function fmtPct1(v: number): string {
-  return `${(v * 100).toFixed(1)}%`;
-}
-
 /** 今日の日付を日本語形式で返す（例: 2026年4月23日） */
 export function fmtDate(): string {
   const d = new Date();

--- a/frontend/src/lib/pdf/format.ts
+++ b/frontend/src/lib/pdf/format.ts
@@ -20,7 +20,7 @@ export function fmtDate(): string {
 }
 
 /** PDFに埋め込む前の文字列サニタイズ（< > & " ' \ を除去） */
-export function sanitize(v: string | number | undefined): string {
-  if (v === undefined || v === null) return "";
+export function sanitize(v: string | number | undefined | null): string {
+  if (v == null) return "";
   return String(v).replace(/[<>&"'\\]/g, "");
 }


### PR DESCRIPTION
## 概要

PDF関連の4つのバグ・改善を対応します。

- **#232 デッドクロス年の誤表示**: `buildingCost=0` のとき `annualDepreciation=0` となり、1年目から元金返済>減価償却となってデッドクロス「1年目」と誤表示されていた問題を修正
- **#230 数値フォーマット崩れ**: `587,874.124円` のように小数が表示される問題を修正。`Math.round` 適用・単位ルール統一（100万円未満→円、以上→百万円・億円）
- **#231 日本語テキスト表示崩れ**: pdfmakeが日本語テキストをグリフ境界で分割する問題に対処（`noWrap: true` + `lineHeight: 1`、ラベル短縮）
- **#235 ヘッダー/フッター統一**: P2以降にヘッダー（タイトル・日付）を追加、フッターにページ番号を追加、PDFメタデータ（title/author）を設定

## 変更ファイル

| ファイル | 操作 |
|---------|------|
| `backend/internal/domain/investment.go` | デッドクロス判定に `BuildingCost > 0` ガードを追加 |
| `backend/internal/domain/investment_test.go` | デッドクロス計算テスト2件追加 |
| `frontend/src/lib/pdf/format.ts` | 新規: フォーマットユーティリティ（fmtYen/fmtPct/fmtDate/sanitize） |
| `frontend/src/lib/__tests__/pdfFormat.test.ts` | 新規: format.ts ユニットテスト21件 |
| `frontend/src/lib/generatePdf.ts` | format.ts インポートへの置換・noWrap追加・ヘッダー/フッター/メタデータ追加 |
| `frontend/src/lib/__tests__/generatePdf.test.ts` | ヘッダー/フッター/メタデータ検証テスト3件追加 |

## テスト

- バックエンド: `go test -race ./internal/domain/... -run TestAnalyze_DeadCross` ✅
- フロントエンド: `npm test` → 154件 ✅

## チェックリスト

- [x] テストが全件パス
- [x] 既存テストの回帰なし
- [x] バックエンドとフロントエンド両方の変更を確認