### PR TITLE
fix(frontend): PDF出力の修正 (#230 #231 #235)

### DIFF
--- a/frontend/src/lib/__tests__/generatePdf.test.ts
+++ b/frontend/src/lib/__tests__/generatePdf.test.ts
@@ -134,26 +134,28 @@ describe("downloadReportPDF", () => {
     expect(info?.author).toBe("yield-guard");
   });
 
-  it("sets header function that returns null on page 1", async () => {
+  it("sets header function that returns null on page 1 and page number on page 2", async () => {
     global.fetch = makeFontFetchMock();
     await downloadReportPDF(makeInput(), makeResult());
 
     const docDef = (mockCreatePdf.mock.calls as unknown[][][])[0]?.[0] as unknown as Record<string, unknown>;
-    const header = docDef?.header as ((page: number) => unknown) | undefined;
+    const header = docDef?.header as ((page: number, count: number) => unknown) | undefined;
     expect(typeof header).toBe("function");
-    expect(header?.(1)).toBeNull();
-    expect(header?.(2)).not.toBeNull();
+    expect(header?.(1, 5)).toBeNull();
+    const h2 = JSON.stringify(header?.(2, 5));
+    expect(h2).toContain("2 / 5");
   });
 
-  it("sets footer function with page number columns", async () => {
+  it("sets footer function with centered disclaimer only", async () => {
     global.fetch = makeFontFetchMock();
     await downloadReportPDF(makeInput(), makeResult());
 
     const docDef = (mockCreatePdf.mock.calls as unknown[][][])[0]?.[0] as unknown as Record<string, unknown>;
-    const footer = docDef?.footer as ((page: number, count: number) => unknown) | undefined;
+    const footer = docDef?.footer as (() => unknown) | undefined;
     expect(typeof footer).toBe("function");
-    const result = footer?.(2, 5) as Record<string, unknown>;
+    const result = footer?.() as Record<string, unknown>;
     const json = JSON.stringify(result);
-    expect(json).toContain("2 / 5");
+    expect(json).toContain("本資料は");
+    expect(json).toContain("center");
   });
 });

--- a/frontend/src/lib/__tests__/pdfFormat.test.ts
+++ b/frontend/src/lib/__tests__/pdfFormat.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fmtYen, fmtPct, sanitize } from "../pdf/format";
+import { fmtYen, fmtPct, fmtYears, sanitize } from "../pdf/format";
 
 describe("fmtYen", () => {
   it("formats zero as 0円", () => {
@@ -70,6 +70,20 @@ describe("fmtPct", () => {
 
   it("formats 0.015 as 1.50%", () => {
     expect(fmtPct(0.015)).toBe("1.50%");
+  });
+});
+
+describe("fmtYears", () => {
+  it("formats integer years", () => {
+    expect(fmtYears(10)).toBe("10年");
+  });
+
+  it("rounds fractional years", () => {
+    expect(fmtYears(10.6)).toBe("11年");
+  });
+
+  it("formats 0 as 0年", () => {
+    expect(fmtYears(0)).toBe("0年");
   });
 });
 

--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -167,33 +167,23 @@ export async function downloadReportPDF(
       subject: `物件分析 ${date}`,
       creator: "yield-guard",
     },
-    header: (currentPage: number) => {
+    header: (currentPage: number, pageCount: number) => {
       if (currentPage === 1) return null;
       return {
         columns: [
-          { text: "yield-guard 不動産投資分析レポート", fontSize: 7, color: C.muted, margin: [36, 16, 0, 0] },
-          { text: date, fontSize: 7, color: C.muted, alignment: "right" as const, margin: [0, 16, 36, 0] },
+          { text: "yield-guard 不動産投資分析レポート", fontSize: 7, color: C.muted },
+          { text: date, fontSize: 7, color: C.muted, alignment: "center" as const },
+          { text: `${currentPage} / ${pageCount}`, fontSize: 7, color: C.muted, alignment: "right" as const },
         ],
+        margin: [36, 16, 36, 0],
       };
     },
-    footer: (currentPage: number, pageCount: number) => ({
-      columns: [
-        {
-          text: "本資料は yield-guard による試算です。実際の投資判断は専門家にご相談ください。",
-          fontSize: 7,
-          color: C.muted,
-          width: "*",
-          margin: [36, 4, 0, 0],
-        },
-        {
-          text: `${currentPage} / ${pageCount}`,
-          fontSize: 7,
-          color: C.muted,
-          width: "auto",
-          alignment: "right" as const,
-          margin: [0, 4, 36, 0],
-        },
-      ],
+    footer: () => ({
+      text: "本資料は yield-guard による試算です。実際の投資判断は専門家にご相談ください。",
+      fontSize: 7,
+      color: C.muted,
+      alignment: "center" as const,
+      margin: [36, 4, 36, 0],
     }),
     content: [
       // ── Page 1: Cover ──────────────────────────────────────────────
@@ -236,12 +226,7 @@ export async function downloadReportPDF(
                 fontSize: 20,
                 bold: true,
                 color: verdict.color,
-              },
-              {
-                text: verdict.label,
-                fontSize: 8,
-                color: verdict.color,
-                marginTop: 2,
+                noWrap: true,
               },
             ],
             width: "30%",

--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -3,7 +3,7 @@ import type {
   InvestmentResult,
   YearlyResult,
 } from "@/types/investment";
-import { fmtYen, fmtPct, fmtDate, sanitize } from "./pdf/format";
+import { fmtYen, fmtPct, fmtDate, fmtYears, sanitize } from "./pdf/format";
 import { calcVerdict } from "./pdf/verdict";
 import { buildCfBarChartSvg, buildDeadCrossLineSvg, buildCostDonutSvg } from "./pdf/charts";
 
@@ -171,9 +171,9 @@ export async function downloadReportPDF(
       if (currentPage === 1) return null;
       return {
         columns: [
-          { text: "yield-guard 不動産投資分析レポート", fontSize: 7, color: C.muted },
-          { text: date, fontSize: 7, color: C.muted, alignment: "center" as const },
-          { text: `${currentPage} / ${pageCount}`, fontSize: 7, color: C.muted, alignment: "right" as const },
+          { text: "yield-guard 不動産投資分析レポート", fontSize: 7, color: C.muted, width: "*" },
+          { text: date, fontSize: 7, color: C.muted, alignment: "center" as const, width: "*" },
+          { text: `${currentPage} / ${pageCount}`, fontSize: 7, color: C.muted, alignment: "right" as const, width: "*" },
         ],
         margin: [36, 16, 36, 0],
       };
@@ -199,14 +199,14 @@ export async function downloadReportPDF(
       { text: "物件概要", fontSize: 9, bold: true, color: C.muted, marginBottom: 8 },
       infoRow("物件価格（土地）", fmtYen(input.landPrice)),
       infoRow("建物費用", fmtYen(input.buildingCost)),
-      infoRow("築年数", input.buildingAge === 0 ? "新築" : `${input.buildingAge}年`),
+      infoRow("築年数", input.buildingAge === 0 ? "新築" : fmtYears(input.buildingAge)),
       infoRow("構造", sanitize(input.buildingType)),
       ...(input.stationMinutes > 0 ? [infoRow("最寄り駅徒歩", `${input.stationMinutes}分`)] : []),
       infoRow("月額賃料", fmtYen(input.monthlyRent)),
       infoRow("想定空室率", fmtPct(input.vacancyRate)),
       infoRow("ローン金額", fmtYen(input.loanAmount)),
       infoRow("ローン金利", fmtPct(input.annualLoanRate)),
-      infoRow("ローン期間", `${input.loanYears}年`),
+      infoRow("ローン期間", fmtYears(input.loanYears)),
 
       { text: "分析情報", fontSize: 9, bold: true, color: C.muted, marginBottom: 8, marginTop: 16 },
       infoRow("分析実施日", date),
@@ -320,7 +320,7 @@ export async function downloadReportPDF(
         : []),
 
       // 出口戦略
-      subTitle(`出口戦略（${input.holdingYears}年後売却）`),
+      subTitle(`出口戦略（${fmtYears(input.holdingYears)}後売却）`),
       hLineTable([
         twoCol("想定売却価格", fmtYen(result.exitSalePrice)),
         twoCol("譲渡所得税", fmtYen(result.exitTransferTax)),
@@ -362,7 +362,7 @@ export async function downloadReportPDF(
               thCell("残債"),
             ],
             ...cfRows.map((r, idx) => [
-              tdCell(`${r.year}年`, idx, { align: "left" }),
+              tdCell(fmtYears(r.year), idx, { align: "left" }),
               tdCell(fmtYen(r.annualRent), idx),
               tdCell(fmtYen(r.annualLoanPayment), idx),
               tdCell(fmtYen(r.annualExpenses), idx),
@@ -401,7 +401,7 @@ export async function downloadReportPDF(
                     tdCell(sc.dscr.toFixed(2), idx, {
                       color: sc.dscr < 1.0 ? C.danger : C.text,
                     }),
-                    tdCell(sc.breakEvenYear > 0 ? `${sc.breakEvenYear}年` : "－", idx),
+                    tdCell(sc.breakEvenYear > 0 ? fmtYears(sc.breakEvenYear) : "－", idx),
                     {
                       text: sc.isSafe ? "安全" : "危険",
                       fontSize: 8,

--- a/frontend/src/lib/pdf/format.ts
+++ b/frontend/src/lib/pdf/format.ts
@@ -26,6 +26,11 @@ export function fmtDate(): string {
   return `${d.getFullYear()}年${d.getMonth() + 1}月${d.getDate()}日`;
 }
 
+/** 年数を整数で表示（例: 10.0 → "10年"） */
+export function fmtYears(v: number): string {
+  return `${Math.round(v)}年`;
+}
+
 /** PDFに埋め込む前の文字列サニタイズ（< > & " ' \ を除去） */
 export function sanitize(v: string | number | undefined | null): string {
   if (v == null) return "";


### PR DESCRIPTION
## 概要

PDF関連の5件のissueを調査し、実装済み分のcloseと残バグの修正を行いました。

## 対応内容

### 実装済みとして close (#233 #234)
- #233 (P1エグゼクティブサマリ再設計): `generatePdf.ts` に verdict badge・6 KPI・ストレステスト要約・出口戦略・自動コメントがすでに実装済みであるため close
- #234 (グラフ追加): `buildCfBarChartSvg` / `buildDeadCrossLineSvg` / `buildCostDonutSvg` として実装済みであるため close

### #230: `fmtYears` ヘルパー追加

- `frontend/src/lib/pdf/format.ts` に `fmtYears(v: number): string` を追加
- `Math.round()` で整数化し `年` を付与（例: `10.6 → "11年"`）
- `pdfFormat.test.ts` にテスト3件追加

### #231: verdict バッジの重複ラベル修正

- P1サマリーの判定バッジで `verdict.label` が fontSize 20 と fontSize 8 で二重レンダリングされていたバグを修正
- fontSize 8 の重複ノードを削除し `noWrap: true` を追加（CJK文字の不正スペース防止）

### #235: ヘッダー・フッターの統一

- **ヘッダー**: 2列（タイトル＋日付）→ 3列（タイトル｜日付[center]｜N/total[right]）に変更
- **フッター**: disclaimer＋ページ番号の2列 → 免責文のみ centered に変更
- `generatePdf.test.ts` のフッターテストをあわせて更新

## テスト

```
Test Files  14 passed (14)
Tests  178 passed (178)
```

型チェック: `npx tsc --noEmit` エラーなし

## チェックリスト

- [x] `npm test` 全通過
- [x] `tsc --noEmit` エラーなし
- [x] 実装済みissue (#233, #234) を close