### PR TITLE
fix(terraform): MQLアラートの notification_rate_limit を duration 延長に置き換える

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -242,16 +242,15 @@ resource "google_monitoring_alert_policy" "cache_hit_rate" {
         | ratio
         | condition val() > 0.5
       EOT
-      duration = "600s"
+      # 30分継続で判定: 再起動直後のキャッシュリセット（約10分）による誤検知を抑制 (#270)
+      # notification_rate_limit はログベースアラート専用のため MQL アラートには使用不可
+      duration = "1800s"
     }
   }
 
   notification_channels = [google_monitoring_notification_channel.email.id]
   alert_strategy {
     auto_close = "3600s"
-    notification_rate_limit {
-      period = "3600s"
-    }
   }
 }
 


### PR DESCRIPTION
## 概要

`cache_hit_rate` アラートポリシーの `notification_rate_limit` を削除し、`duration` を延長することで誤検知を抑制する。

## 変更内容

- `notification_rate_limit` を削除（MQL ベースのアラートには使用不可、ログベース専用）
- `duration` を 600s（10分）→ 1800s（30分）に延長
  - Cloud Run インスタンス再起動直後のキャッシュリセットは約10分で回復するため、30分継続しない限りアラートは発火しない

## 関連 Issue

closes #270

## テスト

- `terraform validate` 相当の構文確認済み