### PR TITLE
fix(terraform): AR リポジトリ更新を IAM binding 完了後に直列化する

### DIFF
--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -4,6 +4,11 @@ resource "google_artifact_registry_repository" "backend" {
   format        = "DOCKER"
   description   = "yield-guard backend Docker images"
 
+  # Ensure the deployer IAM binding is applied before updating repository metadata.
+  # Without this, Terraform applies IAM and repository changes in parallel, causing
+  # a 403 on repositories.update before the new IAM role has propagated.
+  depends_on = [google_project_iam_member.deployer_ar_repo_admin]
+
   # 評価順序: KEEP が優先され、最新5件は保護される。
   # それ以外のタグ付きイメージは older_than を超えた時点で DELETE 対象となる。
   cleanup_policies {


### PR DESCRIPTION
## 概要

PR #240 の IAM ロール変更（`repoAdmin` → `admin`）後も `terraform apply` が 403 で失敗し続ける問題を修正する。

## 問題

`depends_on` がないため、Terraform が IAM バインディングの更新と AR リポジトリの更新を**並列実行**していた。

```
時刻+0s:  IAM binding destroy 開始  ←┐ 並列実行
時刻+0s:  AR repository update 試行 ←┘
時刻+8s:  IAM destroy 完了
時刻+8s:  IAM create 開始（admin ロール）
時刻+15s: IAM create 完了
時刻+15s: Error 403 ← リポジトリ更新がすでに失敗していた
```

IAM バインディングの付け替え（destroy→create）が完了する前にリポジトリ更新が実行されるため、旧来の `repoAdmin`（`repositories.update` なし）が適用された状態で 403 が発生する。

## 変更内容

`artifact_registry.tf` に `depends_on` を追加し、IAM バインディングが完了してからリポジトリ更新が走るよう直列化する。

```hcl
resource "google_artifact_registry_repository" "backend" {
  ...
  depends_on = [google_project_iam_member.deployer_ar_repo_admin]
}
```

## 動作確認

- [ ] `terraform plan` で `depends_on` による変更のみ（no-op に近い差分）
- [ ] `terraform apply` で IAM → AR リポジトリの順に適用されることをログで確認
- [ ] `cleanup_policies` が GCP に正常反映される