### PR TITLE
docs(terraform): 予算アラート作成に必要な手動 IAM 付与手順をコメントで明記

### DIFF
--- a/terraform/billing.tf
+++ b/terraform/billing.tf
@@ -1,5 +1,10 @@
 # ─────────────────────────────────────────────────────
 # 予算アラート (#256)
+# 前提: Deployer SA に請求アカウントレベルの roles/billing.costsManager が必要。
+# Terraform 管理外のため初回のみ手動付与:
+#   gcloud billing accounts add-iam-policy-binding <BILLING_ACCOUNT_ID> \
+#     --member="serviceAccount:<deployer-sa-email>" \
+#     --role="roles/billing.costsManager"
 # ─────────────────────────────────────────────────────
 resource "google_billing_budget" "monthly" {
   billing_account = var.billing_account_id


### PR DESCRIPTION
## 概要

`google_billing_budget` の作成には Deployer SA への請求アカウントレベルの `roles/billing.costsManager` が必要だが、Terraform 管理外のため初回のみ手動付与が必要。その手順を `billing.tf` のコメントに明記する。

## 変更内容

- `billing.tf` に手動 IAM 付与コマンドをコメントとして追記

## 背景

`billing.costsManager` の付与は請求アカウントの IAM 操作であり、Deployer SA 自身では Terraform 経由で自己付与できないため手動対応が必要。今回は以下のコマンドで付与済み：

```bash
gcloud billing accounts add-iam-policy-binding 01DF2F-4DD2D4-DE1B50 \
  --member="serviceAccount:sa-yield-guard-prod-deployer@yield-guard.iam.gserviceaccount.com" \
  --role="roles/billing.costsManager"
```

## 関連 Issue

refs #256