### PR TITLE
docs: README を薄いindex化し docs/ 各層仕様書へのリンクを整備

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,10 @@
 # Yield-Guard
 
-> **はじめてお使いになる方へ（銀行員・不動産会社の方向け）**
->
-> Yield-Guard は、不動産投資を検討しているお客様や担当者が「この物件は買っても大丈夫か？」を数字で確認できる無料のWebツールです。
-> 土地の相場価格・表面利回り・ローン返済とのバランス・将来の売却益を自動で計算します。
-> 専門的な知識がなくても、物件の金額と賃料を入力するだけで結果が表示されます。
-> （インターネットブラウザから利用でき、インストール不要です）
-
 ![Coverage](https://img.shields.io/badge/coverage-計測中-yellow)
 
 不動産投資の意思決定をデータで支援するMVPツール。国土交通省の公式APIから土地取引価格を取得し、表面利回り・デッドクロス・出口戦略をリアルタイムで可視化する。
 
 ## 概要
-
-「Yield-Guard」は不動産投資の3大リスクを定量化するツールです。
 
 | 機能 | 内容 |
 |------|------|
@@ -21,7 +12,7 @@
 | **8%境界線** | 表面利回りが8%を下回る場合、達成に必要な土地値・建築費の削減幅を逆算表示 |
 | **デッドクロス予測** | 元金返済額が減価償却費を超える年を特定し、所得税負担増による黒字倒産リスクをグラフ化 |
 | **出口戦略** | 任意年数後に利回り6%で売却した際の譲渡所得税込み手残り額（Equity）を算出 |
-| **ストレステスト** | 空室率+10%・金利+1.5%時のキャッシュフロー変化をスライダーでリアルタイム可視化 |
+| **ストレステスト** | 空室率+10%・金利+1.5%時のキャッシュフロー変化をリアルタイム可視化 |
 
 ## アーキテクチャ
 
@@ -41,37 +32,10 @@ flowchart TD
     Cache -->|キャッシュ結果| Go
 ```
 
-### `/api/investment/analyze` リクエストフロー
-
-```mermaid
-sequenceDiagram
-    participant B as Browser
-    participant N as Next.js (Vercel)
-    participant G as Go/Gin API
-    participant C as In-Memory Cache (TTL=24h)
-    participant M as MLIT API
-
-    B->>N: フォーム送信（物件情報）
-    N->>G: POST /api/investment/analyze
-    G->>C: キャッシュ確認（都道府県・期間キー）
-
-    alt キャッシュ HIT
-        C-->>G: キャッシュ済み土地データ返却
-    else キャッシュ MISS
-        G->>M: GET 土地取引価格（HTTPS + APIキー）
-        M-->>G: 取引データJSON
-        G->>C: 結果をキャッシュ保存（TTL=24h）
-    end
-
-    G->>G: 投資試算計算（利回り・デッドクロス・出口戦略）
-    G-->>N: 分析結果JSON
-    N-->>B: グラフ・数値レンダリング
-```
-
 **技術スタック**
 
-- Backend: Go 1.25 / Gin / Clean Architecture
-- Frontend: Next.js 16 (App Router) / TypeScript / Tailwind CSS v4 / Shadcn/UI / Recharts
+- Backend: Go 1.25 / Gin / Clean Architecture → Cloud Run
+- Frontend: Next.js 16 (App Router) / TypeScript / Tailwind CSS v4 / Shadcn/UI / Recharts → Vercel
 - Data: 国土交通省 不動産情報ライブラリ API（APIキー必須・要申請）
 
 ## セットアップ
@@ -85,17 +49,14 @@ cd yield-guard
 cp .env.example .env
 # .env を編集して MLIT_API_KEY を設定する
 # APIキー申請: https://www.reinfolib.mlit.go.jp/api/request/（審査5営業日）
-# APP_INTERNAL_API_KEY は本番環境（Vercel-Render 間認証）用。ローカルでは未設定でよい
+# APP_INTERNAL_API_KEY は本番環境（Vercel→Cloud Run 間認証）用。ローカルでは未設定でよい
 ```
 
 ### Docker（推奨）
 
 ```bash
-# ビルドして起動（初回のみ時間がかかります）
-make docker-up
-
-# 停止
-make docker-down
+make docker-up   # ビルドして起動
+make docker-down # 停止
 ```
 
 | サービス | URL |
@@ -105,20 +66,12 @@ make docker-down
 
 ### ローカル開発（Docker不使用）
 
-**バックエンド**
-
 ```bash
-cd backend
-go mod tidy
-go run cmd/server/main.go
-```
+# バックエンド
+cd backend && go run cmd/server/main.go
 
-**フロントエンド**
-
-```bash
-cd frontend
-npm install
-npm run dev
+# フロントエンド
+cd frontend && npm install && npm run dev
 ```
 
 ## 使い方
@@ -128,85 +81,44 @@ npm run dev
 3. 都道府県・市区町村を選択し「相場データ取得」をクリック
 4. 土地価格・建築費・想定賃料・ローン条件を入力して「分析実行」
 
-### APIエンドポイント
+## APIエンドポイント
 
 | メソッド | パス | 説明 |
 |----------|------|------|
 | `GET` | `/health` | ヘルスチェック |
 | `GET` | `/api/land-prices/stats` | 土地取引価格の統計情報 |
 | `GET` | `/api/land-prices/compare` | 検討地と相場の比較 |
-| `GET` | `/api/land-prices/estimate` | 土地価格の推定 |
-| `POST` | `/api/investment/analyze` | 投資シミュレーション実行 |
+| `GET` | `/api/land-prices/estimate` | 土地価格の理論値推定 |
+| `POST` | `/api/investment/analyze` | 投資シミュレーション（CF・デッドクロス・出口戦略） |
+| `POST` | `/api/investment/simulate` | モンテカルロシミュレーション |
+| `POST` | `/api/renovation/analyze` | リフォームROI計算 |
 | `GET` | `/api/municipalities` | 市区町村一覧 |
-| `GET` | `/api/station-ridership` | 駅乗降者数データ |
-| `GET` | `/api/population-forecast` | 人口予測データ |
+| `GET` | `/api/station-ridership` | 駅乗降客数・需要スコア |
+| `GET` | `/api/population-forecast` | 人口予測データ（250mメッシュ） |
 | `GET` | `/api/land-appraisals` | 地価公示データ |
+| `GET` | `/api/urban-risks` | 都市計画リスク（立地適正化計画・盛土・都市計画道路・災害履歴） |
+| `GET` | `/api/hazard` | 自然災害ハザード（洪水・高潮・津波・土砂崩れ） |
+| `GET` | `/api/investment-score` | 投資適地スコア（11 MLIT API並列実行・0–100点） |
 
-**`POST /api/investment/analyze` リクエスト例:**
+リクエスト/レスポンス仕様の詳細は [docs/api-reference.md](docs/api-reference.md) を参照。
 
-```json
-{
-  "landPrice": 5000000,
-  "buildingCost": 10000000,
-  "miscExpenseRate": 0.07,
-  "monthlyRent": 120000,
-  "vacancyRate": 0.05,
-  "loanAmount": 13000000,
-  "annualLoanRate": 0.015,
-  "loanYears": 35,
-  "buildingType": "木造",
-  "expenseRate": 0.20,
-  "incomeTaxRate": 0.33,
-  "holdingYears": 10,
-  "exitYieldTarget": 0.06
-}
-```
+## ドキュメント体系
 
-## ディレクトリ構成
-
-```
-yield-guard/
-├── .github/
-│   └── workflows/
-│       ├── backend-ci.yml          # Go vet / test -race / build
-│       └── frontend-ci.yml         # lint / tsc / build
-├── backend/
-│   ├── Dockerfile                  # マルチステージビルド（BuildKitキャッシュ最適化）
-│   ├── cmd/server/main.go          # エントリポイント
-│   └── internal/
-│       ├── domain/
-│       │   ├── types.go            # ドメインモデル
-│       │   ├── investment.go       # 収支計算ロジック（元利均等・減価償却・税金）
-│       │   └── investment_test.go  # ユニットテスト
-│       ├── mlit/
-│       │   ├── client.go           # 国交省APIクライアント（リトライ・キャッシュ付き）
-│       │   ├── cache.go            # TTL付きインメモリキャッシュ（24時間）
-│       │   ├── client_test.go      # ユニットテスト（httptest モック）
-│       │   ├── integration_test.go # 統合テスト（実API疎通・要APIキー）
-│       │   └── types.go            # APIレスポンス型
-│       └── api/
-│           ├── handler.go          # HTTPハンドラー
-│           └── router.go           # Ginルーター
-├── docs/
-│   ├── overview.md                 # 全体設計概要
-│   ├── mlit-api-integration.md     # 国交省APIクライアント仕様
-│   ├── domain-investment-calculation.md
-│   └── ...
-├── frontend/
-│   ├── Dockerfile                  # マルチステージビルド
-│   └── src/
-│       ├── app/                    # Next.js App Router
-│       ├── components/             # UIコンポーネント
-│       ├── lib/                    # APIクライアント・計算ユーティリティ
-│       └── types/                  # TypeScript型定義
-├── docker-compose.yml              # backend + frontend 一括起動
-├── .env.example                    # 環境変数テンプレート
-└── README.md
-```
+| 対象層 | ドキュメント |
+|--------|-------------|
+| 全体設計・デプロイフロー | [docs/overview.md](docs/overview.md) |
+| インフラ・観測基盤（OTel・Cloud Monitoring） | [docs/architecture.md](docs/architecture.md) |
+| APIリファレンス（全エンドポイント詳細） | [docs/api-reference.md](docs/api-reference.md) |
+| ドメイン計算仕様（投資・デッドクロス・出口戦略） | [docs/domain-investment-calculation.md](docs/domain-investment-calculation.md) |
+| ドメイン計算仕様（減価償却・耐用年数） | [docs/domain-depreciation-dead-cross.md](docs/domain-depreciation-dead-cross.md) |
+| ドメイン計算仕様（出口・譲渡所得税） | [docs/domain-exit-strategy.md](docs/domain-exit-strategy.md) |
+| ドメイン計算仕様（用途地域・ゾーニングリスク） | [docs/domain-zoning.md](docs/domain-zoning.md) |
+| MLIT API連携仕様（タイル変換・キャッシュ・正規化） | [docs/mlit-api-integration.md](docs/mlit-api-integration.md) |
+| フロントエンドコンポーネント仕様 | [docs/frontend-components.md](docs/frontend-components.md) |
+| セキュリティ・認証（WIF・Secret Manager） | [docs/security.md](docs/security.md) |
+| ユースケース一覧（UC-01〜UC-14） | [docs/usecases.md](docs/usecases.md) |
 
 ## 開発
-
-### よく使うコマンド
 
 ```bash
 make help        # 利用可能なコマンド一覧
@@ -214,68 +126,24 @@ make dev         # 開発サーバー起動（backend :8080 + frontend :3000）
 make docker-up   # Dockerコンテナをビルドして起動
 make docker-down # Dockerコンテナを停止・削除
 make test        # バックエンド・フロントエンドの全テスト実行
-make lint        # バックエンド（golangci-lint）・フロントエンド lint
-make build       # バックエンド・フロントエンドのビルド
+make lint        # golangci-lint + eslint + tsc --noEmit
+make build       # go build + next build
+make integration # 統合テスト（実 MLIT API 疎通・MLIT_API_KEY 必須）
 ```
 
-### 国交省API 開発用リクエスト
-
-`.env` の `MLIT_API_KEY` を使って国交省APIに直接リクエストできます（`jq` が必要）。
+**MLIT API デバッグ:**
 
 ```bash
-# 市区町村一覧を取得（XIT002）
-make mlit-municipalities area=13        # 東京都
-
-# 土地取引価格を取得（XIT001）
-make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4
-make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4 city=13101  # 千代田区
-```
-
-| パラメータ | 説明 | 例 |
-|-----------|------|----|
-| `area` | 都道府県コード（必須） | `13`=東京都, `27`=大阪府 |
-| `year` / `to_year` | 取得開始・終了年（必須） | `2024` |
-| `quarter` / `to_quarter` | 四半期（必須、1〜4） | `1` |
-| `city` | 市区町村コード（任意） | `13101`=千代田区 |
-
-個別に実行する場合：
-
-```bash
-# バックエンド
-cd backend && go test -race ./... -v
-
-# フロントエンド
-cd frontend && npm test
+make mlit-municipalities area=13                                             # 市区町村一覧（東京都）
+make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4 # 土地取引価格
 ```
 
 ### CI
 
-PR・mainへのpush時に GitHub Actions が自動実行される（ワークフロー自身の変更でも再トリガーされる）。
-
 | ワークフロー | トリガーパス | チェック内容 |
 |---|---|---|
-| Backend CI | `backend/**`, `backend-ci.yml` | `golangci-lint` / `go test -race` / `go build` |
-| Frontend CI | `frontend/**`, `frontend-ci.yml` | `lint` / `tsc --noEmit` / `vitest run` / `build` |
-
-Dependabot により Go modules・npm の依存パッケージが毎週月曜（JST）に自動更新される（エコシステムごとに1PR）。
-
-### ビルド
-
-```bash
-make build
-```
-
-### 計算ロジック仕様
-
-| 計算 | 式 |
-|------|----|
-| 表面利回り | `(月額賃料 × 12) / 総投資額` |
-| 元利均等返済 | `P × r(1+r)^n / ((1+r)^n - 1)` |
-| 減価償却（定額法） | `建築費 / 法定耐用年数` |
-| デッドクロス | 元金返済額 > 減価償却費 となる最初の年 |
-| 長期譲渡税率 | 20.315%（保有5年超） / 39.363%（5年以下） |
-
-**法定耐用年数:** 木造 22年 / 軽量鉄骨 27年 / 重量鉄骨 34年 / RC造 47年
+| Backend CI | `backend/**` | `golangci-lint` / `go test -race` / `go build` |
+| Frontend CI | `frontend/**` | `lint` / `tsc --noEmit` / `vitest run` / `next build` |
 
 ## ライセンス
 


### PR DESCRIPTION
## 背景・目的

READMEがエンドユーザー向け説明・開発者クイックスタート・APIリファレンス・計算仕様を混在させており、どの読者にとっても情報が中途半端な状態だった。
一方、`docs/` 配下には各アーキテクチャ層の詳細仕様書が揃っているが、READMEから一切参照されていなかった。

## 変更内容

### 削除
- 銀行員・不動産会社向け blockquote（開発者READMEと乖離）
- `/api/investment/analyze` sequence diagram（詳細はdocs/architecture.mdに集約）
- 計算ロジック仕様セクション（docs/domain-*.md に委譲）

### 更新
- APIエンドポイント表：9件 → 14件（`/api/urban-risks`・`/api/hazard`・`/api/investment-score`・`POST /api/investment/simulate`・`POST /api/renovation/analyze` を追記）

### 追加
- **「ドキュメント体系」セクション**：ドメイン層・インフラ層・API層・フロントエンド層・セキュリティの各仕様書へのリンク一覧

## 確認事項

- [ ] APIエンドポイント14件が `backend/internal/api/router.go` の登録ルートと一致していること
- [ ] docs/ リンク先ファイルがすべて実在すること
- [ ] GitHub上でMermaid flowchartが正常にレンダリングされること