### PR TITLE
fix(terraform): add depends_on to billing budget to prevent API race condition

### DIFF
--- a/terraform/billing.tf
+++ b/terraform/billing.tf
@@ -29,4 +29,6 @@ resource "google_billing_budget" "monthly" {
     ]
     disable_default_iam_recipients = true
   }
+
+  depends_on = [google_project_service.billingbudgets]
 }


### PR DESCRIPTION
## 概要

`google_billing_budget` と `google_project_service.billingbudgets` が並列実行され、API 有効化の伝播完了前に Budget 作成が走り 403 エラーになる競合を修正。

## 原因

```
google_project_service.billingbudgets: Creating...  ┐ 並列実行
google_billing_budget.monthly: Creating...           ┘
→ API 有効化（21秒）が完了する前に Budget 作成が 403 で失敗
```

## 修正

`billing.tf` に `depends_on = [google_project_service.billingbudgets]` を追加し、API 有効化の完了後に Budget を作成するよう順序を保証する。

closes #256