### PR TITLE
fix(terraform): Cloud Run の deletion_protection を有効化する

### DIFF
--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -2,7 +2,7 @@ resource "google_cloud_run_v2_service" "backend" {
   name                = local.service_name
   location            = var.region
   ingress             = "INGRESS_TRAFFIC_ALL"
-  deletion_protection = false
+  deletion_protection = true
 
   template {
     service_account = google_service_account.backend.email


### PR DESCRIPTION
## 概要

本番 Cloud Run サービスの `deletion_protection` を `false` → `true` に変更する。

## 変更内容

- `terraform/cloud_run.tf`: `deletion_protection = false` → `true`

## 背景・目的

誤った `terraform destroy` や Cloud Console からの手動削除でサービスが即座に消えるリスクがあった。削除保護を有効化することで本番サービスを保護する。

## 影響範囲

- `terraform plan` でインプレース更新（`~`）のみ発生
- `terraform apply` 後に Cloud Console > Cloud Run の削除保護が有効になることを確認すること

## 確認項目

- [x] `deletion_protection = true` に変更されている
- [ ] `terraform plan` でインプレース更新のみ確認
- [ ] `terraform apply` 後に Cloud Console で削除保護が有効になっていることを確認

Closes #248