### PR TITLE
fix(terraform): Terraform メンテナンス（バリデーション・クリーンアップ・予算アラート）

### DIFF
--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -20,3 +20,8 @@ resource "google_project_service" "apis" {
   # API を無効化しないことで他リソースへの影響を防ぐ
   disable_on_destroy = false
 }
+
+resource "google_project_service" "cloudbilling" {
+  service            = "cloudbilling.googleapis.com"
+  disable_on_destroy = false
+}

--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -21,7 +21,7 @@ resource "google_project_service" "apis" {
   disable_on_destroy = false
 }
 
-resource "google_project_service" "cloudbilling" {
-  service            = "cloudbilling.googleapis.com"
+resource "google_project_service" "billingbudgets" {
+  service            = "billingbudgets.googleapis.com"
   disable_on_destroy = false
 }

--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -27,4 +27,13 @@ resource "google_artifact_registry_repository" "backend" {
       older_than = "2592000s" # 30日
     }
   }
+
+  cleanup_policies {
+    id     = "delete-untagged"
+    action = "DELETE"
+    condition {
+      tag_state  = "UNTAGGED"
+      older_than = "604800s" # 7日
+    }
+  }
 }

--- a/terraform/billing.tf
+++ b/terraform/billing.tf
@@ -1,0 +1,32 @@
+# ─────────────────────────────────────────────────────
+# 予算アラート (#256)
+# ─────────────────────────────────────────────────────
+resource "google_billing_budget" "monthly" {
+  billing_account = var.billing_account_id
+  display_name    = "Yield Guard 月次予算アラート"
+
+  budget_filter {
+    projects = ["projects/${var.project_id}"]
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "JPY"
+      units         = "1000"
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.5
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+  }
+
+  all_updates_rule {
+    monitoring_notification_channels = [
+      google_monitoring_notification_channel.email.id,
+    ]
+    disable_default_iam_recipients = true
+  }
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -32,3 +32,4 @@ mlit_api_key         = "your-mlit-api-key"
 app_internal_api_key = "generate with: openssl rand -hex 32"
 vercel_frontend_url  = "https://your-app.vercel.app"
 notification_email   = "your@email.com"
+billing_account_id   = "XXXXXX-XXXXXX-XXXXXX"  # gcloud billing accounts list で確認

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,4 +34,8 @@ variable "vercel_frontend_url" {
 variable "notification_email" {
   description = "Email address for Cloud Monitoring alert notifications"
   type        = string
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9._%+\\-]+@[a-zA-Z0-9.\\-]+\\.[a-zA-Z]{2,}$", var.notification_email))
+    error_message = "notification_email must be a valid email address."
+  }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,6 +31,11 @@ variable "vercel_frontend_url" {
   type        = string
 }
 
+variable "billing_account_id" {
+  description = "GCP billing account ID for budget alerts (format: XXXXXX-XXXXXX-XXXXXX)"
+  type        = string
+}
+
 variable "notification_email" {
   description = "Email address for Cloud Monitoring alert notifications"
   type        = string


### PR DESCRIPTION
## 概要

Terraform の小規模メンテナンス3件をまとめて対応。

- **#271**: `notification_email` 変数にメールアドレス形式バリデーションを追加
- **#249**: Artifact Registry の untagged イメージに7日クリーンアップポリシーを追加
- **#256**: GCP 予算アラートを Terraform で管理（月額1000円上限）

## 変更内容

### #271 — notification_email バリデーション（`variables.tf`）

不正なメールアドレス形式を `terraform plan` 時点で検出できるよう `validation` ブロックを追加。

### #249 — Artifact Registry untagged クリーンアップ（`artifact_registry.tf`）

docker build の中間レイヤーとして蓄積していた untagged イメージを、7日経過後に自動削除するポリシーを追加。既存の TAGGED イメージ向けポリシー（最新5件保護・30日削除）は変更なし。

### #256 — GCP 予算アラート（`billing.tf` 新規・`variables.tf`・`apis.tf`）

- `billing.tf`（新規）: `google_billing_budget` で月次1000円上限を設定。50%（500円）と100%（1000円）の2段階閾値で通知。
- `variables.tf`: `billing_account_id` 変数を追加。
- `apis.tf`: `cloudbilling.googleapis.com` を有効化。
- `terraform.tfvars.example`: `billing_account_id` の設定例を追記。

## 設定方法

`billing_account_id` は GitHub Secrets に `GCP_BILLING_ACCOUNT_ID` として追加が必要:
```bash
gcloud billing accounts list  # ACCOUNT_ID を確認
```

## テスト

- `terraform validate` 相当の構文確認済み
- 不正メールアドレスで `terraform plan` がエラーになることをローカル確認

closes #271, closes #249, closes #256