### PR TITLE
feat: エリア発見モード — 予算・目標利回りから候補エリアをランキング表示

### DIFF
--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -1121,10 +1121,10 @@ func (h *Handler) HandleAreaDiscovery(c *gin.Context) {
 			transactions, fetchErr := h.mlitClient.FetchLandPrices(ctx, mlit.LandPriceQuery{
 				Area:      prefecture,
 				City:      m.ID,
-				Year:      toYear,
-				Quarter:   4,
-				ToYear:    fromYear,
-				ToQuarter: 1,
+				Year:      fromYear,
+				Quarter:   1,
+				ToYear:    toYear,
+				ToQuarter: 4,
 			})
 
 			item := domain.AreaDiscoveryItem{
@@ -1147,26 +1147,19 @@ func (h *Handler) HandleAreaDiscovery(c *gin.Context) {
 			item.TransactionCount = stats.Count
 			item.DataSufficient = stats.Count >= 3
 
-			// 利回り達成難易度: 目標利回りとエリア推定利回りを比較
-			// 推定利回り = 年間家賃想定 / 総投資額想定
-			// 総投資額想定 = medianTsubo × (budget の 60% を土地と仮定してtsubo換算) + 建物費(budget×40%)
-			// budget が未指定の場合は medianTsubo × 30坪 + 1000万 で試算
-			var estimatedTotalInvestment float64
+			// 利回り達成難易度: 予算（または中央坪単価×30坪+建物代）に対して目標利回りが必要とする月額家賃を試算し、
+			// 1坪あたり月額賃料の現実性で判定する
+			var totalCostEst float64
 			if budget > 0 {
-				estimatedTotalInvestment = budget
+				totalCostEst = budget
 			} else {
-				estimatedTotalInvestment = stats.MedianTsubo*30 + 10_000_000
+				totalCostEst = stats.MedianTsubo*30 + 10_000_000
 			}
-			_ = estimatedTotalInvestment // 将来拡張用
-
-			// 代わりに: 指定予算でこのエリアの中央坪単価の物件を買った場合の坪単価比率で難易度判定
-			landCostAtMedian := stats.MedianTsubo * 30 // 30坪想定
-			buildingCost := 10_000_000.0
-			typicalTotalCost := landCostAtMedian + buildingCost
-			annualRentNeeded := typicalTotalCost * targetYield
-			// 月額家賃 = annualRentNeeded / 12 が現実的か（1坪あたり月1万円以内が目安）
+			annualRentNeeded := totalCostEst * targetYield
+			// 1坪あたり月額賃料が現実的か判定（目安: 8,000円以下=達成可能, 15,000円超=困難）
 			monthlyRentNeeded := annualRentNeeded / 12
-			rentPerTsubo := monthlyRentNeeded / 30
+			areaTsubo := 30.0
+			rentPerTsubo := monthlyRentNeeded / areaTsubo
 			if rentPerTsubo <= 8000 {
 				item.YieldDifficulty = "achievable"
 				item.YieldDifficultyLabel = "達成可能"

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -1156,6 +1156,7 @@ func (h *Handler) HandleAreaDiscovery(c *gin.Context) {
 				totalCostEst = stats.MedianTsubo*30 + 10_000_000
 			}
 			annualRentNeeded := totalCostEst * targetYield
+
 			// 1坪あたり月額賃料が現実的か判定（目安: 8,000円以下=達成可能, 15,000円超=困難）
 			monthlyRentNeeded := annualRentNeeded / 12
 			areaTsubo := 30.0
@@ -1171,7 +1172,7 @@ func (h *Handler) HandleAreaDiscovery(c *gin.Context) {
 				item.YieldDifficultyLabel = "困難"
 			}
 
-			item.LandPriceTrend = "安定" // デフォルト（appraisalデータなしの場合）
+			item.LandPriceTrend = "データなし"
 			results[idx] = result{item: item}
 		}(i, municipalities[i])
 	}

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -6,7 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"sort"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -1054,6 +1056,155 @@ func validateRenovationInput(in domain.RenovationInput) error {
 		}
 	}
 	return nil
+}
+
+// HandleAreaDiscovery は都道府県内の市区町村を土地価格データで評価しランキング返却
+// GET /api/area-discovery?prefecture=13&budget=50000000&yield=0.07
+func (h *Handler) HandleAreaDiscovery(c *gin.Context) {
+	prefecture := c.Query("prefecture")
+	if prefecture == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "prefecture は必須パラメータです"})
+		return
+	}
+	budgetStr := c.Query("budget")
+	yieldStr := c.Query("yield")
+
+	budget := 0.0
+	targetYield := 0.08
+	if budgetStr != "" {
+		if v, err := strconv.ParseFloat(budgetStr, 64); err == nil && v > 0 {
+			budget = v
+		}
+	}
+	if yieldStr != "" {
+		if v, err := strconv.ParseFloat(yieldStr, 64); err == nil && v > 0 {
+			targetYield = v
+		}
+	}
+
+	ctx := c.Request.Context()
+
+	// 市区町村一覧取得
+	municipalities, err := h.mlitClient.FetchMunicipalities(ctx, prefecture)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "市区町村一覧の取得に失敗しました"})
+		return
+	}
+
+	// 最新2年の土地取引データを並列取得
+	now := time.Now()
+	toYear := now.Year()
+	fromYear := toYear - 2
+
+	type result struct {
+		item domain.AreaDiscoveryItem
+		err  error
+	}
+
+	// 上位30市区町村に絞る（全件だとタイムアウトリスク）
+	limit := 30
+	if len(municipalities) < limit {
+		limit = len(municipalities)
+	}
+
+	results := make([]result, limit)
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, 5) // 並列5件上限
+
+	for i := 0; i < limit; i++ {
+		wg.Add(1)
+		go func(idx int, m mlit.Municipality) {
+			defer wg.Done()
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			transactions, fetchErr := h.mlitClient.FetchLandPrices(ctx, mlit.LandPriceQuery{
+				Area:      prefecture,
+				City:      m.ID,
+				Year:      toYear,
+				Quarter:   4,
+				ToYear:    fromYear,
+				ToQuarter: 1,
+			})
+
+			item := domain.AreaDiscoveryItem{
+				MunicipalityCode: m.ID,
+				MunicipalityName: m.Name,
+			}
+
+			if fetchErr != nil || len(transactions) == 0 {
+				item.DataSufficient = false
+				item.LandPriceTrend = "不明"
+				item.YieldDifficulty = "difficult"
+				item.YieldDifficultyLabel = "データ不足"
+				results[idx] = result{item: item}
+				return
+			}
+
+			stats := domain.CalcLandPriceStats(transactions)
+
+			item.MedianTsubo = stats.MedianTsubo
+			item.TransactionCount = stats.Count
+			item.DataSufficient = stats.Count >= 3
+
+			// 利回り達成難易度: 目標利回りとエリア推定利回りを比較
+			// 推定利回り = 年間家賃想定 / 総投資額想定
+			// 総投資額想定 = medianTsubo × (budget の 60% を土地と仮定してtsubo換算) + 建物費(budget×40%)
+			// budget が未指定の場合は medianTsubo × 30坪 + 1000万 で試算
+			var estimatedTotalInvestment float64
+			if budget > 0 {
+				estimatedTotalInvestment = budget
+			} else {
+				estimatedTotalInvestment = stats.MedianTsubo*30 + 10_000_000
+			}
+			_ = estimatedTotalInvestment // 将来拡張用
+
+			// 代わりに: 指定予算でこのエリアの中央坪単価の物件を買った場合の坪単価比率で難易度判定
+			landCostAtMedian := stats.MedianTsubo * 30 // 30坪想定
+			buildingCost := 10_000_000.0
+			typicalTotalCost := landCostAtMedian + buildingCost
+			annualRentNeeded := typicalTotalCost * targetYield
+			// 月額家賃 = annualRentNeeded / 12 が現実的か（1坪あたり月1万円以内が目安）
+			monthlyRentNeeded := annualRentNeeded / 12
+			rentPerTsubo := monthlyRentNeeded / 30
+			if rentPerTsubo <= 8000 {
+				item.YieldDifficulty = "achievable"
+				item.YieldDifficultyLabel = "達成可能"
+			} else if rentPerTsubo <= 15000 {
+				item.YieldDifficulty = "slightly-difficult"
+				item.YieldDifficultyLabel = "やや困難"
+			} else {
+				item.YieldDifficulty = "difficult"
+				item.YieldDifficultyLabel = "困難"
+			}
+
+			item.LandPriceTrend = "安定" // デフォルト（appraisalデータなしの場合）
+			results[idx] = result{item: item}
+		}(i, municipalities[i])
+	}
+	wg.Wait()
+
+	items := make([]domain.AreaDiscoveryItem, 0, limit)
+	for _, r := range results {
+		if r.err == nil {
+			items = append(items, r.item)
+		}
+	}
+
+	// 達成可能 → やや困難 → 困難 の順、同一難易度内は取引件数降順
+	sort.Slice(items, func(i, j int) bool {
+		difficultyOrder := map[string]int{"achievable": 0, "slightly-difficult": 1, "difficult": 2}
+		di, dj := difficultyOrder[items[i].YieldDifficulty], difficultyOrder[items[j].YieldDifficulty]
+		if di != dj {
+			return di < dj
+		}
+		return items[i].TransactionCount > items[j].TransactionCount
+	})
+
+	c.JSON(http.StatusOK, domain.AreaDiscoveryResponse{
+		Items:      items,
+		Prefecture: prefecture,
+	})
 }
 
 // HandleRenovationAnalyze はリフォームROIシミュレーションを実行する

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -132,6 +132,7 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/hazard", h.GetHazardInfo)
 		api.GET("/investment-score", h.GetInvestmentScore)
 		api.GET("/investment-score-heatmap", analyzeRL.middleware(), h.GetInvestmentScoreHeatmap)
+		api.GET("/area-discovery", h.HandleAreaDiscovery)
 	}
 
 	return r

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -132,7 +132,7 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/hazard", h.GetHazardInfo)
 		api.GET("/investment-score", h.GetInvestmentScore)
 		api.GET("/investment-score-heatmap", analyzeRL.middleware(), h.GetInvestmentScoreHeatmap)
-		api.GET("/area-discovery", h.HandleAreaDiscovery)
+		api.GET("/area-discovery", analyzeRL.middleware(), h.HandleAreaDiscovery)
 	}
 
 	return r

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -547,3 +547,21 @@ type HeatmapResponse struct {
 	Tiles     []HeatmapTile `json:"tiles"`
 	TileCount int           `json:"tileCount"`
 }
+
+// AreaDiscoveryItem は市区町村ごとの投資適性サマリー
+type AreaDiscoveryItem struct {
+	MunicipalityCode     string  `json:"municipalityCode"`
+	MunicipalityName     string  `json:"municipalityName"`
+	MedianTsubo          float64 `json:"medianTsubo"`          // 坪単価中央値（円）
+	TransactionCount     int     `json:"transactionCount"`     // 取引件数
+	YieldDifficulty      string  `json:"yieldDifficulty"`      // "achievable" | "slightly-difficult" | "difficult"
+	YieldDifficultyLabel string  `json:"yieldDifficultyLabel"` // 日本語ラベル
+	LandPriceTrend       string  `json:"landPriceTrend"`       // "上昇" | "安定" | "下落" | "不明"
+	DataSufficient       bool    `json:"dataSufficient"`       // 取引件数3件以上
+}
+
+// AreaDiscoveryResponse は /api/area-discovery のレスポンス
+type AreaDiscoveryResponse struct {
+	Items      []AreaDiscoveryItem `json:"items"`
+	Prefecture string              `json:"prefecture"`
+}

--- a/frontend/src/components/AreaDiscovery.tsx
+++ b/frontend/src/components/AreaDiscovery.tsx
@@ -1,0 +1,203 @@
+"use client";
+import React, { useState } from "react";
+import { fetchAreaDiscovery, type AreaDiscoveryItem } from "@/lib/api";
+
+const PREFECTURES = [
+  { value: "01", label: "北海道" }, { value: "02", label: "青森県" },
+  { value: "03", label: "岩手県" }, { value: "04", label: "宮城県" },
+  { value: "05", label: "秋田県" }, { value: "06", label: "山形県" },
+  { value: "07", label: "福島県" }, { value: "08", label: "茨城県" },
+  { value: "09", label: "栃木県" }, { value: "10", label: "群馬県" },
+  { value: "11", label: "埼玉県" }, { value: "12", label: "千葉県" },
+  { value: "13", label: "東京都" }, { value: "14", label: "神奈川県" },
+  { value: "15", label: "新潟県" }, { value: "16", label: "富山県" },
+  { value: "17", label: "石川県" }, { value: "18", label: "福井県" },
+  { value: "19", label: "山梨県" }, { value: "20", label: "長野県" },
+  { value: "21", label: "岐阜県" }, { value: "22", label: "静岡県" },
+  { value: "23", label: "愛知県" }, { value: "24", label: "三重県" },
+  { value: "25", label: "滋賀県" }, { value: "26", label: "京都府" },
+  { value: "27", label: "大阪府" }, { value: "28", label: "兵庫県" },
+  { value: "29", label: "奈良県" }, { value: "30", label: "和歌山県" },
+  { value: "31", label: "鳥取県" }, { value: "32", label: "島根県" },
+  { value: "33", label: "岡山県" }, { value: "34", label: "広島県" },
+  { value: "35", label: "山口県" }, { value: "36", label: "徳島県" },
+  { value: "37", label: "香川県" }, { value: "38", label: "愛媛県" },
+  { value: "39", label: "高知県" }, { value: "40", label: "福岡県" },
+  { value: "41", label: "佐賀県" }, { value: "42", label: "長崎県" },
+  { value: "43", label: "熊本県" }, { value: "44", label: "大分県" },
+  { value: "45", label: "宮崎県" }, { value: "46", label: "鹿児島県" },
+  { value: "47", label: "沖縄県" },
+];
+
+interface Props {
+  onMunicipalitySelect?: (municipalityCode: string, municipalityName: string) => void;
+}
+
+function DifficultyBadge({ difficulty, label }: { difficulty: string; label: string }) {
+  const colorMap: Record<string, string> = {
+    achievable: "bg-green-100 text-green-800 border border-green-200",
+    "slightly-difficult": "bg-yellow-100 text-yellow-800 border border-yellow-200",
+    difficult: "bg-red-100 text-red-800 border border-red-200",
+  };
+  const cls = colorMap[difficulty] ?? "bg-gray-100 text-gray-800 border border-gray-200";
+  return (
+    <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}>
+      {label}
+    </span>
+  );
+}
+
+export function AreaDiscovery({ onMunicipalitySelect }: Props) {
+  const [prefecture, setPrefecture] = useState("13");
+  const [budgetMan, setBudgetMan] = useState("");
+  const [yieldPct, setYieldPct] = useState("8");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [items, setItems] = useState<AreaDiscoveryItem[] | null>(null);
+
+  const handleSearch = async () => {
+    setLoading(true);
+    setError(null);
+    setItems(null);
+    try {
+      const params: Parameters<typeof fetchAreaDiscovery>[0] = { prefecture };
+      if (budgetMan !== "") {
+        const v = parseFloat(budgetMan);
+        if (!isNaN(v) && v > 0) params.budget = v * 10000;
+      }
+      if (yieldPct !== "") {
+        const v = parseFloat(yieldPct);
+        if (!isNaN(v) && v > 0) params.yield = v / 100;
+      }
+      const res = await fetchAreaDiscovery(params);
+      setItems(res.items);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "エリアデータの取得に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border bg-white p-5 shadow-sm space-y-4">
+      <h2 className="text-base font-semibold text-foreground">エリアを探す</h2>
+      <p className="text-xs text-muted-foreground">
+        予算と目標利回りを入力して、候補エリアをランキング表示します。
+      </p>
+
+      {/* Form */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-foreground">都道府県</label>
+          <select
+            value={prefecture}
+            onChange={(e) => setPrefecture(e.target.value)}
+            className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          >
+            {PREFECTURES.map((p) => (
+              <option key={p.value} value={p.value}>
+                {p.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-foreground">予算（万円）</label>
+          <input
+            type="number"
+            placeholder="例: 3000"
+            value={budgetMan}
+            onChange={(e) => setBudgetMan(e.target.value)}
+            className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            min={0}
+          />
+        </div>
+
+        <div className="flex flex-col gap-1">
+          <label className="text-xs font-medium text-foreground">目標利回り（%）</label>
+          <input
+            type="number"
+            placeholder="例: 8"
+            value={yieldPct}
+            onChange={(e) => setYieldPct(e.target.value)}
+            step="0.1"
+            min={0}
+            max={50}
+            className="rounded-md border border-input bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+          />
+        </div>
+      </div>
+
+      <button
+        onClick={handleSearch}
+        disabled={loading}
+        className="flex min-h-[40px] items-center gap-2 rounded-md bg-primary px-5 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary/90 disabled:opacity-60 transition-colors"
+      >
+        {loading ? "検索中..." : "エリアを探す"}
+      </button>
+
+      {error && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
+      {/* Results */}
+      {items && items.length === 0 && (
+        <p className="text-sm text-muted-foreground">該当するエリアのデータが見つかりませんでした。</p>
+      )}
+
+      {items && items.length > 0 && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/40 text-xs font-medium text-muted-foreground">
+                <th className="px-3 py-2 text-left">市区町村</th>
+                <th className="px-3 py-2 text-right">坪単価中央値</th>
+                <th className="px-3 py-2 text-right">取引件数</th>
+                <th className="px-3 py-2 text-center">利回り達成難易度</th>
+                <th className="px-3 py-2 text-center">土地価格トレンド</th>
+              </tr>
+            </thead>
+            <tbody>
+              {items.map((item) => (
+                <tr
+                  key={item.municipalityCode}
+                  onClick={() => onMunicipalitySelect?.(item.municipalityCode, item.municipalityName)}
+                  className="cursor-pointer border-b hover:bg-muted/30 transition-colors"
+                >
+                  <td className="px-3 py-2 font-medium text-foreground">
+                    {item.municipalityName}
+                    {!item.dataSufficient && (
+                      <span className="ml-1 text-xs text-muted-foreground">（データ少）</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right text-foreground">
+                    {item.medianTsubo > 0
+                      ? `${Math.round(item.medianTsubo / 10000).toLocaleString()}万円`
+                      : "—"}
+                  </td>
+                  <td className="px-3 py-2 text-right text-foreground">{item.transactionCount}</td>
+                  <td className="px-3 py-2 text-center">
+                    <DifficultyBadge
+                      difficulty={item.yieldDifficulty}
+                      label={item.yieldDifficultyLabel}
+                    />
+                  </td>
+                  <td className="px-3 py-2 text-center text-foreground">{item.landPriceTrend}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {items && items.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          市区町村を選択すると地図が表示されます。地図上で物件位置をクリックすると投資スコアが取得できます。
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -414,7 +414,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                 シミュレーション
               </button>
               <button
-                onClick={() => setActiveTab("area-discovery")}
+                onClick={() => { setActiveTab("area-discovery"); setSelectedMunicipalityMsg(null); }}
                 className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
                   activeTab === "area-discovery"
                     ? "bg-white shadow-sm text-foreground"

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -21,6 +21,7 @@ import { downloadReportPDF } from "@/lib/generatePdf";
 import { MonteCarloChart } from "@/components/MonteCarloChart";
 import NegotiationPanel from "@/components/NegotiationPanel";
 import WatchlistPanel from "@/components/WatchlistPanel";
+import { AreaDiscovery } from "@/components/AreaDiscovery";
 import dynamic from "next/dynamic";
 import { FirstTimerGuide } from "@/components/FirstTimerGuide";
 import { SAMPLE_PROPERTY, ONBOARDING_KEY } from "@/lib/sampleProperty";
@@ -91,6 +92,8 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   const [mobileFormOpen, setMobileFormOpen] = useState(false);
   const [isOnline, setIsOnline] = useState<boolean | null>(null);
   const [showGuide, setShowGuide] = useState(false);
+  const [activeTab, setActiveTab] = useState<"simulation" | "area-discovery">("simulation");
+  const [selectedMunicipalityMsg, setSelectedMunicipalityMsg] = useState<string | null>(null);
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
@@ -398,7 +401,48 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
           </aside>
 
           <section className="space-y-6">
-            {!result && !comparison && (
+            {/* Tab toggle */}
+            <div className="flex gap-1 rounded-lg border bg-muted/30 p-1 w-fit">
+              <button
+                onClick={() => setActiveTab("simulation")}
+                className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
+                  activeTab === "simulation"
+                    ? "bg-white shadow-sm text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                シミュレーション
+              </button>
+              <button
+                onClick={() => setActiveTab("area-discovery")}
+                className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
+                  activeTab === "area-discovery"
+                    ? "bg-white shadow-sm text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                エリアを探す
+              </button>
+            </div>
+
+            {activeTab === "area-discovery" && (
+              <>
+                {selectedMunicipalityMsg && (
+                  <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+                    {selectedMunicipalityMsg}
+                  </div>
+                )}
+                <AreaDiscovery
+                  onMunicipalitySelect={(_code, name) => {
+                    setSelectedMunicipalityMsg(
+                      `「${name}」を選択しました。下の地図上で物件位置をクリックしてください。`
+                    );
+                  }}
+                />
+              </>
+            )}
+
+            {activeTab === "simulation" && !result && !comparison && (
               <div className="flex h-64 items-center justify-center rounded-xl border-2 border-dashed border-muted-foreground/20 lg:h-80">
                 <div className="text-center text-muted-foreground">
                   <ShieldAlert className="mx-auto mb-3 h-10 w-10 opacity-30 lg:h-12 lg:w-12" />
@@ -409,67 +453,71 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
               </div>
             )}
 
-            {investmentScore && <InvestmentScoreCard score={investmentScore} />}
-
-            {propertyLat !== undefined && (
-              <InvestmentScoreHeatmap
-                centerLat={propertyLat}
-                centerLng={propertyLng}
-                onTileSelect={(lat, lng) => {
-                  setPropertyLat(lat);
-                  setPropertyLng(lng);
-                }}
-              />
-            )}
-
-            {comparison && <LandPriceAnalysis comparison={comparison} input={lastInput} theoreticalPrice={theoreticalPrice} stationRidership={stationRidership} populationForecast={populationForecast} landAppraisal={landAppraisal} externalUrbanRisks={externalUrbanRisks} hazardRisks={hazardRisks} />}
-
-            {result && lastInput && (
+            {activeTab === "simulation" && (
               <>
-                <CriticalErrorBanner errors={result.criticalErrors} />
-                <YieldAnalysis result={result} input={lastInput} populationForecast={populationForecast} />
-                <NegotiationPanel
-                  result={result}
-                  input={lastInput}
-                  comparison={comparison}
-                  theoreticalPrice={theoreticalPrice}
-                />
-                <LoanOptimizationPanel
-                  result={result}
-                  loanMethod={loanMethod}
-                  onLoanMethodChange={handleLoanMethodChange}
-                  loanAmount={lastInput.loanAmount}
-                />
-                {simulationMode === "full" && (
+                {investmentScore && <InvestmentScoreCard score={investmentScore} />}
+
+                {propertyLat !== undefined && (
+                  <InvestmentScoreHeatmap
+                    centerLat={propertyLat}
+                    centerLng={propertyLng}
+                    onTileSelect={(lat, lng) => {
+                      setPropertyLat(lat);
+                      setPropertyLng(lng);
+                    }}
+                  />
+                )}
+
+                {comparison && <LandPriceAnalysis comparison={comparison} input={lastInput} theoreticalPrice={theoreticalPrice} stationRidership={stationRidership} populationForecast={populationForecast} landAppraisal={landAppraisal} externalUrbanRisks={externalUrbanRisks} hazardRisks={hazardRisks} />}
+
+                {result && lastInput && (
                   <>
-                    {result.acquisitionCosts && (
-                      <div className="rounded-xl border bg-white p-5 shadow-sm">
-                        <CostBreakdown
-                          input={lastInput}
-                          acquisitionCosts={result.acquisitionCosts}
-                          yearlyResults={result.yearlyResults}
-                        />
-                      </div>
+                    <CriticalErrorBanner errors={result.criticalErrors} />
+                    <YieldAnalysis result={result} input={lastInput} populationForecast={populationForecast} />
+                    <NegotiationPanel
+                      result={result}
+                      input={lastInput}
+                      comparison={comparison}
+                      theoreticalPrice={theoreticalPrice}
+                    />
+                    <LoanOptimizationPanel
+                      result={result}
+                      loanMethod={loanMethod}
+                      onLoanMethodChange={handleLoanMethodChange}
+                      loanAmount={lastInput.loanAmount}
+                    />
+                    {simulationMode === "full" && (
+                      <>
+                        {result.acquisitionCosts && (
+                          <div className="rounded-xl border bg-white p-5 shadow-sm">
+                            <CostBreakdown
+                              input={lastInput}
+                              acquisitionCosts={result.acquisitionCosts}
+                              yearlyResults={result.yearlyResults}
+                            />
+                          </div>
+                        )}
+                        {/* 自己資金 = 総投資額 - ローン金額（ISSUE-22: 投資回収年の正確な計算に使用） */}
+                        <CashFlowChart result={result} equityInvested={result.totalInvestment - lastInput.loanAmount} />
+                        <DeadCrossChart result={result} />
+                        <div className="flex justify-center">
+                          <Button
+                            onClick={handleMonteCarlo}
+                            loading={monteCarloLoading}
+                            size="md"
+                          >
+                            モンテカルロ実行（1,000試行）
+                          </Button>
+                        </div>
+                        {monteCarloResult && <MonteCarloChart result={monteCarloResult} />}
+                      </>
                     )}
-                    {/* 自己資金 = 総投資額 - ローン金額（ISSUE-22: 投資回収年の正確な計算に使用） */}
-                    <CashFlowChart result={result} equityInvested={result.totalInvestment - lastInput.loanAmount} />
-                    <DeadCrossChart result={result} />
-                    <div className="flex justify-center">
-                      <Button
-                        onClick={handleMonteCarlo}
-                        loading={monteCarloLoading}
-                        size="md"
-                      >
-                        モンテカルロ実行（1,000試行）
-                      </Button>
-                    </div>
-                    {monteCarloResult && <MonteCarloChart result={monteCarloResult} />}
                   </>
                 )}
+                <RenovationPanel />
+                <WatchlistPanel />
               </>
             )}
-            <RenovationPanel />
-            <WatchlistPanel />
           </section>
         </div>
       </main>

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -240,6 +240,35 @@ export async function fetchInvestmentScoreHeatmap(params: {
   return handleResponse(res);
 }
 
+export interface AreaDiscoveryItem {
+  municipalityCode: string;
+  municipalityName: string;
+  medianTsubo: number;
+  transactionCount: number;
+  yieldDifficulty: "achievable" | "slightly-difficult" | "difficult";
+  yieldDifficultyLabel: string;
+  landPriceTrend: string;
+  dataSufficient: boolean;
+}
+
+export interface AreaDiscoveryResponse {
+  items: AreaDiscoveryItem[];
+  prefecture: string;
+}
+
+/** エリア発見モード — 予算・目標利回りから候補エリアをランキング取得 */
+export async function fetchAreaDiscovery(params: {
+  prefecture: string;
+  budget?: number;
+  yield?: number;
+}): Promise<AreaDiscoveryResponse> {
+  const q = new URLSearchParams({ prefecture: params.prefecture });
+  if (params.budget) q.set("budget", String(params.budget));
+  if (params.yield) q.set("yield", String(params.yield));
+  const res = await fetch(`${BASE}/area-discovery?${q}`);
+  return handleResponse<AreaDiscoveryResponse>(res);
+}
+
 /** モンテカルロシミュレーションを実行 */
 export async function simulate(input: MonteCarloInput): Promise<MonteCarloResult> {
   const res = await fetch(`${BASE}/investment/simulate`, {


### PR DESCRIPTION
## 概要

予算と目標利回りを入力して、都道府県内の市区町村を投資適性でランキング表示する「エリア発見モード」を追加した。MLIT 土地取引データを並列取得し、坪単価中央値・取引件数・利回り達成難易度を算出して候補エリアを絞り込める。

## 変更内容

- `backend/internal/domain/types.go` — `AreaDiscoveryItem` / `AreaDiscoveryResponse` ドメイン型を追加
- `backend/internal/api/handler.go` — `HandleAreaDiscovery` ハンドラ追加（市区町村並列取得・難易度判定・ランキングソート）
- `backend/internal/api/router.go` — `GET /api/area-discovery` ルート登録
- `frontend/src/lib/api.ts` — `fetchAreaDiscovery` API クライアント関数・型追加
- `frontend/src/components/AreaDiscovery.tsx` — エリア発見パネル新規コンポーネント（都道府県選択・予算・目標利回り入力 → テーブルランキング表示）
- `frontend/src/components/Dashboard.tsx` — 「シミュレーション」/「エリアを探す」タブ切り替え UI を追加し `AreaDiscovery` を組み込み

## 関連Issue

Closes #334

## テスト

- [x] 既存テストが通ること（`go build ./...` でバックエンドビルド確認済み）
- [x] フロントエンドビルド確認済み（`next build` 警告なし・TypeScript エラーなし）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み