### PR TITLE
fix(terraform): アラートポリシーの構文エラーを修正する

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -164,7 +164,7 @@ resource "google_monitoring_alert_policy" "mlit_latency" {
   conditions {
     display_name = "MLIT API P99 > 15s が 5 分継続"
     condition_threshold {
-      filter          = "metric.type=\"workload.googleapis.com/mlit.api.request.duration\""
+      filter          = "metric.type=\"workload.googleapis.com/mlit.api.request.duration\" AND resource.type=\"generic_task\""
       comparison      = "COMPARISON_GT"
       threshold_value = 15
       duration        = "300s"
@@ -201,7 +201,7 @@ resource "google_monitoring_alert_policy" "cloudrun_error_rate" {
           }
         | ratio
         | every 5m
-        | condition val > 0.05
+        | condition val() > 0.05
       EOT
       duration = "300s"
     }
@@ -231,7 +231,7 @@ resource "google_monitoring_alert_policy" "cache_hit_rate" {
           }
         | ratio
         | every 10m
-        | condition val > 0.5
+        | condition val() > 0.5
       EOT
       duration = "600s"
     }
@@ -249,11 +249,11 @@ resource "google_monitoring_alert_policy" "cloudrun_max_instances" {
   combiner     = "OR"
 
   conditions {
-    display_name = "インスタンス数 >= 2 が 5 分継続"
+    display_name = "インスタンス数 > 1 が 5 分継続（上限 2 に到達）"
     condition_threshold {
       filter          = "metric.type=\"run.googleapis.com/container/instance_count\" AND resource.labels.service_name=\"${local.service_name}\""
-      comparison      = "COMPARISON_GE"
-      threshold_value = 2
+      comparison      = "COMPARISON_GT"
+      threshold_value = 1
       duration        = "300s"
       aggregations {
         alignment_period     = "60s"


### PR DESCRIPTION
## 概要

`terraform apply` 時に4件のアラートポリシー作成エラーが発生したため修正する。

## エラーと修正内容

| アラート | エラー | 修正 |
|---------|-------|------|
| `mlit_latency` | `must specify a restriction on "resource.type"` | filter に `AND resource.type="generic_task"` を追加 |
| `cloudrun_error_rate` | `Cannot find column or metadata name 'val'` | MQL の `condition val >` → `condition val() >` |
| `cache_hit_rate` | 同上 | 同上 |
| `cloudrun_max_instances` | `COMPARISON_GE` 非サポート | `COMPARISON_GT` + 閾値を `2 → 1` に変更（> 1 = ≥ 2） |

## 変更ファイル

- `terraform/monitoring.tf`