### PR TITLE
fix(frontend): APIフェッチ失敗時のサイレントエラーを修正

### DIFF
--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -173,6 +173,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   }, [externalLat, externalLng]);
   const [municipalities, setMunicipalities] = useState<Municipality[]>([]);
   const [muniLoading, setMuniLoading] = useState(false);
+  const [muniError, setMuniError] = useState<string | null>(null);
   const [muniFilter, setMuniFilter] = useState("");
   const [touched, setTouched] = useState<Set<string>>(new Set());
   const [zoningType, setZoningType] = useState<ZoningType>("");
@@ -252,14 +253,16 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
 
   const loadMunicipalities = useCallback(async (areaCode: string) => {
     setMuniLoading(true);
+    setMuniError(null);
     setCity("");
     setMuniFilter("");
     try {
       const data = await fetchMunicipalities(areaCode);
       setMunicipalities(data);
       if (data.length > 0) setCity(data[0].id);
-    } catch {
+    } catch (e) {
       setMunicipalities([]);
+      setMuniError(e instanceof Error ? e.message : "市区町村の取得に失敗しました");
     } finally {
       setMuniLoading(false);
     }
@@ -501,6 +504,9 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                         : filteredMunicipalities.map((m) => <option key={m.id} value={m.id}>{m.name}</option>)
                       }
                     </select>
+                    {muniError && (
+                      <p className="text-xs text-destructive">{muniError}</p>
+                    )}
                   </div>
                 </div>
                 <p className="text-xs text-muted-foreground">
@@ -679,6 +685,9 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                         ))
                     }
                   </select>
+                  {muniError && (
+                    <p className="text-xs text-destructive">{muniError}</p>
+                  )}
                   {muniFilter.trim() && filteredMunicipalities.length > 0 && (
                     <p className="text-xs text-muted-foreground">{filteredMunicipalities.length}件該当</p>
                   )}

--- a/frontend/src/components/__tests__/InvestmentForm.test.tsx
+++ b/frontend/src/components/__tests__/InvestmentForm.test.tsx
@@ -1,9 +1,16 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { InvestmentForm } from "@/components/InvestmentForm";
 import { DEFAULT_INPUT, QUICK_MODE_DEFAULTS } from "@/types/investment";
 import type { SimulationMode } from "@/types/investment";
+
+vi.mock("@/lib/api", () => ({
+  fetchMunicipalities: vi.fn().mockResolvedValue([]),
+  fetchRentDeclineHint: vi.fn(),
+}));
+
+import * as api from "@/lib/api";
 
 function renderForm(mode: SimulationMode = "full") {
   const onAnalyze = vi.fn().mockResolvedValue(undefined);
@@ -22,6 +29,11 @@ function renderForm(mode: SimulationMode = "full") {
 }
 
 describe("InvestmentForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(api.fetchMunicipalities).mockResolvedValue([]);
+  });
+
   it("シミュレーション実行ボタンをクリックすると onAnalyze が呼ばれる", async () => {
     const onAnalyze = vi.fn().mockResolvedValue(undefined);
     const onFetchLandPrices = vi.fn().mockResolvedValue(undefined);
@@ -277,6 +289,38 @@ describe("InvestmentForm", () => {
       expect(screen.getByLabelText(/物件価格（土地＋建物の総額）/)).toHaveValue(3000);
       expect(screen.getByLabelText(/想定月額賃料/)).toHaveValue(150000);
       vi.unstubAllGlobals();
+    });
+  });
+
+  describe("市区町村フェッチエラー", () => {
+    it("詳細モードで市区町村の取得に失敗するとエラーメッセージが表示される", async () => {
+      vi.mocked(api.fetchMunicipalities).mockRejectedValue(new Error("ネットワークエラー"));
+      renderForm("full");
+      await waitFor(() => {
+        expect(screen.getByText("ネットワークエラー")).toBeInTheDocument();
+      });
+    });
+
+    it("fetchMunicipalities がError以外を投げた場合もフォールバックメッセージが表示される", async () => {
+      vi.mocked(api.fetchMunicipalities).mockRejectedValue("unknown");
+      renderForm("full");
+      await waitFor(() => {
+        expect(screen.getByText("市区町村の取得に失敗しました")).toBeInTheDocument();
+      });
+    });
+
+    it("都道府県を変更すると前のエラーがクリアされる", async () => {
+      vi.mocked(api.fetchMunicipalities)
+        .mockRejectedValueOnce(new Error("ネットワークエラー"))
+        .mockResolvedValueOnce([]);
+      renderForm("full");
+      await waitFor(() => {
+        expect(screen.getByText("ネットワークエラー")).toBeInTheDocument();
+      });
+      await userEvent.selectOptions(screen.getByLabelText("都道府県"), "13");
+      await waitFor(() => {
+        expect(screen.queryByText("ネットワークエラー")).not.toBeInTheDocument();
+      });
     });
   });
 });


### PR DESCRIPTION
## 概要

`InvestmentForm` コンポーネントの `loadMunicipalities` 関数において、市区町村一覧の取得（`fetchMunicipalities`）が失敗した際にエラーが `catch` ブロック内で握り潰され、ユーザーに何も通知されていなかった問題を修正した。

## 変更内容

- `InvestmentForm.tsx`: `muniError` state を追加し、`loadMunicipalities` の `catch` ブロックでエラーメッセージをセットするよう変更
- クイックモード・詳細モードの両方の市区町村ドロップダウン直下に `muniError` を表示するよう追加
- 都道府県の変更時に `muniError` をクリアするよう対応（`loadMunicipalities` 冒頭で `setMuniError(null)`）
- `InvestmentForm.test.tsx`: `@/lib/api` のモックを追加し、市区町村フェッチエラー時のUI表示を検証するテストケースを3件追加

## 関連Issue

Closes #289

## テスト

- [x] 既存テストが通ること（228件 全PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること（市区町村フェッチエラー 3件 追加）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み