### PR TITLE
fix(make): lint型チェックをnpmスクリプト経由に統一 & make clean追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ lint:
 	cd backend && golangci-lint run ./...
 	@echo "==> Frontend lint"
 	cd frontend && npm run lint
-	cd frontend && npx tsc --noEmit
+	cd frontend && npm run type-check
 
 ## build: 全ビルドを実行
 build:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test lint build help \
+.PHONY: dev test lint build clean help \
         mlit-land-prices mlit-municipalities mlit-station-ridership mlit-population-forecast mlit-land-appraisals \
         api-station-ridership api-estimate-ridership api-population-forecast api-land-appraisals \
         integration integration-population integration-land-appraisals
@@ -33,6 +33,12 @@ build:
 	cd backend && go build -o yield-guard-server ./cmd/server
 	@echo "==> Frontend build"
 	cd frontend && npm run build
+
+## clean: ビルド成果物を削除
+clean:
+	rm -f backend/yield-guard-server
+	rm -rf frontend/.next
+	rm -rf frontend/out
 
 ## docker-up: Dockerコンテナをビルドして起動
 docker-up:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint src/",
+    "type-check": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## 概要

- closes #222
- closes #223

## 変更内容

### fix(make): make lint の型チェックを npm スクリプト経由に統一 (#222)

`frontend/package.json` に `type-check` スクリプトを追加し、`Makefile` の `lint` ターゲットから `npm run type-check` 経由で呼ぶよう変更。

```diff
# frontend/package.json
+ "type-check": "tsc --noEmit",

# Makefile
- cd frontend && npx tsc --noEmit
+ cd frontend && npm run type-check
```

- `npx tsc` のバージョン解決の不安定性を排除
- 他の lint コマンド（`npm run lint`）と一貫したスタイルに統一

### feat(make): make clean ターゲットを追加 (#223)

ビルド成果物を一括削除する `make clean` ターゲットを追加。

```makefile
clean:
    rm -f backend/yield-guard-server
    rm -rf frontend/.next
    rm -rf frontend/out
```

- `.PHONY` に `clean` を追加
- `help` に説明が表示される

## 動作確認

- [ ] `make lint` が引き続き正常に動作する（型エラーを検出できる）
- [ ] `make clean` でバックエンドバイナリと Next.js ビルドキャッシュが削除される
- [ ] `make help` に `clean` の説明が表示される