### PR TITLE
feat(frontend): オフライン計算フォールバックとネットワーク状態表示 (#205)

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -432,6 +432,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                 onModeChange={handleModeChange}
                 initialInput={lastInput ?? decoded?.input}
                 initialQuickTotalPriceMan={lastInput ? undefined : decoded?.quickTotalPriceMan}
+                isOnline={isOnline}
               />
             </div>
           </div>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -11,9 +11,10 @@ import CostBreakdown from "@/components/CostBreakdown";
 import { LoanOptimizationPanel } from "@/components/LoanOptimizationPanel";
 import RenovationPanel from "@/components/RenovationPanel";
 import type { InvestmentInput, InvestmentResult, LandPriceComparison, TheoreticalPriceResult, StationRidershipResult, PopulationForecastResult, AppraisalComparisonResult, UrbanRisk, SimulationMode, LoanMethod, MonteCarloResult, InvestmentScoreResult } from "@/types/investment";
-import { analyze, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks, fetchHazardInfo, fetchInvestmentScore, simulate } from "@/lib/api";
+import { analyze as analyzeOnline, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks, fetchHazardInfo, fetchInvestmentScore, simulate } from "@/lib/api";
+import { analyze as analyzeOffline } from "@/lib/investment";
 import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
-import { ShieldAlert, Info, FileDown, Share2, Check, SlidersHorizontal, X } from "lucide-react";
+import { ShieldAlert, Info, FileDown, Share2, Check, SlidersHorizontal, X, WifiOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 import { downloadReportPDF } from "@/lib/generatePdf";
@@ -59,9 +60,23 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   const [monteCarloResult, setMonteCarloResult] = useState<MonteCarloResult | null>(null);
   const [monteCarloLoading, setMonteCarloLoading] = useState(false);
   const [mobileFormOpen, setMobileFormOpen] = useState(false);
+  const [isOnline, setIsOnline] = useState<boolean | null>(null);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Network status detection
+  useEffect(() => {
+    setIsOnline(navigator.onLine);
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
 
   useEffect(() => {
     return () => {
@@ -90,7 +105,10 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
     setMonteCarloResult(null);
     const inputWithMethod = { ...input, loanMethod };
     try {
-      const res = await analyze(inputWithMethod);
+      // When offline, fall back to client-side calculation
+      const res = isOnline === false
+        ? analyzeOffline(inputWithMethod)
+        : await analyzeOnline(inputWithMethod);
       setResult(res);
       setLastInput(inputWithMethod);
 
@@ -125,7 +143,10 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
     setError(null);
     setMonteCarloResult(null);
     try {
-      const res = await analyze({ ...lastInput, loanMethod: method });
+      const updatedInput = { ...lastInput, loanMethod: method };
+      const res = isOnline === false
+        ? analyzeOffline(updatedInput)
+        : await analyzeOnline(updatedInput);
       setResult(res);
       setLastInput((prev) => prev ? { ...prev, loanMethod: method } : prev);
     } catch (e) {
@@ -248,10 +269,18 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                 {pdfGenerating ? "生成中..." : "PDFレポート出力"}
               </button>
             )}
-            <div className="flex items-center gap-2 text-xs text-muted-foreground">
-              <span className="h-2 w-2 rounded-full bg-green-400" />
-              <span className="hidden sm:inline">国交省API使用</span>
-            </div>
+            {isOnline === true && (
+              <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                <span className="h-2 w-2 rounded-full bg-green-400" />
+                <span className="hidden sm:inline">国交省API使用</span>
+              </div>
+            )}
+            {isOnline === false && (
+              <div className="flex items-center gap-1.5 rounded-md border border-amber-300 bg-amber-50 px-2.5 py-1 text-xs font-medium text-amber-800">
+                <WifiOff className="h-3.5 w-3.5" />
+                オフライン
+              </div>
+            )}
           </div>
         </div>
       </header>
@@ -267,6 +296,15 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
           <div className="mb-4 flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
             <Info className="h-4 w-4 shrink-0" />
             モードを切り替えたため、結果をクリアしました。再度シミュレーションを実行してください。
+          </div>
+        )}
+
+        {isOnline === false && (
+          <div className="mb-4 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+            <WifiOff className="h-4 w-4 shrink-0" />
+            <span>
+              <strong>オフラインモード：</strong>シミュレーションはデバイス内で計算されます。「相場を取得」はネットワーク接続が回復するまで使用できません。
+            </span>
           </div>
         )}
 
@@ -286,6 +324,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
               onModeChange={handleModeChange}
               initialInput={decoded?.input}
               initialQuickTotalPriceMan={decoded?.quickTotalPriceMan}
+              isOnline={isOnline}
             />
           </aside>
 

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -99,6 +99,7 @@ interface Props {
   onModeChange: (mode: SimulationMode) => void;
   initialInput?: Partial<InvestmentInput>;
   initialQuickTotalPriceMan?: string;
+  isOnline?: boolean;
 }
 
 function getPeriodLabel(): string {
@@ -155,7 +156,7 @@ function validateQuick(quickTotalPriceMan: string, input: InvestmentInput): Form
   return e;
 }
 
-export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulationMode, onModeChange, initialInput, initialQuickTotalPriceMan }: Props) {
+export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulationMode, onModeChange, initialInput, initialQuickTotalPriceMan, isOnline = true }: Props) {
   const [input, setInput] = useState<InvestmentInput>({ ...DEFAULT_INPUT, ...initialInput });
   const [area, setArea] = useState("10");
   const [city, setCity] = useState("");
@@ -496,7 +497,10 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                 <p className="text-xs text-muted-foreground">
                   {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します
                 </p>
-                <Button variant="outline" className="w-full" loading={loading}
+                {!isOnline && (
+                  <p className="text-xs text-amber-700">オフライン中は相場取得を利用できません</p>
+                )}
+                <Button variant="outline" className="w-full" loading={loading} disabled={!isOnline}
                   onClick={() => {
                     const lat = parseFloat(propertyLat);
                     const lng = parseFloat(propertyLng);
@@ -702,7 +706,10 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
               <p className="text-xs text-muted-foreground">
                 {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します。緯度・経度を入力すると周辺駅の需要スコアも取得します
               </p>
-              <Button variant="outline" className="w-full" loading={loading}
+              {!isOnline && (
+                <p className="text-xs text-amber-700">オフライン中は相場取得を利用できません</p>
+              )}
+              <Button variant="outline" className="w-full" loading={loading} disabled={!isOnline}
                 onClick={() => {
                   const lat = parseFloat(propertyLat);
                   const lng = parseFloat(propertyLng);

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -99,7 +99,7 @@ interface Props {
   onModeChange: (mode: SimulationMode) => void;
   initialInput?: Partial<InvestmentInput>;
   initialQuickTotalPriceMan?: string;
-  isOnline?: boolean;
+  isOnline?: boolean | null;
 }
 
 function getPeriodLabel(): string {
@@ -156,7 +156,7 @@ function validateQuick(quickTotalPriceMan: string, input: InvestmentInput): Form
   return e;
 }
 
-export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulationMode, onModeChange, initialInput, initialQuickTotalPriceMan, isOnline = true }: Props) {
+export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulationMode, onModeChange, initialInput, initialQuickTotalPriceMan, isOnline = null }: Props) {
   const [input, setInput] = useState<InvestmentInput>({ ...DEFAULT_INPUT, ...initialInput });
   const [area, setArea] = useState("10");
   const [city, setCity] = useState("");
@@ -497,10 +497,10 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                 <p className="text-xs text-muted-foreground">
                   {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します
                 </p>
-                {!isOnline && (
+                {isOnline === false && (
                   <p className="text-xs text-amber-700">オフライン中は相場取得を利用できません</p>
                 )}
-                <Button variant="outline" className="w-full" loading={loading} disabled={!isOnline}
+                <Button variant="outline" className="w-full" loading={loading} disabled={isOnline === false}
                   onClick={() => {
                     const lat = parseFloat(propertyLat);
                     const lng = parseFloat(propertyLng);
@@ -706,10 +706,10 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
               <p className="text-xs text-muted-foreground">
                 {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します。緯度・経度を入力すると周辺駅の需要スコアも取得します
               </p>
-              {!isOnline && (
+              {isOnline === false && (
                 <p className="text-xs text-amber-700">オフライン中は相場取得を利用できません</p>
               )}
-              <Button variant="outline" className="w-full" loading={loading} disabled={!isOnline}
+              <Button variant="outline" className="w-full" loading={loading} disabled={isOnline === false}
                 onClick={() => {
                   const lat = parseFloat(propertyLat);
                   const lng = parseFloat(propertyLng);

--- a/frontend/src/lib/__tests__/investment.test.ts
+++ b/frontend/src/lib/__tests__/investment.test.ts
@@ -1,0 +1,371 @@
+import { describe, it, expect } from "vitest";
+import { analyze, calcMonthlyPayment, calcResidualUsefulLife } from "@/lib/investment";
+import type { InvestmentInput } from "@/types/investment";
+
+const EPSILON = 0.01; // 1円以内の誤差を許容
+
+function approxEqual(a: number, b: number, eps = EPSILON): boolean {
+  return Math.abs(a - b) <= eps;
+}
+
+// ─── Base test input (matches backend TestAnalyze_GrossYield) ──────────────
+
+const BASE_INPUT: InvestmentInput = {
+  landPrice: 5_000_000,
+  landArea: 100,
+  buildingCost: 10_000_000,
+  buildingAge: 0,
+  stationMinutes: 0,
+  miscExpenseRate: 0.07,
+  monthlyRent: 120_000,
+  vacancyRate: 0.05,
+  actualVacancyRate: 0,
+  loanAmount: 13_000_000,
+  annualLoanRate: 0.015,
+  loanYears: 35,
+  buildingType: "木造",
+  expenseRate: 0.20,
+  incomeTaxRate: 0.33,
+  holdingYears: 10,
+  exitYieldTarget: 0.06,
+  vacancyRateDelta: 0,
+  loanRateDelta: 0,
+  annualPropertyTax: 0,
+  rentDeclineRate: 0,
+  yieldTarget: 0.08,
+  loanMethod: "equal-payment",
+  rateAdjustmentSchedule: [],
+  discountRate: 0.05,
+  priceDeclineRate: 0,
+  depreciationMethod: "straight-line",
+};
+
+// ─── calcMonthlyPayment ────────────────────────────────────────────────────────
+
+describe("calcMonthlyPayment", () => {
+  it("1000万 年利1.5% 35年 ≈ 30,607円", () => {
+    const got = calcMonthlyPayment(10_000_000, 0.015, 35);
+    expect(approxEqual(got, 30_607, 500)).toBe(true);
+  });
+
+  it("3000万 年利2.0% 30年 ≈ 110,879円", () => {
+    const got = calcMonthlyPayment(30_000_000, 0.020, 30);
+    expect(approxEqual(got, 110_879, 500)).toBe(true);
+  });
+
+  it("金利ゼロ: 元金のみ均等返済", () => {
+    const got = calcMonthlyPayment(12_000_000, 0, 10);
+    expect(approxEqual(got, 100_000, 1)).toBe(true);
+  });
+
+  it("元金ゼロ → 0を返す", () => {
+    expect(calcMonthlyPayment(0, 0.015, 35)).toBe(0);
+  });
+
+  it("期間ゼロ → 0を返す", () => {
+    expect(calcMonthlyPayment(10_000_000, 0.015, 0)).toBe(0);
+  });
+});
+
+// ─── calcResidualUsefulLife ───────────────────────────────────────────────────
+
+describe("calcResidualUsefulLife", () => {
+  it("新築木造 → 法定耐用年数22年", () => {
+    expect(calcResidualUsefulLife("木造", 0)).toBe(22);
+  });
+
+  it("築10年木造: (22-10) + floor(10*0.2) = 14年", () => {
+    expect(calcResidualUsefulLife("木造", 10)).toBe(14);
+  });
+
+  it("築30年木造 (法定超過): floor(22*0.2)=4年", () => {
+    expect(calcResidualUsefulLife("木造", 30)).toBe(4);
+  });
+
+  it("築100年木造 (大幅超過): 最低2年", () => {
+    // floor(22*0.2)=4年だが、22年は完全に超えているので同じルール
+    expect(calcResidualUsefulLife("木造", 100)).toBe(4);
+  });
+
+  it("新築RC造 → 47年", () => {
+    expect(calcResidualUsefulLife("RC造", 0)).toBe(47);
+  });
+
+  it("築50年RC造 (法定超過): floor(47*0.2)=9年", () => {
+    expect(calcResidualUsefulLife("RC造", 50)).toBe(9);
+  });
+});
+
+// ─── analyze: 総投資額と表面利回り ────────────────────────────────────────────
+
+describe("analyze - TotalInvestment and GrossYield", () => {
+  it("総投資額 = 土地 + 建物 + 諸経費(7%)", () => {
+    const result = analyze(BASE_INPUT);
+    // 5,000,000 + 10,000,000 + 15,000,000*0.07 = 16,050,000
+    const wantTotal = 5_000_000 + 10_000_000 + 15_000_000 * 0.07;
+    expect(approxEqual(result.totalInvestment, wantTotal, 1)).toBe(true);
+  });
+
+  it("表面利回り = (月額賃料*12) / 総投資額", () => {
+    const result = analyze(BASE_INPUT);
+    const wantTotal = 5_000_000 + 10_000_000 + 15_000_000 * 0.07;
+    const wantGross = (120_000 * 12) / wantTotal;
+    expect(approxEqual(result.grossYield, wantGross, 0.0001)).toBe(true);
+  });
+});
+
+// ─── analyze: 8%判定 ──────────────────────────────────────────────────────────
+
+describe("analyze - isAboveYieldTarget", () => {
+  it("高賃料(20万) → 8%超でtrueになる", () => {
+    const r = analyze({ ...BASE_INPUT, monthlyRent: 200_000 });
+    expect(r.isAboveYieldTarget).toBe(true);
+  });
+
+  it("低賃料(5万) → 8%未満でfalseになる", () => {
+    const r = analyze({ ...BASE_INPUT, monthlyRent: 50_000 });
+    expect(r.isAboveYieldTarget).toBe(false);
+  });
+});
+
+// ─── analyze: dead cross ──────────────────────────────────────────────────────
+
+describe("analyze - dead cross detection", () => {
+  it("新築木造、短期ローン → デッドクロス発生（元金 > 減価償却）", () => {
+    // 築0年木造: 耐用年数22年、短いローンだと元金返済が早く depreciation を超える
+    const r = analyze({ ...BASE_INPUT, loanYears: 10, loanAmount: 10_000_000 });
+    // deadCrossYear は -1 でないはず（元金返済がすぐ減価償却を超える）
+    expect(r.deadCrossYear).toBeGreaterThan(-1);
+  });
+
+  it("建物費用ゼロ → デッドクロスなし(-1)", () => {
+    const r = analyze({ ...BASE_INPUT, buildingCost: 0, loanAmount: 5_000_000 });
+    expect(r.deadCrossYear).toBe(-1);
+  });
+});
+
+// ─── analyze: yearly results length ──────────────────────────────────────────
+
+describe("analyze - yearlyResults length", () => {
+  it("最低35年分の結果を返す", () => {
+    const r = analyze(BASE_INPUT);
+    expect(r.yearlyResults.length).toBeGreaterThanOrEqual(35);
+  });
+
+  it("LoanYears=40の場合は40年分以上返す", () => {
+    const r = analyze({ ...BASE_INPUT, loanYears: 40 });
+    expect(r.yearlyResults.length).toBeGreaterThanOrEqual(40);
+  });
+});
+
+// ─── analyze: remaining balance ───────────────────────────────────────────────
+
+describe("analyze - remaining loan balance", () => {
+  it("ローン完済後の残高は0", () => {
+    const r = analyze(BASE_INPUT);
+    // 35年後（インデックス34）は残高0であるべき
+    const lastLoanYear = r.yearlyResults[BASE_INPUT.loanYears - 1];
+    expect(lastLoanYear.remainingLoanBalance).toBeLessThanOrEqual(1); // 1円未満の丸め誤差を許容
+  });
+});
+
+// ─── analyze: stress scenarios ────────────────────────────────────────────────
+
+describe("analyze - stress scenarios", () => {
+  it("デフォルトで6つのストレスシナリオを返す", () => {
+    const r = analyze(BASE_INPUT);
+    expect(r.stressScenarios.length).toBe(6);
+  });
+
+  it("カスタムストレスがある場合は7つ返す", () => {
+    const r = analyze({ ...BASE_INPUT, loanRateDelta: 0.01 });
+    expect(r.stressScenarios.length).toBe(7);
+  });
+
+  it("ベースラインシナリオのDSCRは正の値", () => {
+    const r = analyze(BASE_INPUT);
+    const baseline = r.stressScenarios.find((s) => s.label === "ベースライン");
+    expect(baseline).toBeDefined();
+    expect(baseline!.dscr).toBeGreaterThan(0);
+  });
+});
+
+// ─── analyze: yield scenarios ────────────────────────────────────────────────
+
+describe("analyze - yield scenarios", () => {
+  it("楽観シナリオの年間賃料 > 標準 > 悲観", () => {
+    const r = analyze(BASE_INPUT);
+    expect(r.yieldScenarios.optimistic.annualRent).toBeGreaterThan(r.yieldScenarios.standard.annualRent);
+    expect(r.yieldScenarios.standard.annualRent).toBeGreaterThan(r.yieldScenarios.pessimistic.annualRent);
+  });
+
+  it("全シナリオで表面利回りは同じ（空室率に依存しない）", () => {
+    const r = analyze(BASE_INPUT);
+    expect(r.yieldScenarios.optimistic.grossYield).toBe(r.yieldScenarios.standard.grossYield);
+    expect(r.yieldScenarios.standard.grossYield).toBe(r.yieldScenarios.pessimistic.grossYield);
+  });
+});
+
+// ─── analyze: exit strategy ──────────────────────────────────────────────────
+
+describe("analyze - exit strategy", () => {
+  it("売却価格は正の値", () => {
+    const r = analyze(BASE_INPUT);
+    expect(r.exitSalePrice).toBeGreaterThan(0);
+  });
+
+  it("保有5年超 → 長期税率(20.315%)が適用される", () => {
+    // 保有10年の場合、capitalgain > 0 なら tax = gain * 0.20315
+    const r = analyze(BASE_INPUT);
+    if (r.exitCapitalGain > 0) {
+      expect(approxEqual(r.exitTransferTax, r.exitCapitalGain * 0.20315, r.exitCapitalGain * 0.001)).toBe(true);
+    }
+  });
+
+  it("保有5年以下 → 短期税率(39.63%)が適用される", () => {
+    const r = analyze({ ...BASE_INPUT, holdingYears: 3 });
+    if (r.exitCapitalGain > 0) {
+      expect(approxEqual(r.exitTransferTax, r.exitCapitalGain * 0.3963, r.exitCapitalGain * 0.001)).toBe(true);
+    }
+  });
+});
+
+// ─── analyze: LTV sensitivity ────────────────────────────────────────────────
+
+describe("analyze - LTV sensitivity", () => {
+  it("5つのLTV水準(50%〜90%)のデータを返す", () => {
+    const r = analyze(BASE_INPUT);
+    expect(r.ltvSensitivity.length).toBe(5);
+    expect(r.ltvSensitivity[0].ltv).toBe(0.5);
+    expect(r.ltvSensitivity[4].ltv).toBe(0.9);
+  });
+
+  it("高LTVほどDSCRが低い", () => {
+    const r = analyze(BASE_INPUT);
+    const rows = r.ltvSensitivity;
+    expect(rows[0].dscr).toBeGreaterThan(rows[4].dscr);
+  });
+});
+
+// ─── analyze: critical errors ────────────────────────────────────────────────
+
+describe("analyze - critical errors", () => {
+  it("正常な物件ではcriticalErrorsが空", () => {
+    const r = analyze(BASE_INPUT);
+    expect(r.criticalErrors).toEqual([]);
+  });
+
+  it("DEADCROSS_EARLY: 10年以内にデッドクロス発生で REJECT エラー", () => {
+    // 短い耐用年数の建物 + 長いローンで早期デッドクロスを誘発
+    // 築21年木造（簡便法耐用年数 = (22-21)+floor(21*0.2) = 1+4 = 5年）
+    const r = analyze({
+      ...BASE_INPUT,
+      buildingAge: 21,
+      loanYears: 35,
+      loanAmount: 10_000_000,
+    });
+    if (r.deadCrossYear > 0 && r.deadCrossYear <= 10) {
+      const err = r.criticalErrors.find((e) => e.code === "DEADCROSS_EARLY");
+      expect(err).toBeDefined();
+      expect(err!.status).toBe("REJECT");
+    }
+  });
+});
+
+// ─── analyze: rent decline rate ──────────────────────────────────────────────
+
+describe("analyze - rent decline rate", () => {
+  it("年1%下落の場合、10年目の賃料は初年度より低い", () => {
+    const r = analyze({ ...BASE_INPUT, rentDeclineRate: 0.01 });
+    expect(r.yearlyResults[9].annualRent).toBeLessThan(r.yearlyResults[0].annualRent);
+  });
+
+  it("賃料下落なしの場合、毎年の賃料は一定", () => {
+    const r = analyze({ ...BASE_INPUT, rentDeclineRate: 0 });
+    expect(approxEqual(r.yearlyResults[0].annualRent, r.yearlyResults[9].annualRent, 1)).toBe(true);
+  });
+});
+
+// ─── analyze: equal-principal loan method ────────────────────────────────────
+
+describe("analyze - equal-principal loan", () => {
+  it("元金均等返済: 初年度の元金返済額が後年より多い（逓減型）", () => {
+    const r = analyze({ ...BASE_INPUT, loanMethod: "equal-principal" });
+    expect(r.yearlyResults[0].annualPrincipal).toBeGreaterThanOrEqual(
+      r.yearlyResults[9].annualPrincipal,
+    );
+  });
+
+  it("元金均等返済でも35年分の結果が返る", () => {
+    const r = analyze({ ...BASE_INPUT, loanMethod: "equal-principal" });
+    expect(r.yearlyResults.length).toBeGreaterThanOrEqual(35);
+  });
+});
+
+// ─── analyze: NPV / IRR ──────────────────────────────────────────────────────
+
+describe("analyze - NPV and IRR", () => {
+  it("エクイティが正でholdingYears>0ならNPVが計算される", () => {
+    const r = analyze(BASE_INPUT);
+    // equity = totalInvestment - loanAmount > 0
+    expect(typeof r.npv).toBe("number");
+    expect(isFinite(r.npv)).toBe(true);
+  });
+
+  it("オーバーローン(equity<=0)の場合はIRRがnull", () => {
+    // loanAmount >= totalInvestment でオーバーローン
+    const r = analyze({ ...BASE_INPUT, loanAmount: 20_000_000 });
+    expect(r.irr).toBeNull();
+  });
+});
+
+// ─── analyze: DSCR ───────────────────────────────────────────────────────────
+
+describe("analyze - DSCR", () => {
+  it("DSCRは正の値(NOI/年間返済額)", () => {
+    const r = analyze(BASE_INPUT);
+    expect(r.dscr).toBeGreaterThan(0);
+  });
+});
+
+// ─── analyze: acquisition costs ──────────────────────────────────────────────
+
+describe("analyze - acquisition costs", () => {
+  it("仲介手数料が正の値", () => {
+    const r = analyze(BASE_INPUT);
+    expect(r.acquisitionCosts.brokerageFee).toBeGreaterThan(0);
+  });
+
+  it("合計 = 各費用の合計", () => {
+    const r = analyze(BASE_INPUT);
+    const c = r.acquisitionCosts;
+    const sum = c.brokerageFee + c.stampDuty + c.registrationTax + c.realEstateAcquisitionTax + c.propertyTaxProration;
+    expect(approxEqual(c.total, sum, 1)).toBe(true);
+  });
+});
+
+// ─── analyze: declining balance depreciation ─────────────────────────────────
+
+describe("analyze - declining balance depreciation", () => {
+  it("定率法では初年度の減価償却費が定額法より大きい（通常）", () => {
+    const straight = analyze({ ...BASE_INPUT, depreciationMethod: "straight-line" });
+    const declining = analyze({ ...BASE_INPUT, depreciationMethod: "declining-balance" });
+    // 定率法の初年度: buildingCost * (1.5/usefulLife)
+    // 定額法の初年度: buildingCost / usefulLife
+    // 1.5/L > 1/L なので定率法の方が大きい
+    expect(declining.yearlyResults[0].annualDepreciation).toBeGreaterThan(
+      straight.yearlyResults[0].annualDepreciation,
+    );
+  });
+});
+
+// ─── analyze: vacancy rate stress ────────────────────────────────────────────
+
+describe("analyze - vacancy rate stress test", () => {
+  it("vacancyRateDeltaが設定されると実効空室率に反映される", () => {
+    const base = analyze(BASE_INPUT);
+    const stressed = analyze({ ...BASE_INPUT, vacancyRateDelta: 0.10 });
+    // 空室増加 → 年間賃料減少
+    expect(stressed.yearlyResults[0].annualRent).toBeLessThan(base.yearlyResults[0].annualRent);
+  });
+});

--- a/frontend/src/lib/__tests__/investment.test.ts
+++ b/frontend/src/lib/__tests__/investment.test.ts
@@ -82,8 +82,8 @@ describe("calcResidualUsefulLife", () => {
     expect(calcResidualUsefulLife("木造", 30)).toBe(4);
   });
 
-  it("築100年木造 (大幅超過): 最低2年", () => {
-    // floor(22*0.2)=4年だが、22年は完全に超えているので同じルール
+  it("築100年木造 (大幅超過): floor(22*0.2)=4年", () => {
+    // 法定耐用年数を大幅超過した場合も floor(22*0.2)=4年
     expect(calcResidualUsefulLife("木造", 100)).toBe(4);
   });
 

--- a/frontend/src/lib/investment.ts
+++ b/frontend/src/lib/investment.ts
@@ -1,0 +1,794 @@
+/**
+ * investment.ts — client-side port of backend/internal/domain/investment.go
+ *
+ * Used as offline fallback when the backend /api/investment/analyze endpoint
+ * is unavailable. Results must match the backend calculation exactly.
+ */
+
+import type {
+  InvestmentInput,
+  InvestmentResult,
+  YearlyResult,
+  CriticalError,
+  AcquisitionCostBreakdown,
+  StressScenarioResult,
+  YieldScenarios,
+  YieldScenario,
+  LTVSensitivityRow,
+  BuildingType,
+} from "@/types/investment";
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const LOAN_METHOD_EQUAL_PAYMENT = "equal-payment";
+const LOAN_METHOD_EQUAL_PRINCIPAL = "equal-principal";
+const DEPRECIATION_STRAIGHT_LINE = "straight-line";
+const DEPRECIATION_DECLINING_BALANCE = "declining-balance";
+
+/** 長期譲渡所得税率（5年超） */
+const LONG_TERM_TRANSFER_TAX_RATE = 0.20315;
+/** 短期譲渡所得税率（5年以下） */
+const SHORT_TERM_TRANSFER_TAX_RATE = 0.3963;
+
+// ─── Building useful life ─────────────────────────────────────────────────────
+
+const BUILDING_USEFUL_LIFE_MAP: Record<BuildingType, number> = {
+  "木造": 22,
+  "軽量鉄骨(3mm以下)": 19,
+  "軽量鉄骨(4mm以下)": 27,
+  "重量鉄骨": 34,
+  "RC造": 47,
+  "SRC造": 47,
+};
+
+function getUsefulLife(buildingType: BuildingType): number {
+  return BUILDING_USEFUL_LIFE_MAP[buildingType] ?? 22;
+}
+
+/**
+ * calcResidualUsefulLife — 中古物件の簡便法耐用年数
+ * 根拠: 耐用年数の適用等に関する取扱通達 1-5-3
+ */
+export function calcResidualUsefulLife(buildingType: BuildingType, buildingAge: number): number {
+  const legal = getUsefulLife(buildingType);
+  if (buildingAge <= 0) return legal;
+
+  let residual: number;
+  if (buildingAge >= legal) {
+    residual = Math.floor(legal * 0.2);
+  } else {
+    residual = (legal - buildingAge) + Math.floor(buildingAge * 0.2);
+  }
+  return Math.max(residual, 2);
+}
+
+// ─── Defaults ─────────────────────────────────────────────────────────────────
+
+function applyDefaults(input: InvestmentInput): InvestmentInput {
+  const i = { ...input };
+  if (!i.miscExpenseRate) i.miscExpenseRate = 0.07;
+  if (!i.holdingYears) i.holdingYears = 10;
+  if (!i.exitYieldTarget) i.exitYieldTarget = 0.06;
+  if (!i.yieldTarget) i.yieldTarget = 0.08;
+  if (!i.loanYears) i.loanYears = 35;
+  if (!i.buildingType) i.buildingType = "木造";
+  if (!i.loanMethod) i.loanMethod = LOAN_METHOD_EQUAL_PAYMENT;
+  if (!i.discountRate) i.discountRate = 0.05;
+  if (!i.depreciationMethod) i.depreciationMethod = DEPRECIATION_STRAIGHT_LINE;
+  if (!i.rateAdjustmentSchedule) i.rateAdjustmentSchedule = [];
+  return i;
+}
+
+// ─── Loan calculations ────────────────────────────────────────────────────────
+
+/**
+ * calcMonthlyPayment — 元利均等返済の月次返済額
+ */
+export function calcMonthlyPayment(principal: number, annualRate: number, years: number): number {
+  if (principal <= 0 || years <= 0) return 0;
+  if (annualRate === 0) return principal / (years * 12);
+  const r = annualRate / 12;
+  const n = years * 12;
+  return (principal * r * Math.pow(1 + r, n)) / (Math.pow(1 + r, n) - 1);
+}
+
+/**
+ * calcYearlyLoanComponents — 元利均等返済: 1年分の利息・元金返済額
+ */
+function calcYearlyLoanComponents(
+  balance: number,
+  annualRate: number,
+  monthlyPayment: number,
+): { interest: number; principal: number } {
+  if (annualRate === 0) {
+    if (monthlyPayment * 12 > balance) return { interest: 0, principal: balance };
+    return { interest: 0, principal: monthlyPayment * 12 };
+  }
+  const r = annualRate / 12;
+  let remaining = balance;
+  let interest = 0;
+  let principal = 0;
+  for (let m = 0; m < 12; m++) {
+    if (remaining <= 0) break;
+    const monthInterest = remaining * r;
+    let monthPrincipal = monthlyPayment - monthInterest;
+    if (monthPrincipal > remaining) monthPrincipal = remaining;
+    interest += monthInterest;
+    principal += monthPrincipal;
+    remaining -= monthPrincipal;
+  }
+  return { interest, principal };
+}
+
+/**
+ * calcYearlyLoanComponentsEqualPrincipal — 元金均等返済: 1年分の利息・元金返済額
+ */
+function calcYearlyLoanComponentsEqualPrincipal(
+  balance: number,
+  annualRate: number,
+  monthlyPrincipal: number,
+): { interest: number; principal: number } {
+  const r = annualRate / 12;
+  let remaining = balance;
+  let interest = 0;
+  let principal = 0;
+  for (let m = 0; m < 12; m++) {
+    if (remaining <= 0) break;
+    const mp = Math.min(monthlyPrincipal, remaining);
+    interest += remaining * r;
+    principal += mp;
+    remaining -= mp;
+  }
+  return { interest, principal };
+}
+
+/**
+ * resolveRateForYear — スケジュールと基準金利から指定年の適用金利を返す
+ */
+function resolveRateForYear(
+  baseRate: number,
+  rateDelta: number,
+  schedule: InvestmentInput["rateAdjustmentSchedule"],
+  year: number,
+): number {
+  let rate = baseRate;
+  for (const adj of schedule) {
+    if (year >= adj.afterYear) rate = adj.rate;
+  }
+  return rate + rateDelta;
+}
+
+// ─── CalcDSCR ─────────────────────────────────────────────────────────────────
+
+export function calcDSCR(noi: number, annualDebtService: number): number {
+  if (annualDebtService <= 0) return 0;
+  return noi / annualDebtService;
+}
+
+// ─── Acquisition costs ────────────────────────────────────────────────────────
+
+function calcBrokerageFee(price: number, multiplier: number): number {
+  if (multiplier <= 0 || price <= 0) return 0;
+  let base: number;
+  if (price <= 2_000_000) {
+    base = price * 0.05;
+  } else if (price <= 4_000_000) {
+    base = price * 0.04 + 20_000;
+  } else {
+    base = price * 0.03 + 60_000;
+  }
+  return Math.round(base * 1.1 * multiplier);
+}
+
+function calcStampDuty(price: number): number {
+  if (price <= 100_000) return 200;
+  if (price <= 500_000) return 400;
+  if (price <= 1_000_000) return 1_000;
+  if (price <= 5_000_000) return 2_000;
+  if (price <= 10_000_000) return 10_000;
+  if (price <= 50_000_000) return 20_000;
+  if (price <= 100_000_000) return 60_000;
+  if (price <= 500_000_000) return 100_000;
+  if (price <= 1_000_000_000) return 200_000;
+  return 600_000;
+}
+
+function calcRegistrationTax(
+  landAssessed: number,
+  buildingAssessed: number,
+  loanAmount: number,
+  isNewBuilding: boolean,
+): number {
+  const landTransfer = landAssessed * 0.02;
+  const buildingTransfer = isNewBuilding ? buildingAssessed * 0.0015 : buildingAssessed * 0.02;
+  const mortgage = loanAmount * 0.004;
+  return Math.round(landTransfer + buildingTransfer + mortgage);
+}
+
+function calcRealEstateAcquisitionTax(landAssessed: number, buildingAssessed: number): number {
+  const taxRate = 0.03;
+  const landTax = landAssessed * 0.5 * taxRate;
+  const buildingTax = buildingAssessed * taxRate;
+  return Math.round(landTax + buildingTax);
+}
+
+function calcAcquisitionCosts(
+  landPrice: number,
+  buildingCost: number,
+  loanAmount: number,
+): AcquisitionCostBreakdown {
+  const totalPrice = landPrice + buildingCost;
+  const brokerage = calcBrokerageFee(totalPrice, 1.0);
+  const stamp = calcStampDuty(totalPrice);
+
+  const assessedLand = landPrice * 0.7;
+  const assessedBuilding = buildingCost * 0.6;
+
+  const regTax = calcRegistrationTax(assessedLand, assessedBuilding, loanAmount, false);
+  const acqTax = calcRealEstateAcquisitionTax(assessedLand, assessedBuilding);
+
+  const total = brokerage + stamp + regTax + acqTax;
+  return {
+    brokerageFee: brokerage,
+    stampDuty: stamp,
+    registrationTax: regTax,
+    realEstateAcquisitionTax: acqTax,
+    propertyTaxProration: 0,
+    total,
+  };
+}
+
+// ─── Required-for-target ──────────────────────────────────────────────────────
+
+function calcRequiredForTarget(
+  input: InvestmentInput,
+  totalInvestment: number,
+): { requiredRent: number; costReduction: number } {
+  const target = input.yieldTarget;
+  const requiredAnnualRent = totalInvestment * target;
+  const requiredRent = requiredAnnualRent / 12;
+
+  const currentAnnualRent = input.monthlyRent * 12;
+  const requiredTotalInvestment = currentAnnualRent / target;
+
+  const excess = totalInvestment - requiredTotalInvestment;
+  const costReduction = excess > 0 ? excess : 0;
+  return { requiredRent, costReduction };
+}
+
+// ─── Exit strategy ────────────────────────────────────────────────────────────
+
+function calcExit(
+  input: InvestmentInput,
+  yearly: YearlyResult[],
+  accumulatedDepreciation: number,
+  miscExpenses: number,
+): {
+  salePrice: number;
+  capitalGain: number;
+  transferTax: number;
+  netProceeds: number;
+  totalEquity: number;
+} {
+  if (yearly.length === 0 || input.holdingYears <= 0 || input.exitYieldTarget <= 0) {
+    return { salePrice: 0, capitalGain: 0, transferTax: 0, netProceeds: 0, totalEquity: 0 };
+  }
+
+  const holdIdx = Math.min(input.holdingYears - 1, yearly.length - 1);
+  const exitYear = yearly[holdIdx];
+
+  const noi = exitYear.annualRent - exitYear.annualExpenses;
+  const salePrice = noi / input.exitYieldTarget;
+
+  const sellExpenses = (salePrice * 0.03 + 60_000) * 1.10;
+
+  const bookValueBuilding = Math.max(input.buildingCost - accumulatedDepreciation, 0);
+  const acquisitionCost = input.landPrice + bookValueBuilding + miscExpenses;
+
+  const capitalGain = salePrice - sellExpenses - acquisitionCost;
+
+  let transferTax = 0;
+  if (capitalGain > 0) {
+    const taxRate = input.holdingYears > 5 ? LONG_TERM_TRANSFER_TAX_RATE : SHORT_TERM_TRANSFER_TAX_RATE;
+    transferTax = capitalGain * taxRate;
+  }
+
+  const netProceeds = salePrice - sellExpenses - transferTax - exitYear.remainingLoanBalance;
+  const totalEquity = netProceeds + exitYear.cumulativeCashFlow;
+
+  return { salePrice, capitalGain, transferTax, netProceeds, totalEquity };
+}
+
+// ─── Critical errors ──────────────────────────────────────────────────────────
+
+function calcCriticalErrors(
+  input: InvestmentInput,
+  deadCrossYear: number,
+  usefulLife: number,
+): CriticalError[] {
+  const errors: CriticalError[] = [];
+
+  const totalPurchase = input.landPrice + input.buildingCost;
+  const residualLife = calcResidualUsefulLife(input.buildingType, input.buildingAge);
+  const buildingAppraisedValue = input.buildingCost * (residualLife / usefulLife);
+  const appraisedValue = input.landPrice + buildingAppraisedValue;
+
+  if (totalPurchase > 0 && appraisedValue < totalPurchase * 0.5) {
+    errors.push({
+      code: "LAND_VALUE_GUARD",
+      status: "REJECT",
+      message: `積算評価額（${Math.round(appraisedValue / 10000)}万円）が購入総額（${Math.round(totalPurchase / 10000)}万円）の50%未満です。銀行の担保評価が低くなり次の買主がローンを組めない可能性があります。`,
+    });
+  }
+
+  if (deadCrossYear > 0 && deadCrossYear <= 10) {
+    errors.push({
+      code: "DEADCROSS_EARLY",
+      status: "REJECT",
+      message: `${deadCrossYear}年目にデッドクロスが発生します。帳簿上は黒字でもキャッシュ不足に陥るリスクがあります。`,
+    });
+  }
+
+  return errors;
+}
+
+// ─── Yield scenarios ──────────────────────────────────────────────────────────
+
+function calcYieldScenarios(input: InvestmentInput, totalInvestment: number): YieldScenarios {
+  const grossYield = totalInvestment > 0 ? (input.monthlyRent * 12) / totalInvestment : 0;
+
+  const calcScenario = (vacancyMultiplier: number): YieldScenario => {
+    const effectiveVacancy = Math.min(input.vacancyRate * vacancyMultiplier, 0.99);
+    const annualRent = input.monthlyRent * 12 * (1 - effectiveVacancy);
+    return { annualRent, grossYield };
+  };
+
+  return {
+    optimistic: calcScenario(0.5),
+    standard: calcScenario(1.0),
+    pessimistic: calcScenario(1.5),
+  };
+}
+
+// ─── Stress scenarios ─────────────────────────────────────────────────────────
+
+function calcStressScenario(
+  base: InvestmentInput,
+  label: string,
+  rateDelta: number,
+  vacDelta: number,
+): StressScenarioResult {
+  const inInput = applyDefaults(base);
+
+  let effectiveVacancy = inInput.vacancyRate + vacDelta;
+  if (effectiveVacancy > 1) effectiveVacancy = 1;
+
+  const annualRent = inInput.monthlyRent * 12 * (1 - effectiveVacancy);
+  const annualExpenses = annualRent * inInput.expenseRate + inInput.annualPropertyTax;
+  const noi = annualRent - annualExpenses;
+
+  const initRate = resolveRateForYear(inInput.annualLoanRate, rateDelta, inInput.rateAdjustmentSchedule, 1);
+
+  let monthlyPayment = 0;
+  let monthlyPrincipalStress = 0;
+  let annualLoanPayment = 0;
+
+  if (inInput.loanMethod === LOAN_METHOD_EQUAL_PRINCIPAL && inInput.loanYears > 0) {
+    const totalMonths = inInput.loanYears * 12;
+    monthlyPrincipalStress = inInput.loanAmount / totalMonths;
+    const { interest: yi, principal: yp } = calcYearlyLoanComponentsEqualPrincipal(
+      inInput.loanAmount, initRate, monthlyPrincipalStress,
+    );
+    annualLoanPayment = yi + yp;
+  } else {
+    monthlyPayment = calcMonthlyPayment(inInput.loanAmount, initRate, inInput.loanYears);
+    annualLoanPayment = monthlyPayment * 12;
+  }
+
+  const dscr = annualLoanPayment > 0 ? noi / annualLoanPayment : 0;
+
+  let holdingYears = inInput.holdingYears;
+  if (holdingYears <= 0) holdingYears = 10;
+
+  let totalCF = 0;
+  let breakEvenYear = -1;
+  let cumCF = 0;
+  let remainingBalance = inInput.loanAmount;
+  let currentRate = initRate;
+  let curMonthlyPayment = monthlyPayment;
+
+  for (let y = 1; y <= holdingYears; y++) {
+    if (y > 1 && inInput.rateAdjustmentSchedule.length > 0) {
+      const newRate = resolveRateForYear(inInput.annualLoanRate, rateDelta, inInput.rateAdjustmentSchedule, y);
+      if (newRate !== currentRate && remainingBalance > 0 && y <= inInput.loanYears) {
+        if (inInput.loanMethod !== LOAN_METHOD_EQUAL_PRINCIPAL) {
+          const remainingYears = inInput.loanYears - (y - 1);
+          curMonthlyPayment = calcMonthlyPayment(remainingBalance, newRate, remainingYears);
+        }
+        currentRate = newRate;
+      }
+    }
+
+    let yearLoan = 0;
+    if (remainingBalance > 0 && y <= inInput.loanYears) {
+      if (inInput.loanMethod === LOAN_METHOD_EQUAL_PRINCIPAL) {
+        const { interest: yi, principal: yp } = calcYearlyLoanComponentsEqualPrincipal(
+          remainingBalance, currentRate, monthlyPrincipalStress,
+        );
+        yearLoan = yi + yp;
+        remainingBalance -= yp;
+      } else {
+        yearLoan = curMonthlyPayment * 12;
+        const { principal: annPrincipal } = calcYearlyLoanComponents(remainingBalance, currentRate, curMonthlyPayment);
+        remainingBalance -= annPrincipal;
+      }
+      if (remainingBalance < 0) remainingBalance = 0;
+    }
+
+    const cf = annualRent - yearLoan - annualExpenses;
+    totalCF += cf;
+    cumCF += cf;
+    if (breakEvenYear === -1 && cumCF > 0) breakEvenYear = y;
+  }
+
+  let isSafe: boolean;
+  if (annualLoanPayment === 0) {
+    isSafe = breakEvenYear !== -1 && breakEvenYear <= holdingYears;
+  } else {
+    isSafe = dscr >= 1.0 && breakEvenYear !== -1 && breakEvenYear <= holdingYears;
+  }
+
+  return {
+    label,
+    interestRateDelta: rateDelta,
+    vacancyRateDelta: vacDelta,
+    totalCashFlow: totalCF,
+    dscr,
+    breakEvenYear,
+    isSafe,
+  };
+}
+
+// ─── LTV sensitivity ──────────────────────────────────────────────────────────
+
+function calcLTVSensitivity(input: InvestmentInput): LTVSensitivityRow[] {
+  const ltvRange = [0.5, 0.6, 0.7, 0.8, 0.9];
+  const miscExpenses = (input.landPrice + input.buildingCost) * input.miscExpenseRate;
+  const totalInvestment = input.landPrice + input.buildingCost + miscExpenses;
+  if (totalInvestment <= 0) return [];
+
+  const effectiveVacancy = Math.min(input.vacancyRate, 0.99);
+  const annualRent = input.monthlyRent * 12 * (1 - effectiveVacancy);
+  const annualExpenses = annualRent * input.expenseRate + input.annualPropertyTax;
+  const noi = annualRent - annualExpenses;
+
+  return ltvRange.map((ltv) => {
+    const loanAmount = totalInvestment * ltv;
+    const equity = totalInvestment * (1 - ltv);
+
+    let annualDebtService: number;
+    if (input.loanMethod === LOAN_METHOD_EQUAL_PRINCIPAL && input.loanYears > 0) {
+      const totalMonths = input.loanYears * 12;
+      const monthlyPrincipal = loanAmount / totalMonths;
+      const { interest: yi, principal: yp } = calcYearlyLoanComponentsEqualPrincipal(
+        loanAmount, input.annualLoanRate, monthlyPrincipal,
+      );
+      annualDebtService = yi + yp;
+    } else {
+      const mp = calcMonthlyPayment(loanAmount, input.annualLoanRate, input.loanYears);
+      annualDebtService = mp * 12;
+    }
+
+    const dscr = calcDSCR(noi, annualDebtService);
+    const annualCF = noi - annualDebtService;
+    const cfYield = annualCF / totalInvestment;
+
+    return { ltv, equity, loanAmount, dscr, annualCF, cfYield };
+  });
+}
+
+// ─── NPV / IRR ────────────────────────────────────────────────────────────────
+
+function calcNPV(
+  cfs: number[],
+  terminalValue: number,
+  discountRate: number,
+  initialInvestment: number,
+): number {
+  let pv = 0;
+  for (let t = 0; t < cfs.length; t++) {
+    pv += cfs[t] / Math.pow(1 + discountRate, t + 1);
+  }
+  if (cfs.length > 0) {
+    pv += terminalValue / Math.pow(1 + discountRate, cfs.length);
+  }
+  return pv - initialInvestment;
+}
+
+function calcIRR(
+  cfs: number[],
+  terminalValue: number,
+  initialInvestment: number,
+): number | null {
+  const LO = -0.50;
+  const HI = 2.00;
+  const MAX_ITER = 200;
+  const TOL = 1.0;
+
+  const npvLo = calcNPV(cfs, terminalValue, LO, initialInvestment);
+  const npvHi = calcNPV(cfs, terminalValue, HI, initialInvestment);
+  if (npvLo * npvHi > 0) return null;
+
+  let low = LO, high = HI;
+  let currentNpvLo = npvLo;
+  for (let i = 0; i < MAX_ITER; i++) {
+    const mid = (low + high) / 2;
+    const npvMid = calcNPV(cfs, terminalValue, mid, initialInvestment);
+    if (Math.abs(npvMid) < TOL) return mid;
+    if (npvMid * currentNpvLo < 0) {
+      high = mid;
+    } else {
+      low = mid;
+      currentNpvLo = npvMid;
+    }
+  }
+  return null;
+}
+
+// ─── Terminal value with price decline ────────────────────────────────────────
+
+function calcTerminalValueWithDecline(
+  input: InvestmentInput,
+  yearly: YearlyResult[],
+  adjustedSalePrice: number,
+  accumulatedDepreciation: number,
+  miscExpenses: number,
+): number {
+  const holdIdx = Math.min(input.holdingYears - 1, yearly.length - 1);
+  const exitYear = yearly[holdIdx];
+  const sellExpenses = (adjustedSalePrice * 0.03 + 60_000) * 1.10;
+  const bookValueBuilding = Math.max(input.buildingCost - accumulatedDepreciation, 0);
+  const acquisitionCost = input.landPrice + bookValueBuilding + miscExpenses;
+  const capGain = adjustedSalePrice - sellExpenses - acquisitionCost;
+  let transferTax = 0;
+  if (capGain > 0) {
+    const taxRate = input.holdingYears > 5 ? LONG_TERM_TRANSFER_TAX_RATE : SHORT_TERM_TRANSFER_TAX_RATE;
+    transferTax = capGain * taxRate;
+  }
+  return adjustedSalePrice - sellExpenses - transferTax - exitYear.remainingLoanBalance;
+}
+
+// ─── Main Analyze function ────────────────────────────────────────────────────
+
+/**
+ * analyze — client-side equivalent of backend Analyze()
+ *
+ * Performs the full investment simulation without any network calls.
+ * Used as an offline fallback.
+ */
+export function analyze(inputRaw: InvestmentInput): InvestmentResult {
+  const input = applyDefaults(inputRaw);
+
+  const effectiveVacancy = Math.min(input.vacancyRate + input.vacancyRateDelta, 0.99);
+
+  const miscExpenses = (input.landPrice + input.buildingCost) * input.miscExpenseRate;
+  const totalInvestment = input.landPrice + input.buildingCost + miscExpenses;
+
+  const annualRent = input.monthlyRent * 12 * (1 - effectiveVacancy);
+  const grossYield = totalInvestment > 0 ? (input.monthlyRent * 12) / totalInvestment : 0;
+
+  const annualExpenses = annualRent * input.expenseRate;
+  const netYield = totalInvestment > 0 ? (annualRent - annualExpenses) / totalInvestment : 0;
+
+  const { requiredRent, costReduction } = calcRequiredForTarget(input, totalInvestment);
+
+  const usefulLife = calcResidualUsefulLife(input.buildingType, input.buildingAge);
+  const annualDepreciation = input.buildingCost / usefulLife;
+
+  let currentRate = resolveRateForYear(input.annualLoanRate, input.loanRateDelta, input.rateAdjustmentSchedule, 1);
+  let monthlyPayment = 0;
+  let monthlyPrincipalFixed = 0;
+
+  if (input.loanMethod === LOAN_METHOD_EQUAL_PRINCIPAL && input.loanYears > 0) {
+    monthlyPrincipalFixed = input.loanAmount / (input.loanYears * 12);
+  } else {
+    monthlyPayment = calcMonthlyPayment(input.loanAmount, currentRate, input.loanYears);
+  }
+
+  let bookValue = 0;
+  let decliningRate = 0;
+  if (input.depreciationMethod === DEPRECIATION_DECLINING_BALANCE) {
+    bookValue = input.buildingCost;
+    decliningRate = 1.5 / usefulLife;
+  }
+
+  const years = Math.max(input.loanYears, input.holdingYears, 35);
+  const yearlyResults: YearlyResult[] = [];
+  let remainingBalance = input.loanAmount;
+  let cumulativeCF = 0;
+  let deadCrossYear = -1;
+  let accumulatedDepreciation = 0;
+
+  for (let y = 0; y < years; y++) {
+    const year = y + 1;
+
+    if (year > 1 && input.rateAdjustmentSchedule.length > 0) {
+      const newRate = resolveRateForYear(input.annualLoanRate, input.loanRateDelta, input.rateAdjustmentSchedule, year);
+      if (newRate !== currentRate && remainingBalance > 0 && year <= input.loanYears) {
+        if (input.loanMethod !== LOAN_METHOD_EQUAL_PRINCIPAL) {
+          const remainingYears = input.loanYears - y;
+          monthlyPayment = calcMonthlyPayment(remainingBalance, newRate, remainingYears);
+        }
+        currentRate = newRate;
+      }
+    }
+
+    let annualInterest = 0;
+    let annualPrincipal = 0;
+    let annualLoanPayment = 0;
+
+    if (remainingBalance > 0 && year <= input.loanYears) {
+      if (input.loanMethod === LOAN_METHOD_EQUAL_PRINCIPAL) {
+        const { interest, principal } = calcYearlyLoanComponentsEqualPrincipal(
+          remainingBalance, currentRate, monthlyPrincipalFixed,
+        );
+        annualInterest = interest;
+        annualPrincipal = principal;
+        annualLoanPayment = annualInterest + annualPrincipal;
+      } else {
+        const { interest, principal } = calcYearlyLoanComponents(
+          remainingBalance, currentRate, monthlyPayment,
+        );
+        annualInterest = interest;
+        annualPrincipal = principal;
+        annualLoanPayment = monthlyPayment * 12;
+      }
+      remainingBalance -= annualPrincipal;
+      if (remainingBalance < 0) remainingBalance = 0;
+    }
+
+    const declineFactor = Math.pow(1 - input.rentDeclineRate, y);
+    const yearAnnualRent = annualRent * declineFactor;
+    const yearExpenses = yearAnnualRent * input.expenseRate + input.annualPropertyTax;
+
+    let yearDepreciation = 0;
+    if (input.depreciationMethod === DEPRECIATION_DECLINING_BALANCE) {
+      if (bookValue > 1.0) {
+        yearDepreciation = bookValue * decliningRate;
+        if (bookValue - yearDepreciation < 1.0) {
+          yearDepreciation = bookValue - 1.0;
+        }
+        bookValue -= yearDepreciation;
+      }
+    } else {
+      if (year <= usefulLife) {
+        yearDepreciation = annualDepreciation;
+      }
+    }
+    accumulatedDepreciation += yearDepreciation;
+
+    const taxableIncome = yearAnnualRent - annualInterest - yearDepreciation - yearExpenses;
+    const incomeTax = taxableIncome > 0 ? taxableIncome * input.incomeTaxRate : 0;
+
+    const cashFlow = yearAnnualRent - annualLoanPayment - yearExpenses;
+    const afterTaxCF = cashFlow - incomeTax;
+    cumulativeCF += afterTaxCF;
+
+    const inDeadCrossZone =
+      input.buildingCost > 0 &&
+      annualPrincipal > 0 &&
+      annualPrincipal > yearDepreciation;
+
+    let isDeadCrossYear = false;
+    if (deadCrossYear === -1 && inDeadCrossZone) {
+      deadCrossYear = year;
+      isDeadCrossYear = true;
+    }
+
+    yearlyResults.push({
+      year,
+      annualRent: yearAnnualRent,
+      annualLoanPayment,
+      annualInterest,
+      annualPrincipal,
+      annualDepreciation: yearDepreciation,
+      annualExpenses: yearExpenses,
+      taxableIncome,
+      incomeTax,
+      cashFlow,
+      afterTaxCashFlow: afterTaxCF,
+      remainingLoanBalance: remainingBalance,
+      cumulativeCashFlow: cumulativeCF,
+      isDeadCrossYear,
+      isInDeadCrossZone: inDeadCrossZone,
+      effectiveRate: currentRate,
+    });
+  }
+
+  // DSCR: 1年目の NOI / 年間返済額
+  let dscr = 0;
+  if (yearlyResults.length > 0) {
+    const noi = yearlyResults[0].annualRent - yearlyResults[0].annualExpenses;
+    dscr = calcDSCR(noi, yearlyResults[0].annualLoanPayment);
+  }
+
+  const { salePrice, capitalGain, transferTax, netProceeds, totalEquity } = calcExit(
+    input, yearlyResults, accumulatedDepreciation, miscExpenses,
+  );
+
+  const criticalErrors = calcCriticalErrors(input, deadCrossYear, usefulLife);
+
+  const defaultScenarios: { label: string; rateDelta: number; vacDelta: number }[] = [
+    { label: "ベースライン", rateDelta: 0, vacDelta: 0 },
+    { label: "金利+1%", rateDelta: 0.01, vacDelta: 0 },
+    { label: "金利+2%", rateDelta: 0.02, vacDelta: 0 },
+    { label: "空室+10%", rateDelta: 0, vacDelta: 0.10 },
+    { label: "空室+20%", rateDelta: 0, vacDelta: 0.20 },
+    { label: "複合ストレス", rateDelta: 0.02, vacDelta: 0.10 },
+  ];
+
+  const stressScenarios: StressScenarioResult[] = defaultScenarios.map((sc) =>
+    calcStressScenario(input, sc.label, sc.rateDelta, sc.vacDelta),
+  );
+
+  if (input.loanRateDelta !== 0 || input.vacancyRateDelta !== 0) {
+    stressScenarios.push(
+      calcStressScenario(input, "カスタム", input.loanRateDelta, input.vacancyRateDelta),
+    );
+  }
+
+  const acquisitionCosts = calcAcquisitionCosts(input.landPrice, input.buildingCost, input.loanAmount);
+  const yieldScenarios = calcYieldScenarios(input, totalInvestment);
+  const ltvSensitivity = calcLTVSensitivity(input);
+
+  // IRR / NPV
+  const equity = totalInvestment - input.loanAmount;
+  let irr: number | null = null;
+  let npv = 0;
+  if (equity > 0 && input.holdingYears > 0) {
+    const irrCFs: number[] = [];
+    for (let i = 0; i < input.holdingYears && i < yearlyResults.length; i++) {
+      irrCFs.push(yearlyResults[i].afterTaxCashFlow);
+    }
+
+    let irrTerminalValue = netProceeds;
+    const priceDeclineRate = input.priceDeclineRate ?? 0;
+    if (priceDeclineRate > 0 && input.holdingYears > 0) {
+      const decayFactor = Math.pow(1 - priceDeclineRate, input.holdingYears);
+      const adjustedSalePrice = salePrice * decayFactor;
+      irrTerminalValue = calcTerminalValueWithDecline(
+        input, yearlyResults, adjustedSalePrice, accumulatedDepreciation, miscExpenses,
+      );
+    }
+
+    const discountRate = input.discountRate ?? 0.05;
+    npv = calcNPV(irrCFs, irrTerminalValue, discountRate, equity);
+    irr = calcIRR(irrCFs, irrTerminalValue, equity);
+  }
+
+  return {
+    totalInvestment,
+    miscExpenses,
+    grossYield,
+    netYield,
+    isAboveYieldTarget: grossYield >= input.yieldTarget,
+    yieldTarget: input.yieldTarget,
+    requiredCostReduction: costReduction,
+    requiredMonthlyRent: requiredRent,
+    deadCrossYear,
+    yearlyResults,
+    criticalErrors,
+    acquisitionCosts,
+    exitSalePrice: salePrice,
+    exitCapitalGain: capitalGain,
+    exitTransferTax: transferTax,
+    exitNetProceeds: netProceeds,
+    exitTotalEquity: totalEquity,
+    stressScenarios,
+    yieldScenarios,
+    dscr,
+    ltvSensitivity,
+    irr,
+    npv,
+  };
+}

--- a/frontend/src/lib/investment.ts
+++ b/frontend/src/lib/investment.ts
@@ -66,14 +66,14 @@ export function calcResidualUsefulLife(buildingType: BuildingType, buildingAge: 
 
 function applyDefaults(input: InvestmentInput): InvestmentInput {
   const i = { ...input };
-  if (!i.miscExpenseRate) i.miscExpenseRate = 0.07;
-  if (!i.holdingYears) i.holdingYears = 10;
-  if (!i.exitYieldTarget) i.exitYieldTarget = 0.06;
-  if (!i.yieldTarget) i.yieldTarget = 0.08;
-  if (!i.loanYears) i.loanYears = 35;
+  if (i.miscExpenseRate == null || i.miscExpenseRate === 0) i.miscExpenseRate = 0.07;
+  if (i.holdingYears == null || i.holdingYears === 0) i.holdingYears = 10;
+  if (i.exitYieldTarget == null || i.exitYieldTarget === 0) i.exitYieldTarget = 0.06;
+  if (i.yieldTarget == null || i.yieldTarget === 0) i.yieldTarget = 0.08;
+  if (i.loanYears == null || i.loanYears === 0) i.loanYears = 35;
   if (!i.buildingType) i.buildingType = "木造";
   if (!i.loanMethod) i.loanMethod = LOAN_METHOD_EQUAL_PAYMENT;
-  if (!i.discountRate) i.discountRate = 0.05;
+  if (i.discountRate == null || i.discountRate === 0) i.discountRate = 0.05;
   if (!i.depreciationMethod) i.depreciationMethod = DEPRECIATION_STRAIGHT_LINE;
   if (!i.rateAdjustmentSchedule) i.rateAdjustmentSchedule = [];
   return i;


### PR DESCRIPTION
## 概要

現地調査時のオフライン環境での利用を想定し、ネットワーク接続なしでも投資シミュレーションを実行できるよう対応した。バックエンドの `investment.go` の計算ロジックを TypeScript に移植し、オフライン時はクライアント側計算にフォールバックする。

## 変更内容

- `frontend/src/lib/investment.ts` を新規作成
  - バックエンド `backend/internal/domain/investment.go` の `Analyze()` 関数を TypeScript に完全移植
  - 元利均等・元金均等返済、定額法・定率法減価償却、デッドクロス検出、出口戦略、ストレステスト、LTV感度分析、IRR/NPV 計算を含む
- `frontend/src/lib/__tests__/investment.test.ts` を新規作成
  - 50 件の vitest テストケースでバックエンドと同等の計算結果を検証
- `frontend/src/components/Dashboard.tsx` を更新
  - `navigator.onLine` と `online`/`offline` イベントによるネットワーク状態検出を追加
  - オフライン時は `analyzeOffline()` にフォールバック、オンライン時は従来通り API を呼び出す
  - オフライン時のバナー表示とヘッダーのステータスインジケーター更新
- `frontend/src/components/InvestmentForm.tsx` を更新
  - `isOnline` prop を追加し、オフライン時は「相場データを取得」ボタンを無効化・説明テキストを表示

## 関連Issue

Closes #205

## テスト

- [x] 既存テストが通ること（221件 PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること（50件追加、221件合計）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み