### PR TITLE
feat(frontend): 物件候補ウォッチリスト（ローカル保存・ステータス管理）

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -20,6 +20,7 @@ import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 import { downloadReportPDF } from "@/lib/generatePdf";
 import { MonteCarloChart } from "@/components/MonteCarloChart";
 import NegotiationPanel from "@/components/NegotiationPanel";
+import WatchlistPanel from "@/components/WatchlistPanel";
 import dynamic from "next/dynamic";
 
 const InvestmentScoreHeatmap = dynamic(() => import("./InvestmentScoreHeatmap"), { ssr: false });
@@ -412,6 +413,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
               </>
             )}
             <RenovationPanel />
+            <WatchlistPanel />
           </section>
         </div>
       </main>

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -1,0 +1,200 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Trash2, ClipboardList } from "lucide-react";
+import type { WatchlistItem, WatchlistStatus } from "@/types/investment";
+
+const STORAGE_KEY = "yg_watchlist";
+
+const STATUS_OPTIONS: { value: WatchlistStatus; label: string }[] = [
+  { value: "検討中", label: "検討中" },
+  { value: "見送り", label: "見送り" },
+  { value: "購入済み", label: "購入済み" },
+];
+
+const STATUS_BADGE: Record<WatchlistStatus, string> = {
+  検討中: "bg-blue-100 text-blue-800",
+  見送り: "bg-gray-100 text-gray-600",
+  購入済み: "bg-emerald-100 text-emerald-800",
+};
+
+function loadItems(): WatchlistItem[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    return JSON.parse(raw) as WatchlistItem[];
+  } catch {
+    return [];
+  }
+}
+
+function saveItems(items: WatchlistItem[]): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("ja-JP", { year: "numeric", month: "2-digit", day: "2-digit" });
+}
+
+export default function WatchlistPanel() {
+  const [items, setItems] = useState<WatchlistItem[]>([]);
+  const [nameInput, setNameInput] = useState("");
+  const [memoInput, setMemoInput] = useState("");
+  const [nameError, setNameError] = useState("");
+
+  // Load from localStorage on mount
+  useEffect(() => {
+    setItems(loadItems());
+  }, []);
+
+  // Persist to localStorage whenever items change
+  useEffect(() => {
+    saveItems(items);
+  }, [items]);
+
+  function handleAdd() {
+    const trimmed = nameInput.trim();
+    if (!trimmed) {
+      setNameError("物件名を入力してください");
+      return;
+    }
+    setNameError("");
+    const newItem: WatchlistItem = {
+      id: typeof crypto !== "undefined" && crypto.randomUUID
+        ? crypto.randomUUID()
+        : String(Date.now()),
+      name: trimmed,
+      memo: memoInput.trim(),
+      status: "検討中",
+      addedAt: new Date().toISOString(),
+    };
+    setItems((prev) => [newItem, ...prev]);
+    setNameInput("");
+    setMemoInput("");
+  }
+
+  function handleStatusChange(id: string, status: WatchlistStatus) {
+    setItems((prev) =>
+      prev.map((item) => (item.id === id ? { ...item, status } : item))
+    );
+  }
+
+  function handleDelete(id: string) {
+    setItems((prev) => prev.filter((item) => item.id !== id));
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter") handleAdd();
+  }
+
+  return (
+    <Card className="rounded-xl shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base font-semibold">
+          <ClipboardList className="h-4 w-4 text-primary" />
+          物件候補ウォッチリスト
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Add form */}
+        <div className="space-y-2">
+          <div className="flex gap-2">
+            <div className="flex-1">
+              <input
+                type="text"
+                placeholder="物件名（必須）"
+                value={nameInput}
+                onChange={(e) => {
+                  setNameInput(e.target.value);
+                  if (nameError) setNameError("");
+                }}
+                onKeyDown={handleKeyDown}
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                aria-label="物件名"
+              />
+              {nameError && (
+                <p className="mt-0.5 text-xs text-destructive">{nameError}</p>
+              )}
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleAdd}
+              className="shrink-0"
+            >
+              追加
+            </Button>
+          </div>
+          <input
+            type="text"
+            placeholder="メモ（任意）"
+            value={memoInput}
+            onChange={(e) => setMemoInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            aria-label="メモ"
+          />
+        </div>
+
+        {/* List */}
+        {items.length === 0 ? (
+          <p className="py-6 text-center text-sm text-muted-foreground">
+            まだ物件が登録されていません
+          </p>
+        ) : (
+          <ul className="divide-y divide-border">
+            {items.map((item) => (
+              <li key={item.id} className="flex flex-col gap-2 py-3 sm:flex-row sm:items-start sm:gap-3">
+                {/* Left: name + meta */}
+                <div className="min-w-0 flex-1 space-y-0.5">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="truncate text-sm font-medium">{item.name}</span>
+                    <span
+                      className={`inline-flex shrink-0 rounded px-2 py-0.5 text-xs font-medium ${STATUS_BADGE[item.status]}`}
+                    >
+                      {item.status}
+                    </span>
+                  </div>
+                  {item.memo && (
+                    <p className="truncate text-xs text-muted-foreground">{item.memo}</p>
+                  )}
+                  <p className="text-xs text-muted-foreground">
+                    登録日: {formatDate(item.addedAt)}
+                  </p>
+                </div>
+
+                {/* Right: status selector + delete */}
+                <div className="flex shrink-0 items-center gap-2">
+                  <select
+                    value={item.status}
+                    onChange={(e) => handleStatusChange(item.id, e.target.value as WatchlistStatus)}
+                    className="h-8 rounded-md border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                    aria-label={`${item.name} のステータスを変更`}
+                  >
+                    {STATUS_OPTIONS.map((o) => (
+                      <option key={o.value} value={o.value}>
+                        {o.label}
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={() => handleDelete(item.id)}
+                    className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+                    aria-label={`${item.name} を削除`}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -41,17 +41,11 @@ function formatDate(iso: string): string {
 }
 
 export default function WatchlistPanel() {
-  const [items, setItems] = useState<WatchlistItem[]>([]);
+  const [items, setItems] = useState<WatchlistItem[]>(loadItems);
   const [nameInput, setNameInput] = useState("");
   const [memoInput, setMemoInput] = useState("");
   const [nameError, setNameError] = useState("");
 
-  // Load from localStorage on mount
-  useEffect(() => {
-    setItems(loadItems());
-  }, []);
-
-  // Persist to localStorage whenever items change
   useEffect(() => {
     saveItems(items);
   }, [items]);

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -415,3 +415,13 @@ export interface HeatmapResponse {
   tiles: HeatmapTile[];
   tileCount: number;
 }
+
+export type WatchlistStatus = "検討中" | "見送り" | "購入済み";
+
+export interface WatchlistItem {
+  id: string;
+  name: string;
+  memo: string;
+  status: WatchlistStatus;
+  addedAt: string; // ISO 8601
+}


### PR DESCRIPTION
## 概要
物件候補を手動で追加し、`localStorage` に永続化するウォッチリスト機能を実装しました。物件名・メモ・ステータス（検討中 / 見送り / 購入済み）を管理でき、バックエンド API への依存は一切ありません。

## 変更内容
- `frontend/src/types/investment.ts` に `WatchlistItem`・`WatchlistStatus` 型を追加
- `frontend/src/components/WatchlistPanel.tsx` を新規作成
  - 物件名入力 + 追加ボタン（空白は追加不可、Enter キー対応）
  - リスト表示（物件名・ステータスバッジ・メモ・登録日）
  - ステータス変更ドロップダウン（検討中 / 見送り / 購入済み）
  - 削除ボタン（アイコン付き）
  - `useEffect` + `localStorage` (`yg_watchlist` キー) で永続化
- `frontend/src/components/Dashboard.tsx` にウォッチリストを組み込み（RenovationPanel の直下）

## 関連Issue
Closes #299

## テスト
- [x] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み
- [x] `tsc --noEmit` でエラーなし（テストファイル以外）
- [x] 既存 Shadcn/UI + Tailwind CSS v4 スタイルに統一