### PR TITLE
feat(infra): Staging 環境デプロイワークフローを整備する

### DIFF
--- a/.github/workflows/deploy-backend-stg.yml
+++ b/.github/workflows/deploy-backend-stg.yml
@@ -1,0 +1,59 @@
+name: Deploy Backend to Cloud Run (Staging)
+
+on:
+  push:
+    branches:
+      - "feature/**"
+    paths:
+      - "backend/**"
+      - ".github/workflows/deploy-backend-stg.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build & Deploy (stg)
+    runs-on: ubuntu-24.04
+
+    env:
+      IMAGE: asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/yield-guard/backend
+      DEPLOY_SHA: ${{ github.sha }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Authenticate to Google Cloud (OIDC)
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.SA_EMAIL }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
+
+      - name: Build and push Docker image
+        run: |
+          docker build \
+            --tag "${{ env.IMAGE }}:stg-${{ env.DEPLOY_SHA }}" \
+            --tag "${{ env.IMAGE }}:stg-latest" \
+            ./backend
+          docker push "${{ env.IMAGE }}:stg-${{ env.DEPLOY_SHA }}"
+          docker push "${{ env.IMAGE }}:stg-latest"
+
+      - name: Deploy to Cloud Run (stg)
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d  # v3.0.1
+        with:
+          service: yield-guard-stg-backend
+          region: asia-northeast1
+          image: ${{ env.IMAGE }}:stg-${{ env.DEPLOY_SHA }}

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -128,3 +128,42 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.apply
         run: terraform apply -auto-approve tfplan
         working-directory: terraform
+
+  terraform-stg:
+    name: Plan (stg)
+    runs-on: ubuntu-24.04
+    needs: [terraform]
+    if: github.event_name == 'pull_request'
+
+    env:
+      TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
+      TF_VAR_env: "stg"
+      TF_VAR_region: "asia-northeast1"
+      TF_VAR_mlit_api_key: ${{ secrets.MLIT_API_KEY }}
+      TF_VAR_app_internal_api_key: ${{ secrets.APP_INTERNAL_API_KEY }}
+      TF_VAR_vercel_frontend_url: ${{ vars.VERCEL_FRONTEND_URL }}
+      TF_VAR_notification_email: ${{ vars.NOTIFICATION_EMAIL }}
+      TF_VAR_billing_account_id: ${{ secrets.GCP_BILLING_ACCOUNT_ID }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85  # v4.0.0
+        with:
+          terraform_version: "1.14.9"
+
+      - name: Authenticate to Google Cloud (OIDC)
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.SA_EMAIL }}
+
+      - name: Terraform Init (stg)
+        run: terraform init -backend-config="prefix=yield-guard/stg"
+        working-directory: terraform
+
+      - name: Terraform Plan (stg)
+        run: terraform plan -no-color
+        working-directory: terraform

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -33,3 +33,6 @@ app_internal_api_key = "generate with: openssl rand -hex 32"
 vercel_frontend_url  = "https://your-app.vercel.app"
 notification_email   = "your@email.com"
 billing_account_id   = "XXXXXX-XXXXXX-XXXXXX"  # gcloud billing accounts list で確認
+
+# stg 環境で `terraform init -backend-config="prefix=yield-guard/stg"` を使用する
+# TF_VAR_env=stg で apply すると yield-guard-stg-backend が作成される


### PR DESCRIPTION
## 概要

**#221**: Staging 環境（Cloud Run + デプロイワークフロー）を整備する。

feature ブランチへの push で自動的に `yield-guard-stg-backend` へデプロイできるようにする。

## 変更内容

### deploy-backend-stg.yml 新規作成

- **トリガー**: `feature/**` ブランチへの push（`backend/**` 変更時）または手動
- **イメージタグ**: `stg-{SHA}` + `stg-latest`（prod の `{SHA}` / `latest` と分離）
- **Cloud Run サービス**: `yield-guard-stg-backend`
- **GCP 認証**: prod と同一の WIF / Deployer SA を使用

### terraform-ci.yml に stg plan ジョブを追加

PR 時に stg 環境の Terraform Plan も確認できるよう `terraform-stg` ジョブを追加。  
`-backend-config="prefix=yield-guard/stg"` で prod state と分離した状態を参照する。

### terraform.tfvars.example に stg 手順を追記

stg 環境の `terraform init` コマンドと `TF_VAR_env=stg` の使い方を記載。

## Terraform で stg 環境を作成する手順

```bash
# stg 用 state で init
terraform init -backend-config="prefix=yield-guard/stg"

# stg リソースを plan / apply
terraform plan -var="env=stg" -var="project_id=<PROJECT_ID>" ...
terraform apply -var="env=stg" ...
```

## 注意事項

- `yield-guard-stg-backend` Cloud Run サービスは Terraform apply 後に初めて存在する（本 PR は CI/CD ワークフローのみ）
- stg と prod の Secret Manager シークレットは同一プロジェクト内で共有。別シークレットが必要な場合は個別対応

closes #221