### PR TITLE
fix(terraform): mlit_latency MQL の閾値に秒単位を追加

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -170,7 +170,7 @@ resource "google_monitoring_alert_policy" "mlit_latency" {
         | align delta(5m)
         | every 5m
         | percentile(99)
-        | condition val() > 15
+        | condition val() > 15 "s"
       EOT
       duration = "300s"
     }


### PR DESCRIPTION
## 概要

`mlit_latency` アラートポリシーの MQL クエリで、`percentile(99)` の戻り値（単位: 秒）と閾値 `15`（単位なし）の不一致により GCP API が 400 エラーを返していた。

## 修正内容

```
# 変更前: 単位不一致 → Error 400
| condition val() > 15

# 変更後: リテラルに秒単位を注記
| condition val() > 15 "s"
```

## 関連ファイル

- `terraform/monitoring.tf`