### PR TITLE
fix(terraform): cache_hit_rate アラートのリソースタイプ確認と誤検知対策

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -225,8 +225,8 @@ resource "google_monitoring_alert_policy" "cache_hit_rate" {
   conditions {
     display_name = "キャッシュヒット率 < 50% が 10 分継続"
     # fetch generic_task: OTel exporter が GCP リソース検出器なしの場合のデフォルト。
-    # setup.go で resource.WithDetectors() を使っていないため generic_task が正しい。
-    # Metrics Explorer で workload.googleapis.com/mlit.cache.misses を確認済み (#269)。
+    # setup.go で resource.WithDetectors() を使っていないため generic_task が正しいとコード解析で確認 (#269)。
+    # apply 後は Metrics Explorer で workload.googleapis.com/mlit.cache.misses のリソースタイプを目視確認すること。
     condition_monitoring_query_language {
       query    = <<-EOT
         fetch generic_task

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -224,6 +224,9 @@ resource "google_monitoring_alert_policy" "cache_hit_rate" {
 
   conditions {
     display_name = "キャッシュヒット率 < 50% が 10 分継続"
+    # fetch generic_task: OTel exporter が GCP リソース検出器なしの場合のデフォルト。
+    # setup.go で resource.WithDetectors() を使っていないため generic_task が正しい。
+    # Metrics Explorer で workload.googleapis.com/mlit.cache.misses を確認済み (#269)。
     condition_monitoring_query_language {
       query    = <<-EOT
         fetch generic_task
@@ -246,6 +249,9 @@ resource "google_monitoring_alert_policy" "cache_hit_rate" {
   notification_channels = [google_monitoring_notification_channel.email.id]
   alert_strategy {
     auto_close = "3600s"
+    notification_rate_limit {
+      period = "3600s"
+    }
   }
 }
 


### PR DESCRIPTION
## 概要

- **#269**: `fetch generic_task` が正しいことをコードレベルで確認し、コメントで明示
- **#270**: インスタンス再起動後の誤検知対策として `notification_rate_limit` を追加（1時間に1回まで抑制）

## 変更内容

### #269 — MQL リソースタイプ確認

`backend/internal/telemetry/setup.go` を調査した結果、`monitoring.New()` に `resource.WithDetectors()` が渡されていないため、`opentelemetry-operations-go` exporter はデフォルトで `generic_task` にフォールバックすることを確認。現在の MQL クエリ `fetch generic_task` は正しいため、コードは変更せずコメントで根拠を明記した。

### #270 — 誤検知対策

`cache_hit_rate` アラートポリシーの `alert_strategy` に `notification_rate_limit { period = "3600s" }` を追加。Cloud Run インスタンス再起動直後のキャッシュリセットで発生する誤検知を、1時間に1回の通知上限で抑制する。

## テスト

- `terraform validate` 相当の構文確認済み
- 他の3つのアラートポリシー（`mlit_latency`、`cloudrun_error_rate`、`cloudrun_max_instances`）は変更なし

closes #269, closes #270