### PR TITLE
feat: 投資適地スコアの自動算出（#65）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,26 @@
 .PHONY: dev test lint build clean help \
         mlit-land-prices mlit-municipalities mlit-station-ridership mlit-population-forecast mlit-land-appraisals \
-        api-station-ridership api-estimate-ridership api-population-forecast api-land-appraisals \
+        mlit-urban-zoning mlit-liquefaction mlit-flood-hazard mlit-storm-hazard mlit-tsunami-hazard mlit-landslide-hazard \
+        api-station-ridership api-estimate-ridership api-population-forecast api-land-appraisals api-investment-score \
         integration integration-population integration-land-appraisals
 
 ## dev: バックエンド・フロントエンドの開発サーバーを起動
 dev:
+	@if [ ! -f .env ]; then \
+	  echo "ERROR: .env が見つかりません。worktree の場合は以下を実行してください:"; \
+	  echo "  cp ../yield-guard/.env .env"; \
+	  exit 1; \
+	fi
 	@trap 'kill 0' INT TERM EXIT; \
 	echo "==> Starting backend..."; \
-	(cd backend && set -a; . ../.env 2>/dev/null; set +a; go run ./cmd/server) & \
+	(cd backend && set -a; . ../.env; set +a; go run ./cmd/server) & \
+	BACKEND_PID=$$!; \
+	sleep 3; \
+	if ! kill -0 $$BACKEND_PID 2>/dev/null; then \
+	  echo "ERROR: バックエンドの起動に失敗しました。ログを確認してください。"; \
+	  exit 1; \
+	fi; \
+	echo "==> Backend started (PID=$$BACKEND_PID)"; \
 	echo "==> Starting frontend..."; \
 	(cd frontend && npm run dev -- --webpack) & \
 	wait
@@ -130,6 +143,84 @@ mlit-population-forecast:
 # ---------------------------------------------------------------------------
 API_BASE := http://localhost:8080/api
 
+## mlit-urban-zoning: 都市計画区域/区域区分を取得 (XKT001) ※フィールド値確認用
+##   使い方: make mlit-urban-zoning z=14 x=14547 y=6451
+mlit-urban-zoning:
+	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
+	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
+	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
+	@source .env 2>/dev/null; \
+	 curl -s \
+	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
+	   --compressed \
+	   "$(MLIT_BASE)/XKT001?response_format=geojson&z=$(z)&x=$(x)&y=$(y)" \
+	   | jq '{feature_count: (.features | length), sample: (.features[:3] | map(.properties | {area_classification_ja, kubun_id, city_name}))}'
+
+## mlit-liquefaction: 液状化発生傾向図を取得 (XKT025) ※liquefaction_tendency_level の実値確認用
+##   使い方: make mlit-liquefaction z=14 x=14547 y=6451
+mlit-liquefaction:
+	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
+	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
+	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
+	@source .env 2>/dev/null; \
+	 curl -s \
+	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
+	   --compressed \
+	   "$(MLIT_BASE)/XKT025?response_format=geojson&z=$(z)&x=$(x)&y=$(y)" \
+	   | jq '{feature_count: (.features | length), sample: (.features[:5] | map(.properties | {liquefaction_tendency_level, note, mesh_code}))}'
+
+## mlit-flood-hazard: 洪水浸水想定区域を取得 (XKT026) ※A31a_205 浸水深ランクの実値確認用
+##   使い方: make mlit-flood-hazard z=14 x=14547 y=6451
+mlit-flood-hazard:
+	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
+	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
+	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
+	@source .env 2>/dev/null; \
+	 curl -s \
+	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
+	   --compressed \
+	   "$(MLIT_BASE)/XKT026?response_format=geojson&z=$(z)&x=$(x)&y=$(y)" \
+	   | jq '{feature_count: (.features | length), sample: (.features[:3] | map(.properties | {A31a_205, A31a_202, A31a_204}))}'
+
+## mlit-storm-hazard: 高潮浸水想定区域を取得 (XKT027) ※A49_003 浸水深区分の実値確認用
+##   使い方: make mlit-storm-hazard z=14 x=14547 y=6451
+mlit-storm-hazard:
+	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
+	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
+	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
+	@source .env 2>/dev/null; \
+	 curl -s \
+	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
+	   --compressed \
+	   "$(MLIT_BASE)/XKT027?response_format=geojson&z=$(z)&x=$(x)&y=$(y)" \
+	   | jq '{feature_count: (.features | length), sample: (.features[:3] | map(.properties | {A49_003, A49_001, target_year}))}'
+
+## mlit-tsunami-hazard: 津波浸水想定を取得 (XKT028) ※A40_003 浸水深区分の実値確認用
+##   使い方: make mlit-tsunami-hazard z=14 x=14547 y=6451
+mlit-tsunami-hazard:
+	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
+	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
+	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
+	@source .env 2>/dev/null; \
+	 curl -s \
+	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
+	   --compressed \
+	   "$(MLIT_BASE)/XKT028?response_format=geojson&z=$(z)&x=$(x)&y=$(y)" \
+	   | jq '{feature_count: (.features | length), sample: (.features[:3] | map(.properties | {A40_003, A40_001, target_year}))}'
+
+## mlit-landslide-hazard: 土砂災害警戒区域を取得 (XKT029) ※A33_001/A33_002 の実値確認用
+##   使い方: make mlit-landslide-hazard z=14 x=14547 y=6451
+mlit-landslide-hazard:
+	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
+	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
+	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
+	@source .env 2>/dev/null; \
+	 curl -s \
+	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
+	   --compressed \
+	   "$(MLIT_BASE)/XKT029?response_format=geojson&z=$(z)&x=$(x)&y=$(y)" \
+	   | jq '{feature_count: (.features | length), sample: (.features[:3] | map(.properties | {A33_001, A33_002, A33_005, A33_007}))}'
+
 ## api-station-ridership: ローカルの /api/station-ridership を呼び出す
 ##   使い方: make api-station-ridership lat=35.6762 lng=139.6503 [z=14]
 api-station-ridership:
@@ -157,6 +248,16 @@ api-population-forecast:
 	curl -s \
 	  "$(API_BASE)/population-forecast?lat=$(lat)&lng=$(lng)$(if $(z),&z=$(z),)" \
 	  | jq .
+
+## api-investment-score: ローカルの /api/investment-score を呼び出す
+##   使い方: make api-investment-score lat=35.6580 lng=139.7016
+##   渋谷付近: lat=35.6580 lng=139.7016 / 前橋付近: lat=36.3897 lng=139.0607
+api-investment-score:
+	@test -n "$(lat)" || (echo "ERROR: lat は必須です (例: lat=35.6580)"; exit 1)
+	@test -n "$(lng)" || (echo "ERROR: lng は必須です (例: lng=139.7016)"; exit 1)
+	curl -s \
+	  "$(API_BASE)/investment-score?lat=$(lat)&lng=$(lng)" \
+	  | jq '{totalScore: .totalScore, grade: .grade, breakdown: (.breakdown | {population: .population, ridership: .ridership, urbanArea: .urbanArea, locationOptimization: .locationOptimization, hazardRisk: .hazardRisk, liquefactionRisk: .liquefactionRisk, embankment: .embankment, disasterHistory: .disasterHistory})}'
 
 ## api-estimate-ridership: 需要スコア補正付き理論価格推定を呼び出す
 ##   使い方: make api-estimate-ridership area=13 city=13113 price=50000000 area_sqm=100 building_age=10 station_minutes=5 ridership_score=A

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -25,6 +25,12 @@ type MLITClient interface {
 	FetchEmbankment(ctx context.Context, z, x, y int) ([]domain.EmbankmentItem, error)
 	FetchUrbanRoad(ctx context.Context, z, x, y int) ([]domain.UrbanRoadItem, error)
 	FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domain.DisasterHistoryItem, error)
+	FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.UrbanZoningItem, error)
+	FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.LiquefactionRiskItem, error)
+	FetchFloodHazard(ctx context.Context, z, x, y int) ([]domain.FloodHazardItem, error)
+	FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.StormHazardItem, error)
+	FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.TsunamiHazardItem, error)
+	FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domain.LandslideHazardItem, error)
 }
 
 type Handler struct {
@@ -562,6 +568,131 @@ func (h *Handler) GetUrbanRisks(c *gin.Context) {
 		risks = []domain.UrbanRisk{}
 	}
 	c.JSON(http.StatusOK, risks)
+}
+
+// GetInvestmentScore は物件の緯度経度から複数 API を並列呼び出しし、投資適地スコアを算出して返す。
+// GET /api/investment-score?lat=35.6762&lng=139.6503
+func (h *Handler) GetInvestmentScore(c *gin.Context) {
+	latStr := c.Query("lat")
+	lngStr := c.Query("lng")
+	if latStr == "" || lngStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lat と lng は必須パラメータです"})
+		return
+	}
+	lat, err := strconv.ParseFloat(latStr, 64)
+	if err != nil || lat < 20 || lat > 46 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lat は日本国内の緯度（20〜46）で指定してください"})
+		return
+	}
+	lng, err := strconv.ParseFloat(lngStr, 64)
+	if err != nil || lng < 122 || lng > 154 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lng は日本国内の経度（122〜154）で指定してください"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	z := 14
+	x, y := mlit.LatLngToTile(lat, lng, z)
+
+	type result[T any] struct {
+		data T
+		err  error
+	}
+
+	popCh := make(chan result[[]domain.PopulationForecastItem], 1)
+	ridCh := make(chan result[[]mlit.StationRidership], 1)
+	locCh := make(chan result[[]domain.LocationOptimizationItem], 1)
+	embCh := make(chan result[[]domain.EmbankmentItem], 1)
+	disCh := make(chan result[[]domain.DisasterHistoryItem], 1)
+	zonCh := make(chan result[[]domain.UrbanZoningItem], 1)
+	liqCh := make(chan result[[]domain.LiquefactionRiskItem], 1)
+	floCh := make(chan result[[]domain.FloodHazardItem], 1)
+	stoCh := make(chan result[[]domain.StormHazardItem], 1)
+	tsuCh := make(chan result[[]domain.TsunamiHazardItem], 1)
+	lanCh := make(chan result[[]domain.LandslideHazardItem], 1)
+
+	go func() { d, e := h.mlitClient.FetchPopulationForecast(ctx, z, x, y); popCh <- result[[]domain.PopulationForecastItem]{d, e} }()
+	go func() { d, e := h.mlitClient.FetchStationRidership(ctx, z, x, y); ridCh <- result[[]mlit.StationRidership]{d, e} }()
+	go func() { d, e := h.mlitClient.FetchLocationOptimization(ctx, z, x, y); locCh <- result[[]domain.LocationOptimizationItem]{d, e} }()
+	go func() { d, e := h.mlitClient.FetchEmbankment(ctx, z, x, y); embCh <- result[[]domain.EmbankmentItem]{d, e} }()
+	go func() { d, e := h.mlitClient.FetchDisasterHistory(ctx, z, x, y); disCh <- result[[]domain.DisasterHistoryItem]{d, e} }()
+	go func() { d, e := h.mlitClient.FetchUrbanZoning(ctx, z, x, y); zonCh <- result[[]domain.UrbanZoningItem]{d, e} }()
+	go func() { d, e := h.mlitClient.FetchLiquefaction(ctx, z, x, y); liqCh <- result[[]domain.LiquefactionRiskItem]{d, e} }()
+	go func() { d, e := h.mlitClient.FetchFloodHazard(ctx, z, x, y); floCh <- result[[]domain.FloodHazardItem]{d, e} }()
+	go func() { d, e := h.mlitClient.FetchStormHazard(ctx, z, x, y); stoCh <- result[[]domain.StormHazardItem]{d, e} }()
+	go func() { d, e := h.mlitClient.FetchTsunamiHazard(ctx, z, x, y); tsuCh <- result[[]domain.TsunamiHazardItem]{d, e} }()
+	go func() { d, e := h.mlitClient.FetchLandslideHazard(ctx, z, x, y); lanCh <- result[[]domain.LandslideHazardItem]{d, e} }()
+
+	input := domain.InvestmentScoreInput{}
+
+	if r := <-popCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchPopulationForecast failed", "error", r.err)
+	} else {
+		input.PopulationItems = r.data
+	}
+	if r := <-ridCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchStationRidership failed", "error", r.err)
+	} else {
+		input.StationRiderships = make([]domain.StationRidershipResult, 0, len(r.data))
+		for _, s := range r.data {
+			score := domain.CalcRidershipDemandScore(s.Passengers)
+			input.StationRiderships = append(input.StationRiderships, domain.StationRidershipResult{
+				StationName: s.StationName,
+				LineName:    s.LineName,
+				Passengers:  s.Passengers,
+				DemandScore: score,
+				Correction:  domain.RidershipCorrectionFactor(score),
+			})
+		}
+	}
+	if r := <-locCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchLocationOptimization failed", "error", r.err)
+	} else {
+		input.LocationItems = r.data
+	}
+	if r := <-embCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchEmbankment failed", "error", r.err)
+	} else {
+		input.EmbankmentItems = r.data
+	}
+	if r := <-disCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchDisasterHistory failed", "error", r.err)
+	} else {
+		input.DisasterItems = r.data
+	}
+	if r := <-zonCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchUrbanZoning failed", "error", r.err)
+	} else {
+		input.UrbanZoningItems = r.data
+	}
+	if r := <-liqCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchLiquefaction failed", "error", r.err)
+	} else {
+		input.LiquefactionItems = r.data
+	}
+	if r := <-floCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchFloodHazard failed", "error", r.err)
+	} else {
+		input.FloodItems = r.data
+	}
+	if r := <-stoCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchStormHazard failed", "error", r.err)
+	} else {
+		input.StormItems = r.data
+	}
+	if r := <-tsuCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchTsunamiHazard failed", "error", r.err)
+	} else {
+		input.TsunamiItems = r.data
+	}
+	if r := <-lanCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchLandslideHazard failed", "error", r.err)
+	} else {
+		input.LandslideItems = r.data
+	}
+
+	score := domain.CalcInvestmentScore(input)
+	c.JSON(http.StatusOK, score)
 }
 
 // HealthCheck はサーバーの生存確認

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -96,6 +96,25 @@ func (m *mockMLITClient) FetchDisasterHistory(ctx context.Context, z, x, y int) 
 	return []domain.DisasterHistoryItem{}, nil
 }
 
+func (m *mockMLITClient) FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.UrbanZoningItem, error) {
+	return []domain.UrbanZoningItem{}, nil
+}
+func (m *mockMLITClient) FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.LiquefactionRiskItem, error) {
+	return []domain.LiquefactionRiskItem{}, nil
+}
+func (m *mockMLITClient) FetchFloodHazard(ctx context.Context, z, x, y int) ([]domain.FloodHazardItem, error) {
+	return []domain.FloodHazardItem{}, nil
+}
+func (m *mockMLITClient) FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.StormHazardItem, error) {
+	return []domain.StormHazardItem{}, nil
+}
+func (m *mockMLITClient) FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.TsunamiHazardItem, error) {
+	return []domain.TsunamiHazardItem{}, nil
+}
+func (m *mockMLITClient) FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domain.LandslideHazardItem, error) {
+	return []domain.LandslideHazardItem{}, nil
+}
+
 // newTestRouter はモッククライアントを使ったテスト用ルーターを返す
 func newTestRouter(client MLITClient) *gin.Engine {
 	h := NewHandler(client)

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -31,6 +31,12 @@ type mockMLITClient struct {
 	embankmentFunc       func(ctx context.Context, z, x, y int) ([]domain.EmbankmentItem, error)
 	urbanRoadFunc        func(ctx context.Context, z, x, y int) ([]domain.UrbanRoadItem, error)
 	disasterHistoryFunc  func(ctx context.Context, z, x, y int) ([]domain.DisasterHistoryItem, error)
+	urbanZoningFunc      func(ctx context.Context, z, x, y int) ([]domain.UrbanZoningItem, error)
+	liquefactionFunc     func(ctx context.Context, z, x, y int) ([]domain.LiquefactionRiskItem, error)
+	floodHazardFunc      func(ctx context.Context, z, x, y int) ([]domain.FloodHazardItem, error)
+	stormHazardFunc      func(ctx context.Context, z, x, y int) ([]domain.StormHazardItem, error)
+	tsunamiHazardFunc    func(ctx context.Context, z, x, y int) ([]domain.TsunamiHazardItem, error)
+	landslideHazardFunc  func(ctx context.Context, z, x, y int) ([]domain.LandslideHazardItem, error)
 }
 
 func (m *mockMLITClient) FetchLandPrices(ctx context.Context, q mlit.LandPriceQuery) ([]domain.LandTransaction, error) {
@@ -97,21 +103,39 @@ func (m *mockMLITClient) FetchDisasterHistory(ctx context.Context, z, x, y int) 
 }
 
 func (m *mockMLITClient) FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.UrbanZoningItem, error) {
+	if m.urbanZoningFunc != nil {
+		return m.urbanZoningFunc(ctx, z, x, y)
+	}
 	return []domain.UrbanZoningItem{}, nil
 }
 func (m *mockMLITClient) FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.LiquefactionRiskItem, error) {
+	if m.liquefactionFunc != nil {
+		return m.liquefactionFunc(ctx, z, x, y)
+	}
 	return []domain.LiquefactionRiskItem{}, nil
 }
 func (m *mockMLITClient) FetchFloodHazard(ctx context.Context, z, x, y int) ([]domain.FloodHazardItem, error) {
+	if m.floodHazardFunc != nil {
+		return m.floodHazardFunc(ctx, z, x, y)
+	}
 	return []domain.FloodHazardItem{}, nil
 }
 func (m *mockMLITClient) FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.StormHazardItem, error) {
+	if m.stormHazardFunc != nil {
+		return m.stormHazardFunc(ctx, z, x, y)
+	}
 	return []domain.StormHazardItem{}, nil
 }
 func (m *mockMLITClient) FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.TsunamiHazardItem, error) {
+	if m.tsunamiHazardFunc != nil {
+		return m.tsunamiHazardFunc(ctx, z, x, y)
+	}
 	return []domain.TsunamiHazardItem{}, nil
 }
 func (m *mockMLITClient) FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domain.LandslideHazardItem, error) {
+	if m.landslideHazardFunc != nil {
+		return m.landslideHazardFunc(ctx, z, x, y)
+	}
 	return []domain.LandslideHazardItem{}, nil
 }
 
@@ -1007,5 +1031,119 @@ func TestGetUrbanRisks_PartialAPIFailure(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected DISASTER_HISTORY in response despite embankment API failure")
+	}
+}
+
+// ---- /api/investment-score テスト ----
+
+func TestGetInvestmentScore_MissingParams(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{})
+	for _, url := range []string{
+		"/api/investment-score",
+		"/api/investment-score?lat=35.68",
+		"/api/investment-score?lng=139.69",
+	} {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("url=%s: expected 400, got %d", url, w.Code)
+		}
+	}
+}
+
+func TestGetInvestmentScore_InvalidRange(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{})
+	for _, url := range []string{
+		"/api/investment-score?lat=10&lng=139.69",   // lat 範囲外（< 20）
+		"/api/investment-score?lat=35.68&lng=200",   // lng 範囲外（> 154）
+		"/api/investment-score?lat=abc&lng=139.69",  // 数値でない
+	} {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, url, nil))
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("url=%s: expected 400, got %d", url, w.Code)
+		}
+	}
+}
+
+func TestGetInvestmentScore_EmptyResult(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{})
+	req := httptest.NewRequest(http.MethodGet, "/api/investment-score?lat=35.68&lng=139.69", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var result domain.InvestmentScoreResult
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if result.TotalScore != 50 {
+		t.Errorf("all-empty input should yield base score 50, got %d", result.TotalScore)
+	}
+	if result.Grade != "普通" {
+		t.Errorf("expected grade 普通, got %q", result.Grade)
+	}
+	if len(result.Breakdown.RadarData) != 5 {
+		t.Errorf("expected 5 radar categories, got %d", len(result.Breakdown.RadarData))
+	}
+}
+
+func TestGetInvestmentScore_WithData(t *testing.T) {
+	mock := &mockMLITClient{
+		urbanZoningFunc: func(_ context.Context, _, _, _ int) ([]domain.UrbanZoningItem, error) {
+			return []domain.UrbanZoningItem{{AreaClassificationJa: "市街化区域"}}, nil
+		},
+		floodHazardFunc: func(_ context.Context, _, _, _ int) ([]domain.FloodHazardItem, error) {
+			return []domain.FloodHazardItem{{DepthRank: 3, RiverName: "多摩川"}}, nil
+		},
+	}
+	r := newTestRouter(mock)
+	req := httptest.NewRequest(http.MethodGet, "/api/investment-score?lat=35.68&lng=139.69", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var result domain.InvestmentScoreResult
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	// 市街化区域 +10、洪水 -5 → base50 + 10 - 5 = 55
+	if result.TotalScore != 55 {
+		t.Errorf("expected score 55, got %d", result.TotalScore)
+	}
+	if result.Breakdown.UrbanArea.Score != 10 {
+		t.Errorf("expected urbanArea score 10, got %d", result.Breakdown.UrbanArea.Score)
+	}
+	if result.Breakdown.HazardRisk.Score != -5 {
+		t.Errorf("expected hazardRisk score -5, got %d", result.Breakdown.HazardRisk.Score)
+	}
+}
+
+func TestGetInvestmentScore_PartialAPIFailure(t *testing.T) {
+	mock := &mockMLITClient{
+		floodHazardFunc: func(_ context.Context, _, _, _ int) ([]domain.FloodHazardItem, error) {
+			return nil, errors.New("API timeout")
+		},
+		urbanZoningFunc: func(_ context.Context, _, _, _ int) ([]domain.UrbanZoningItem, error) {
+			return []domain.UrbanZoningItem{{AreaClassificationJa: "市街化区域"}}, nil
+		},
+	}
+	r := newTestRouter(mock)
+	req := httptest.NewRequest(http.MethodGet, "/api/investment-score?lat=35.68&lng=139.69", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	// 一部 API 失敗でも 200 を返すこと
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 even with partial API failure, got %d", w.Code)
+	}
+	var result domain.InvestmentScoreResult
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	// flood 失敗 → hazard=0、urban +10 → base50 + 10 = 60
+	if result.TotalScore != 60 {
+		t.Errorf("expected score 60 with flood API failure, got %d", result.TotalScore)
 	}
 }

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -128,6 +128,7 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/population-forecast", h.GetPopulationForecast)
 		api.GET("/land-appraisals", h.GetLandAppraisals)
 		api.GET("/urban-risks", h.GetUrbanRisks)
+		api.GET("/investment-score", h.GetInvestmentScore)
 	}
 
 	return r

--- a/backend/internal/domain/investment_score.go
+++ b/backend/internal/domain/investment_score.go
@@ -1,0 +1,299 @@
+package domain
+
+import (
+	"fmt"
+	"math"
+	"strings"
+)
+
+// InvestmentScoreInput は CalcInvestmentScore への入力パラメータ
+type InvestmentScoreInput struct {
+	PopulationItems   []PopulationForecastItem
+	StationRiderships []StationRidershipResult
+	LocationItems     []LocationOptimizationItem
+	EmbankmentItems   []EmbankmentItem
+	DisasterItems     []DisasterHistoryItem
+	UrbanZoningItems  []UrbanZoningItem
+	LiquefactionItems []LiquefactionRiskItem
+	FloodItems        []FloodHazardItem
+	StormItems        []StormHazardItem
+	TsunamiItems      []TsunamiHazardItem
+	LandslideItems    []LandslideHazardItem
+}
+
+// CalcInvestmentScore は複数 MLIT API の結果を統合して投資適地スコアを算出する。
+// baseScore=50 を起点に各指標を加減し、0〜100 にクランプして返す。
+func CalcInvestmentScore(input InvestmentScoreInput) InvestmentScoreResult {
+	pop := calcPopulationScore(input.PopulationItems)
+	ridership := calcRidershipScore(input.StationRiderships)
+	urbanArea := calcUrbanAreaScore(input.UrbanZoningItems)
+	locationOpt := calcLocationOptScore(input.LocationItems)
+	hazard := calcHazardScore(input.FloodItems, input.StormItems, input.TsunamiItems, input.LandslideItems)
+	liquefaction := calcLiquefactionScore(input.LiquefactionItems)
+	embankment := calcEmbankmentScore(input.EmbankmentItems)
+	disaster := calcDisasterScore(input.DisasterItems)
+
+	total := 50 + pop.Score + ridership.Score + urbanArea.Score + locationOpt.Score +
+		hazard.Score + liquefaction.Score + embankment.Score + disaster.Score
+	if total > 100 {
+		total = 100
+	}
+	if total < 0 {
+		total = 0
+	}
+
+	return InvestmentScoreResult{
+		TotalScore: total,
+		Grade:      gradeFromScore(total),
+		Breakdown: ScoreBreakdown{
+			Population:       pop,
+			Ridership:        ridership,
+			UrbanArea:        urbanArea,
+			LocationOpt:      locationOpt,
+			HazardRisk:       hazard,
+			LiquefactionRisk: liquefaction,
+			Embankment:       embankment,
+			DisasterHistory:  disaster,
+			RadarData:        buildRadarData(pop.Score, ridership.Score, urbanArea.Score, locationOpt.Score, hazard.Score, liquefaction.Score, embankment.Score),
+		},
+	}
+}
+
+func gradeFromScore(score int) string {
+	switch {
+	case score >= 80:
+		return "優良"
+	case score >= 65:
+		return "良好"
+	case score >= 50:
+		return "普通"
+	case score >= 35:
+		return "注意"
+	default:
+		return "要注意"
+	}
+}
+
+// calcPopulationScore は XKT013 の人口予測から ±15 点を算出する。
+// changeRate30yr が +30%→+15, 0%→0, -50%以下→-15 で線形補間。
+func calcPopulationScore(items []PopulationForecastItem) ScoreItem {
+	if len(items) == 0 {
+		return ScoreItem{Score: 0, Label: "人口動態", Description: "データなし"}
+	}
+	result := CalcPopulationForecast(items)
+	r := result.ChangeRate30yr
+
+	var raw float64
+	if r >= 0 {
+		raw = math.Min(r/0.30, 1.0) * 15
+	} else {
+		raw = math.Max(r/0.50, -1.0) * 15
+	}
+	score := int(math.Round(raw))
+
+	desc := fmt.Sprintf("%s（30年後%+.0f%%）", result.Trend, r*100)
+	return ScoreItem{Score: score, Label: "人口動態", Description: desc}
+}
+
+// calcRidershipScore は XKT015 の最大乗降客数から 0〜+20 点を算出する。
+// 5万人/日以上で満点。
+func calcRidershipScore(riderships []StationRidershipResult) ScoreItem {
+	if len(riderships) == 0 {
+		return ScoreItem{Score: 0, Label: "交通利便性", Description: "駅データなし"}
+	}
+	var maxPassengers int
+	var topStation string
+	for _, s := range riderships {
+		if s.Passengers > maxPassengers {
+			maxPassengers = s.Passengers
+			topStation = s.StationName
+		}
+	}
+	raw := float64(maxPassengers) / 50_000.0 * 20.0
+	score := int(math.Min(math.Round(raw), 20))
+	desc := fmt.Sprintf("%s %s人/日", topStation, formatPassengers(maxPassengers))
+	return ScoreItem{Score: score, Label: "交通利便性", Description: desc}
+}
+
+// calcUrbanAreaScore は XKT001 の区域区分から +10 or 0 点を算出する。
+func calcUrbanAreaScore(items []UrbanZoningItem) ScoreItem {
+	if len(items) == 0 {
+		return ScoreItem{Score: 0, Label: "市街化区域", Description: "都市計画区域データなし"}
+	}
+	for _, item := range items {
+		if strings.Contains(item.AreaClassificationJa, "市街化区域") &&
+			!strings.Contains(item.AreaClassificationJa, "調整") {
+			return ScoreItem{Score: 10, Label: "市街化区域", Description: "市街化区域内"}
+		}
+	}
+	return ScoreItem{Score: 0, Label: "市街化区域", Description: "市街化区域外"}
+}
+
+// calcLocationOptScore は XKT003 の居住誘導区域から +10 or -5 or 0 点を算出する。
+// フィーチャなし（未策定自治体）→ 0、居住誘導区域内 → +10、区域外 → -5
+func calcLocationOptScore(items []LocationOptimizationItem) ScoreItem {
+	if len(items) == 0 {
+		return ScoreItem{Score: 0, Label: "居住誘導区域", Description: "立地適正化計画未策定"}
+	}
+	for _, item := range items {
+		if strings.Contains(item.KubunNameJa, "居住誘導区域") {
+			return ScoreItem{Score: 10, Label: "居住誘導区域", Description: "居住誘導区域内"}
+		}
+	}
+	return ScoreItem{Score: -5, Label: "居住誘導区域", Description: "居住誘導区域外（将来の行政サービス縮小リスク）"}
+}
+
+// calcHazardScore は XKT026〜029 のハザードリスクを合算し 0〜-20 点を算出する。
+func calcHazardScore(flood []FloodHazardItem, storm []StormHazardItem, tsunami []TsunamiHazardItem, landslide []LandslideHazardItem) ScoreItem {
+	total := 0
+	var risks []string
+
+	// 洪水リスク（XKT026）
+	if len(flood) > 0 {
+		maxRank := 0
+		for _, f := range flood {
+			if f.DepthRank > maxRank {
+				maxRank = f.DepthRank
+			}
+		}
+		if maxRank >= 3 {
+			total -= 5
+			risks = append(risks, "洪水（深）")
+		} else if maxRank >= 1 {
+			total -= 3
+			risks = append(risks, "洪水")
+		}
+	}
+
+	// 高潮リスク（XKT027）
+	if len(storm) > 0 {
+		total -= 5
+		risks = append(risks, "高潮")
+	}
+
+	// 津波リスク（XKT028）
+	if len(tsunami) > 0 {
+		total -= 5
+		risks = append(risks, "津波")
+	}
+
+	// 土砂リスク（XKT029）
+	if len(landslide) > 0 {
+		minZone := 9
+		for _, l := range landslide {
+			if l.ZoneCode < minZone {
+				minZone = l.ZoneCode
+			}
+		}
+		if minZone == 1 {
+			total -= 5
+			risks = append(risks, "土砂（特別警戒）")
+		} else {
+			total -= 3
+			risks = append(risks, "土砂（警戒）")
+		}
+	}
+
+	// 最大 -20 にクランプ
+	if total < -20 {
+		total = -20
+	}
+
+	var desc string
+	if len(risks) == 0 {
+		desc = "ハザードリスクなし"
+	} else {
+		desc = strings.Join(risks, "・") + "リスクあり"
+	}
+	return ScoreItem{Score: total, Label: "ハザードリスク", Description: desc}
+}
+
+// calcLiquefactionScore は XKT025 の液状化発生傾向から 0〜-10 点を算出する。
+// TendencyLevel: 6段階（低値ほど液状化しやすい）
+func calcLiquefactionScore(items []LiquefactionRiskItem) ScoreItem {
+	if len(items) == 0 {
+		return ScoreItem{Score: 0, Label: "液状化リスク", Description: "液状化データなし"}
+	}
+	minLevel := 9
+	for _, item := range items {
+		if item.TendencyLevel < minLevel {
+			minLevel = item.TendencyLevel
+		}
+	}
+	switch {
+	case minLevel <= 2:
+		return ScoreItem{Score: -10, Label: "液状化リスク", Description: "液状化リスク：非常に高い"}
+	case minLevel <= 4:
+		return ScoreItem{Score: -5, Label: "液状化リスク", Description: "液状化リスク：中程度"}
+	default:
+		return ScoreItem{Score: 0, Label: "液状化リスク", Description: "液状化リスク：低い"}
+	}
+}
+
+// calcEmbankmentScore は XKT020 の大規模盛土造成地から 0 or -5 点を算出する。
+func calcEmbankmentScore(items []EmbankmentItem) ScoreItem {
+	if len(items) == 0 {
+		return ScoreItem{Score: 0, Label: "大規模盛土", Description: "大規模盛土造成地に非該当"}
+	}
+	desc := "大規模盛土造成地に該当"
+	if c := items[0].Classification; c != "" {
+		desc = fmt.Sprintf("大規模盛土造成地（%s）", c)
+	}
+	return ScoreItem{Score: -5, Label: "大規模盛土", Description: desc}
+}
+
+// calcDisasterScore は XST001 の災害履歴から 0 or -10 点を算出する。
+func calcDisasterScore(items []DisasterHistoryItem) ScoreItem {
+	if len(items) == 0 {
+		return ScoreItem{Score: 0, Label: "災害履歴", Description: "災害履歴なし"}
+	}
+	names := make([]string, 0, len(items))
+	seen := make(map[string]bool)
+	for _, d := range items {
+		if d.Name != "" && !seen[d.Name] {
+			names = append(names, d.Name)
+			seen[d.Name] = true
+		}
+	}
+	var desc string
+	if len(names) > 0 {
+		desc = fmt.Sprintf("過去の災害記録あり（%s）", strings.Join(names, "・"))
+	} else {
+		desc = "過去の災害記録あり"
+	}
+	return ScoreItem{Score: -10, Label: "災害履歴", Description: desc}
+}
+
+// buildRadarData はレーダーチャート用の5カテゴリ正規化スコアを生成する（0〜100）。
+func buildRadarData(pop, ridership, urbanArea, locationOpt, hazard, liquefaction, embankment int) []RadarPoint {
+	clamp := func(v float64) float64 {
+		if v < 0 {
+			return 0
+		}
+		if v > 100 {
+			return 100
+		}
+		return v
+	}
+
+	popNorm := clamp((float64(pop) + 15) / 30.0 * 100)
+	ridershipNorm := clamp(float64(ridership) / 20.0 * 100)
+	urbanNorm := clamp((float64(urbanArea+locationOpt) + 5) / 25.0 * 100)
+	hazardNorm := clamp((20.0 + float64(hazard)) / 20.0 * 100)
+	groundNorm := clamp((15.0 + float64(liquefaction+embankment)) / 15.0 * 100)
+
+	return []RadarPoint{
+		{Category: "人口動態", Score: math.Round(popNorm)},
+		{Category: "交通利便性", Score: math.Round(ridershipNorm)},
+		{Category: "都市計画", Score: math.Round(urbanNorm)},
+		{Category: "ハザード", Score: math.Round(hazardNorm)},
+		{Category: "地盤", Score: math.Round(groundNorm)},
+	}
+}
+
+func formatPassengers(n int) string {
+	if n >= 10_000 {
+		return fmt.Sprintf("%.1f万", float64(n)/10_000)
+	}
+	return fmt.Sprintf("%d", n)
+}

--- a/backend/internal/domain/investment_score.go
+++ b/backend/internal/domain/investment_score.go
@@ -54,7 +54,7 @@ func CalcInvestmentScore(input InvestmentScoreInput) InvestmentScoreResult {
 			LiquefactionRisk: liquefaction,
 			Embankment:       embankment,
 			DisasterHistory:  disaster,
-			RadarData:        buildRadarData(pop.Score, ridership.Score, urbanArea.Score, locationOpt.Score, hazard.Score, liquefaction.Score, embankment.Score),
+			RadarData:        buildRadarData(pop.Score, ridership.Score, urbanArea.Score, locationOpt.Score, hazard.Score, liquefaction.Score, embankment.Score, disaster.Score),
 		},
 	}
 }
@@ -179,7 +179,7 @@ func calcHazardScore(flood []FloodHazardItem, storm []StormHazardItem, tsunami [
 
 	// 土砂リスク（XKT029）
 	if len(landslide) > 0 {
-		minZone := 9
+		minZone := math.MaxInt
 		for _, l := range landslide {
 			if l.ZoneCode < minZone {
 				minZone = l.ZoneCode
@@ -265,7 +265,8 @@ func calcDisasterScore(items []DisasterHistoryItem) ScoreItem {
 }
 
 // buildRadarData はレーダーチャート用の5カテゴリ正規化スコアを生成する（0〜100）。
-func buildRadarData(pop, ridership, urbanArea, locationOpt, hazard, liquefaction, embankment int) []RadarPoint {
+// disaster スコアはハザードカテゴリに合算し、総合スコアとレーダーの乖離を防ぐ。
+func buildRadarData(pop, ridership, urbanArea, locationOpt, hazard, liquefaction, embankment, disaster int) []RadarPoint {
 	clamp := func(v float64) float64 {
 		if v < 0 {
 			return 0
@@ -279,7 +280,8 @@ func buildRadarData(pop, ridership, urbanArea, locationOpt, hazard, liquefaction
 	popNorm := clamp((float64(pop) + 15) / 30.0 * 100)
 	ridershipNorm := clamp(float64(ridership) / 20.0 * 100)
 	urbanNorm := clamp((float64(urbanArea+locationOpt) + 5) / 25.0 * 100)
-	hazardNorm := clamp((20.0 + float64(hazard)) / 20.0 * 100)
+	// ハザード＋災害履歴の合算: 最良=0+0=0、最悪=-20+(-10)=-30 → 分母30で正規化
+	hazardNorm := clamp((30.0 + float64(hazard) + float64(disaster)) / 30.0 * 100)
 	groundNorm := clamp((15.0 + float64(liquefaction+embankment)) / 15.0 * 100)
 
 	return []RadarPoint{

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2032,3 +2032,149 @@ func TestAnalyze_DeadCross_NewWoodFrame(t *testing.T) {
 		t.Errorf("DeadCrossYear = %d, want 23", result.DeadCrossYear)
 	}
 }
+
+// ---- CalcInvestmentScore テスト ----
+
+func TestCalcInvestmentScore_EmptyInput(t *testing.T) {
+	result := CalcInvestmentScore(InvestmentScoreInput{})
+	if result.TotalScore < 0 || result.TotalScore > 100 {
+		t.Errorf("TotalScore out of range: %d", result.TotalScore)
+	}
+	if result.TotalScore != 50 {
+		t.Errorf("empty input should yield base score 50, got %d", result.TotalScore)
+	}
+	if result.Grade != "普通" {
+		t.Errorf("empty input grade = %q, want 普通", result.Grade)
+	}
+	if len(result.Breakdown.RadarData) != 5 {
+		t.Errorf("expected 5 radar categories, got %d", len(result.Breakdown.RadarData))
+	}
+}
+
+func TestCalcInvestmentScore_AllPositive(t *testing.T) {
+	input := InvestmentScoreInput{
+		PopulationItems: []PopulationForecastItem{
+			{Year: 2020, Pop: 1000},
+			{Year: 2050, Pop: 1300}, // +30%
+		},
+		StationRiderships: []StationRidershipResult{
+			{StationName: "渋谷", Passengers: 500_000},
+		},
+		UrbanZoningItems: []UrbanZoningItem{
+			{AreaClassificationJa: "市街化区域"},
+		},
+		LocationItems: []LocationOptimizationItem{
+			{KubunNameJa: "居住誘導区域"},
+		},
+	}
+	result := CalcInvestmentScore(input)
+	if result.TotalScore > 100 {
+		t.Errorf("TotalScore exceeds 100: %d", result.TotalScore)
+	}
+	if result.TotalScore < 90 {
+		t.Errorf("all positive inputs should score high, got %d", result.TotalScore)
+	}
+}
+
+func TestCalcInvestmentScore_AllNegative(t *testing.T) {
+	input := InvestmentScoreInput{
+		PopulationItems: []PopulationForecastItem{
+			{Year: 2020, Pop: 1000},
+			{Year: 2050, Pop: 400}, // -60%
+		},
+		FloodItems: []FloodHazardItem{
+			{DepthRank: 4},
+		},
+		StormItems:    []StormHazardItem{{DepthJa: "5m以上"}},
+		TsunamiItems:  []TsunamiHazardItem{{DepthJa: "3m以上"}},
+		LandslideItems: []LandslideHazardItem{{ZoneCode: 1}},
+		LiquefactionItems: []LiquefactionRiskItem{{TendencyLevel: 1}},
+		EmbankmentItems:   []EmbankmentItem{{Classification: "谷埋め型"}},
+		DisasterItems:     []DisasterHistoryItem{{Name: "浸水域", Year: 2019}},
+	}
+	result := CalcInvestmentScore(input)
+	if result.TotalScore < 0 {
+		t.Errorf("TotalScore below 0: %d", result.TotalScore)
+	}
+	if result.TotalScore > 20 {
+		t.Errorf("all negative inputs should score low, got %d", result.TotalScore)
+	}
+}
+
+func TestCalcPopulationScore_LinearInterpolation(t *testing.T) {
+	tests := []struct {
+		name  string
+		items []PopulationForecastItem
+		want  int
+	}{
+		{"増加30%", []PopulationForecastItem{{Year: 2020, Pop: 100}, {Year: 2050, Pop: 130}}, 15},
+		{"変化なし", []PopulationForecastItem{{Year: 2020, Pop: 100}, {Year: 2050, Pop: 100}}, 0},
+		{"減少50%", []PopulationForecastItem{{Year: 2020, Pop: 100}, {Year: 2050, Pop: 50}}, -15},
+		{"データなし", nil, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			item := calcPopulationScore(tt.items)
+			if item.Score != tt.want {
+				t.Errorf("calcPopulationScore() = %d, want %d", item.Score, tt.want)
+			}
+		})
+	}
+}
+
+func TestCalcRidershipScore_MaxCap(t *testing.T) {
+	riderships := []StationRidershipResult{
+		{StationName: "新宿", Passengers: 500_000},
+	}
+	item := calcRidershipScore(riderships)
+	if item.Score != 20 {
+		t.Errorf("500k passengers should give max score 20, got %d", item.Score)
+	}
+}
+
+func TestCalcLiquefactionScore_Levels(t *testing.T) {
+	tests := []struct {
+		level int
+		want  int
+	}{
+		{1, -10},
+		{2, -10},
+		{3, -5},
+		{4, -5},
+		{5, 0},
+		{6, 0},
+	}
+	for _, tt := range tests {
+		items := []LiquefactionRiskItem{{TendencyLevel: tt.level}}
+		item := calcLiquefactionScore(items)
+		if item.Score != tt.want {
+			t.Errorf("level %d: got %d, want %d", tt.level, item.Score, tt.want)
+		}
+	}
+}
+
+func TestCalcUrbanAreaScore_MarketArea(t *testing.T) {
+	market := []UrbanZoningItem{{AreaClassificationJa: "市街化区域"}}
+	if s := calcUrbanAreaScore(market); s.Score != 10 {
+		t.Errorf("市街化区域 should give +10, got %d", s.Score)
+	}
+	control := []UrbanZoningItem{{AreaClassificationJa: "市街化調整区域"}}
+	if s := calcUrbanAreaScore(control); s.Score != 0 {
+		t.Errorf("市街化調整区域 should give 0, got %d", s.Score)
+	}
+}
+
+func TestCalcHazardScore_Combined(t *testing.T) {
+	flood := []FloodHazardItem{{DepthRank: 3}}
+	storm := []StormHazardItem{{DepthJa: "5m以上"}}
+	tsunami := []TsunamiHazardItem{{DepthJa: "3m以上"}}
+	landslide := []LandslideHazardItem{{ZoneCode: 1}}
+
+	item := calcHazardScore(flood, storm, tsunami, landslide)
+	if item.Score < -20 {
+		t.Errorf("hazard score must not go below -20, got %d", item.Score)
+	}
+	if item.Score != -20 {
+		t.Errorf("all 4 hazards should give -20 (capped), got %d", item.Score)
+	}
+}

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -374,6 +374,73 @@ type DisasterHistoryItem struct {
 	Year int    // 発生年（不明時は0）
 }
 
+// UrbanZoningItem は XKT001 都市計画区域/区域区分のドメイン層受け渡し用軽量型
+type UrbanZoningItem struct {
+	AreaClassificationJa string
+	KubunID              int
+}
+
+// LiquefactionRiskItem は XKT025 液状化発生傾向図のドメイン層受け渡し用軽量型
+type LiquefactionRiskItem struct {
+	TendencyLevel int    // liquefaction_tendency_level（6段階: 低値ほど高リスク）
+	Note          string
+}
+
+// FloodHazardItem は XKT026 洪水浸水想定区域のドメイン層受け渡し用軽量型
+type FloodHazardItem struct {
+	DepthRank int    // A31a_205（浸水深ランク）
+	RiverName string
+}
+
+// StormHazardItem は XKT027 高潮浸水想定区域のドメイン層受け渡し用軽量型
+type StormHazardItem struct {
+	DepthJa string // A49_003
+}
+
+// TsunamiHazardItem は XKT028 津波浸水想定のドメイン層受け渡し用軽量型
+type TsunamiHazardItem struct {
+	DepthJa string // A40_003
+}
+
+// LandslideHazardItem は XKT029 土砂災害警戒区域のドメイン層受け渡し用軽量型
+type LandslideHazardItem struct {
+	PhenomenonType int // A33_001（1=急傾斜地崩壊, 2=土石流, 3=地すべり）
+	ZoneCode       int // A33_002（1=特別警戒区域, 2=警戒区域）
+}
+
+// InvestmentScoreResult は投資適地スコアの算出結果
+type InvestmentScoreResult struct {
+	TotalScore int            `json:"totalScore"`
+	Grade      string         `json:"grade"` // 優良/良好/普通/注意/要注意
+	Breakdown  ScoreBreakdown `json:"breakdown"`
+}
+
+// ScoreItem は各指標のスコアと説明
+type ScoreItem struct {
+	Score       int    `json:"score"`
+	Label       string `json:"label"`
+	Description string `json:"description"`
+}
+
+// RadarPoint はレーダーチャート用の正規化スコア（0〜100）
+type RadarPoint struct {
+	Category string  `json:"category"`
+	Score    float64 `json:"score"`
+}
+
+// ScoreBreakdown は投資適地スコアの内訳
+type ScoreBreakdown struct {
+	Population       ScoreItem    `json:"population"`
+	Ridership        ScoreItem    `json:"ridership"`
+	UrbanArea        ScoreItem    `json:"urbanArea"`
+	LocationOpt      ScoreItem    `json:"locationOptimization"`
+	HazardRisk       ScoreItem    `json:"hazardRisk"`
+	LiquefactionRisk ScoreItem    `json:"liquefactionRisk"`
+	Embankment       ScoreItem    `json:"embankment"`
+	DisasterHistory  ScoreItem    `json:"disasterHistory"`
+	RadarData        []RadarPoint `json:"radarData"`
+}
+
 // ZoningSummary はエリア内の取引から抽出した代表的な用途地域情報
 type ZoningSummary struct {
 	CityPlanning     string `json:"cityPlanning"`     // 最頻の都市計画区域（例: 第一種住居地域）

--- a/backend/internal/mlit/cache.go
+++ b/backend/internal/mlit/cache.go
@@ -28,6 +28,12 @@ type cache struct {
 	embankmentEntries          map[string]embankmentCacheEntry
 	urbanRoadEntries           map[string]urbanRoadCacheEntry
 	disasterEntries            map[string]disasterCacheEntry
+	urbanZoningEntries         map[string]urbanZoningCacheEntry
+	liquefactionEntries        map[string]liquefactionCacheEntry
+	floodHazardEntries         map[string]floodHazardCacheEntry
+	stormHazardEntries         map[string]stormHazardCacheEntry
+	tsunamiHazardEntries       map[string]tsunamiHazardCacheEntry
+	landslideHazardEntries     map[string]landslideHazardCacheEntry
 }
 
 func newCache() *cache {
@@ -41,6 +47,12 @@ func newCache() *cache {
 		embankmentEntries:          make(map[string]embankmentCacheEntry),
 		urbanRoadEntries:           make(map[string]urbanRoadCacheEntry),
 		disasterEntries:            make(map[string]disasterCacheEntry),
+		urbanZoningEntries:         make(map[string]urbanZoningCacheEntry),
+		liquefactionEntries:        make(map[string]liquefactionCacheEntry),
+		floodHazardEntries:         make(map[string]floodHazardCacheEntry),
+		stormHazardEntries:         make(map[string]stormHazardCacheEntry),
+		tsunamiHazardEntries:       make(map[string]tsunamiHazardCacheEntry),
+		landslideHazardEntries:     make(map[string]landslideHazardCacheEntry),
 	}
 }
 
@@ -350,6 +362,186 @@ func (c *cache) setDisaster(key string, data []domain.DisasterHistoryItem) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.disasterEntries[key] = disasterCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+}
+
+// urbanZoningCacheEntry は都市計画区域/区域区分キャッシュの1エントリ
+type urbanZoningCacheEntry struct {
+	data      []domain.UrbanZoningItem
+	expiresAt time.Time
+}
+
+func (c *cache) getUrbanZoning(key string) ([]domain.UrbanZoningItem, bool) {
+	c.mu.RLock()
+	entry, ok := c.urbanZoningEntries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		c.mu.Lock()
+		delete(c.urbanZoningEntries, key)
+		c.mu.Unlock()
+		return nil, false
+	}
+	copied := make([]domain.UrbanZoningItem, len(entry.data))
+	copy(copied, entry.data)
+	return copied, true
+}
+
+func (c *cache) setUrbanZoning(key string, data []domain.UrbanZoningItem) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.urbanZoningEntries[key] = urbanZoningCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+}
+
+// liquefactionCacheEntry は液状化発生傾向図キャッシュの1エントリ
+type liquefactionCacheEntry struct {
+	data      []domain.LiquefactionRiskItem
+	expiresAt time.Time
+}
+
+func (c *cache) getLiquefaction(key string) ([]domain.LiquefactionRiskItem, bool) {
+	c.mu.RLock()
+	entry, ok := c.liquefactionEntries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		c.mu.Lock()
+		delete(c.liquefactionEntries, key)
+		c.mu.Unlock()
+		return nil, false
+	}
+	copied := make([]domain.LiquefactionRiskItem, len(entry.data))
+	copy(copied, entry.data)
+	return copied, true
+}
+
+func (c *cache) setLiquefaction(key string, data []domain.LiquefactionRiskItem) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.liquefactionEntries[key] = liquefactionCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+}
+
+// floodHazardCacheEntry は洪水浸水想定区域キャッシュの1エントリ
+type floodHazardCacheEntry struct {
+	data      []domain.FloodHazardItem
+	expiresAt time.Time
+}
+
+func (c *cache) getFloodHazard(key string) ([]domain.FloodHazardItem, bool) {
+	c.mu.RLock()
+	entry, ok := c.floodHazardEntries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		c.mu.Lock()
+		delete(c.floodHazardEntries, key)
+		c.mu.Unlock()
+		return nil, false
+	}
+	copied := make([]domain.FloodHazardItem, len(entry.data))
+	copy(copied, entry.data)
+	return copied, true
+}
+
+func (c *cache) setFloodHazard(key string, data []domain.FloodHazardItem) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.floodHazardEntries[key] = floodHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+}
+
+// stormHazardCacheEntry は高潮浸水想定区域キャッシュの1エントリ
+type stormHazardCacheEntry struct {
+	data      []domain.StormHazardItem
+	expiresAt time.Time
+}
+
+func (c *cache) getStormHazard(key string) ([]domain.StormHazardItem, bool) {
+	c.mu.RLock()
+	entry, ok := c.stormHazardEntries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		c.mu.Lock()
+		delete(c.stormHazardEntries, key)
+		c.mu.Unlock()
+		return nil, false
+	}
+	copied := make([]domain.StormHazardItem, len(entry.data))
+	copy(copied, entry.data)
+	return copied, true
+}
+
+func (c *cache) setStormHazard(key string, data []domain.StormHazardItem) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.stormHazardEntries[key] = stormHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+}
+
+// tsunamiHazardCacheEntry は津波浸水想定キャッシュの1エントリ
+type tsunamiHazardCacheEntry struct {
+	data      []domain.TsunamiHazardItem
+	expiresAt time.Time
+}
+
+func (c *cache) getTsunamiHazard(key string) ([]domain.TsunamiHazardItem, bool) {
+	c.mu.RLock()
+	entry, ok := c.tsunamiHazardEntries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		c.mu.Lock()
+		delete(c.tsunamiHazardEntries, key)
+		c.mu.Unlock()
+		return nil, false
+	}
+	copied := make([]domain.TsunamiHazardItem, len(entry.data))
+	copy(copied, entry.data)
+	return copied, true
+}
+
+func (c *cache) setTsunamiHazard(key string, data []domain.TsunamiHazardItem) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.tsunamiHazardEntries[key] = tsunamiHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+}
+
+// landslideHazardCacheEntry は土砂災害警戒区域キャッシュの1エントリ
+type landslideHazardCacheEntry struct {
+	data      []domain.LandslideHazardItem
+	expiresAt time.Time
+}
+
+func (c *cache) getLandslideHazard(key string) ([]domain.LandslideHazardItem, bool) {
+	c.mu.RLock()
+	entry, ok := c.landslideHazardEntries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if time.Now().After(entry.expiresAt) {
+		c.mu.Lock()
+		delete(c.landslideHazardEntries, key)
+		c.mu.Unlock()
+		return nil, false
+	}
+	copied := make([]domain.LandslideHazardItem, len(entry.data))
+	copy(copied, entry.data)
+	return copied, true
+}
+
+func (c *cache) setLandslideHazard(key string, data []domain.LandslideHazardItem) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.landslideHazardEntries[key] = landslideHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // cacheKey は LandPriceQuery からキャッシュキーを生成する。

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -38,6 +38,12 @@ const (
 	endpointEmbankment             = "/XKT020"
 	endpointUrbanRoad              = "/XKT030"
 	endpointDisasterHistory        = "/XST001"
+	endpointUrbanZoning            = "/XKT001"
+	endpointLiquefaction           = "/XKT025"
+	endpointFloodHazard            = "/XKT026"
+	endpointStormHazard            = "/XKT027"
+	endpointTsunamiHazard          = "/XKT028"
+	endpointLandslideHazard        = "/XKT029"
 
 	requestTimeout = 30 * time.Second
 
@@ -873,6 +879,132 @@ func (c *Client) FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domai
 		})
 	}
 	c.cache.setDisaster(key, result)
+	return result, nil
+}
+
+// FetchUrbanZoning はタイル座標で XKT001 を呼び出し都市計画区域/区域区分情報を取得する。
+// キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
+func (c *Client) FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.UrbanZoningItem, error) {
+	key := fmt.Sprintf("urban_zoning:%d:%d:%d", z, x, y)
+	if cached, ok := c.cache.getUrbanZoning(key); ok {
+		return cached, nil
+	}
+	var geoResp UrbanZoningGeoJSON
+	if err := c.fetchTileGeoJSON(ctx, endpointUrbanZoning, z, x, y, &geoResp); err != nil {
+		return nil, err
+	}
+	result := make([]domain.UrbanZoningItem, 0, len(geoResp.Features))
+	for _, f := range geoResp.Features {
+		result = append(result, domain.UrbanZoningItem{
+			AreaClassificationJa: f.Properties.AreaClassificationJa,
+			KubunID:              f.Properties.KubunID,
+		})
+	}
+	c.cache.setUrbanZoning(key, result)
+	return result, nil
+}
+
+// FetchLiquefaction はタイル座標で XKT025 を呼び出し液状化発生傾向情報を取得する。
+// キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
+func (c *Client) FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.LiquefactionRiskItem, error) {
+	key := fmt.Sprintf("liquefaction:%d:%d:%d", z, x, y)
+	if cached, ok := c.cache.getLiquefaction(key); ok {
+		return cached, nil
+	}
+	var geoResp LiquefactionGeoJSON
+	if err := c.fetchTileGeoJSON(ctx, endpointLiquefaction, z, x, y, &geoResp); err != nil {
+		return nil, err
+	}
+	result := make([]domain.LiquefactionRiskItem, 0, len(geoResp.Features))
+	for _, f := range geoResp.Features {
+		result = append(result, domain.LiquefactionRiskItem{
+			TendencyLevel: f.Properties.LiquefactionTendencyLevel,
+			Note:          f.Properties.Note,
+		})
+	}
+	c.cache.setLiquefaction(key, result)
+	return result, nil
+}
+
+// FetchFloodHazard はタイル座標で XKT026 を呼び出し洪水浸水想定区域情報を取得する。
+// キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
+func (c *Client) FetchFloodHazard(ctx context.Context, z, x, y int) ([]domain.FloodHazardItem, error) {
+	key := fmt.Sprintf("flood_hazard:%d:%d:%d", z, x, y)
+	if cached, ok := c.cache.getFloodHazard(key); ok {
+		return cached, nil
+	}
+	var geoResp FloodHazardGeoJSON
+	if err := c.fetchTileGeoJSON(ctx, endpointFloodHazard, z, x, y, &geoResp); err != nil {
+		return nil, err
+	}
+	result := make([]domain.FloodHazardItem, 0, len(geoResp.Features))
+	for _, f := range geoResp.Features {
+		result = append(result, domain.FloodHazardItem{
+			DepthRank: f.Properties.DepthRank,
+			RiverName: f.Properties.RiverName,
+		})
+	}
+	c.cache.setFloodHazard(key, result)
+	return result, nil
+}
+
+// FetchStormHazard はタイル座標で XKT027 を呼び出し高潮浸水想定区域情報を取得する。
+// キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
+func (c *Client) FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.StormHazardItem, error) {
+	key := fmt.Sprintf("storm_hazard:%d:%d:%d", z, x, y)
+	if cached, ok := c.cache.getStormHazard(key); ok {
+		return cached, nil
+	}
+	var geoResp StormHazardGeoJSON
+	if err := c.fetchTileGeoJSON(ctx, endpointStormHazard, z, x, y, &geoResp); err != nil {
+		return nil, err
+	}
+	result := make([]domain.StormHazardItem, 0, len(geoResp.Features))
+	for _, f := range geoResp.Features {
+		result = append(result, domain.StormHazardItem{DepthJa: f.Properties.DepthJa})
+	}
+	c.cache.setStormHazard(key, result)
+	return result, nil
+}
+
+// FetchTsunamiHazard はタイル座標で XKT028 を呼び出し津波浸水想定情報を取得する。
+// キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
+func (c *Client) FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.TsunamiHazardItem, error) {
+	key := fmt.Sprintf("tsunami_hazard:%d:%d:%d", z, x, y)
+	if cached, ok := c.cache.getTsunamiHazard(key); ok {
+		return cached, nil
+	}
+	var geoResp TsunamiHazardGeoJSON
+	if err := c.fetchTileGeoJSON(ctx, endpointTsunamiHazard, z, x, y, &geoResp); err != nil {
+		return nil, err
+	}
+	result := make([]domain.TsunamiHazardItem, 0, len(geoResp.Features))
+	for _, f := range geoResp.Features {
+		result = append(result, domain.TsunamiHazardItem{DepthJa: f.Properties.DepthJa})
+	}
+	c.cache.setTsunamiHazard(key, result)
+	return result, nil
+}
+
+// FetchLandslideHazard はタイル座標で XKT029 を呼び出し土砂災害警戒区域情報を取得する。
+// キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
+func (c *Client) FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domain.LandslideHazardItem, error) {
+	key := fmt.Sprintf("landslide_hazard:%d:%d:%d", z, x, y)
+	if cached, ok := c.cache.getLandslideHazard(key); ok {
+		return cached, nil
+	}
+	var geoResp LandslideHazardGeoJSON
+	if err := c.fetchTileGeoJSON(ctx, endpointLandslideHazard, z, x, y, &geoResp); err != nil {
+		return nil, err
+	}
+	result := make([]domain.LandslideHazardItem, 0, len(geoResp.Features))
+	for _, f := range geoResp.Features {
+		result = append(result, domain.LandslideHazardItem{
+			PhenomenonType: f.Properties.PhenomenonType,
+			ZoneCode:       f.Properties.ZoneCode,
+		})
+	}
+	c.cache.setLandslideHazard(key, result)
 	return result, nil
 }
 

--- a/backend/internal/mlit/types.go
+++ b/backend/internal/mlit/types.go
@@ -239,6 +239,118 @@ type DisasterHistoryProperties struct {
 	DisasterSource   string `json:"disaster_source"`
 }
 
+// UrbanZoningGeoJSON は XKT001 都市計画区域/区域区分APIのGeoJSONレスポンス
+type UrbanZoningGeoJSON struct {
+	Type     string              `json:"type"`
+	Features []UrbanZoningFeature `json:"features"`
+}
+
+// UrbanZoningFeature は GeoJSON の1フィーチャ
+type UrbanZoningFeature struct {
+	Properties UrbanZoningProperties `json:"properties"`
+}
+
+// UrbanZoningProperties は都市計画区域/区域区分の属性。フィールド名は国交省 XKT001 仕様に準拠。
+type UrbanZoningProperties struct {
+	AreaClassificationJa string `json:"area_classification_ja"` // 例: "市街化区域"、"市街化調整区域"
+	KubunID              int    `json:"kubun_id"`
+	Prefecture           string `json:"prefecture"`
+	CityCode             string `json:"city_code"`
+	CityName             string `json:"city_name"`
+}
+
+// LiquefactionGeoJSON は XKT025 液状化発生傾向図APIのGeoJSONレスポンス
+type LiquefactionGeoJSON struct {
+	Type     string               `json:"type"`
+	Features []LiquefactionFeature `json:"features"`
+}
+
+// LiquefactionFeature は GeoJSON の1フィーチャ
+type LiquefactionFeature struct {
+	Properties LiquefactionProperties `json:"properties"`
+}
+
+// LiquefactionProperties は液状化発生傾向図の属性。フィールド名は国交省 XKT025 仕様に準拠。
+type LiquefactionProperties struct {
+	LiquefactionTendencyLevel int    `json:"liquefaction_tendency_level"` // 6段階（低値ほど液状化リスク高）
+	Note                      string `json:"note"`                        // 例: "液状化しにくい"
+	MeshCode                  string `json:"mesh_code"`
+}
+
+// FloodHazardGeoJSON は XKT026 洪水浸水想定区域APIのGeoJSONレスポンス
+type FloodHazardGeoJSON struct {
+	Type     string             `json:"type"`
+	Features []FloodHazardFeature `json:"features"`
+}
+
+// FloodHazardFeature は GeoJSON の1フィーチャ
+type FloodHazardFeature struct {
+	Properties FloodHazardProperties `json:"properties"`
+}
+
+// FloodHazardProperties は洪水浸水想定区域の属性。フィールド名は国交省 XKT026 仕様に準拠。
+type FloodHazardProperties struct {
+	DepthRank    int    `json:"A31a_205"` // 浸水深ランク（高いほど深い）
+	RiverName    string `json:"A31a_202"` // 河川名
+	RiverManager string `json:"A31a_204"` // 河川管理者
+}
+
+// StormHazardGeoJSON は XKT027 高潮浸水想定区域APIのGeoJSONレスポンス
+type StormHazardGeoJSON struct {
+	Type     string              `json:"type"`
+	Features []StormHazardFeature `json:"features"`
+}
+
+// StormHazardFeature は GeoJSON の1フィーチャ
+type StormHazardFeature struct {
+	Properties StormHazardProperties `json:"properties"`
+}
+
+// StormHazardProperties は高潮浸水想定区域の属性。フィールド名は国交省 XKT027 仕様に準拠。
+type StormHazardProperties struct {
+	DepthJa    string `json:"A49_003"`    // 浸水深区分（例: "5m以上10m未満"）
+	Prefecture string `json:"A49_001"`    // 都道府県名
+	TargetYear int    `json:"target_year"`
+}
+
+// TsunamiHazardGeoJSON は XKT028 津波浸水想定APIのGeoJSONレスポンス
+type TsunamiHazardGeoJSON struct {
+	Type     string               `json:"type"`
+	Features []TsunamiHazardFeature `json:"features"`
+}
+
+// TsunamiHazardFeature は GeoJSON の1フィーチャ
+type TsunamiHazardFeature struct {
+	Properties TsunamiHazardProperties `json:"properties"`
+}
+
+// TsunamiHazardProperties は津波浸水想定の属性。フィールド名は国交省 XKT028 仕様に準拠。
+type TsunamiHazardProperties struct {
+	DepthJa    string `json:"A40_003"`    // 津波浸水深区分（例: "3m以上～5m未満"）
+	Prefecture string `json:"A40_001"`    // 都道府県名
+	TargetYear int    `json:"target_year"`
+}
+
+// LandslideHazardGeoJSON は XKT029 土砂災害警戒区域APIのGeoJSONレスポンス
+type LandslideHazardGeoJSON struct {
+	Type     string                 `json:"type"`
+	Features []LandslideHazardFeature `json:"features"`
+}
+
+// LandslideHazardFeature は GeoJSON の1フィーチャ
+type LandslideHazardFeature struct {
+	Properties LandslideHazardProperties `json:"properties"`
+}
+
+// LandslideHazardProperties は土砂災害警戒区域の属性。フィールド名は国交省 XKT029 仕様に準拠。
+type LandslideHazardProperties struct {
+	PhenomenonType  int    `json:"A33_001"` // 現象種類（1=急傾斜地崩壊, 2=土石流, 3=地すべり）
+	ZoneCode        int    `json:"A33_002"` // 区域区分（1=特別警戒区域, 2=警戒区域）
+	PrefectureCode  string `json:"A33_003"` // 都道府県コード
+	ZoneNumber      string `json:"A33_004"` // 区域番号
+	SpecialZoneFlag int    `json:"A33_008"` // 特別警戒未指定フラグ
+}
+
 // Prefectures は都道府県コードマップ
 var Prefectures = map[string]string{
 	"01": "北海道", "02": "青森県", "03": "岩手県", "04": "宮城県",

--- a/docs/mlit-api-integration.md
+++ b/docs/mlit-api-integration.md
@@ -987,3 +987,259 @@ type DisasterHistoryFeatureProps struct {
     DisasterSource   string `json:"disaster_source"`
 }
 ```
+
+---
+
+## XKT001 都市計画区域/区域区分API
+
+### エンドポイント（タイル座標形式）
+
+```
+GET /ex-api/external/XKT001?response_format=geojson&z={z}&x={x}&y={y}
+```
+
+| パラメータ | 必須 | 説明 |
+|-----------|------|------|
+| `response_format` | ○ | `"geojson"` 固定 |
+| `z` | ○ | ズームレベル 11〜15 |
+| `x` / `y` | ○ | WebMercator タイル座標 |
+
+### GeoJSONレスポンス フィールド
+
+| フィールド名 | 型 | 説明 | 例 |
+|------------|----|----|-----|
+| `area_classification_ja` | string | 区域区分名 | "市街化区域"、"市街化調整区域" |
+| `kubun_id` | int | 区分コード | 21 |
+| `prefecture` | string | 都道府県名 | 北海道 |
+| `city_code` | string | 市区町村コード | 01100 |
+| `city_name` | string | 市区町村名 | 札幌市 |
+| `decision_date` | string | 設定年月日 | - |
+| `decision_classification` | string | 設定区分 | - |
+| `decision_maker` | string | 設定者名 | - |
+| `notice_number` | string | 告示番号 | - |
+| `first_decision_date` | string | 当初決定日 | - |
+| `notice_number_s` | string | 告示番号（当初） | - |
+
+### リスク判定方針
+
+- `area_classification_ja` が "市街化区域" を含み "調整" を含まない → 投資適地スコア +10点
+- それ以外 → 0点
+
+### 型定義
+
+```go
+type UrbanZoningProperties struct {
+    AreaClassificationJa string `json:"area_classification_ja"`
+    KubunID              int    `json:"kubun_id"`
+    Prefecture           string `json:"prefecture"`
+    CityCode             string `json:"city_code"`
+    CityName             string `json:"city_name"`
+}
+```
+
+---
+
+## XKT025 液状化発生傾向図API
+
+### エンドポイント（タイル座標形式）
+
+```
+GET /ex-api/external/XKT025?response_format=geojson&z={z}&x={x}&y={y}
+```
+
+| パラメータ | 必須 | 説明 |
+|-----------|------|------|
+| `response_format` | ○ | `"geojson"` 固定 |
+| `z` | ○ | ズームレベル 11〜15 |
+| `x` / `y` | ○ | WebMercator タイル座標 |
+
+### GeoJSONレスポンス フィールド
+
+| フィールド名 | 型 | 説明 | 例 |
+|------------|----|----|-----|
+| `liquefaction_tendency_level` | int | 液状化発生傾向（6段階: 低値ほど高リスク） | 5 |
+| `note` | string | 傾向説明 | "液状化しにくい" |
+| `mesh_code` | string | メッシュコード | "5339359931" |
+| `topographic_classification_code` | int | 微地形区分コード（28区分） | 9 |
+| `topographic_classification_name_ja` | string | 微地形区分名称 | "ローム台地" |
+
+### リスク判定方針
+
+- `liquefaction_tendency_level` ≤ 2 → −10点（非常に高リスク）
+- `liquefaction_tendency_level` ≤ 4 → −5点（中程度リスク）
+- `liquefaction_tendency_level` ≥ 5 → 0点（低リスク）
+
+### 型定義
+
+```go
+type LiquefactionProperties struct {
+    LiquefactionTendencyLevel int    `json:"liquefaction_tendency_level"`
+    Note                      string `json:"note"`
+    MeshCode                  string `json:"mesh_code"`
+}
+```
+
+---
+
+## XKT026 洪水浸水想定区域API
+
+### エンドポイント（タイル座標形式）
+
+```
+GET /ex-api/external/XKT026?response_format=geojson&z={z}&x={x}&y={y}
+```
+
+| パラメータ | 必須 | 説明 |
+|-----------|------|------|
+| `response_format` | ○ | `"geojson"` 固定 |
+| `z` | ○ | ズームレベル 14〜15 |
+| `x` / `y` | ○ | WebMercator タイル座標 |
+
+### GeoJSONレスポンス フィールド
+
+| フィールド名 | 型 | 説明 | 例 |
+|------------|----|----|-----|
+| `A31a_205` | int | 浸水深ランク（高いほど深い） | 1 |
+| `A31a_202` | string | 河川名 | 庄川 |
+| `A31a_201` | string | 河川番号 | 8404090001 |
+| `A31a_203` | string | 河川管理番号 | 84 |
+| `A31a_204` | string | 河川管理者 | 北陸地方整備局 |
+
+### リスク判定方針
+
+- `A31a_205` ≥ 3 → −5点（深刻な洪水リスク）
+- `A31a_205` ≥ 1 → −3点（洪水リスクあり）
+
+### 型定義
+
+```go
+type FloodHazardProperties struct {
+    DepthRank    int    `json:"A31a_205"`
+    RiverName    string `json:"A31a_202"`
+    RiverManager string `json:"A31a_204"`
+}
+```
+
+---
+
+## XKT027 高潮浸水想定区域API
+
+### エンドポイント（タイル座標形式）
+
+```
+GET /ex-api/external/XKT027?response_format=geojson&z={z}&x={x}&y={y}
+```
+
+| パラメータ | 必須 | 説明 |
+|-----------|------|------|
+| `response_format` | ○ | `"geojson"` 固定 |
+| `z` | ○ | ズームレベル 13〜15 |
+| `x` / `y` | ○ | WebMercator タイル座標 |
+
+### GeoJSONレスポンス フィールド
+
+| フィールド名 | 型 | 説明 | 例 |
+|------------|----|----|-----|
+| `A49_003` | string | 浸水深区分 | "5m以上10m未満" |
+| `A49_001` | string | 都道府県名 | 三重県 |
+| `A49_002` | string | 都道府県コード | 24 |
+| `target_year` | int | 対象年 | 2021 |
+
+### リスク判定方針
+
+- フィーチャが1件以上存在 → −5点（高潮リスクあり）
+
+### 型定義
+
+```go
+type StormHazardProperties struct {
+    DepthJa    string `json:"A49_003"`
+    Prefecture string `json:"A49_001"`
+    TargetYear int    `json:"target_year"`
+}
+```
+
+---
+
+## XKT028 津波浸水想定API
+
+### エンドポイント（タイル座標形式）
+
+```
+GET /ex-api/external/XKT028?response_format=geojson&z={z}&x={x}&y={y}
+```
+
+| パラメータ | 必須 | 説明 |
+|-----------|------|------|
+| `response_format` | ○ | `"geojson"` 固定 |
+| `z` | ○ | ズームレベル 14〜15 |
+| `x` / `y` | ○ | WebMercator タイル座標 |
+
+### GeoJSONレスポンス フィールド
+
+| フィールド名 | 型 | 説明 | 例 |
+|------------|----|----|-----|
+| `A40_003` | string | 津波浸水深区分 | "3m以上～5m未満" |
+| `A40_001` | string | 都道府県名 | 東京都 |
+| `A40_002` | string | 都道府県コード | 13 |
+| `target_year` | int | 対象年 | 2023 |
+
+### リスク判定方針
+
+- フィーチャが1件以上存在 → −5点（津波リスクあり）
+
+### 型定義
+
+```go
+type TsunamiHazardProperties struct {
+    DepthJa    string `json:"A40_003"`
+    Prefecture string `json:"A40_001"`
+    TargetYear int    `json:"target_year"`
+}
+```
+
+---
+
+## XKT029 土砂災害警戒区域API
+
+### エンドポイント（タイル座標形式）
+
+```
+GET /ex-api/external/XKT029?response_format=geojson&z={z}&x={x}&y={y}
+```
+
+| パラメータ | 必須 | 説明 |
+|-----------|------|------|
+| `response_format` | ○ | `"geojson"` 固定 |
+| `z` | ○ | ズームレベル 11〜15 |
+| `x` / `y` | ○ | WebMercator タイル座標 |
+
+### GeoJSONレスポンス フィールド
+
+| フィールド名 | 型 | 説明 | 例 |
+|------------|----|----|-----|
+| `A33_001` | int | 現象種類（1=急傾斜地崩壊, 2=土石流, 3=地すべり） | 1 |
+| `A33_002` | int | 区域区分（1=特別警戒区域, 2=警戒区域） | 1 |
+| `A33_003` | string | 都道府県コード | 34 |
+| `A33_004` | string | 区域番号 | Ⅱ-1-4279-1 |
+| `A33_005` | string | 区域名 | 才ノ原1543(4279-1) |
+| `A33_006` | string | 所在地 | 広島市安佐北区 |
+| `A33_007` | string | 公示日 | 2018/03/15 |
+| `A33_008` | int | 特別警戒未指定フラグ | 0 |
+
+### リスク判定方針
+
+- `A33_002` == 1（特別警戒区域） → −5点
+- `A33_002` == 2（警戒区域） → −3点
+
+### 型定義
+
+```go
+type LandslideHazardProperties struct {
+    PhenomenonType  int    `json:"A33_001"`
+    ZoneCode        int    `json:"A33_002"`
+    PrefectureCode  string `json:"A33_003"`
+    ZoneNumber      string `json:"A33_004"`
+    SpecialZoneFlag int    `json:"A33_008"`
+}
+```

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -10,8 +10,9 @@ import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
 import CostBreakdown from "@/components/CostBreakdown";
 import { LoanOptimizationPanel } from "@/components/LoanOptimizationPanel";
 import RenovationPanel from "@/components/RenovationPanel";
-import type { InvestmentInput, InvestmentResult, LandPriceComparison, TheoreticalPriceResult, StationRidershipResult, PopulationForecastResult, AppraisalComparisonResult, UrbanRisk, SimulationMode, LoanMethod, MonteCarloResult } from "@/types/investment";
-import { analyze, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks, simulate } from "@/lib/api";
+import type { InvestmentInput, InvestmentResult, LandPriceComparison, TheoreticalPriceResult, StationRidershipResult, PopulationForecastResult, AppraisalComparisonResult, UrbanRisk, SimulationMode, LoanMethod, MonteCarloResult, InvestmentScoreResult } from "@/types/investment";
+import { analyze, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks, fetchInvestmentScore, simulate } from "@/lib/api";
+import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
 import { ShieldAlert, Info, FileDown, Share2, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
@@ -46,6 +47,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   const [populationForecast, setPopulationForecast] = useState<PopulationForecastResult | null>(null);
   const [landAppraisal, setLandAppraisal] = useState<AppraisalComparisonResult | null>(null);
   const [externalUrbanRisks, setExternalUrbanRisks] = useState<UrbanRisk[] | null>(null);
+  const [investmentScore, setInvestmentScore] = useState<InvestmentScoreResult | null>(null);
   const [simulationMode, setSimulationMode] = useState<SimulationMode>(
     decoded?.mode ?? "quick"
   );
@@ -133,6 +135,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
     setPopulationForecast(null);
     setLandAppraisal(null);
     setExternalUrbanRisks(null);
+    setInvestmentScore(null);
     const { year, quarter, toYear, toQuarter } = getCurrentPeriods();
     try {
       const baseParams = {
@@ -166,14 +169,16 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
       setLandAppraisal(appraisal.status === "fulfilled" ? appraisal.value : null);
 
       if (lat !== undefined && lng !== undefined) {
-        const [ridership, population, urbanRisks] = await Promise.allSettled([
+        const [ridership, population, urbanRisks, scoreResult] = await Promise.allSettled([
           fetchStationRidership({ lat, lng }),
           fetchPopulationForecast({ lat, lng }),
           fetchUrbanRisks(lat, lng),
+          fetchInvestmentScore({ lat, lng }),
         ]);
         setStationRidership(ridership.status === "fulfilled" ? ridership.value : null);
         setPopulationForecast(population.status === "fulfilled" ? population.value : null);
         setExternalUrbanRisks(urbanRisks.status === "fulfilled" ? urbanRisks.value : null);
+        setInvestmentScore(scoreResult.status === "fulfilled" ? scoreResult.value : null);
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "相場データの取得に失敗しました。しばらく後に再試行してください");
@@ -278,6 +283,8 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                 </div>
               </div>
             )}
+
+            {investmentScore && <InvestmentScoreCard score={investmentScore} />}
 
             {comparison && <LandPriceAnalysis comparison={comparison} input={lastInput} theoreticalPrice={theoreticalPrice} stationRidership={stationRidership} populationForecast={populationForecast} landAppraisal={landAppraisal} externalUrbanRisks={externalUrbanRisks} />}
 

--- a/frontend/src/components/InvestmentScoreCard.tsx
+++ b/frontend/src/components/InvestmentScoreCard.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import {
+  Radar,
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import type { InvestmentScoreResult, ScoreItem } from "@/types/investment";
+
+interface Props {
+  score: InvestmentScoreResult;
+}
+
+const GRADE_STYLE: Record<string, { badge: "success" | "default" | "warning" | "danger"; color: string }> = {
+  優良: { badge: "success", color: "text-green-600" },
+  良好: { badge: "default", color: "text-blue-600" },
+  普通: { badge: "warning", color: "text-yellow-600" },
+  注意: { badge: "warning", color: "text-orange-600" },
+  要注意: { badge: "danger", color: "text-red-600" },
+};
+
+function ScoreRow({ item }: { item: ScoreItem }) {
+  const isPositive = item.score > 0;
+  const isNegative = item.score < 0;
+  return (
+    <div className="flex items-start justify-between gap-2 py-1 text-xs border-b border-gray-100 last:border-0">
+      <span className="text-gray-600 min-w-[6rem]">{item.label}</span>
+      <span
+        className={`font-semibold tabular-nums min-w-[3rem] text-right ${
+          isPositive ? "text-green-600" : isNegative ? "text-red-600" : "text-gray-500"
+        }`}
+      >
+        {isPositive ? `+${item.score}` : item.score}
+      </span>
+      <span className="text-gray-500 flex-1 text-right leading-tight">{item.description}</span>
+    </div>
+  );
+}
+
+export function InvestmentScoreCard({ score }: Props) {
+  const { totalScore, grade, breakdown } = score;
+  const gradeStyle = GRADE_STYLE[grade] ?? GRADE_STYLE["普通"];
+
+  const items: ScoreItem[] = [
+    breakdown.population,
+    breakdown.ridership,
+    breakdown.urbanArea,
+    breakdown.locationOptimization,
+    breakdown.hazardRisk,
+    breakdown.liquefactionRisk,
+    breakdown.embankment,
+    breakdown.disasterHistory,
+  ];
+
+  return (
+    <Card className="border border-indigo-200">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center justify-between text-sm font-semibold text-indigo-900">
+          <span>投資適地スコア（XKT013/015/001/003/025〜029/020/XST001）</span>
+          <div className="flex items-center gap-2">
+            <span className={`text-3xl font-bold tabular-nums ${gradeStyle.color}`}>
+              {totalScore}
+            </span>
+            <span className="text-gray-400 text-sm font-normal">/ 100</span>
+            <Badge variant={gradeStyle.badge}>{grade}</Badge>
+          </div>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="pt-0">
+        {breakdown.radarData.length > 0 && (
+          <div className="h-48 w-full mb-3">
+            <ResponsiveContainer width="100%" height="100%">
+              <RadarChart data={breakdown.radarData} margin={{ top: 8, right: 24, left: 24, bottom: 8 }}>
+                <PolarGrid stroke="#e0e7ff" />
+                <PolarAngleAxis
+                  dataKey="category"
+                  tick={{ fontSize: 10, fill: "#4338ca" }}
+                />
+                <Radar
+                  name="スコア"
+                  dataKey="score"
+                  stroke="#6366f1"
+                  fill="#6366f1"
+                  fillOpacity={0.25}
+                  strokeWidth={2}
+                />
+              </RadarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+        <div className="space-y-0">
+          {items.map((item) => (
+            <ScoreRow key={item.label} item={item} />
+          ))}
+        </div>
+        <p className="mt-2 text-[10px] text-gray-400 leading-tight">
+          基準スコア50点 + 各指標の加減点（0〜100にクランプ）。API取得失敗時は該当指標を0点として算出。
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   RenovationResult,
   MonteCarloInput,
   MonteCarloResult,
+  InvestmentScoreResult,
 } from "@/types/investment";
 
 const BASE = "/api";
@@ -191,7 +192,7 @@ export async function analyzeRenovation(input: RenovationInput): Promise<Renovat
 export async function fetchInvestmentScore(params: {
   lat: number;
   lng: number;
-}): Promise<import("@/types/investment").InvestmentScoreResult> {
+}): Promise<InvestmentScoreResult> {
   const p = new URLSearchParams({
     lat: String(params.lat),
     lng: String(params.lng),

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -187,6 +187,19 @@ export async function analyzeRenovation(input: RenovationInput): Promise<Renovat
   return handleResponse<RenovationResult>(res);
 }
 
+/** 投資適地スコアを取得 */
+export async function fetchInvestmentScore(params: {
+  lat: number;
+  lng: number;
+}): Promise<import("@/types/investment").InvestmentScoreResult> {
+  const p = new URLSearchParams({
+    lat: String(params.lat),
+    lng: String(params.lng),
+  });
+  const res = await fetch(`${BASE}/investment-score?${p}`);
+  return handleResponse(res);
+}
+
 /** モンテカルロシミュレーションを実行 */
 export async function simulate(input: MonteCarloInput): Promise<MonteCarloResult> {
   const res = await fetch(`${BASE}/investment/simulate`, {

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -354,6 +354,35 @@ export interface RenovationResult {
   classifiedItems: ClassifiedRenovationItem[];
 }
 
+export interface ScoreItem {
+  score: number;
+  label: string;
+  description: string;
+}
+
+export interface RadarPoint {
+  category: string;
+  score: number;
+}
+
+export interface ScoreBreakdown {
+  population: ScoreItem;
+  ridership: ScoreItem;
+  urbanArea: ScoreItem;
+  locationOptimization: ScoreItem;
+  hazardRisk: ScoreItem;
+  liquefactionRisk: ScoreItem;
+  embankment: ScoreItem;
+  disasterHistory: ScoreItem;
+  radarData: RadarPoint[];
+}
+
+export interface InvestmentScoreResult {
+  totalScore: number;
+  grade: string;
+  breakdown: ScoreBreakdown;
+}
+
 export const DEFAULT_RENOVATION_INPUT: RenovationInput = {
   propertyPrice: 10_000_000,
   annualBaseRent: 1_200_000,


### PR DESCRIPTION
## 概要

issue #65 の対応。複数の MLIT API を並列統合し、物件の投資適性を **0〜100 点** でスコア化する差別化機能を実装した。

## 変更内容

### バックエンド
- **新規 MLIT API 対応（6種）**: XKT001（都市計画区域）・XKT025（液状化）・XKT026（洪水）・XKT027（高潮）・XKT028（津波）・XKT029（土砂）のGeoJSON型・キャッシュ・Fetch関数を追加（公式仕様 2026-04-23 確認済みのフィールド名を使用）
- **`CalcInvestmentScore()`**: `domain/investment_score.go` を新規作成。11指標を独立関数で算出し、baseScore=50 に加減してクランプ。RadarChart用の5カテゴリ正規化スコアも生成
- **`GET /api/investment-score`**: 11 goroutine で既存+新規 API を並列取得。いずれか失敗時も部分スコアで継続（既存 GetUrbanRisks と同パターン）

### フロントエンド
- **`InvestmentScoreCard.tsx`**: Recharts `RadarChart` で5カテゴリ（人口動態・交通利便性・都市計画・ハザード・地盤）を可視化。各指標の加減点と説明を一覧表示
- **`Dashboard.tsx`**: lat/lng 入力時に `fetchInvestmentScore` を既存 `Promise.allSettled` ブロックに追加。スコアカードを比較データより上位に表示

### ドキュメント
- `docs/mlit-api-integration.md` に XKT001/025〜029 の公式仕様（エンドポイント・フィールド・型定義・判定方針）を追加

## スコアリング設計

| 指標 | API | 配点 |
|---|---|---|
| 30年後人口変化率 | XKT013 | ±15点（線形補間） |
| 駅乗降客数 | XKT015 | 0〜+20点（5万人/日で満点） |
| 市街化区域内 | XKT001 | +10 or 0点 |
| 居住誘導区域内 | XKT003 | +10 or −5点（未策定は0点） |
| 洪水・高潮・津波・土砂 | XKT026〜029 | 各 0〜−5点（合計最大−20点） |
| 液状化リスク | XKT025 | 0〜−10点（6段階） |
| 大規模盛土造成地 | XKT020 | 0 or −5点 |
| 過去の災害履歴 | XST001 | 0 or −10点 |

## テスト

- `TestCalcInvestmentScore_EmptyInput` / `_AllPositive` / `_AllNegative`
- `TestCalcPopulationScore_LinearInterpolation`
- `TestCalcRidershipScore_MaxCap`
- `TestCalcLiquefactionScore_Levels`
- `TestCalcUrbanAreaScore_MarketArea`
- `TestCalcHazardScore_Combined`
- `go test -race ./...` 全パス確認済み

## 補注

- XKT025 の液状化傾向レベル 6段階スケールは「低値ほど高リスク」と仮定。実 API レスポンスの `note` フィールドと照合して検証が必要
- XKT026 の浸水深ランクの具体的な数値範囲は実 API レスポンスで確認推奨

closes #65