### PR TITLE
feat: ハザード情報（XKT026-029）による割安物件リスク警告表示

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,9 @@ Copy `.env.example` → `.env` (project root).
 | `GET` | `/api/station-ridership` | Station ridership (tile coords) |
 | `GET` | `/api/population-forecast` | Population forecast (tile coords) |
 | `GET` | `/api/land-appraisals` | Official land appraisals |
+| `GET` | `/api/urban-risks` | Urban planning risks (tile coords) |
+| `GET` | `/api/hazard` | Hazard info: flood/storm/tsunami/landslide (tile coords) |
+| `GET` | `/api/investment-score` | Investment suitability score (tile coords) |
 
 ## Directory structure
 

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -570,6 +570,89 @@ func (h *Handler) GetUrbanRisks(c *gin.Context) {
 	c.JSON(http.StatusOK, risks)
 }
 
+// GetHazardInfo は物件の緯度経度から洪水・高潮・津波・土砂災害のハザード情報を返す。
+// GET /api/hazard?lat=35.6895&lng=139.6917
+func (h *Handler) GetHazardInfo(c *gin.Context) {
+	latStr := c.Query("lat")
+	lngStr := c.Query("lng")
+	if latStr == "" || lngStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lat と lng は必須パラメータです"})
+		return
+	}
+	lat, err := strconv.ParseFloat(latStr, 64)
+	if err != nil || lat < 20 || lat > 46 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lat は日本国内の緯度（20〜46）で指定してください"})
+		return
+	}
+	lng, err := strconv.ParseFloat(lngStr, 64)
+	if err != nil || lng < 122 || lng > 154 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lng は日本国内の経度（122〜154）で指定してください"})
+		return
+	}
+
+	ctx := c.Request.Context()
+	z := 14
+	x, y := mlit.LatLngToTile(lat, lng, z)
+
+	type apiResult[T any] struct {
+		data []T
+		err  error
+	}
+	floCh := make(chan apiResult[domain.FloodHazardItem], 1)
+	stmCh := make(chan apiResult[domain.StormHazardItem], 1)
+	tsuCh := make(chan apiResult[domain.TsunamiHazardItem], 1)
+	lsCh := make(chan apiResult[domain.LandslideHazardItem], 1)
+
+	go func() {
+		d, e := h.mlitClient.FetchFloodHazard(ctx, z, x, y)
+		floCh <- apiResult[domain.FloodHazardItem]{d, e}
+	}()
+	go func() {
+		d, e := h.mlitClient.FetchStormHazard(ctx, z, x, y)
+		stmCh <- apiResult[domain.StormHazardItem]{d, e}
+	}()
+	go func() {
+		d, e := h.mlitClient.FetchTsunamiHazard(ctx, z, x, y)
+		tsuCh <- apiResult[domain.TsunamiHazardItem]{d, e}
+	}()
+	go func() {
+		d, e := h.mlitClient.FetchLandslideHazard(ctx, z, x, y)
+		lsCh <- apiResult[domain.LandslideHazardItem]{d, e}
+	}()
+
+	var floods []domain.FloodHazardItem
+	var storms []domain.StormHazardItem
+	var tsunamis []domain.TsunamiHazardItem
+	var landslides []domain.LandslideHazardItem
+
+	if r := <-floCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchFloodHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		floods = r.data
+	}
+	if r := <-stmCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchStormHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		storms = r.data
+	}
+	if r := <-tsuCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchTsunamiHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		tsunamis = r.data
+	}
+	if r := <-lsCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchLandslideHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		landslides = r.data
+	}
+
+	risks := domain.BuildHazardRisks(floods, storms, tsunamis, landslides)
+	if risks == nil {
+		risks = []domain.UrbanRisk{}
+	}
+	c.JSON(http.StatusOK, risks)
+}
+
 // GetInvestmentScore は物件の緯度経度から複数 API を並列呼び出しし、投資適地スコアを算出して返す。
 // GET /api/investment-score?lat=35.6762&lng=139.6503
 func (h *Handler) GetInvestmentScore(c *gin.Context) {

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -1147,3 +1147,117 @@ func TestGetInvestmentScore_PartialAPIFailure(t *testing.T) {
 		t.Errorf("expected score 60 with flood API failure, got %d", result.TotalScore)
 	}
 }
+
+func TestGetHazardInfo_MissingLatLng(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{})
+	for _, url := range []string{"/api/hazard", "/api/hazard?lat=35.68", "/api/hazard?lng=139.69"} {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("url=%s: expected 400, got %d", url, w.Code)
+		}
+	}
+}
+
+func TestGetHazardInfo_InvalidLatLng(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{})
+	cases := []string{
+		"/api/hazard?lat=999&lng=139.69",  // lat 範囲外
+		"/api/hazard?lat=35.68&lng=200",   // lng 範囲外
+		"/api/hazard?lat=abc&lng=139.69",  // lat 非数値
+	}
+	for _, url := range cases {
+		req := httptest.NewRequest(http.MethodGet, url, nil)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("url=%s: expected 400, got %d", url, w.Code)
+		}
+	}
+}
+
+func TestGetHazardInfo_Success(t *testing.T) {
+	client := &mockMLITClient{
+		floodHazardFunc: func(_ context.Context, z, x, y int) ([]domain.FloodHazardItem, error) {
+			return []domain.FloodHazardItem{{DepthRank: 4, RiverName: "荒川"}}, nil
+		},
+		tsunamiHazardFunc: func(_ context.Context, z, x, y int) ([]domain.TsunamiHazardItem, error) {
+			return []domain.TsunamiHazardItem{{DepthJa: "3m以上"}}, nil
+		},
+	}
+	r := newTestRouter(client)
+	req := httptest.NewRequest(http.MethodGet, "/api/hazard?lat=35.68&lng=139.69", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var risks []domain.UrbanRisk
+	if err := json.NewDecoder(w.Body).Decode(&risks); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(risks) != 2 {
+		t.Fatalf("expected 2 risks (flood + tsunami), got %d", len(risks))
+	}
+	codes := map[string]bool{}
+	for _, r := range risks {
+		codes[r.Code] = true
+	}
+	if !codes["FLOOD_HAZARD"] {
+		t.Error("expected FLOOD_HAZARD in response")
+	}
+	if !codes["TSUNAMI_HAZARD"] {
+		t.Error("expected TSUNAMI_HAZARD in response")
+	}
+}
+
+func TestGetHazardInfo_PartialAPIFailure(t *testing.T) {
+	client := &mockMLITClient{
+		floodHazardFunc: func(_ context.Context, z, x, y int) ([]domain.FloodHazardItem, error) {
+			return nil, fmt.Errorf("upstream error")
+		},
+		landslideHazardFunc: func(_ context.Context, z, x, y int) ([]domain.LandslideHazardItem, error) {
+			return []domain.LandslideHazardItem{{PhenomenonType: 2, ZoneCode: 1}}, nil
+		},
+	}
+	r := newTestRouter(client)
+	req := httptest.NewRequest(http.MethodGet, "/api/hazard?lat=35.68&lng=139.69", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// flood 失敗でも 200 を返し、他のハザード結果は含まれること
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 even with partial API failure, got %d", w.Code)
+	}
+	var risks []domain.UrbanRisk
+	if err := json.NewDecoder(w.Body).Decode(&risks); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	if len(risks) != 1 || risks[0].Code != "LANDSLIDE_HAZARD" {
+		t.Errorf("expected only LANDSLIDE_HAZARD, got %+v", risks)
+	}
+}
+
+func TestGetHazardInfo_EmptyResult(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{})
+	req := httptest.NewRequest(http.MethodGet, "/api/hazard?lat=35.68&lng=139.69", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var risks []domain.UrbanRisk
+	if err := json.NewDecoder(w.Body).Decode(&risks); err != nil {
+		t.Fatalf("decode error: %v", err)
+	}
+	// ハザードなし → 空スライス（null でなく []）
+	if risks == nil {
+		t.Error("expected empty slice, got nil")
+	}
+	if len(risks) != 0 {
+		t.Errorf("expected 0 risks, got %d", len(risks))
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -128,6 +128,7 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/population-forecast", h.GetPopulationForecast)
 		api.GET("/land-appraisals", h.GetLandAppraisals)
 		api.GET("/urban-risks", h.GetUrbanRisks)
+		api.GET("/hazard", h.GetHazardInfo)
 		api.GET("/investment-score", h.GetInvestmentScore)
 	}
 

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -960,6 +960,97 @@ func BuildUrbanRisksFromAPIs(
 	return risks
 }
 
+// BuildHazardRisks は XKT026–029 ハザード API の結果を UrbanRisk スライスに変換する。
+// 各ハザード種別で最も深刻な 1 件のみを返す（重複排除）。
+func BuildHazardRisks(
+	floods []FloodHazardItem,
+	storms []StormHazardItem,
+	tsunamis []TsunamiHazardItem,
+	landslides []LandslideHazardItem,
+) []UrbanRisk {
+	var risks []UrbanRisk
+
+	// XKT026: 洪水浸水想定区域 — DepthRank >= 3 を ERROR、それ以外を WARNING
+	if len(floods) > 0 {
+		worst := floods[0]
+		for _, f := range floods[1:] {
+			if f.DepthRank > worst.DepthRank {
+				worst = f
+			}
+		}
+		level := UrbanRiskLevelWarning
+		if worst.DepthRank >= 3 {
+			level = UrbanRiskLevelError
+		}
+		desc := fmt.Sprintf("洪水浸水想定区域（深さランク %d）に該当します。大雨・河川氾濫時に浸水リスクがあります。", worst.DepthRank)
+		if worst.RiverName != "" {
+			desc = fmt.Sprintf("洪水浸水想定区域（%s、深さランク %d）に該当します。大雨・河川氾濫時に浸水リスクがあります。", worst.RiverName, worst.DepthRank)
+		}
+		risks = append(risks, UrbanRisk{
+			Code:        "FLOOD_HAZARD",
+			Level:       level,
+			Title:       "洪水浸水想定区域",
+			Description: desc,
+		})
+	}
+
+	// XKT027: 高潮浸水想定区域 — 存在すれば WARNING
+	if len(storms) > 0 {
+		desc := "高潮浸水想定区域に該当します。台風・高波時に浸水リスクがあります。"
+		if storms[0].DepthJa != "" {
+			desc = fmt.Sprintf("高潮浸水想定区域（%s）に該当します。台風・高波時に浸水リスクがあります。", storms[0].DepthJa)
+		}
+		risks = append(risks, UrbanRisk{
+			Code:        "STORM_HAZARD",
+			Level:       UrbanRiskLevelWarning,
+			Title:       "高潮浸水想定区域",
+			Description: desc,
+		})
+	}
+
+	// XKT028: 津波浸水想定区域 — 存在すれば ERROR
+	if len(tsunamis) > 0 {
+		desc := "津波浸水想定区域に該当します。沿岸部の津波・高潮による浸水リスクがあります。"
+		if tsunamis[0].DepthJa != "" {
+			desc = fmt.Sprintf("津波浸水想定区域（%s）に該当します。沿岸部の津波・高潮による浸水リスクがあります。", tsunamis[0].DepthJa)
+		}
+		risks = append(risks, UrbanRisk{
+			Code:        "TSUNAMI_HAZARD",
+			Level:       UrbanRiskLevelError,
+			Title:       "津波浸水想定区域",
+			Description: desc,
+		})
+	}
+
+	// XKT029: 土砂災害警戒区域 — ZoneCode=1（特別警戒）を ERROR、ZoneCode=2（警戒）を WARNING
+	if len(landslides) > 0 {
+		// 最も深刻な ZoneCode（1 < 2、つまり 1 が最重要）を選択
+		worst := landslides[0]
+		for _, l := range landslides[1:] {
+			if l.ZoneCode < worst.ZoneCode {
+				worst = l
+			}
+		}
+		level := UrbanRiskLevelWarning
+		zoneName := "警戒区域"
+		if worst.ZoneCode == 1 {
+			level = UrbanRiskLevelError
+			zoneName = "特別警戒区域"
+		}
+		phenomenonNames := map[int]string{1: "急傾斜地崩壊", 2: "土石流", 3: "地すべり"}
+		pName := phenomenonNames[worst.PhenomenonType]
+		desc := fmt.Sprintf("土砂災害%s（%s）に該当します。大雨時の土砂崩れ・土石流リスクがあります。", zoneName, pName)
+		risks = append(risks, UrbanRisk{
+			Code:        "LANDSLIDE_HAZARD",
+			Level:       level,
+			Title:       "土砂災害警戒区域",
+			Description: desc,
+		})
+	}
+
+	return risks
+}
+
 // modalString は transactions から getter で取得した文字列の最頻値を返す（空文字は除外）
 func modalString(transactions []LandTransaction, getter func(LandTransaction) string) string {
 	counts := make(map[string]int, len(transactions))

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -994,11 +994,18 @@ func BuildHazardRisks(
 		})
 	}
 
-	// XKT027: 高潮浸水想定区域 — 存在すれば WARNING
+	// XKT027: 高潮浸水想定区域 — 存在すれば WARNING（深さ文字列は最初の非空エントリを採用）
 	if len(storms) > 0 {
+		depthJa := ""
+		for _, s := range storms {
+			if s.DepthJa != "" {
+				depthJa = s.DepthJa
+				break
+			}
+		}
 		desc := "高潮浸水想定区域に該当します。台風・高波時に浸水リスクがあります。"
-		if storms[0].DepthJa != "" {
-			desc = fmt.Sprintf("高潮浸水想定区域（%s）に該当します。台風・高波時に浸水リスクがあります。", storms[0].DepthJa)
+		if depthJa != "" {
+			desc = fmt.Sprintf("高潮浸水想定区域（%s）に該当します。台風・高波時に浸水リスクがあります。", depthJa)
 		}
 		risks = append(risks, UrbanRisk{
 			Code:        "STORM_HAZARD",
@@ -1038,7 +1045,10 @@ func BuildHazardRisks(
 			zoneName = "特別警戒区域"
 		}
 		phenomenonNames := map[int]string{1: "急傾斜地崩壊", 2: "土石流", 3: "地すべり"}
-		pName := phenomenonNames[worst.PhenomenonType]
+		pName, ok := phenomenonNames[worst.PhenomenonType]
+		if !ok {
+			pName = "土砂災害"
+		}
 		desc := fmt.Sprintf("土砂災害%s（%s）に該当します。大雨時の土砂崩れ・土石流リスクがあります。", zoneName, pName)
 		risks = append(risks, UrbanRisk{
 			Code:        "LANDSLIDE_HAZARD",

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2178,3 +2178,69 @@ func TestCalcHazardScore_Combined(t *testing.T) {
 		t.Errorf("all 4 hazards should give -20 (capped), got %d", item.Score)
 	}
 }
+
+func TestBuildHazardRisks_Empty(t *testing.T) {
+	risks := BuildHazardRisks(nil, nil, nil, nil)
+	if len(risks) != 0 {
+		t.Errorf("expected 0 risks for empty input, got %d", len(risks))
+	}
+}
+
+func TestBuildHazardRisks_FloodDepthRank(t *testing.T) {
+	// DepthRank < 3 → WARNING
+	risks := BuildHazardRisks([]FloodHazardItem{{DepthRank: 2, RiverName: "荒川"}}, nil, nil, nil)
+	if len(risks) != 1 || risks[0].Code != "FLOOD_HAZARD" {
+		t.Fatalf("unexpected risks: %+v", risks)
+	}
+	if risks[0].Level != UrbanRiskLevelWarning {
+		t.Errorf("DepthRank 2 should be WARNING, got %s", risks[0].Level)
+	}
+
+	// DepthRank >= 3 → ERROR
+	risks = BuildHazardRisks([]FloodHazardItem{{DepthRank: 3}}, nil, nil, nil)
+	if risks[0].Level != UrbanRiskLevelError {
+		t.Errorf("DepthRank 3 should be ERROR, got %s", risks[0].Level)
+	}
+}
+
+func TestBuildHazardRisks_TsunamiAlwaysError(t *testing.T) {
+	risks := BuildHazardRisks(nil, nil, []TsunamiHazardItem{{DepthJa: "3m未満"}}, nil)
+	if len(risks) != 1 || risks[0].Level != UrbanRiskLevelError {
+		t.Errorf("tsunami should always be ERROR, got %+v", risks)
+	}
+}
+
+func TestBuildHazardRisks_LandslideZoneCode(t *testing.T) {
+	// ZoneCode=2 警戒 → WARNING
+	risks := BuildHazardRisks(nil, nil, nil, []LandslideHazardItem{{PhenomenonType: 2, ZoneCode: 2}})
+	if risks[0].Level != UrbanRiskLevelWarning {
+		t.Errorf("ZoneCode 2 should be WARNING, got %s", risks[0].Level)
+	}
+
+	// ZoneCode=1 特別警戒 → ERROR
+	risks = BuildHazardRisks(nil, nil, nil, []LandslideHazardItem{{PhenomenonType: 1, ZoneCode: 1}})
+	if risks[0].Level != UrbanRiskLevelError {
+		t.Errorf("ZoneCode 1 should be ERROR, got %s", risks[0].Level)
+	}
+}
+
+func TestBuildHazardRisks_AllFour(t *testing.T) {
+	risks := BuildHazardRisks(
+		[]FloodHazardItem{{DepthRank: 4}},
+		[]StormHazardItem{{DepthJa: "5m以上"}},
+		[]TsunamiHazardItem{{DepthJa: "3m以上"}},
+		[]LandslideHazardItem{{PhenomenonType: 2, ZoneCode: 1}},
+	)
+	if len(risks) != 4 {
+		t.Errorf("expected 4 risks, got %d", len(risks))
+	}
+	codes := map[string]bool{}
+	for _, r := range risks {
+		codes[r.Code] = true
+	}
+	for _, c := range []string{"FLOOD_HAZARD", "STORM_HAZARD", "TSUNAMI_HAZARD", "LANDSLIDE_HAZARD"} {
+		if !codes[c] {
+			t.Errorf("missing risk code: %s", c)
+		}
+	}
+}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -11,7 +11,7 @@ import CostBreakdown from "@/components/CostBreakdown";
 import { LoanOptimizationPanel } from "@/components/LoanOptimizationPanel";
 import RenovationPanel from "@/components/RenovationPanel";
 import type { InvestmentInput, InvestmentResult, LandPriceComparison, TheoreticalPriceResult, StationRidershipResult, PopulationForecastResult, AppraisalComparisonResult, UrbanRisk, SimulationMode, LoanMethod, MonteCarloResult, InvestmentScoreResult } from "@/types/investment";
-import { analyze, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks, fetchInvestmentScore, simulate } from "@/lib/api";
+import { analyze, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks, fetchHazardInfo, fetchInvestmentScore, simulate } from "@/lib/api";
 import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
 import { ShieldAlert, Info, FileDown, Share2, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -48,6 +48,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   const [landAppraisal, setLandAppraisal] = useState<AppraisalComparisonResult | null>(null);
   const [externalUrbanRisks, setExternalUrbanRisks] = useState<UrbanRisk[] | null>(null);
   const [investmentScore, setInvestmentScore] = useState<InvestmentScoreResult | null>(null);
+  const [hazardRisks, setHazardRisks] = useState<UrbanRisk[] | null>(null);
   const [simulationMode, setSimulationMode] = useState<SimulationMode>(
     decoded?.mode ?? "quick"
   );
@@ -136,6 +137,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
     setLandAppraisal(null);
     setExternalUrbanRisks(null);
     setInvestmentScore(null);
+    setHazardRisks(null);
     const { year, quarter, toYear, toQuarter } = getCurrentPeriods();
     try {
       const baseParams = {
@@ -169,16 +171,18 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
       setLandAppraisal(appraisal.status === "fulfilled" ? appraisal.value : null);
 
       if (lat !== undefined && lng !== undefined) {
-        const [ridership, population, urbanRisks, scoreResult] = await Promise.allSettled([
+        const [ridership, population, urbanRisks, scoreResult, hazard] = await Promise.allSettled([
           fetchStationRidership({ lat, lng }),
           fetchPopulationForecast({ lat, lng }),
           fetchUrbanRisks(lat, lng),
           fetchInvestmentScore({ lat, lng }),
+          fetchHazardInfo(lat, lng),
         ]);
         setStationRidership(ridership.status === "fulfilled" ? ridership.value : null);
         setPopulationForecast(population.status === "fulfilled" ? population.value : null);
         setExternalUrbanRisks(urbanRisks.status === "fulfilled" ? urbanRisks.value : null);
         setInvestmentScore(scoreResult.status === "fulfilled" ? scoreResult.value : null);
+        setHazardRisks(hazard.status === "fulfilled" ? hazard.value : null);
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "相場データの取得に失敗しました。しばらく後に再試行してください");
@@ -286,7 +290,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
 
             {investmentScore && <InvestmentScoreCard score={investmentScore} />}
 
-            {comparison && <LandPriceAnalysis comparison={comparison} input={lastInput} theoreticalPrice={theoreticalPrice} stationRidership={stationRidership} populationForecast={populationForecast} landAppraisal={landAppraisal} externalUrbanRisks={externalUrbanRisks} />}
+            {comparison && <LandPriceAnalysis comparison={comparison} input={lastInput} theoreticalPrice={theoreticalPrice} stationRidership={stationRidership} populationForecast={populationForecast} landAppraisal={landAppraisal} externalUrbanRisks={externalUrbanRisks} hazardRisks={hazardRisks} />}
 
             {result && lastInput && (
               <>

--- a/frontend/src/components/LandPriceAnalysis.tsx
+++ b/frontend/src/components/LandPriceAnalysis.tsx
@@ -41,6 +41,7 @@ interface Props {
   populationForecast?: PopulationForecastResult | null;
   landAppraisal?: AppraisalComparisonResult | null;
   externalUrbanRisks?: UrbanRisk[] | null;
+  hazardRisks?: UrbanRisk[] | null;
 }
 
 const ASSESSMENT_BADGE: Record<string, "success" | "warning" | "danger"> = {
@@ -78,7 +79,7 @@ const RIDERSHIP_SCORE_LABEL: Record<string, { label: string; color: string }> = 
   E: { label: "E（極小駅）", color: "text-red-700" },
 };
 
-export function LandPriceAnalysis({ comparison, input, theoreticalPrice, stationRidership, populationForecast, landAppraisal, externalUrbanRisks }: Props) {
+export function LandPriceAnalysis({ comparison, input, theoreticalPrice, stationRidership, populationForecast, landAppraisal, externalUrbanRisks, hazardRisks }: Props) {
   const { stats, assessment, inputPricePerTsubo, diffFromMedian } = comparison;
 
   const allUrbanRisks: UrbanRisk[] = [
@@ -152,6 +153,31 @@ export function LandPriceAnalysis({ comparison, input, theoreticalPrice, station
               </p>
               <p className="text-xs mt-0.5">以下の結果は参考値としてご確認ください。</p>
             </div>
+          </div>
+        )}
+
+        {/* 割安リスク警告: 中央値比 -15% 以下の割安物件にハザード情報を表示 */}
+        {assessment === "割安" && diffFromMedian <= -0.15 && hazardRisks && hazardRisks.length > 0 && (
+          <div className="rounded-md border-2 border-orange-300 bg-orange-50 p-3 space-y-2">
+            <p className="text-xs font-semibold text-orange-900 flex items-center gap-1.5">
+              <AlertTriangle className="h-4 w-4 shrink-0" />
+              割安の背景にリスクがある可能性があります
+            </p>
+            {hazardRisks.map((risk) => {
+              const style = RISK_STYLE[risk.level];
+              return (
+                <div
+                  key={risk.code}
+                  className={`flex items-start gap-2 rounded border ${style.border} ${style.bg} px-3 py-2`}
+                >
+                  {style.icon}
+                  <div>
+                    <p className={`text-xs font-semibold ${style.text}`}>{risk.title}</p>
+                    <p className={`text-xs mt-0.5 ${style.text}`}>{risk.description}</p>
+                  </div>
+                </div>
+              );
+            })}
           </div>
         )}
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -168,6 +168,13 @@ export async function fetchUrbanRisks(lat: number, lng: number): Promise<UrbanRi
   return handleResponse<UrbanRisk[]>(res);
 }
 
+/** 緯度経度からハザード情報（洪水・高潮・津波・土砂災害）を取得 */
+export async function fetchHazardInfo(lat: number, lng: number): Promise<UrbanRisk[]> {
+  const q = new URLSearchParams({ lat: String(lat), lng: String(lng) });
+  const res = await fetch(`${BASE}/hazard?${q}`);
+  return handleResponse<UrbanRisk[]>(res);
+}
+
 /** 投資シミュレーションを実行 */
 export async function analyze(input: InvestmentInput): Promise<InvestmentResult> {
   const res = await fetch(`${BASE}/investment/analyze`, {


### PR DESCRIPTION
## 概要

closes #60

割安判定（中央値比 -15% 以下）の物件に対して、洪水・高潮・津波・土砂災害のハザード情報を照合し、「割安の背景にリスクがある可能性があります」という警告を土地価格相場分析UIに表示する。

## 変更内容

### バックエンド

- `internal/domain/investment.go` — `BuildHazardRisks` 関数を追加。XKT026–029 ハザードアイテムを `[]UrbanRisk` に変換するドメインロジック
  - 洪水（XKT026）: DepthRank ≥ 3 → ERROR、1-2 → WARNING
  - 高潮（XKT027）: 該当あり → WARNING
  - 津波（XKT028）: 該当あり → ERROR
  - 土砂災害（XKT029）: 特別警戒区域(ZoneCode=1) → ERROR、警戒区域(ZoneCode=2) → WARNING
- `internal/api/handler.go` — `GetHazardInfo` ハンドラを追加。4 ハザード API を goroutine で並列取得
- `internal/api/router.go` — `GET /api/hazard` ルートを追加

### フロントエンド

- `src/lib/api.ts` — `fetchHazardInfo(lat, lng)` 関数を追加
- `src/components/Dashboard.tsx` — `hazardRisks` state を追加し、lat/lng がある場合の並列フェッチに組み込み
- `src/components/LandPriceAnalysis.tsx` — `hazardRisks` prop を追加。`assessment === "割安"` かつ `diffFromMedian <= -0.15` の条件でハザード警告セクションを表示

## 技術的補足

- ハザードメソッド（`FetchFloodHazard` 等）は既存の `mlit/client.go` に実装済みであり、今回はエンドポイント公開とフロントエンド統合のみ
- キャッシュは既存の 24h TTL を流用（ハザード情報は変更頻度が低い）
- 既存 `/api/urban-risks`（XKT003/020/030/XST001）とエンドポイントの重複なし

## テスト

- `TestBuildHazardRisks_*` 5件追加（空入力、洪水ランク判定、津波ERROR固定、土砂ZoneCode判定、4種同時）
- `go test -race ./...` 全通過
- `tsc --noEmit` エラーなし