### PR TITLE
feat: 必要自己資金ウィジェット + ファーストタイマーガイド

### DIFF
--- a/frontend/src/components/CostBreakdown.tsx
+++ b/frontend/src/components/CostBreakdown.tsx
@@ -2,11 +2,13 @@
 
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from "recharts";
 import { AcquisitionCostBreakdown, InvestmentInput, YearlyResult } from "@/types/investment";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface Props {
   input: InvestmentInput;
   acquisitionCosts: AcquisitionCostBreakdown;
   yearlyResults: YearlyResult[];
+  loanAmount: number;
 }
 
 const fmt = (n: number) =>
@@ -19,7 +21,7 @@ const COLORS = [
   "#8b5cf6", "#06b6d4", "#f97316",
 ];
 
-export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }: Props) {
+export default function CostBreakdown({ input, acquisitionCosts, yearlyResults, loanAmount }: Props) {
   // 初期投資の内訳（miscExpenses は別軸の概算値のため表示しない）
   const initialCostItems = [
     { name: "土地", value: input.landPrice },
@@ -45,9 +47,55 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
 
   const totalInitial = initialCostItems.reduce((s, i) => s + i.value, 0);
 
+  const downPayment = input.landPrice + input.buildingCost - loanAmount;
+  const emergencyReserve = input.monthlyRent * 3;
+  const minimumRequired = downPayment + acquisitionCosts.total;
+  const propertyValue = input.landPrice + input.buildingCost;
+  const downPaymentRatio = propertyValue > 0 ? downPayment / propertyValue : 0;
+
   return (
     <div className="space-y-6">
       <h2 className="text-lg font-semibold">コスト内訳</h2>
+
+      {/* 必要自己資金サマリー */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">必要自己資金</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="flex items-center justify-between text-sm font-semibold">
+            <span className="text-gray-700">最低必要額</span>
+            <span className="font-mono text-lg text-gray-900">{fmt(minimumRequired)}</span>
+          </div>
+          <div className="border-t pt-3 space-y-2">
+            <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">内訳</p>
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-gray-600">頭金（借入控除後）</span>
+              <span className="font-mono text-gray-900">{fmt(downPayment)}</span>
+            </div>
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-gray-600">諸費用合計</span>
+              <span className="font-mono text-gray-900">{fmt(acquisitionCosts.total)}</span>
+            </div>
+          </div>
+          <div className="border-t pt-3">
+            <div className="flex items-center justify-between text-sm text-muted-foreground">
+              <span>推奨: 緊急予備費</span>
+              <span className="font-mono">+{fmt(emergencyReserve)} （月額家賃×3ヶ月）</span>
+            </div>
+          </div>
+          {downPayment <= 0 && (
+            <div className="rounded-md bg-red-50 border border-red-200 px-3 py-2 text-sm text-red-700">
+              頭金がありません。ローン審査が困難になる可能性があります
+            </div>
+          )}
+          {downPayment > 0 && downPaymentRatio < 0.2 && (
+            <div className="rounded-md bg-orange-50 border border-orange-200 px-3 py-2 text-sm text-orange-700">
+              頭金比率が低め（20%未満）です
+            </div>
+          )}
+        </CardContent>
+      </Card>
 
       {/* 初期投資内訳 */}
       <div>

--- a/frontend/src/components/CostBreakdown.tsx
+++ b/frontend/src/components/CostBreakdown.tsx
@@ -8,7 +8,6 @@ interface Props {
   input: InvestmentInput;
   acquisitionCosts: AcquisitionCostBreakdown;
   yearlyResults: YearlyResult[];
-  loanAmount: number;
 }
 
 const fmt = (n: number) =>
@@ -21,7 +20,7 @@ const COLORS = [
   "#8b5cf6", "#06b6d4", "#f97316",
 ];
 
-export default function CostBreakdown({ input, acquisitionCosts, yearlyResults, loanAmount }: Props) {
+export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }: Props) {
   // 初期投資の内訳（miscExpenses は別軸の概算値のため表示しない）
   const initialCostItems = [
     { name: "土地", value: input.landPrice },
@@ -47,9 +46,9 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults, 
 
   const totalInitial = initialCostItems.reduce((s, i) => s + i.value, 0);
 
-  const downPayment = input.landPrice + input.buildingCost - loanAmount;
+  const downPayment = input.landPrice + input.buildingCost - input.loanAmount;
   const emergencyReserve = input.monthlyRent * 3;
-  const minimumRequired = downPayment + acquisitionCosts.total;
+  const minimumRequired = Math.max(0, downPayment) + acquisitionCosts.total;
   const propertyValue = input.landPrice + input.buildingCost;
   const downPaymentRatio = propertyValue > 0 ? downPayment / propertyValue : 0;
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -414,7 +414,6 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                           input={lastInput}
                           acquisitionCosts={result.acquisitionCosts}
                           yearlyResults={result.yearlyResults}
-                          loanAmount={lastInput.loanAmount}
                         />
                       </div>
                     )}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -21,6 +21,8 @@ import { downloadReportPDF } from "@/lib/generatePdf";
 import { MonteCarloChart } from "@/components/MonteCarloChart";
 import NegotiationPanel from "@/components/NegotiationPanel";
 import dynamic from "next/dynamic";
+import { FirstTimerGuide } from "@/components/FirstTimerGuide";
+import { SAMPLE_PROPERTY, ONBOARDING_KEY } from "@/lib/sampleProperty";
 
 const InvestmentScoreHeatmap = dynamic(() => import("./InvestmentScoreHeatmap"), { ssr: false });
 
@@ -67,6 +69,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   const [monteCarloLoading, setMonteCarloLoading] = useState(false);
   const [mobileFormOpen, setMobileFormOpen] = useState(false);
   const [isOnline, setIsOnline] = useState<boolean | null>(null);
+  const [showGuide, setShowGuide] = useState(false);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -94,6 +97,12 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   useEffect(() => {
     if (mobileFormOpen) closeButtonRef.current?.focus();
   }, [mobileFormOpen]);
+
+  useEffect(() => {
+    if (!localStorage.getItem(ONBOARDING_KEY)) {
+      setShowGuide(true);
+    }
+  }, []);
 
   const handleModeChange = (mode: SimulationMode) => {
     if (result) {
@@ -238,6 +247,20 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
 
   return (
     <div className="min-h-screen bg-background">
+      {showGuide && (
+        <FirstTimerGuide
+          sampleProperty={SAMPLE_PROPERTY}
+          onUseSample={(input) => {
+            localStorage.setItem(ONBOARDING_KEY, "1");
+            setShowGuide(false);
+            handleAnalyze(input);
+          }}
+          onDismiss={() => {
+            localStorage.setItem(ONBOARDING_KEY, "1");
+            setShowGuide(false);
+          }}
+        />
+      )}
       <header className="border-b bg-white px-4 py-3 shadow-sm lg:px-6 lg:py-4">
         <div className="mx-auto flex max-w-7xl items-center gap-3">
           <ShieldAlert className="h-6 w-6 text-primary lg:h-7 lg:w-7" />

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -391,6 +391,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                           input={lastInput}
                           acquisitionCosts={result.acquisitionCosts}
                           yearlyResults={result.yearlyResults}
+                          loanAmount={lastInput.loanAmount}
                         />
                       </div>
                     )}

--- a/frontend/src/components/FirstTimerGuide.tsx
+++ b/frontend/src/components/FirstTimerGuide.tsx
@@ -1,0 +1,86 @@
+"use client";
+import React from "react";
+import { X, TrendingUp, AlertTriangle, MapPin, DoorOpen } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import type { InvestmentInput } from "@/types/investment";
+
+interface Props {
+  onUseSample: (input: InvestmentInput, sampleName: string) => void;
+  onDismiss: () => void;
+  sampleProperty: InvestmentInput;
+}
+
+const STEPS = [
+  {
+    icon: <TrendingUp className="h-5 w-5 text-blue-600" />,
+    title: "利回りチェック",
+    body: "表面利回り8%を目安に。これを下回る場合は価格交渉の余地を探りましょう。",
+  },
+  {
+    icon: <AlertTriangle className="h-5 w-5 text-orange-500" />,
+    title: "デッドクロス確認",
+    body: "元金返済が減価償却費を上回る年（デッドクロス）が10年以内なら要注意。税負担が突然重くなります。",
+  },
+  {
+    icon: <MapPin className="h-5 w-5 text-green-600" />,
+    title: "立地スコア",
+    body: "人口動態・駅需要・ハザードリスクを統合した60点以上のエリアが目安です。",
+  },
+  {
+    icon: <DoorOpen className="h-5 w-5 text-purple-600" />,
+    title: "出口戦略",
+    body: "5年超保有で譲渡税が約20%に下がります。売却時の手残りも必ず試算しましょう。",
+  },
+];
+
+export function FirstTimerGuide({ onUseSample, onDismiss, sampleProperty }: Props) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+      <div className="relative w-full max-w-lg rounded-2xl bg-white shadow-2xl">
+        <button
+          onClick={onDismiss}
+          className="absolute right-4 top-4 rounded-full p-1 text-muted-foreground hover:bg-muted"
+          aria-label="閉じる"
+        >
+          <X className="h-4 w-4" />
+        </button>
+
+        <div className="p-6">
+          <h2 className="text-lg font-bold">🏠 Yield-Guard の使い方</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            不動産投資を4つの視点で判断しよう
+          </p>
+
+          <ol className="mt-4 space-y-3">
+            {STEPS.map((step, i) => (
+              <li key={i} className="flex gap-3 rounded-lg border bg-muted/30 p-3">
+                <span className="mt-0.5 shrink-0">{step.icon}</span>
+                <div>
+                  <p className="text-sm font-semibold">
+                    {i + 1}. {step.title}
+                  </p>
+                  <p className="mt-0.5 text-xs text-muted-foreground">{step.body}</p>
+                </div>
+              </li>
+            ))}
+          </ol>
+
+          <div className="mt-5 flex flex-col gap-2 sm:flex-row">
+            <Button
+              className="flex-1"
+              onClick={() => onUseSample(sampleProperty, "木造アパート（築15年・月25万円）")}
+            >
+              サンプル物件で試す
+            </Button>
+            <Button variant="outline" className="flex-1" onClick={onDismiss}>
+              自分で入力する
+            </Button>
+          </div>
+          <p className="mt-2 text-center text-xs text-muted-foreground">
+            サンプル: 木造アパート 3,500万円・月額家賃25万円・借入2,400万円
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/sampleProperty.ts
+++ b/frontend/src/lib/sampleProperty.ts
@@ -1,0 +1,33 @@
+import type { InvestmentInput } from "@/types/investment";
+
+export const SAMPLE_PROPERTY: InvestmentInput = {
+  landPrice: 20_000_000,
+  landArea: 100,
+  buildingCost: 15_000_000,
+  buildingAge: 15,
+  stationMinutes: 8,
+  miscExpenseRate: 0.07,
+  monthlyRent: 250_000,
+  vacancyRate: 0.05,
+  actualVacancyRate: 0,
+  loanAmount: 24_000_000,
+  annualLoanRate: 0.018,
+  loanYears: 30,
+  buildingType: "木造",
+  expenseRate: 0.20,
+  incomeTaxRate: 0.33,
+  holdingYears: 10,
+  exitYieldTarget: 0.06,
+  vacancyRateDelta: 0,
+  loanRateDelta: 0,
+  annualPropertyTax: 0,
+  rentDeclineRate: 0.005,
+  yieldTarget: 0.08,
+  loanMethod: "equal-payment",
+  rateAdjustmentSchedule: [],
+  discountRate: 0.05,
+  priceDeclineRate: 0.02,
+  depreciationMethod: "straight-line" as const,
+};
+
+export const ONBOARDING_KEY = "yield-guard:onboarded";


### PR DESCRIPTION
## 概要

「不動産投資未経験のエンジニア」向けに2つの機能を追加。

1. **必要自己資金サマリーカード** — `CostBreakdown.tsx` に「最低XX万円の現金が必要」を最優先表示。頭金・諸費用・緊急予備費の内訳を一目で把握できる。
2. **ファーストタイマーガイド** — 初回訪問時に不動産投資の4つの判断軸（利回り・デッドクロス・立地スコア・出口戦略）を案内するオンボーディングモーダル。サンプル物件（木造アパート 3,500万円）でそのまま試せる。

## 変更ファイル

- `frontend/src/components/CostBreakdown.tsx` — 必要自己資金サマリーカード追加
- `frontend/src/components/Dashboard.tsx` — `loanAmount` prop追加 + FirstTimerGuide組み込み
- `frontend/src/components/FirstTimerGuide.tsx` — 新規: オンボーディングモーダル
- `frontend/src/lib/sampleProperty.ts` — 新規: サンプル物件定数・`ONBOARDING_KEY`

## 関連Issue

Closes #335
Closes #337

## テスト

- [x] `npm run build` 通過（TypeScript エラーなし）
- [x] 初回訪問時にガイドが表示されること
- [x] 「サンプルで試す」でフォームが埋まりシミュレーション結果が表示されること
- [x] localStorage フラグにより2回目以降は非表示になること
- [x] 頭金比率が低い場合に警告バッジが表示されること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み