### PR TITLE
fix: calcStressScenario に賃料下落・税引後CF・DSCR バッジ改善を適用

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -328,10 +328,8 @@ func calcStressScenario(base InvestmentInput, label string, rateDelta, vacDelta 
 		effectiveVacancy = 1
 	}
 
+	// 初年度賃料（空室率調整済み）— 賃料下落はループ内で年次適用
 	annualRent := in.MonthlyRent * 12 * (1 - effectiveVacancy)
-	annualExpenses := annualRent*in.ExpenseRate + in.AnnualPropertyTax
-	// noi はシナリオ期間中一定（calcStressScenario は賃料下落率を適用しない簡略計算）
-	noi := annualRent - annualExpenses
 
 	// 初年度の実効金利（スケジュール+ストレスdelta）
 	initRate := resolveRateForYear(in.AnnualLoanRate, rateDelta, in.RateAdjustmentSchedule, 1)
@@ -344,7 +342,7 @@ func calcStressScenario(base InvestmentInput, label string, rateDelta, vacDelta 
 		monthlyPayment = calcMonthlyPayment(in.LoanAmount, initRate, in.LoanYears)
 	}
 
-	// HoldingYears年間の累積CF（税引前）とブレークイーン年を算出
+	// HoldingYears年間の累積CF（税引後）とブレークイーン年を算出
 	// DSCR は各年返済額から算出した保有期間内最悪値（変動金利上昇ケースで正確なリスク評価を行うため）
 	holdingYears := in.HoldingYears
 	if holdingYears <= 0 {
@@ -372,29 +370,47 @@ func calcStressScenario(base InvestmentInput, label string, rateDelta, vacDelta 
 		}
 
 		yearLoan := 0.0
+		yearInterest := 0.0
 		if remainingBalance > 0 && y <= in.LoanYears {
 			if in.LoanMethod == LoanMethodEqualPrincipal {
 				yi, yp := calcYearlyLoanComponentsEqualPrincipal(remainingBalance, currentRate, monthlyPrincipalStress)
 				yearLoan = yi + yp
+				yearInterest = yi
 				remainingBalance -= yp
 			} else {
+				annInterest, annPrincipal := calcYearlyLoanComponents(remainingBalance, currentRate, curMonthlyPayment)
 				yearLoan = curMonthlyPayment * 12
-				_, annPrincipal := calcYearlyLoanComponents(remainingBalance, currentRate, curMonthlyPayment)
+				yearInterest = annInterest
 				remainingBalance -= annPrincipal
 			}
 			if remainingBalance < 0 {
 				remainingBalance = 0
 			}
 		}
+
+		// 賃料下落率を年次適用（Analyze() の declineFactor と同じロジック、1-indexed なので y-1 を指数に使用）
+		declineFactor := math.Pow(1-in.RentDeclineRate, float64(y-1))
+		yearRent := annualRent * declineFactor
+		yearExpenses := yearRent*in.ExpenseRate + in.AnnualPropertyTax
+		yearNOI := yearRent - yearExpenses
+
 		if yearLoan > 0 {
 			hasLoanYear = true
-			if yearDSCR := noi / yearLoan; yearDSCR < minDSCR {
+			if yearDSCR := yearNOI / yearLoan; yearDSCR < minDSCR {
 				minDSCR = yearDSCR
 			}
 		}
-		cf := annualRent - yearLoan - annualExpenses
-		totalCF += cf
-		cumCF += cf
+
+		cf := yearNOI - yearLoan
+		// 減価償却は省略した保守的近似（簡略ストレス計算のため過大に税を見積もる）
+		taxableIncome := yearNOI - yearInterest
+		incomeTax := 0.0
+		if taxableIncome > 0 {
+			incomeTax = taxableIncome * in.IncomeTaxRate
+		}
+		afterTaxCF := cf - incomeTax
+		totalCF += afterTaxCF
+		cumCF += afterTaxCF
 		if breakEvenYear == -1 && cumCF > 0 {
 			breakEvenYear = y
 		}

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -420,6 +420,8 @@ func calcStressScenario(base InvestmentInput, label string, rateDelta, vacDelta 
 		dscr = minDSCR
 	}
 
+	// BreakEvenYear は税引後 cumCF が初めて正転した年（#312）
+	// IsSafe の DSCR 閾値は 1.0 のまま維持（UI バッジは別途 1.2 で表示、#313）
 	isSafe := false
 	if !hasLoanYear {
 		// 保有期間内に返済が発生しない場合（無借金物件等）はブレークイーン達成のみで安全と判定

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -922,13 +922,14 @@ func TestCalcStressScenario_AfterTaxCFDelaysBreakEven(t *testing.T) {
 	r1 := calcStressScenario(withTax, "税40%", 0, 0)
 
 	// 税なしは初年度から CF > 0 → breakEven = 1
-	if r0.BreakEvenYear == -1 {
-		t.Fatal("税なしで黒転しない: テスト設計を確認（yearNOI がローン返済額を下回っている）")
+	if r0.BreakEvenYear != 1 {
+		t.Fatalf("税なし: breakEvenYear = %d, want 1（yearNOI がローン返済額を上回っていない）", r0.BreakEvenYear)
 	}
-	// 税ありは incomeTax が CF を超えるため afterTaxCF < 0 → 黒転なし or 大幅遅延
-	if r1.BreakEvenYear != -1 && r1.BreakEvenYear <= r0.BreakEvenYear {
-		t.Errorf("税40%%の黒転年(%d) <= 税なし黒転年(%d): 税引後CFが正しく反映されていない",
-			r1.BreakEvenYear, r0.BreakEvenYear)
+	// 税ありは incomeTax(40%) が CF を超えるため afterTaxCF < 0 → 保有期間中に黒転しない
+	// 数値設定（77,000円・15M・2%・30y）で afterTaxCF < 0 が確定するため -1 を直接検証する
+	if r1.BreakEvenYear != -1 {
+		t.Errorf("税40%%: breakEvenYear = %d, want -1（afterTaxCF < 0 なのに黒転年が存在する）",
+			r1.BreakEvenYear)
 	}
 	t.Logf("noTax breakEven=%d, withTax breakEven=%d", r0.BreakEvenYear, r1.BreakEvenYear)
 }

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -851,6 +851,88 @@ func TestCalcStressScenario_IsSafeFlipsWithVariableRate(t *testing.T) {
 		dscrYear1, result.DSCR, result.IsSafe, result.BreakEvenYear)
 }
 
+// TestCalcStressScenario_RentDeclineLowersDSCR は、RentDeclineRate > 0 の場合に
+// DSCR が下落率ゼロのケースより低くなることを検証する（#311）。
+//
+// 設計: 3% の賃料下落率を設定し、変動金利上昇スケジュールも加えることで
+// 保有期間後半に yearNOI と yearLoan の両方が悪化するケースを再現する。
+func TestCalcStressScenario_RentDeclineLowersDSCR(t *testing.T) {
+	base := InvestmentInput{
+		LandPrice:    5_000_000,
+		BuildingCost: 15_000_000,
+		MonthlyRent:  130_000,
+		VacancyRate:  0.05,
+		LoanAmount:   18_000_000,
+		AnnualLoanRate: 0.015,
+		LoanYears:    25,
+		ExpenseRate:  0.20,
+		IncomeTaxRate: 0.33,
+		HoldingYears: 10,
+		BuildingType: BuildingTypeRC,
+		RateAdjustmentSchedule: []RateAdjustment{
+			{AfterYear: 5, Rate: 0.03},
+		},
+	}
+
+	withoutDecline := base
+	withoutDecline.RentDeclineRate = 0
+
+	withDecline := base
+	withDecline.RentDeclineRate = 0.03
+
+	r0 := calcStressScenario(withoutDecline, "下落なし", 0, 0)
+	r1 := calcStressScenario(withDecline, "下落3%", 0, 0)
+
+	if r1.DSCR >= r0.DSCR {
+		t.Errorf("RentDeclineRate=3%% の DSCR(%.4f) >= 下落なし DSCR(%.4f): 賃料下落が反映されていない",
+			r1.DSCR, r0.DSCR)
+	}
+	t.Logf("noDeclineDSCR=%.4f, declineDSCR=%.4f", r0.DSCR, r1.DSCR)
+}
+
+// TestCalcStressScenario_AfterTaxCFDelaysBreakEven は、IncomeTaxRate > 0 の場合に
+// 税引後 CF ベースの黒転が税引前より悪化（遅延または未達）することを検証する（#312）。
+//
+// 設計: yearNOI がローン返済額をわずかに上回る（CF > 0）一方、
+// 利息控除後の課税所得×税率がそのCFを上回るよう貸出額を調整する。
+// 等払い方式・金利 2%・30年では初年度利息 ≈ L×2%、yearNOI ≈ 0.050L となるよう設定し、
+// noTax: breakEven=1、withTax: afterTaxCF < 0 → breakEven=-1 となることを確認する。
+func TestCalcStressScenario_AfterTaxCFDelaysBreakEven(t *testing.T) {
+	base := InvestmentInput{
+		LandPrice:    5_000_000,
+		BuildingCost: 15_000_000,
+		MonthlyRent:  77_000, // yearNOI ≈ 746k: CF > 0 だが incomeTax(40%) が CF を超える
+		VacancyRate:  0.05,
+		LoanAmount:   15_000_000,
+		AnnualLoanRate: 0.02,
+		LoanYears:    30,
+		ExpenseRate:  0.15,
+		HoldingYears: 15,
+		BuildingType: BuildingTypeRC,
+		RentDeclineRate: 0,
+	}
+
+	noTax := base
+	noTax.IncomeTaxRate = 0
+
+	withTax := base
+	withTax.IncomeTaxRate = 0.40
+
+	r0 := calcStressScenario(noTax, "税なし", 0, 0)
+	r1 := calcStressScenario(withTax, "税40%", 0, 0)
+
+	// 税なしは初年度から CF > 0 → breakEven = 1
+	if r0.BreakEvenYear == -1 {
+		t.Fatal("税なしで黒転しない: テスト設計を確認（yearNOI がローン返済額を下回っている）")
+	}
+	// 税ありは incomeTax が CF を超えるため afterTaxCF < 0 → 黒転なし or 大幅遅延
+	if r1.BreakEvenYear != -1 && r1.BreakEvenYear <= r0.BreakEvenYear {
+		t.Errorf("税40%%の黒転年(%d) <= 税なし黒転年(%d): 税引後CFが正しく反映されていない",
+			r1.BreakEvenYear, r0.BreakEvenYear)
+	}
+	t.Logf("noTax breakEven=%d, withTax breakEven=%d", r0.BreakEvenYear, r1.BreakEvenYear)
+}
+
 func TestDetectUrbanRisks_NilZoning(t *testing.T) {
 	risks := detectUrbanRisks(nil, nil)
 	if len(risks) != 0 {

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -242,8 +242,8 @@ type StressScenarioResult struct {
 	VacancyRateDelta  float64 `json:"vacancyRateDelta"`
 	TotalCashFlow     float64 `json:"totalCashFlow"`
 	DSCR              float64 `json:"dscr"`
-	BreakEvenYear     int     `json:"breakEvenYear"` // 累積CFが正転する年（-1=なし）
-	IsSafe            bool    `json:"isSafe"`        // DSCR >= 1.0 && BreakEvenYear <= HoldingYears
+	BreakEvenYear     int     `json:"breakEvenYear"` // 累積税引後CFが初めて正転する年（-1=なし）
+	IsSafe            bool    `json:"isSafe"`        // DSCR >= 1.0 && BreakEvenYear <= HoldingYears（UIバッジは1.2閾値、フラグ定義は変更しない）
 }
 
 // YieldScenario は1つの空室シナリオにおける利回り結果

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -464,19 +464,20 @@ DeviationPct         = (price - TheoreticalPrice) / TheoreticalPrice × 100
 | `label` | string | シナリオ名（上表参照） |
 | `interestRateDelta` | float64 | 基準金利からの上昇幅（例: `0.02` = +2%） |
 | `vacancyRateDelta` | float64 | 基準空室率からの上昇幅（例: `0.10` = +10%） |
-| `totalCashFlow` | float64 | 保有期間の税引前累積キャッシュフロー（円） |
-| `dscr` | float64 | DSCR（Debt Service Coverage Ratio）。ローンなしの場合は `0` |
-| `breakEvenYear` | int | 累積CF黒字転換年（保有期間内に未達なら `-1`） |
+| `totalCashFlow` | float64 | 保有期間の税引後累積キャッシュフロー（円）。減価償却は省略した保守的近似 |
+| `dscr` | float64 | 保有期間内の最悪年 DSCR（賃料下落率を年次適用した yearNOI / 年間ローン返済額）。ローンなしの場合は `0` |
+| `breakEvenYear` | int | 累積**税引後**CF黒字転換年（保有期間内に未達なら `-1`） |
 | `isSafe` | bool | 安全判定フラグ（下記参照） |
 
 **DSCR（負債返済カバレッジ比率）の計算式:**
 
 ```
-NOI = 年間実効賃料収入 × (1 − 空室率) − 経費 − 固定資産税
-DSCR = NOI / 年間ローン返済額
+NOI(y) = 年間実効賃料 × (1 − RentDeclineRate)^(y−1) − 経費 − 固定資産税
+DSCR   = min{ NOI(y) / 年間ローン返済額(y) }  // 保有期間内の最悪年
 ```
 
-DSCR が 1.0 以上であれば NOI だけでローン返済を賄える状態（銀行融資審査の基準値）。
+DSCR が 1.0 以上であれば NOI だけでローン返済を賄える状態（銀行融資審査の最低ライン）。  
+実務基準は 1.2 以上。UI バッジは `≥1.2`: 緑（安全）/ `1.0〜1.2`: 黄（注意）/ `<1.0`: 赤（危険）で表示。
 
 **`isSafe` の判定ロジック:**
 

--- a/docs/domain-investment-calculation.md
+++ b/docs/domain-investment-calculation.md
@@ -377,8 +377,8 @@ yearAnnualRent = baseAnnualRent × (1 - RentDeclineRate)^y
 | `InterestRateDelta` | float64 | 金利上昇幅（率。例: 0.01 = +1%） |
 | `VacancyRateDelta` | float64 | 空室率上昇幅（率。例: 0.10 = +10%pt） |
 | `TotalCashFlow` | float64 | `HoldingYears` 期間の税引後累積キャッシュフロー（円） |
-| `DSCR` | float64 | 負債返済カバレッジ比率（= 年間NOI / 年間ローン返済額）。ローンなしの場合は 0 |
-| `BreakEvenYear` | int | 累積CFが初めてプラスに転じる年次（1-indexed）。期間内に達成できない場合は `-1` |
+| `DSCR` | float64 | 保有期間内の最悪年 DSCR（賃料下落率を年次適用した yearNOI / 年間ローン返済額の最小値）。ローンなしの場合は 0 |
+| `BreakEvenYear` | int | 累積**税引後**CFが初めてプラスに転じる年次（1-indexed）。期間内に達成できない場合は `-1` |
 | `IsSafe` | bool | 安全判定フラグ（判定ロジックは下記参照） |
 
 ### 6 つのデフォルトシナリオ
@@ -400,9 +400,11 @@ yearAnnualRent = baseAnnualRent × (1 - RentDeclineRate)^y
 IsSafe = DSCR >= 1.0 && BreakEvenYear != -1 && BreakEvenYear <= HoldingYears
 ```
 
-- `DSCR >= 1.0`: 年間NOIがローン返済額を上回っている（債務返済能力あり）
-- `BreakEvenYear != -1`: 保有期間内に累積CFが黒字転換する
+- `DSCR >= 1.0`: 保有期間内の最悪年においても NOI がローン返済額を上回っている（債務返済能力あり）
+- `BreakEvenYear != -1`: 保有期間内に累積**税引後**CFが黒字転換する
 - `BreakEvenYear <= HoldingYears`: 黒字転換が出口売却年以内に収まる
+
+> **注意**: UI バッジの「安全」表示は `IsSafe` ではなく DSCR 値を直接使用し、実務基準の 1.2 を閾値とする（`IsSafe` の閾値定義 1.0 は変更しない）。
 
 **ローンなし（`LoanAmount == 0`）の場合:**
 

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -162,7 +162,7 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                 {stressScenarios.map((s) => {
                   const isCompound = s.label === "複合ストレス";
                   const rowBg = isCompound ? "bg-orange-50" : "";
-                  const safeBadge = s.isSafe
+                  const safeBadge = s.dscr >= 1.2
                     ? <Badge variant="success">安全</Badge>
                     : s.dscr >= 1.0
                       ? <Badge variant="warning">注意</Badge>
@@ -179,7 +179,7 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                       <td className="py-2 text-right">
                         {s.vacancyRateDelta !== 0 ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%` : "±0"}
                       </td>
-                      <td className={`py-2 text-right font-medium ${s.dscr >= 1.0 ? "text-green-600" : "text-red-600"}`}>
+                      <td className={`py-2 text-right font-medium ${s.dscr >= 1.2 ? "text-green-600" : s.dscr >= 1.0 ? "text-yellow-600" : "text-red-600"}`}>
                         {s.dscr.toFixed(2)}
                       </td>
                       <td className="py-2 text-right text-muted-foreground">
@@ -193,7 +193,7 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
             </table>
           </div>
           <p className="mt-2 text-xs text-muted-foreground">
-            ※ DSCR（借債返済カバー率）= NOI / 年間ローン返済額（保有期間内の最悪年）。1.0以上が銀行審査の目安。黒転年は保有期間内での累積CF黒転年度。
+            ※ DSCR（借債返済カバー率）= NOI（賃料下落・空室調整済み）/ 年間ローン返済額（保有期間内の最悪年）。1.2以上が実務基準、1.0以上が銀行審査の最低ライン（<span className="text-green-600">緑≥1.2</span>・<span className="text-yellow-600">黄1.0〜1.2</span>・<span className="text-red-600">赤&lt;1.0</span>）。黒転年は累積CF黒転年度（税引後）。年間CFがプラスに転じた年であり、自己資金の回収年ではありません。
           </p>
 
           {/* 人口減少シナリオ */}

--- a/frontend/src/lib/__tests__/investment.test.ts
+++ b/frontend/src/lib/__tests__/investment.test.ts
@@ -462,9 +462,8 @@ describe("calcStressScenario - rent decline and after-tax CF", () => {
 
     // 税なしは年1から黒転
     expect(s0.breakEvenYear).toBe(1);
-    // 税ありは afterTaxCF < 0 → 黒転なし（-1）または遅延
-    if (s1.breakEvenYear !== -1) {
-      expect(s1.breakEvenYear).toBeGreaterThan(s0.breakEvenYear);
-    }
+    // 税ありは incomeTax(40%) が CF を超えるため afterTaxCF < 0 → 保有期間中に黒転しない
+    // 数値設定（77,000円・15M・2%・30y）で afterTaxCF < 0 が確定するため -1 を直接検証する
+    expect(s1.breakEvenYear).toBe(-1);
   });
 });

--- a/frontend/src/lib/__tests__/investment.test.ts
+++ b/frontend/src/lib/__tests__/investment.test.ts
@@ -416,3 +416,55 @@ describe("analyze - vacancy rate stress test", () => {
     expect(stressed.yearlyResults[0].annualRent).toBeLessThan(base.yearlyResults[0].annualRent);
   });
 });
+
+// ─── stress scenario: rent decline and after-tax CF (#311, #312) ──────────────
+
+describe("calcStressScenario - rent decline and after-tax CF", () => {
+  it("RentDeclineRate > 0 のとき DSCR が下落率なしより低くなる (#311)", () => {
+    const base: InvestmentInput = {
+      ...BASE_INPUT,
+      monthlyRent: 130_000,
+      loanAmount: 18_000_000,
+      loanYears: 25,
+      expenseRate: 0.20,
+      incomeTaxRate: 0.33,
+      holdingYears: 10,
+      rateAdjustmentSchedule: [{ afterYear: 5, rate: 0.03 }],
+    };
+    const r0 = analyze({ ...base, rentDeclineRate: 0 });
+    const r1 = analyze({ ...base, rentDeclineRate: 0.03 });
+
+    const baseline0 = r0.stressScenarios.find((s) => s.label === "ベースライン")!;
+    const baseline1 = r1.stressScenarios.find((s) => s.label === "ベースライン")!;
+
+    expect(baseline1.dscr).toBeLessThan(baseline0.dscr);
+  });
+
+  it("IncomeTaxRate > 0 のとき税引後CF基準の黒転が税なしより悪化（遅延またはなし）する (#312)", () => {
+    // yearNOI がローン返済額をわずかに上回る（CF > 0）が、
+    // incomeTax(40%) がそのCFを超えるよう設定 → afterTaxCF < 0 → 黒転なし
+    const base: InvestmentInput = {
+      ...BASE_INPUT,
+      monthlyRent: 77_000,
+      vacancyRate: 0.05,
+      loanAmount: 15_000_000,
+      annualLoanRate: 0.02,
+      loanYears: 30,
+      expenseRate: 0.15,
+      holdingYears: 15,
+      rentDeclineRate: 0,
+    };
+    const r0 = analyze({ ...base, incomeTaxRate: 0 });
+    const r1 = analyze({ ...base, incomeTaxRate: 0.40 });
+
+    const s0 = r0.stressScenarios.find((s) => s.label === "ベースライン")!;
+    const s1 = r1.stressScenarios.find((s) => s.label === "ベースライン")!;
+
+    // 税なしは年1から黒転
+    expect(s0.breakEvenYear).toBe(1);
+    // 税ありは afterTaxCF < 0 → 黒転なし（-1）または遅延
+    if (s1.breakEvenYear !== -1) {
+      expect(s1.breakEvenYear).toBeGreaterThan(s0.breakEvenYear);
+    }
+  });
+});

--- a/frontend/src/lib/investment.ts
+++ b/frontend/src/lib/investment.ts
@@ -363,10 +363,8 @@ function calcStressScenario(
   let effectiveVacancy = inInput.vacancyRate + vacDelta;
   if (effectiveVacancy > 1) effectiveVacancy = 1;
 
+  // 初年度賃料（空室率調整済み）— 賃料下落はループ内で年次適用
   const annualRent = inInput.monthlyRent * 12 * (1 - effectiveVacancy);
-  const annualExpenses = annualRent * inInput.expenseRate + inInput.annualPropertyTax;
-  // noi はシナリオ期間中一定（calcStressScenario は賃料下落率を適用しない簡略計算）
-  const noi = annualRent - annualExpenses;
 
   const initRate = resolveRateForYear(inInput.annualLoanRate, rateDelta, inInput.rateAdjustmentSchedule, 1);
 
@@ -406,29 +404,45 @@ function calcStressScenario(
     }
 
     let yearLoan = 0;
+    let yearInterest = 0;
     if (remainingBalance > 0 && y <= inInput.loanYears) {
       if (inInput.loanMethod === LOAN_METHOD_EQUAL_PRINCIPAL) {
         const { interest: yi, principal: yp } = calcYearlyLoanComponentsEqualPrincipal(
           remainingBalance, currentRate, monthlyPrincipalStress,
         );
         yearLoan = yi + yp;
+        yearInterest = yi;
         remainingBalance -= yp;
       } else {
+        const { interest: annInterest, principal: annPrincipal } = calcYearlyLoanComponents(
+          remainingBalance, currentRate, curMonthlyPayment,
+        );
         yearLoan = curMonthlyPayment * 12;
-        const { principal: annPrincipal } = calcYearlyLoanComponents(remainingBalance, currentRate, curMonthlyPayment);
+        yearInterest = annInterest;
         remainingBalance -= annPrincipal;
       }
       if (remainingBalance < 0) remainingBalance = 0;
     }
+
+    // 賃料下落率を年次適用（Analyze() の declineFactor と同じロジック、1-indexed なので y-1 を指数に使用）
+    const declineFactor = Math.pow(1 - inInput.rentDeclineRate, y - 1);
+    const yearRent = annualRent * declineFactor;
+    const yearExpenses = yearRent * inInput.expenseRate + inInput.annualPropertyTax;
+    const yearNOI = yearRent - yearExpenses;
+
     if (yearLoan > 0) {
       hasLoanYear = true;
-      const yearDSCR = noi / yearLoan;
+      const yearDSCR = yearNOI / yearLoan;
       if (yearDSCR < minDSCR) minDSCR = yearDSCR;
     }
 
-    const cf = annualRent - yearLoan - annualExpenses;
-    totalCF += cf;
-    cumCF += cf;
+    const cf = yearNOI - yearLoan;
+    // 減価償却は省略した保守的近似（簡略ストレス計算のため過大に税を見積もる）
+    const taxableIncome = yearNOI - yearInterest;
+    const incomeTax = taxableIncome > 0 ? taxableIncome * inInput.incomeTaxRate : 0;
+    const afterTaxCF = cf - incomeTax;
+    totalCF += afterTaxCF;
+    cumCF += afterTaxCF;
     if (breakEvenYear === -1 && cumCF > 0) breakEvenYear = y;
   }
 


### PR DESCRIPTION
## 概要

PR #308 (calcStressScenario DSCR 最悪年修正) のレビューで発見された Issue #311〜#314 を一括対応する。

## 変更内容

### #311 (bug, high) — NOI に賃料下落率を年次適用

`calcStressScenario` では NOI がシナリオ期間中固定だったため、`RentDeclineRate > 0` の物件で DSCR が楽観的になっていた。`Analyze()` と同じ `declineFactor = (1 - rate)^(y-1)` を毎年適用し、`yearNOI` で DSCR・CF を計算するよう修正。Go・TS 両方に適用。

### #312 (bug, medium) — 累積 CF を税引後ベースに変更

`calcStressScenario` の累積 CF が税引前だったため `Analyze()` と不整合だった。利息を年次抽出し `taxableIncome = yearNOI - yearInterest` で簡易課税（減価償却は保守的省略）。`cumCF` / `totalCF` 共に `afterTaxCF` に変更。UI 注釈を「累積CF黒転年度（税引後）」に更新。

### #313 (enhancement, medium) — DSCR バッジ閾値を実務基準の 1.2 に引き上げ

表示のみ変更（`isSafe` フラグ定義は変更なし）。
| DSCR | バッジ | セル色 |
|------|--------|--------|
| ≥ 1.2 | 安全（緑） | text-green-600 |
| 1.0〜1.2 | 注意（黄） | text-yellow-600 |
| < 1.0 | 危険（赤） | text-red-600 |

### #314 (enhancement, low) — 黒転年の誤読防止注釈

脚注に「年間CFがプラスに転じた年であり、自己資金の回収年ではありません」を追記。

## テスト

- **Go**: `TestCalcStressScenario_RentDeclineLowersDSCR`・`TestCalcStressScenario_AfterTaxCFDelaysBreakEven` を追加
- **TS**: 同等テスト 2 件を追加
- 既存テスト全件 PASS 確認済み

## 動作確認方法

```bash
cd backend && go test ./... -timeout 120s
cd frontend && npm test
```