### PR TITLE
feat(frontend): 逆算最大買付価格 & 交渉シミュレーション (#296 #297)

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -19,6 +19,7 @@ import { Button } from "@/components/ui/button";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 import { downloadReportPDF } from "@/lib/generatePdf";
 import { MonteCarloChart } from "@/components/MonteCarloChart";
+import NegotiationPanel from "@/components/NegotiationPanel";
 import dynamic from "next/dynamic";
 
 const InvestmentScoreHeatmap = dynamic(() => import("./InvestmentScoreHeatmap"), { ssr: false });
@@ -361,6 +362,12 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
               <>
                 <CriticalErrorBanner errors={result.criticalErrors} />
                 <YieldAnalysis result={result} input={lastInput} populationForecast={populationForecast} />
+                <NegotiationPanel
+                  result={result}
+                  input={lastInput}
+                  comparison={comparison}
+                  theoreticalPrice={theoreticalPrice}
+                />
                 <LoanOptimizationPanel
                   result={result}
                   loanMethod={loanMethod}

--- a/frontend/src/components/NegotiationPanel.tsx
+++ b/frontend/src/components/NegotiationPanel.tsx
@@ -53,54 +53,53 @@ export default function NegotiationPanel({
 }: Props) {
   const askingPropertyPrice = input.landPrice + input.buildingCost;
 
-  // Max purchase price = max total investment / (1 + miscExpenseRate)
+  // Max purchase price derived from existing requiredCostReduction field
   const maxTotalInvestment = result.totalInvestment - result.requiredCostReduction;
-  const maxPropertyPrice =
-    input.miscExpenseRate > -1
-      ? maxTotalInvestment / (1 + input.miscExpenseRate)
-      : maxTotalInvestment;
+  const maxPropertyPrice = maxTotalInvestment / (1 + input.miscExpenseRate);
 
   const diffFromAsking = maxPropertyPrice - askingPropertyPrice;
   const diffPct =
     askingPropertyPrice > 0 ? (diffFromAsking / askingPropertyPrice) * 100 : 0;
+  // Property price discount needed (positive = need to negotiate down)
+  const discountNeeded = diffFromAsking < 0 ? -diffFromAsking : 0;
 
-  // Market-implied property price from land transaction data
+  // Market-implied property price: median land tsubo × area + building cost
   const marketLandValue =
     comparison && input.landArea > 0
       ? comparison.stats.medianTsubo * (input.landArea / TSUBO_PER_SQM)
       : null;
-  const marketPropertyPrice =
+  const rawMarketPrice =
     marketLandValue !== null ? marketLandValue + input.buildingCost : null;
-  const marketDiff =
-    marketPropertyPrice !== null ? askingPropertyPrice - marketPropertyPrice : null;
-  const marketDiffPct =
-    marketPropertyPrice !== null && marketPropertyPrice > 0
-      ? (marketDiff! / marketPropertyPrice) * 100
+  const marketData =
+    rawMarketPrice !== null && rawMarketPrice > 0
+      ? {
+          price: rawMarketPrice,
+          diff: askingPropertyPrice - rawMarketPrice,
+          pct: ((askingPropertyPrice - rawMarketPrice) / rawMarketPrice) * 100,
+        }
       : null;
 
-  // Theoretical price from estimate endpoint
-  const theoreticalPropertyPrice = theoreticalPrice?.theoreticalPriceJPY ?? null;
-  const theoreticalDiff =
-    theoreticalPropertyPrice !== null
-      ? askingPropertyPrice - theoreticalPropertyPrice
-      : null;
-  const theoreticalDiffPct =
-    theoreticalPropertyPrice !== null && theoreticalPropertyPrice > 0
-      ? (theoreticalDiff! / theoreticalPropertyPrice) * 100
+  // Theoretical price from /api/land-prices/estimate
+  const theoreticalPriceJPY = theoreticalPrice?.theoreticalPriceJPY ?? null;
+  const theoreticalData =
+    theoreticalPriceJPY !== null && theoreticalPriceJPY > 0
+      ? {
+          price: theoreticalPriceJPY,
+          diff: askingPropertyPrice - theoreticalPriceJPY,
+          pct: ((askingPropertyPrice - theoreticalPriceJPY) / theoreticalPriceJPY) * 100,
+        }
       : null;
 
-  // Negotiation range: between theoretical/market lower bound and max purchase price
+  // Negotiation range: min/max across all available price anchors
   const rangeAnchors = [
-    theoreticalPropertyPrice,
-    marketPropertyPrice,
+    theoreticalData?.price ?? null,
+    marketData?.price ?? null,
     maxPropertyPrice,
   ].filter((v): v is number => v !== null && v > 0);
   const rangeLow = rangeAnchors.length > 0 ? Math.min(...rangeAnchors) : null;
   const rangeHigh = rangeAnchors.length > 0 ? Math.max(...rangeAnchors) : null;
 
-  const showNegotiationSection =
-    (comparison !== null && marketPropertyPrice !== null) ||
-    theoreticalPropertyPrice !== null;
+  const showNegotiationSection = marketData !== null || theoreticalData !== null;
 
   return (
     <Card className="rounded-xl shadow-sm">
@@ -138,9 +137,9 @@ export default function NegotiationPanel({
               ) : (
                 <p className="text-sm text-muted-foreground">—</p>
               )}
-              {askingPropertyPrice > 0 && diffFromAsking < 0 && (
+              {discountNeeded > 0 && (
                 <p className="mt-1 text-xs text-muted-foreground">
-                  値引き必要額: {formatYen(Math.abs(diffFromAsking))}
+                  値引き必要額: {formatYen(discountNeeded)}
                 </p>
               )}
             </div>
@@ -178,42 +177,42 @@ export default function NegotiationPanel({
                     </td>
                     <td className="py-2 pl-4" />
                   </tr>
-                  {marketPropertyPrice !== null && marketDiff !== null && marketDiffPct !== null && (
+                  {marketData !== null && (
                     <tr>
                       <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">
                         市場取引実勢
                       </td>
                       <td className="py-2 font-semibold">
-                        {formatYen(marketPropertyPrice)}
+                        {formatYen(marketData.price)}
                       </td>
                       <td className="py-2 pl-4">
-                        <DiffBadge diff={marketDiff} pct={marketDiffPct} />
+                        <DiffBadge diff={marketData.diff} pct={marketData.pct} />
                       </td>
                     </tr>
                   )}
-                  {theoreticalPropertyPrice !== null && theoreticalDiff !== null && theoreticalDiffPct !== null && (
+                  {theoreticalData !== null && (
                     <tr>
                       <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">
                         理論価格
                       </td>
                       <td className="py-2 font-semibold">
-                        {formatYen(theoreticalPropertyPrice)}
+                        {formatYen(theoreticalData.price)}
                       </td>
                       <td className="py-2 pl-4">
-                        <DiffBadge diff={theoreticalDiff} pct={theoreticalDiffPct} />
+                        <DiffBadge diff={theoreticalData.diff} pct={theoreticalData.pct} />
                       </td>
                     </tr>
                   )}
-                  {result.requiredCostReduction > 0 && (
+                  {discountNeeded > 0 && askingPropertyPrice > 0 && (
                     <tr>
                       <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">
                         目標利回り達成に必要な値引き
                       </td>
                       <td className="py-2 font-semibold text-red-600">
-                        {formatYen(result.requiredCostReduction)}
+                        {formatYen(discountNeeded)}
                       </td>
                       <td className="py-2 pl-4 text-red-600 text-sm">
-                        ({formatPct(-result.requiredCostReduction / result.totalInvestment)})
+                        ({formatPct(discountNeeded / askingPropertyPrice)})
                       </td>
                     </tr>
                   )}

--- a/frontend/src/components/NegotiationPanel.tsx
+++ b/frontend/src/components/NegotiationPanel.tsx
@@ -1,0 +1,241 @@
+"use client";
+import React from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import type {
+  InvestmentInput,
+  InvestmentResult,
+  LandPriceComparison,
+  TheoreticalPriceResult,
+} from "@/types/investment";
+import { formatYen, formatPct } from "@/lib/utils";
+import { TrendingDown, TrendingUp, Minus } from "lucide-react";
+
+const TSUBO_PER_SQM = 3.30578;
+
+function DiffBadge({ diff, pct }: { diff: number; pct: number }) {
+  if (Math.abs(pct) < 0.1) {
+    return (
+      <span className="inline-flex items-center gap-1 text-sm text-muted-foreground">
+        <Minus className="h-3.5 w-3.5" />
+        ほぼ同額
+      </span>
+    );
+  }
+  const expensive = diff > 0;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 text-sm font-medium ${expensive ? "text-red-600" : "text-emerald-600"}`}
+    >
+      {expensive ? (
+        <TrendingUp className="h-3.5 w-3.5" />
+      ) : (
+        <TrendingDown className="h-3.5 w-3.5" />
+      )}
+      {expensive ? "▲" : "▼"}
+      {formatYen(Math.abs(diff))}（{expensive ? "+" : ""}
+      {pct.toFixed(1)}%）
+    </span>
+  );
+}
+
+interface Props {
+  result: InvestmentResult;
+  input: InvestmentInput;
+  comparison: LandPriceComparison | null;
+  theoreticalPrice: TheoreticalPriceResult | null;
+}
+
+export default function NegotiationPanel({
+  result,
+  input,
+  comparison,
+  theoreticalPrice,
+}: Props) {
+  const askingPropertyPrice = input.landPrice + input.buildingCost;
+
+  // Max purchase price = max total investment / (1 + miscExpenseRate)
+  const maxTotalInvestment = result.totalInvestment - result.requiredCostReduction;
+  const maxPropertyPrice =
+    input.miscExpenseRate > -1
+      ? maxTotalInvestment / (1 + input.miscExpenseRate)
+      : maxTotalInvestment;
+
+  const diffFromAsking = maxPropertyPrice - askingPropertyPrice;
+  const diffPct =
+    askingPropertyPrice > 0 ? (diffFromAsking / askingPropertyPrice) * 100 : 0;
+
+  // Market-implied property price from land transaction data
+  const marketLandValue =
+    comparison && input.landArea > 0
+      ? comparison.stats.medianTsubo * (input.landArea / TSUBO_PER_SQM)
+      : null;
+  const marketPropertyPrice =
+    marketLandValue !== null ? marketLandValue + input.buildingCost : null;
+  const marketDiff =
+    marketPropertyPrice !== null ? askingPropertyPrice - marketPropertyPrice : null;
+  const marketDiffPct =
+    marketPropertyPrice !== null && marketPropertyPrice > 0
+      ? (marketDiff! / marketPropertyPrice) * 100
+      : null;
+
+  // Theoretical price from estimate endpoint
+  const theoreticalPropertyPrice = theoreticalPrice?.theoreticalPriceJPY ?? null;
+  const theoreticalDiff =
+    theoreticalPropertyPrice !== null
+      ? askingPropertyPrice - theoreticalPropertyPrice
+      : null;
+  const theoreticalDiffPct =
+    theoreticalPropertyPrice !== null && theoreticalPropertyPrice > 0
+      ? (theoreticalDiff! / theoreticalPropertyPrice) * 100
+      : null;
+
+  // Negotiation range: between theoretical/market lower bound and max purchase price
+  const rangeAnchors = [
+    theoreticalPropertyPrice,
+    marketPropertyPrice,
+    maxPropertyPrice,
+  ].filter((v): v is number => v !== null && v > 0);
+  const rangeLow = rangeAnchors.length > 0 ? Math.min(...rangeAnchors) : null;
+  const rangeHigh = rangeAnchors.length > 0 ? Math.max(...rangeAnchors) : null;
+
+  const showNegotiationSection =
+    (comparison !== null && marketPropertyPrice !== null) ||
+    theoreticalPropertyPrice !== null;
+
+  return (
+    <Card className="rounded-xl shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base font-semibold">
+          逆算・交渉シミュレーション
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {/* Section 1: Reverse yield calculation (#296) */}
+        <section>
+          <h3 className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+            逆算モード
+          </h3>
+          <p className="mb-3 text-xs text-muted-foreground">
+            目標利回り{" "}
+            <span className="font-semibold text-foreground">
+              {formatPct(input.yieldTarget)}
+            </span>{" "}
+            ／ 想定賃料{" "}
+            <span className="font-semibold text-foreground">
+              ¥{input.monthlyRent.toLocaleString("ja-JP")}
+            </span>{" "}
+            円/月
+          </p>
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="rounded-lg bg-muted/50 p-3">
+              <p className="text-xs text-muted-foreground mb-1">最大買付可能価格</p>
+              <p className="text-lg font-bold">{formatYen(maxPropertyPrice)}</p>
+            </div>
+            <div className="rounded-lg bg-muted/50 p-3">
+              <p className="text-xs text-muted-foreground mb-1">売出価格との差額</p>
+              {askingPropertyPrice > 0 ? (
+                <DiffBadge diff={-diffFromAsking} pct={-diffPct} />
+              ) : (
+                <p className="text-sm text-muted-foreground">—</p>
+              )}
+              {askingPropertyPrice > 0 && diffFromAsking < 0 && (
+                <p className="mt-1 text-xs text-muted-foreground">
+                  値引き必要額: {formatYen(Math.abs(diffFromAsking))}
+                </p>
+              )}
+            </div>
+            <div className="rounded-lg bg-muted/50 p-3">
+              <p className="text-xs text-muted-foreground mb-1">
+                売出価格での表面利回り
+              </p>
+              <p
+                className={`text-lg font-bold ${result.isAboveYieldTarget ? "text-emerald-600" : "text-red-600"}`}
+              >
+                {formatPct(result.grossYield)}
+              </p>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                目標 {formatPct(input.yieldTarget)}
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Section 2: Negotiation simulation (#297) */}
+        {showNegotiationSection && (
+          <section className="border-t pt-4">
+            <h3 className="mb-3 text-sm font-semibold text-muted-foreground uppercase tracking-wide">
+              交渉シミュレーション
+            </h3>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <tbody className="divide-y divide-muted/50">
+                  <tr>
+                    <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">
+                      売出価格
+                    </td>
+                    <td className="py-2 font-semibold">
+                      {formatYen(askingPropertyPrice)}
+                    </td>
+                    <td className="py-2 pl-4" />
+                  </tr>
+                  {marketPropertyPrice !== null && marketDiff !== null && marketDiffPct !== null && (
+                    <tr>
+                      <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">
+                        市場取引実勢
+                      </td>
+                      <td className="py-2 font-semibold">
+                        {formatYen(marketPropertyPrice)}
+                      </td>
+                      <td className="py-2 pl-4">
+                        <DiffBadge diff={marketDiff} pct={marketDiffPct} />
+                      </td>
+                    </tr>
+                  )}
+                  {theoreticalPropertyPrice !== null && theoreticalDiff !== null && theoreticalDiffPct !== null && (
+                    <tr>
+                      <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">
+                        理論価格
+                      </td>
+                      <td className="py-2 font-semibold">
+                        {formatYen(theoreticalPropertyPrice)}
+                      </td>
+                      <td className="py-2 pl-4">
+                        <DiffBadge diff={theoreticalDiff} pct={theoreticalDiffPct} />
+                      </td>
+                    </tr>
+                  )}
+                  {result.requiredCostReduction > 0 && (
+                    <tr>
+                      <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">
+                        目標利回り達成に必要な値引き
+                      </td>
+                      <td className="py-2 font-semibold text-red-600">
+                        {formatYen(result.requiredCostReduction)}
+                      </td>
+                      <td className="py-2 pl-4 text-red-600 text-sm">
+                        ({formatPct(-result.requiredCostReduction / result.totalInvestment)})
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+            {rangeLow !== null && rangeHigh !== null && rangeLow !== rangeHigh && (
+              <div className="mt-3 rounded-lg bg-blue-50 dark:bg-blue-950/30 p-3">
+                <p className="text-xs text-muted-foreground mb-1">
+                  交渉推奨価格レンジ
+                </p>
+                <p className="text-sm font-semibold text-blue-700 dark:text-blue-300">
+                  {formatYen(rangeLow)} 〜 {formatYen(rangeHigh)}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  この範囲での成約であれば目標利回りを満たしつつ市場実勢に沿った交渉が可能です
+                </p>
+              </div>
+            )}
+          </section>
+        )}
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## 概要

Issues #296・#297 に対応する `NegotiationPanel` コンポーネントを追加した。

- **#296**: 目標利回りから逆算した最大買付可能価格を表示する「逆算モード」
- **#297**: 市場取引実勢・理論価格・売出価格の乖離率と交渉推奨レンジを表示する「交渉シミュレーション」

## 変更内容

- `frontend/src/components/NegotiationPanel.tsx` — 新規作成
  - **逆算モード**: `requiredCostReduction`（既存フィールド）から最大買付可能価格を算出し、売出価格との差額・現在利回りを表示
  - **交渉シミュレーション**: `LandPriceComparison.stats.medianTsubo` × 地積から市場価格を算出、`theoreticalPrice.theoreticalPriceJPY` と合わせて乖離率を表示。両データが存在する場合のみセクションを表示
  - 交渉推奨価格レンジ = 理論価格・市場価格・最大買付可能価格の min〜max
- `frontend/src/components/Dashboard.tsx` — `YieldAnalysis` 直後に `NegotiationPanel` を追加

## 主要計算式

```
maxPropertyPrice = (totalInvestment - requiredCostReduction) / (1 + miscExpenseRate)
marketPropertyPrice = medianTsubo × (landArea / 3.30578) + buildingCost
```

## テスト

- `tsc --noEmit` → エラーなし
- `npm test` → 221 件すべてパス

## 確認手順

1. `make dev` でローカル起動
2. フォームに条件入力 → 分析実行
3. `YieldAnalysis` の直下に「逆算・交渉シミュレーション」カードが表示されることを確認
4. 「地価データ取得」後、交渉シミュレーションセクションが追加表示されることを確認
5. 売出価格が目標利回りを既に達成している場合（`requiredCostReduction = 0`）、差額が 0 または正になることを確認

## 関連 Issue

- Close #296
- Close #297