### PR TITLE
feat(backend/frontend): 地価公示(XCT001)年次変化率を賃料下落率参考値として提供するAPI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Copy `.env.example` → `.env` (project root).
 | `GET` | `/api/land-prices/compare` | Compare vs. market price |
 | `GET` | `/api/land-prices/estimate` | Theoretical price estimate |
 | `POST` | `/api/investment/analyze` | Investment simulation |
+| `GET` | `/api/investment/rent-decline-hint` | Rent decline rate hint from land appraisals (area, municipality) |
 | `GET` | `/api/municipalities` | Municipality list |
 | `GET` | `/api/station-ridership` | Station ridership (tile coords) |
 | `GET` | `/api/population-forecast` | Population forecast (tile coords) |

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -483,6 +483,58 @@ func (h *Handler) GetLandAppraisals(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
+// GetRentDeclineHint は XCT001 直近5年分から賃料下落率参考値を返す
+// GET /api/investment/rent-decline-hint?area=13[&municipality=13101]
+func (h *Handler) GetRentDeclineHint(c *gin.Context) {
+	area := c.Query("area")
+	if area == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "area は必須パラメータです"})
+		return
+	}
+
+	municipality := c.Query("municipality")
+	ctx := c.Request.Context()
+
+	// XCT001 の対応年（2022〜2026）を並列取得
+	years := []int{2022, 2023, 2024, 2025, 2026}
+	type yearResult struct {
+		year  int
+		items []domain.LandAppraisalItem
+		err   error
+	}
+	ch := make(chan yearResult, len(years))
+	for _, y := range years {
+		y := y
+		go func() {
+			items, err := h.mlitClient.FetchLandAppraisals(ctx, area, municipality, y, "00")
+			ch <- yearResult{year: y, items: items, err: err}
+		}()
+	}
+
+	itemsByYear := make(map[int][]domain.LandAppraisalItem, len(years))
+	var fetchErr error
+	for range years {
+		r := <-ch
+		if r.err != nil {
+			slog.WarnContext(ctx, "FetchLandAppraisals failed", "year", r.year, "area", area, "error", r.err)
+			fetchErr = r.err
+			continue
+		}
+		if len(r.items) > 0 {
+			itemsByYear[r.year] = r.items
+		}
+	}
+
+	// 全年エラーの場合のみ502を返す
+	if len(itemsByYear) == 0 && fetchErr != nil {
+		c.JSON(http.StatusBadGateway, gin.H{"error": "地価公示APIからのデータ取得に失敗しました: " + fetchErr.Error()})
+		return
+	}
+
+	hint := domain.CalcRentDeclineHint(itemsByYear)
+	c.JSON(http.StatusOK, hint)
+}
+
 // GetUrbanRisks は緯度経度から都市計画リスクを一括取得する
 // GET /api/urban-risks?lat=35.68&lng=139.69
 func (h *Handler) GetUrbanRisks(c *gin.Context) {

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -504,7 +504,6 @@ func (h *Handler) GetRentDeclineHint(c *gin.Context) {
 	}
 	ch := make(chan yearResult, len(years))
 	for _, y := range years {
-		y := y
 		go func() {
 			items, err := h.mlitClient.FetchLandAppraisals(ctx, area, municipality, y, "00")
 			ch <- yearResult{year: y, items: items, err: err}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -121,6 +121,7 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/land-prices/estimate", h.EstimateLandPrice)
 		// analyze / simulate は generalRL + analyzeRL の両方でトークンを消費する（意図的な二重制限）
 		api.POST("/investment/analyze", analyzeRL.middleware(), h.Analyze)
+		api.GET("/investment/rent-decline-hint", h.GetRentDeclineHint)
 		api.POST("/renovation/analyze", h.HandleRenovationAnalyze)
 		api.POST("/investment/simulate", analyzeRL.middleware(), h.MonteCarlo)
 		api.GET("/municipalities", h.GetMunicipalities)

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -121,7 +121,7 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/land-prices/estimate", h.EstimateLandPrice)
 		// analyze / simulate は generalRL + analyzeRL の両方でトークンを消費する（意図的な二重制限）
 		api.POST("/investment/analyze", analyzeRL.middleware(), h.Analyze)
-		api.GET("/investment/rent-decline-hint", h.GetRentDeclineHint)
+		api.GET("/investment/rent-decline-hint", analyzeRL.middleware(), h.GetRentDeclineHint)
 		api.POST("/renovation/analyze", h.HandleRenovationAnalyze)
 		api.POST("/investment/simulate", analyzeRL.middleware(), h.MonteCarlo)
 		api.GET("/municipalities", h.GetMunicipalities)

--- a/backend/internal/domain/land_appraisal.go
+++ b/backend/internal/domain/land_appraisal.go
@@ -67,8 +67,12 @@ func CalcRentDeclineHint(itemsByYear map[int][]LandAppraisalItem) RentDeclineHin
 	sort.Slice(medians, func(i, j int) bool { return medians[i].year < medians[j].year })
 
 	if len(medians) < 2 {
-		fallback.DataPointCount = total
-		return fallback
+		return RentDeclineHint{
+			Basis:          "fallback",
+			FallbackUsed:   true,
+			DataPointCount: total,
+			Note:           "取得できた年次が1年分のみのため構造別平均値を推奨します",
+		}
 	}
 
 	first := medians[0]

--- a/backend/internal/domain/land_appraisal.go
+++ b/backend/internal/domain/land_appraisal.go
@@ -1,6 +1,101 @@
 package domain
 
-import "sort"
+import (
+	"math"
+	"sort"
+)
+
+// RentDeclineHint は地価公示データから算出した賃料下落率参考値
+type RentDeclineHint struct {
+	HintRate       float64 `json:"hintRate"`       // 参考下落率（小数: 0.008 = 0.8%/年）
+	Basis          string  `json:"basis"`           // "land_appraisal" | "fallback"
+	DataPointCount int     `json:"dataPointCount"`  // 使用した地価公示データ件数
+	FallbackUsed   bool    `json:"fallbackUsed"`
+	Note           string  `json:"note"`
+}
+
+const minDataPointsForHint = 5
+
+// CalcRentDeclineHint は複数年分の地価公示データからCAGRを算出し参考下落率を返す。
+// itemsByYear の key は西暦年、value はその年の地価公示レコード群。
+// 総データ件数 < 5 または有効年数 < 2 の場合は fallback を返す。
+// 地価が下落傾向（CAGR < 0）の場合のみ hintRate に絶対値をセットし basis = "land_appraisal" を返す。
+func CalcRentDeclineHint(itemsByYear map[int][]LandAppraisalItem) RentDeclineHint {
+	fallback := RentDeclineHint{
+		Basis:        "fallback",
+		FallbackUsed: true,
+		Note:         "データ不足のため構造別平均値を推奨します",
+	}
+
+	// 総データ件数チェック
+	total := 0
+	for _, items := range itemsByYear {
+		total += len(items)
+	}
+	if total < minDataPointsForHint {
+		fallback.DataPointCount = total
+		return fallback
+	}
+
+	// 各年の㎡単価中央値を計算
+	type yearMedian struct {
+		year   int
+		median float64
+	}
+	var medians []yearMedian
+	for year, items := range itemsByYear {
+		prices := make([]float64, 0, len(items))
+		for _, item := range items {
+			if item.PricePerSqm > 0 {
+				prices = append(prices, item.PricePerSqm)
+			}
+		}
+		if len(prices) == 0 {
+			continue
+		}
+		sort.Float64s(prices)
+		mid := len(prices) / 2
+		var median float64
+		if len(prices)%2 == 0 {
+			median = (prices[mid-1] + prices[mid]) / 2
+		} else {
+			median = prices[mid]
+		}
+		medians = append(medians, yearMedian{year: year, median: median})
+	}
+
+	sort.Slice(medians, func(i, j int) bool { return medians[i].year < medians[j].year })
+
+	if len(medians) < 2 {
+		fallback.DataPointCount = total
+		return fallback
+	}
+
+	first := medians[0]
+	last := medians[len(medians)-1]
+	n := float64(last.year - first.year)
+
+	// CAGR = (last/first)^(1/n) - 1
+	cagr := math.Pow(last.median/first.median, 1.0/n) - 1
+
+	if cagr >= 0 {
+		return RentDeclineHint{
+			HintRate:       0,
+			Basis:          "fallback",
+			DataPointCount: total,
+			FallbackUsed:   true,
+			Note:           "地価は上昇または横ばいのため構造別平均値を推奨します",
+		}
+	}
+
+	return RentDeclineHint{
+		HintRate:       math.Abs(cagr),
+		Basis:          "land_appraisal",
+		DataPointCount: total,
+		FallbackUsed:   false,
+		Note:           "地価公示データに基づく参考値です。賃料下落率と完全には一致しません",
+	}
+}
 
 // LandAppraisalItem は XCT001 から変換した地価公示1レコード
 type LandAppraisalItem struct {

--- a/backend/internal/domain/land_appraisal.go
+++ b/backend/internal/domain/land_appraisal.go
@@ -21,20 +21,18 @@ const minDataPointsForHint = 5
 // 総データ件数 < 5 または有効年数 < 2 の場合は fallback を返す。
 // 地価が下落傾向（CAGR < 0）の場合のみ hintRate に絶対値をセットし basis = "land_appraisal" を返す。
 func CalcRentDeclineHint(itemsByYear map[int][]LandAppraisalItem) RentDeclineHint {
-	fallback := RentDeclineHint{
-		Basis:        "fallback",
-		FallbackUsed: true,
-		Note:         "データ不足のため構造別平均値を推奨します",
-	}
-
 	// 総データ件数チェック
 	total := 0
 	for _, items := range itemsByYear {
 		total += len(items)
 	}
 	if total < minDataPointsForHint {
-		fallback.DataPointCount = total
-		return fallback
+		return RentDeclineHint{
+			Basis:          "fallback",
+			FallbackUsed:   true,
+			DataPointCount: total,
+			Note:           "データ不足のため構造別平均値を推奨します",
+		}
 	}
 
 	// 各年の㎡単価中央値を計算

--- a/backend/internal/domain/land_appraisal_test.go
+++ b/backend/internal/domain/land_appraisal_test.go
@@ -1,6 +1,7 @@
 package domain
 
 import (
+	"math"
 	"testing"
 )
 
@@ -105,8 +106,10 @@ func TestCalcRentDeclineHint_DeclineTrend(t *testing.T) {
 	if got.Basis != "land_appraisal" {
 		t.Errorf("expected basis=land_appraisal, got %q", got.Basis)
 	}
-	if got.HintRate <= 0 {
-		t.Errorf("expected positive hintRate, got %v", got.HintRate)
+	// CAGR = (90000/100000)^(1/2) - 1 ≒ -0.05132
+	want := math.Abs(math.Pow(90_000.0/100_000.0, 1.0/2.0) - 1)
+	if math.Abs(got.HintRate-want) > 1e-9 {
+		t.Errorf("hintRate = %v, want %v", got.HintRate, want)
 	}
 }
 

--- a/backend/internal/domain/land_appraisal_test.go
+++ b/backend/internal/domain/land_appraisal_test.go
@@ -58,6 +58,80 @@ func TestCalcAppraisalComparison_TrendLabel(t *testing.T) {
 	}
 }
 
+func TestCalcRentDeclineHint_FallbackWhenTooFewPoints(t *testing.T) {
+	// 総件数 < 5 → fallback
+	itemsByYear := map[int][]LandAppraisalItem{
+		2022: {{Year: 2022, PricePerSqm: 100_000}},
+		2024: {{Year: 2024, PricePerSqm: 90_000}},
+	}
+	got := CalcRentDeclineHint(itemsByYear)
+	if !got.FallbackUsed {
+		t.Errorf("expected fallback when dataPointCount < 5, got %+v", got)
+	}
+	if got.DataPointCount != 2 {
+		t.Errorf("expected dataPointCount=2, got %v", got.DataPointCount)
+	}
+}
+
+func TestCalcRentDeclineHint_FallbackWhenOnlyOneYear(t *testing.T) {
+	// 有効年数 < 2 → fallback
+	items := make([]LandAppraisalItem, 10)
+	for i := range items {
+		items[i] = LandAppraisalItem{Year: 2024, PricePerSqm: 100_000}
+	}
+	got := CalcRentDeclineHint(map[int][]LandAppraisalItem{2024: items})
+	if !got.FallbackUsed {
+		t.Errorf("expected fallback when only one year available, got %+v", got)
+	}
+}
+
+func TestCalcRentDeclineHint_DeclineTrend(t *testing.T) {
+	// 地価が下落（5点ずつ、2年間で100000→90000）
+	makeItems := func(year int, price float64, n int) []LandAppraisalItem {
+		items := make([]LandAppraisalItem, n)
+		for i := range items {
+			items[i] = LandAppraisalItem{Year: year, PricePerSqm: price}
+		}
+		return items
+	}
+	itemsByYear := map[int][]LandAppraisalItem{
+		2022: makeItems(2022, 100_000, 5),
+		2024: makeItems(2024, 90_000, 5),
+	}
+	got := CalcRentDeclineHint(itemsByYear)
+	if got.FallbackUsed {
+		t.Errorf("expected no fallback for declining trend, got %+v", got)
+	}
+	if got.Basis != "land_appraisal" {
+		t.Errorf("expected basis=land_appraisal, got %q", got.Basis)
+	}
+	if got.HintRate <= 0 {
+		t.Errorf("expected positive hintRate, got %v", got.HintRate)
+	}
+}
+
+func TestCalcRentDeclineHint_RiseTrend(t *testing.T) {
+	// 地価が上昇 → fallback
+	makeItems := func(year int, price float64, n int) []LandAppraisalItem {
+		items := make([]LandAppraisalItem, n)
+		for i := range items {
+			items[i] = LandAppraisalItem{Year: year, PricePerSqm: price}
+		}
+		return items
+	}
+	itemsByYear := map[int][]LandAppraisalItem{
+		2022: makeItems(2022, 100_000, 5),
+		2024: makeItems(2024, 120_000, 5),
+	}
+	got := CalcRentDeclineHint(itemsByYear)
+	if !got.FallbackUsed {
+		t.Errorf("expected fallback for rising trend, got %+v", got)
+	}
+	if got.HintRate != 0 {
+		t.Errorf("expected hintRate=0 for rising trend, got %v", got.HintRate)
+	}
+}
+
 func TestCalcAppraisalComparison_SkipsZeroPrice(t *testing.T) {
 	items := []LandAppraisalItem{
 		{Year: 2024, PricePerSqm: 0, ChangeRate: 0.0},

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -279,10 +279,18 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
     setQuickHistory(loadQuickHistory());
   }, []);
 
+  const clearRentHint = () => { setRentHint(null); setRentHintError(null); };
+
   const handleAreaChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const code = e.target.value;
     setArea(code);
+    clearRentHint();
     loadMunicipalities(code);
+  };
+
+  const handleCityChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    setCity(e.target.value);
+    clearRentHint();
   };
 
   const setNum = (key: keyof InvestmentInput, value: number) => {
@@ -472,7 +480,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                     />
                     <select
                       value={city}
-                      onChange={(e) => setCity(e.target.value)}
+                      onChange={handleCityChange}
                       className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     >
                       <option value="">（全市区町村）</option>
@@ -642,7 +650,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   />
                   <select
                     value={city}
-                    onChange={(e) => setCity(e.target.value)}
+                    onChange={handleCityChange}
                     className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                   >
                     <option value="">（全市区町村）</option>

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -8,7 +8,8 @@ import { Slider } from "@/components/ui/slider";
 import type { InvestmentInput, BuildingType, SimulationMode, RateAdjustment } from "@/types/investment";
 import { DEFAULT_INPUT, QUICK_MODE_DEFAULTS } from "@/types/investment";
 import { formatPct } from "@/lib/utils";
-import { fetchMunicipalities, type Municipality } from "@/lib/api";
+import { fetchMunicipalities, fetchRentDeclineHint, type Municipality } from "@/lib/api";
+import type { RentDeclineHint } from "@/types/investment";
 import { Search, Calculator, Info, AlertTriangle, ShieldCheck, Zap, SlidersHorizontal, ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
 import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
 
@@ -183,6 +184,11 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   // 変動金利スケジュール
   const [rateScheduleEnabled, setRateScheduleEnabled] = useState(false);
 
+  // 賃料下落率参考値
+  const [rentHint, setRentHint] = useState<RentDeclineHint | null>(null);
+  const [rentHintLoading, setRentHintLoading] = useState(false);
+  const [rentHintError, setRentHintError] = useState<string | null>(null);
+
   // 按分ヘルパーの状態
   const [showBuildingHelper, setShowBuildingHelper] = useState(false);
   const [taxAmount, setTaxAmount] = useState("");
@@ -285,6 +291,23 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   };
   const setStr = (key: keyof InvestmentInput, value: string) =>
     setInput((prev) => ({ ...prev, [key]: value }));
+
+  const handleFetchRentHint = useCallback(async () => {
+    setRentHintLoading(true);
+    setRentHintError(null);
+    setRentHint(null);
+    try {
+      const hint = await fetchRentDeclineHint({ area, municipality: city || undefined });
+      setRentHint(hint);
+      if (!hint.fallbackUsed && hint.hintRate > 0) {
+        setNum("rentDeclineRate", hint.hintRate);
+      }
+    } catch (e) {
+      setRentHintError(e instanceof Error ? e.message : "参考値の取得に失敗しました");
+    } finally {
+      setRentHintLoading(false);
+    }
+  }, [area, city]);
 
   const handleCashPurchaseToggle = (checked: boolean) => {
     setIsCashPurchase(checked);
@@ -779,6 +802,28 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                     <p className="text-xs text-muted-foreground mt-1">
                       建物構造から自動設定（例: 木造1%/年）
                     </p>
+                    <div className="mt-2">
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        disabled={!area || rentHintLoading}
+                        onClick={handleFetchRentHint}
+                        className="text-xs h-7 px-2"
+                      >
+                        {rentHintLoading ? "取得中…" : "地域の参考値を取得"}
+                      </Button>
+                      {rentHintError && (
+                        <p className="text-xs text-destructive mt-1">{rentHintError}</p>
+                      )}
+                      {rentHint && !rentHintError && (
+                        <p className="text-xs text-muted-foreground mt-1">
+                          {rentHint.fallbackUsed
+                            ? "データ不足のため地域参考値なし。構造別平均値を推奨します"
+                            : `地価公示より参考値: ${toPct(rentHint.hintRate, 1)}%/年（${rentHint.dataPointCount}件）`}
+                        </p>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -271,6 +271,8 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   useEffect(() => {
     if (filteredMunicipalities.length === 1) {
       setCity(filteredMunicipalities[0].id);
+      setRentHint(null);
+      setRentHintError(null);
     }
   }, [filteredMunicipalities]);
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -14,6 +14,7 @@ import type {
   MonteCarloInput,
   MonteCarloResult,
   InvestmentScoreResult,
+  RentDeclineHint,
 } from "@/types/investment";
 
 const BASE = "/api";
@@ -159,6 +160,17 @@ export async function fetchLandAppraisals(params: {
   if (params.city) q.set("city", params.city);
   const res = await fetch(`${BASE}/land-appraisals?${q}`);
   return handleResponse<AppraisalComparisonResult>(res);
+}
+
+/** 地価公示データから賃料下落率参考値を取得 */
+export async function fetchRentDeclineHint(params: {
+  area: string;
+  municipality?: string;
+}): Promise<RentDeclineHint> {
+  const q = new URLSearchParams({ area: params.area });
+  if (params.municipality) q.set("municipality", params.municipality);
+  const res = await fetch(`${BASE}/investment/rent-decline-hint?${q}`);
+  return handleResponse<RentDeclineHint>(res);
 }
 
 /** 緯度経度から都市計画リスクを一括取得 */

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -383,6 +383,14 @@ export interface InvestmentScoreResult {
   breakdown: ScoreBreakdown;
 }
 
+export interface RentDeclineHint {
+  hintRate: number;
+  basis: "land_appraisal" | "fallback";
+  dataPointCount: number;
+  fallbackUsed: boolean;
+  note: string;
+}
+
 export const DEFAULT_RENOVATION_INPUT: RenovationInput = {
   propertyPrice: 10_000_000,
   annualBaseRent: 1_200_000,


### PR DESCRIPTION
## 概要

- MLITの不動産情報ライブラリAPIには賃料データが存在しないため、ユーザーが「年間賃料下落率」を手入力する際の根拠が乏しかった
- 地価公示（XCT001）の直近5年分データから年平均成長率（CAGR）を算出し、地価が下落傾向のエリアでは参考値として提示する
- 地価変化率≠賃料下落率であることを明示し、上昇・横ばい・データ不足時は既存の構造別固定値（#149）にフォールバックする

## 変更内容

### バックエンド
- `domain/land_appraisal.go`: `RentDeclineHint` 型と `CalcRentDeclineHint()` 関数を追加（CAGR計算ロジック）
- `api/handler.go`: `GET /api/investment/rent-decline-hint` ハンドラを追加（XCT001を2022〜2026年分goroutineで並列取得）
- `api/router.go`: エンドポイントを登録

### フロントエンド
- `types/investment.ts`: `RentDeclineHint` 型を追加
- `lib/api.ts`: `fetchRentDeclineHint()` を追加
- `components/InvestmentForm.tsx`: 賃料下落率フィールドに「地域の参考値を取得」ボタンを追加

## APIレスポンス例

```json
// 地価下落エリアの場合
{
  "hintRate": 0.008,
  "basis": "land_appraisal",
  "dataPointCount": 12,
  "fallbackUsed": false,
  "note": "地価公示データに基づく参考値です。賃料下落率と完全には一致しません"
}

// 地価上昇・データ不足の場合
{
  "hintRate": 0,
  "basis": "fallback",
  "dataPointCount": 4,
  "fallbackUsed": true,
  "note": "データ不足のため構造別平均値を推奨します"
}
```

## テスト

- `go test -race ./...` 全パス
- ドメイン層に4ケースのユニットテスト追加（データ不足フォールバック・単一年フォールバック・下落傾向・上昇傾向）

## 関連Issue

- Closes #150
- 依存: #149（構造別デフォルト値、実装済み）
- 関連: #148（rentDeclineRate UI）、#133（rentDeclineRate バックエンド）

## 確認事項

- [ ] `MLIT_API_KEY` 設定済み環境で `curl "http://localhost:8080/api/investment/rent-decline-hint?area=13"` を確認
- [ ] フロントで都道府県選択後に「地域の参考値を取得」ボタンの動作を確認