### PR TITLE
feat(frontend): モバイルファーストレイアウト最適化 (#206)

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -13,7 +13,7 @@ import RenovationPanel from "@/components/RenovationPanel";
 import type { InvestmentInput, InvestmentResult, LandPriceComparison, TheoreticalPriceResult, StationRidershipResult, PopulationForecastResult, AppraisalComparisonResult, UrbanRisk, SimulationMode, LoanMethod, MonteCarloResult, InvestmentScoreResult } from "@/types/investment";
 import { analyze, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks, fetchHazardInfo, fetchInvestmentScore, simulate } from "@/lib/api";
 import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
-import { ShieldAlert, Info, FileDown, Share2, Check } from "lucide-react";
+import { ShieldAlert, Info, FileDown, Share2, Check, SlidersHorizontal, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 import { downloadReportPDF } from "@/lib/generatePdf";
@@ -58,6 +58,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   const [copied, setCopied] = useState(false);
   const [monteCarloResult, setMonteCarloResult] = useState<MonteCarloResult | null>(null);
   const [monteCarloLoading, setMonteCarloLoading] = useState(false);
+  const [mobileFormOpen, setMobileFormOpen] = useState(false);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -201,18 +202,18 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
 
   return (
     <div className="min-h-screen bg-background">
-      <header className="border-b bg-white px-6 py-4 shadow-sm">
+      <header className="border-b bg-white px-4 py-3 shadow-sm lg:px-6 lg:py-4">
         <div className="mx-auto flex max-w-7xl items-center gap-3">
-          <ShieldAlert className="h-7 w-7 text-primary" />
+          <ShieldAlert className="h-6 w-6 text-primary lg:h-7 lg:w-7" />
           <div>
-            <h1 className="text-xl font-bold text-foreground">Yield-Guard</h1>
+            <h1 className="text-lg font-bold text-foreground lg:text-xl">Yield-Guard</h1>
             <p className="text-xs text-muted-foreground">不動産投資リスク可視化ツール</p>
           </div>
-          <div className="ml-auto flex items-center gap-3">
+          <div className="ml-auto flex items-center gap-2 lg:gap-3">
             {result && lastInput && (
               <button
                 onClick={handleShare}
-                className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium shadow-sm hover:bg-muted transition-colors"
+                className="hidden items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium shadow-sm hover:bg-muted transition-colors lg:flex"
                 title="この条件をクリップボードにコピー"
               >
                 {copied ? (
@@ -236,7 +237,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                     setPdfGenerating(false);
                   }
                 }}
-                className="flex items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-primary/90 disabled:opacity-60"
+                className="hidden items-center gap-1.5 rounded-md bg-primary px-3 py-1.5 text-xs font-medium text-white shadow-sm hover:bg-primary/90 disabled:opacity-60 lg:flex"
               >
                 <FileDown className="h-3.5 w-3.5" />
                 {pdfGenerating ? "生成中..." : "PDFレポート出力"}
@@ -244,13 +245,13 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
             )}
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               <span className="h-2 w-2 rounded-full bg-green-400" />
-              国交省API使用
+              <span className="hidden sm:inline">国交省API使用</span>
             </div>
           </div>
         </div>
       </header>
 
-      <main className="mx-auto max-w-7xl px-4 py-6">
+      <main className="mx-auto max-w-7xl px-4 py-4 lg:py-6">
         {error && (
           <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
             ⚠ {error}
@@ -264,10 +265,16 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
           </div>
         )}
 
+        {/* Desktop: side-by-side layout (form left, results right) */}
+        {/* Mobile: results-first layout (results on top, form hidden in bottom sheet) */}
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[400px_1fr]">
-          <aside>
+          {/* Form: hidden on mobile (shown in bottom sheet), visible on desktop */}
+          <aside className="hidden lg:block">
             <InvestmentForm
-              onAnalyze={handleAnalyze}
+              onAnalyze={(input, quickTotalMan) => {
+                setMobileFormOpen(false);
+                return handleAnalyze(input, quickTotalMan);
+              }}
               onFetchLandPrices={handleFetchLandPrices}
               loading={loading}
               simulationMode={simulationMode}
@@ -279,11 +286,12 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
 
           <section className="space-y-6">
             {!result && !comparison && (
-              <div className="flex h-80 items-center justify-center rounded-xl border-2 border-dashed border-muted-foreground/20">
+              <div className="flex h-64 items-center justify-center rounded-xl border-2 border-dashed border-muted-foreground/20 lg:h-80">
                 <div className="text-center text-muted-foreground">
-                  <ShieldAlert className="mx-auto mb-3 h-12 w-12 opacity-30" />
-                  <p className="text-sm font-medium">左のフォームから条件を入力して</p>
-                  <p className="text-sm">シミュレーションを実行してください</p>
+                  <ShieldAlert className="mx-auto mb-3 h-10 w-10 opacity-30 lg:h-12 lg:w-12" />
+                  <p className="text-sm font-medium">条件を入力してシミュレーションを実行してください</p>
+                  <p className="mt-1 text-xs lg:hidden">下の「条件を編集」ボタンから入力できます</p>
+                  <p className="mt-1 hidden text-sm lg:block">左のフォームから条件を入力してください</p>
                 </div>
               </div>
             )}
@@ -334,6 +342,56 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
           </section>
         </div>
       </main>
+
+      {/* Mobile: floating "条件を編集" button */}
+      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-40 lg:hidden">
+        <button
+          onClick={() => setMobileFormOpen(true)}
+          className="flex min-h-[44px] items-center gap-2 rounded-full bg-primary px-6 py-3 text-sm font-semibold text-white shadow-lg hover:bg-primary/90 active:scale-95 transition-transform"
+          aria-label="条件を編集"
+        >
+          <SlidersHorizontal className="h-4 w-4" />
+          条件を編集
+        </button>
+      </div>
+
+      {/* Mobile: bottom sheet overlay */}
+      {mobileFormOpen && (
+        <div className="fixed inset-0 z-50 lg:hidden" role="dialog" aria-modal="true" aria-label="投資条件入力">
+          {/* Backdrop */}
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setMobileFormOpen(false)}
+          />
+          {/* Sheet */}
+          <div className="absolute bottom-0 left-0 right-0 max-h-[90dvh] overflow-y-auto rounded-t-2xl bg-background shadow-xl">
+            <div className="sticky top-0 flex items-center justify-between border-b bg-background px-4 py-3">
+              <h2 className="text-base font-semibold">投資条件を編集</h2>
+              <button
+                onClick={() => setMobileFormOpen(false)}
+                className="flex h-[44px] w-[44px] items-center justify-center rounded-full hover:bg-muted transition-colors"
+                aria-label="閉じる"
+              >
+                <X className="h-5 w-5" />
+              </button>
+            </div>
+            <div className="px-4 py-4">
+              <InvestmentForm
+                onAnalyze={(input, quickTotalMan) => {
+                  setMobileFormOpen(false);
+                  return handleAnalyze(input, quickTotalMan);
+                }}
+                onFetchLandPrices={handleFetchLandPrices}
+                loading={loading}
+                simulationMode={simulationMode}
+                onModeChange={handleModeChange}
+                initialInput={decoded?.input}
+                initialQuickTotalPriceMan={decoded?.quickTotalPriceMan}
+              />
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -256,7 +256,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
         </div>
       </header>
 
-      <main className="mx-auto max-w-7xl px-4 py-4 lg:py-6">
+      <main className="mx-auto max-w-7xl px-4 py-4 pb-24 lg:py-6 lg:pb-6">
         {error && (
           <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
             ⚠ {error}
@@ -392,7 +392,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                 simulationMode={simulationMode}
                 onModeChange={handleModeChange}
                 initialInput={lastInput ?? decoded?.input}
-                initialQuickTotalPriceMan={decoded?.quickTotalPriceMan}
+                initialQuickTotalPriceMan={lastInput ? undefined : decoded?.quickTotalPriceMan}
               />
             </div>
           </div>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -61,6 +61,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   const [mobileFormOpen, setMobileFormOpen] = useState(false);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     return () => {
@@ -68,6 +69,10 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
       if (copiedTimer.current) clearTimeout(copiedTimer.current);
     };
   }, []);
+
+  useEffect(() => {
+    if (mobileFormOpen) closeButtonRef.current?.focus();
+  }, [mobileFormOpen]);
 
   const handleModeChange = (mode: SimulationMode) => {
     if (result) {
@@ -364,10 +369,11 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
             onClick={() => setMobileFormOpen(false)}
           />
           {/* Sheet */}
-          <div className="absolute bottom-0 left-0 right-0 max-h-[90dvh] overflow-y-auto rounded-t-2xl bg-background shadow-xl">
+          <div className="absolute bottom-0 left-0 right-0 max-h-[90vh] overflow-y-auto rounded-t-2xl bg-background shadow-xl">
             <div className="sticky top-0 flex items-center justify-between border-b bg-background px-4 py-3">
               <h2 className="text-base font-semibold">投資条件を編集</h2>
               <button
+                ref={closeButtonRef}
                 onClick={() => setMobileFormOpen(false)}
                 className="flex h-[44px] w-[44px] items-center justify-center rounded-full hover:bg-muted transition-colors"
                 aria-label="閉じる"
@@ -385,7 +391,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                 loading={loading}
                 simulationMode={simulationMode}
                 onModeChange={handleModeChange}
-                initialInput={decoded?.input}
+                initialInput={lastInput ?? decoded?.input}
                 initialQuickTotalPriceMan={decoded?.quickTotalPriceMan}
               />
             </div>

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -499,6 +499,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   <Input
                     label="物件価格（土地＋建物の総額）"
                     type="number"
+                    inputMode="numeric"
                     suffix="万円"
                     value={quickTotalPriceMan}
                     onChange={(e) => {
@@ -509,7 +510,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   />
                   <p className="text-xs text-muted-foreground mt-1">内部で土地70%・建物30%に按分して計算します</p>
                 </div>
-                <Input label="想定月額賃料" type="number" suffix="円"
+                <Input label="想定月額賃料" type="number" inputMode="numeric" suffix="円"
                   value={String(input.monthlyRent)}
                   onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
                   error={fieldError("monthlyRent")} />
@@ -540,7 +541,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                       )}
                       {showCustomLoan && (
                         <div className="space-y-1">
-                          <Input label="ローン金額" type="number" suffix="万円"
+                          <Input label="ローン金額" type="number" inputMode="numeric" suffix="万円"
                             value={toMan(input.loanAmount)}
                             onChange={(e) => setNum("loanAmount", fromMan(e.target.value))}
                             error={fieldError("loanAmount")} />
@@ -556,7 +557,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                     </>
                   )}
                 </div>
-                <Input label="目標利回り" type="number" suffix="%" step="0.5"
+                <Input label="目標利回り" type="number" inputMode="decimal" suffix="%" step="0.5"
                   value={toPct(input.yieldTarget, 1)}
                   onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
                   error={fieldError("yieldTarget")} />
@@ -642,6 +643,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   <label className="text-sm font-medium text-foreground">緯度（任意）</label>
                   <input
                     type="number"
+                    inputMode="decimal"
                     placeholder="例: 35.6762"
                     step="0.0001"
                     value={propertyLat}
@@ -654,6 +656,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   <label className="text-sm font-medium text-foreground">経度（任意）</label>
                   <input
                     type="number"
+                    inputMode="decimal"
                     placeholder="例: 139.6503"
                     step="0.0001"
                     value={propertyLng}
@@ -692,15 +695,15 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
               <div>
                 <p className="text-sm font-semibold text-foreground mb-3">物件情報</p>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <Input label="土地取得価格" type="number" suffix="万円"
+                  <Input label="土地取得価格" type="number" inputMode="numeric" suffix="万円"
                     value={toMan(input.landPrice)}
                     onChange={(e) => setNum("landPrice", fromMan(e.target.value))}
                     error={fieldError("landPrice")} />
-                  <Input label="土地面積" type="number" suffix="m²"
+                  <Input label="土地面積" type="number" inputMode="decimal" suffix="m²"
                     value={String(input.landArea)}
                     onChange={(e) => setNum("landArea", parseFloat(e.target.value) || 0)} />
                   <div className="sm:col-span-2">
-                    <Input label="建物価格" type="number" suffix="万円"
+                    <Input label="建物価格" type="number" inputMode="numeric" suffix="万円"
                       value={toMan(input.buildingCost)}
                       onChange={(e) => setNum("buildingCost", fromMan(e.target.value))}
                       error={fieldError("buildingCost")} />
@@ -720,7 +723,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                           <p className="font-medium text-xs mb-1">① 消費税額から計算（最も確実）</p>
                           <div className="flex gap-2 items-end">
                             <div className="flex-1">
-                              <Input label="消費税額" type="number" suffix="万円"
+                              <Input label="消費税額" type="number" inputMode="numeric" suffix="万円"
                                 value={taxAmount} onChange={(e) => setTaxAmount(e.target.value)} />
                             </div>
                             <Button type="button" variant="outline" size="sm" className="mb-0 shrink-0"
@@ -737,11 +740,11 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                         <div>
                           <p className="font-medium text-xs mb-1">② 固定資産税評価額の比率で按分</p>
                           <div className="grid grid-cols-3 gap-2">
-                            <Input label="土地評価額" type="number" suffix="万円"
+                            <Input label="土地評価額" type="number" inputMode="numeric" suffix="万円"
                               value={landAssess} onChange={(e) => setLandAssess(e.target.value)} />
-                            <Input label="建物評価額" type="number" suffix="万円"
+                            <Input label="建物評価額" type="number" inputMode="numeric" suffix="万円"
                               value={buildingAssess} onChange={(e) => setBuildingAssess(e.target.value)} />
-                            <Input label="購入総額" type="number" suffix="万円"
+                            <Input label="購入総額" type="number" inputMode="numeric" suffix="万円"
                               value={totalPrice} onChange={(e) => setTotalPrice(e.target.value)} />
                           </div>
                           <Button type="button" variant="outline" size="sm" className="mt-2"
@@ -759,10 +762,10 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                       </div>
                     )}
                   </div>
-                  <Input label="築年数" type="number" suffix="年（0=新築）"
+                  <Input label="築年数" type="number" inputMode="numeric" suffix="年（0=新築）"
                     value={String(input.buildingAge)}
                     onChange={(e) => setNum("buildingAge", parseInt(e.target.value) || 0)} />
-                  <Input label="最寄り駅徒歩" type="number" suffix="分（0=未入力）"
+                  <Input label="最寄り駅徒歩" type="number" inputMode="numeric" suffix="分（0=未入力）"
                     value={String(input.stationMinutes)}
                     onChange={(e) => setNum("stationMinutes", parseInt(e.target.value) || 0)} />
                   <Select label="建物構造" value={input.buildingType}
@@ -787,22 +790,22 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
               <div className="border-t pt-4">
                 <p className="text-sm font-semibold text-foreground mb-3">収益条件</p>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <Input label="想定月額賃料" type="number" suffix="円"
+                  <Input label="想定月額賃料" type="number" inputMode="numeric" suffix="円"
                     value={String(input.monthlyRent)}
                     onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
                     error={fieldError("monthlyRent")} />
-                  <Input label="現況空室率" type="number" suffix="%" step="1"
+                  <Input label="現況空室率" type="number" inputMode="numeric" suffix="%" step="1"
                     value={toPct(input.actualVacancyRate, 0)}
                     onChange={(e) => setNum("actualVacancyRate", fromPct(e.target.value))} />
-                  <Input label="想定空室率（長期）" type="number" suffix="%" step="1"
+                  <Input label="想定空室率（長期）" type="number" inputMode="numeric" suffix="%" step="1"
                     value={toPct(input.vacancyRate, 0)}
                     onChange={(e) => setNum("vacancyRate", fromPct(e.target.value))}
                     error={fieldError("vacancyRate")} />
-                  <Input label="運営経費率※" type="number" suffix="%" step="1"
+                  <Input label="運営経費率※" type="number" inputMode="numeric" suffix="%" step="1"
                     value={toPct(input.expenseRate, 0)}
                     onChange={(e) => setNum("expenseRate", fromPct(e.target.value))}
                     error={fieldError("expenseRate")} />
-                  <Input label="諸経費率" type="number" suffix="%" step="0.5"
+                  <Input label="諸経費率" type="number" inputMode="decimal" suffix="%" step="0.5"
                     value={toPct(input.miscExpenseRate, 1)}
                     onChange={(e) => setNum("miscExpenseRate", fromPct(e.target.value))}
                     error={fieldError("miscExpenseRate")} />
@@ -864,17 +867,17 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   </label>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                  <Input label="ローン金額" type="number" suffix="万円"
+                  <Input label="ローン金額" type="number" inputMode="numeric" suffix="万円"
                     value={toMan(input.loanAmount)}
                     onChange={(e) => { if (!isCashPurchase) setNum("loanAmount", fromMan(e.target.value)); }}
                     error={fieldError("loanAmount")}
                     disabled={isCashPurchase} />
-                  <Input label="年利" type="number" suffix="%" step="0.01"
+                  <Input label="年利" type="number" inputMode="decimal" suffix="%" step="0.01"
                     value={toPct(input.annualLoanRate)}
                     onChange={(e) => { if (!isCashPurchase) setNum("annualLoanRate", fromPct(e.target.value)); }}
                     error={fieldError("annualLoanRate")}
                     disabled={isCashPurchase} />
-                  <Input label="返済期間" type="number" suffix="年"
+                  <Input label="返済期間" type="number" inputMode="numeric" suffix="年"
                     value={String(input.loanYears)}
                     onChange={(e) => { if (!isCashPurchase) setNum("loanYears", parseInt(e.target.value) || 0); }}
                     error={fieldError("loanYears")}
@@ -886,19 +889,19 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
               <div className="border-t pt-4">
                 <p className="text-sm font-semibold text-foreground mb-3">出口戦略</p>
                 <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                  <Input label="売却予定年数" type="number" suffix="年後"
+                  <Input label="売却予定年数" type="number" inputMode="numeric" suffix="年後"
                     value={String(input.holdingYears)}
                     onChange={(e) => setNum("holdingYears", parseInt(e.target.value) || 10)}
                     error={fieldError("holdingYears")} />
-                  <Input label="売却時目標利回り（実質）" type="number" suffix="%" step="0.5"
+                  <Input label="売却時目標利回り（実質）" type="number" inputMode="decimal" suffix="%" step="0.5"
                     value={toPct(input.exitYieldTarget, 1)}
                     onChange={(e) => setNum("exitYieldTarget", fromPct(e.target.value))}
                     error={fieldError("exitYieldTarget")} />
-                  <Input label="目標表面利回り" type="number" suffix="%" step="0.5"
+                  <Input label="目標表面利回り" type="number" inputMode="decimal" suffix="%" step="0.5"
                     value={toPct(input.yieldTarget, 1)}
                     onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
                     error={fieldError("yieldTarget")} />
-                  <Input label="所得税率（実効）" type="number" suffix="%" step="1"
+                  <Input label="所得税率（実効）" type="number" inputMode="numeric" suffix="%" step="1"
                     value={toPct(input.incomeTaxRate, 0)}
                     onChange={(e) => setNum("incomeTaxRate", fromPct(e.target.value))}
                     error={fieldError("incomeTaxRate")} />
@@ -908,11 +911,11 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                 <div className="mt-4">
                   <p className="text-xs font-semibold text-muted-foreground mb-2">NPV / IRR 設定</p>
                   <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                    <Input label="割引率" type="number" suffix="%" step="0.1"
+                    <Input label="割引率" type="number" inputMode="decimal" suffix="%" step="0.1"
                       value={toPct(input.discountRate ?? 0.05, 1)}
                       onChange={(e) => setNum("discountRate", fromPct(e.target.value))}
                       error={fieldError("discountRate")} />
-                    <Input label="物件価格下落率" type="number" suffix="%" step="0.1"
+                    <Input label="物件価格下落率" type="number" inputMode="decimal" suffix="%" step="0.1"
                       value={toPct(input.priceDeclineRate ?? 0, 1)}
                       onChange={(e) => setNum("priceDeclineRate", fromPct(e.target.value))}
                       error={fieldError("priceDeclineRate")} />
@@ -966,6 +969,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                           <Input
                             label={i === 0 ? "開始年" : ""}
                             type="number"
+                            inputMode="numeric"
                             suffix="年目〜"
                             min="2"
                             max={String(maxYear)}
@@ -977,6 +981,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                           <Input
                             label={i === 0 ? "適用金利" : ""}
                             type="number"
+                            inputMode="decimal"
                             suffix="%"
                             min="0.1"
                             max="30"

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -6,6 +6,59 @@ import type { InvestmentInput, InvestmentResult, PopulationForecastResult, Stres
 import { formatMan, formatPct, formatYen } from "@/lib/utils";
 import { TrendingUp, TrendingDown, AlertTriangle, CheckCircle, Users } from "lucide-react";
 
+/** Mobile 2×2 KPI grid showing the 4 most important metrics at a glance */
+function MobileKpiGrid({ result, isGood, targetPct, yieldPct, netYieldPct }: {
+  result: InvestmentResult;
+  isGood: boolean;
+  targetPct: number;
+  yieldPct: number;
+  netYieldPct: number;
+}) {
+  const firstYearCF = result.yearlyResults[0]?.afterTaxCashFlow ?? 0;
+  const kpis = [
+    {
+      label: "表面利回り",
+      value: `${yieldPct.toFixed(2)}%`,
+      sub: isGood ? `目標${targetPct}%超え` : `目標${targetPct}%未満`,
+      color: isGood ? "text-green-600" : "text-red-600",
+      bg: isGood ? "bg-green-50 border-green-200" : "bg-red-50 border-red-200",
+    },
+    {
+      label: "実質利回り",
+      value: `${netYieldPct.toFixed(2)}%`,
+      sub: "空室・経費控除後",
+      color: "text-foreground",
+      bg: "bg-muted/40 border-border",
+    },
+    {
+      label: "総投資額",
+      value: formatMan(result.totalInvestment),
+      sub: "諸経費込み",
+      color: "text-primary",
+      bg: "bg-muted/40 border-border",
+    },
+    {
+      label: "1年目税引後CF",
+      value: formatYen(firstYearCF),
+      sub: "年間キャッシュフロー",
+      color: firstYearCF >= 0 ? "text-green-600" : "text-red-600",
+      bg: firstYearCF >= 0 ? "bg-green-50 border-green-200" : "bg-red-50 border-red-200",
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 gap-3 lg:hidden">
+      {kpis.map((kpi) => (
+        <div key={kpi.label} className={`rounded-xl border p-3 ${kpi.bg}`}>
+          <p className="text-xs text-muted-foreground">{kpi.label}</p>
+          <p className={`mt-1 text-xl font-bold leading-tight ${kpi.color}`}>{kpi.value}</p>
+          <p className="mt-0.5 text-xs text-muted-foreground">{kpi.sub}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 interface Props {
   result: InvestmentResult;
   input: InvestmentInput;
@@ -29,31 +82,40 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
 
   return (
     <div className="space-y-4">
+      {/* Mobile: 2×2 KPI grid (hidden on desktop) */}
+      <MobileKpiGrid
+        result={result}
+        isGood={isGood}
+        targetPct={targetPct}
+        yieldPct={yieldPct}
+        netYieldPct={netYieldPct}
+      />
+
       {/* メイン利回り表示 */}
       <Card className={`border-2 ${isGood ? "border-green-400" : "border-red-400"}`}>
         <CardContent className="pt-6">
           <div className="flex items-center justify-between">
-            <div>
-              <p className="text-sm text-muted-foreground">表面利回り（満室想定年収 / 総投資額）</p>
+            <div className="min-w-0 flex-1">
+              <p className="text-xs text-muted-foreground sm:text-sm">表面利回り（満室想定年収 / 総投資額）</p>
               <div className="flex items-end gap-2">
-                <span className={`text-5xl font-bold ${isGood ? "text-green-600" : "text-red-600"}`}>
+                <span className={`text-4xl font-bold sm:text-5xl ${isGood ? "text-green-600" : "text-red-600"}`}>
                   {yieldPct.toFixed(2)}
                 </span>
-                <span className="mb-2 text-2xl font-semibold text-muted-foreground">%</span>
+                <span className="mb-1 text-xl font-semibold text-muted-foreground sm:mb-2 sm:text-2xl">%</span>
               </div>
-              <p className="mt-1 text-sm text-muted-foreground">
+              <p className="mt-1 text-xs text-muted-foreground sm:text-sm">
                 実質利回り（空室・経費控除後）：{netYieldPct.toFixed(2)}%
               </p>
             </div>
-            <div className="flex flex-col items-center gap-2">
+            <div className="ml-3 flex flex-col items-center gap-2 shrink-0">
               {isGood ? (
                 <>
-                  <CheckCircle className="h-12 w-12 text-green-500" />
+                  <CheckCircle className="h-10 w-10 text-green-500 sm:h-12 sm:w-12" />
                   <Badge variant="success">{targetPct}%超え ✓</Badge>
                 </>
               ) : (
                 <>
-                  <AlertTriangle className="h-12 w-12 text-red-500" />
+                  <AlertTriangle className="h-10 w-10 text-red-500 sm:h-12 sm:w-12" />
                   <Badge variant="danger">{targetPct}%未満 ✗</Badge>
                 </>
               )}

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -35,7 +35,7 @@ describe("Dashboard", () => {
 
   it("初期状態でプレースホルダーが表示される", () => {
     render(<Dashboard />);
-    expect(screen.getByText(/左のフォームから条件を入力して/)).toBeInTheDocument();
+    expect(screen.getByText(/条件を入力してシミュレーションを実行してください/)).toBeInTheDocument();
   });
 
   it("analyzeAPIの応答後にYieldAnalysisが表示される（クイックモード）", async () => {


### PR DESCRIPTION
## 概要

モバイルファースト対応のレイアウト最適化を実装しました。銀行員等への物件説明時に、スマートフォンで結果をすぐに見せられるよう、PC向けのレイアウトをモバイル最適化しました。

## 変更内容

- **Dashboard.tsx**: モバイルでは結果エリアを最上部に表示し、フォームをボトムシートに収納。フローティング「条件を編集」ボタン（最低44px）を画面下部に配置
- **InvestmentForm.tsx**: 数値入力フィールドに `inputMode="numeric"` / `inputMode="decimal"` を追加し、モバイルで数値キーボードが表示されるよう対応
- **YieldAnalysis.tsx**: モバイル用2×2 KPIグリッドを追加（表面利回り・実質利回り・総投資額・1年目CF）し、主要指標を1画面で確認可能に

## 関連Issue

Closes #206

## テスト
- [x] 既存テストが通ること
- [x] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み
- デスクトップ（`lg:` ブレークポイント）では従来のレイアウトを完全維持
- モバイル（375px iPhone SE）では横スクロールなし
- タッチターゲット最低44px確保（フローティングボタン・チェックボックスラベル等）
- クイックモード→結果表示まで5タップ以内（条件を編集 → 物件価格入力 → 月額賃料入力 → 実行ボタン）