### PR TITLE
build(make): add backend / frontend / install / logs convenience targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev test lint build clean help \
+.PHONY: dev backend frontend install logs test lint build clean help \
         mlit-land-prices mlit-municipalities mlit-station-ridership mlit-population-forecast mlit-land-appraisals \
         mlit-urban-zoning mlit-liquefaction mlit-flood-hazard mlit-storm-hazard mlit-tsunami-hazard mlit-landslide-hazard \
         api-station-ridership api-estimate-ridership api-population-forecast api-land-appraisals api-investment-score \
@@ -24,6 +24,26 @@ dev:
 	echo "==> Starting frontend..."; \
 	(cd frontend && npm run dev) & \
 	wait
+
+## backend: バックエンド開発サーバーのみ起動
+backend:
+	cd backend && go run ./cmd/server
+
+## frontend: フロントエンド開発サーバーのみ起動
+frontend:
+	cd frontend && npm run dev
+
+## install: フロントエンド依存関係をインストール
+install:
+	cd frontend && npm install
+
+## logs: Dockerコンテナのログを表示（未起動の場合は案内）
+logs:
+	@if docker compose ps --quiet 2>/dev/null | grep -q .; then \
+	  docker compose logs -f; \
+	else \
+	  echo "Docker コンテナが起動していません。先に 'make docker-up' を実行してください。"; \
+	fi
 
 ## test: 全テストを実行
 test:


### PR DESCRIPTION
## 概要

Issue #288 対応。開発体験向上のため、Makefile に4つの便利ターゲットを追加した。

## 変更内容

- `make backend` — `cd backend && go run ./cmd/server` を実行（バックエンドのみ起動）
- `make frontend` — `cd frontend && npm run dev` を実行（フロントエンドのみ起動）
- `make install` — `cd frontend && npm install` を実行（依存関係インストール）
- `make logs` — Docker が起動中なら `docker compose logs -f`、未起動なら案内メッセージを表示
- `.PHONY` リストに上記4ターゲットを追記

## 関連Issue

Closes #288

## テスト

- [x] `make --dry-run backend` / `make --dry-run frontend` / `make --dry-run install` / `make --dry-run logs` が構文エラーなく通ることを確認済み

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] 既存ターゲット（`dev`, `docker-up`, `test`, `lint`, `build` 等）との重複・衝突なし
- [x] 既存スタイル（タブインデント、`## ターゲット名: 説明` コメント形式）に合わせて追加