### PR TITLE
perf: parallelize stress scenarios and add heatmap tile limits

### DIFF
--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -941,10 +941,16 @@ func (h *Handler) GetInvestmentScoreHeatmap(c *gin.Context) {
 		z = zVal
 	}
 
-	// z=15 の高解像度モードはタイル上限を 25 に縮小する
-	maxTiles := maxHeatmapTiles
-	if z == 15 {
-		maxTiles = 25
+	// ズームレベルに応じてタイル数上限を決定
+	// z=11-12: 20, z=13-14: 30, z=15: 50
+	var maxTiles int
+	switch {
+	case z <= 12:
+		maxTiles = 20
+	case z <= 14:
+		maxTiles = 30
+	default:
+		maxTiles = maxHeatmapTiles
 	}
 
 	// 高緯度 → 小さい y 値のため注意
@@ -954,7 +960,7 @@ func (h *Handler) GetInvestmentScoreHeatmap(c *gin.Context) {
 	tileCount := (xMax - xMin + 1) * (yMax - yMin + 1)
 	if tileCount > maxTiles {
 		c.JSON(http.StatusBadRequest, gin.H{
-			"error": fmt.Sprintf("タイル数 %d が上限 %d を超えています。ズームレベルを下げるか範囲を狭めてください", tileCount, maxTiles),
+			"error": fmt.Sprintf("too many tiles: max %d for zoom level %d", maxTiles, z),
 		})
 		return
 	}

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"sort"
 	"strings"
+	"sync"
 )
 
 const (
@@ -212,27 +213,38 @@ func Analyze(input InvestmentInput) InvestmentResult {
 	criticalErrors := calcCriticalErrors(input, deadCrossYear, usefulLife)
 
 	// ストレスシナリオ自動計算（6つのデフォルト + 入力値が非ゼロなら第7シナリオ）
-	defaultScenarios := []struct {
+	// goroutine で並列計算（インデックス固定の slice に直書きするため mutex 不要）
+	type scenarioDef struct {
 		label    string
 		rateDelta float64
 		vacDelta  float64
-	}{
+	}
+	allScenarioDefs := [7]scenarioDef{
 		{"ベースライン", 0, 0},
 		{"金利+1%", 0.01, 0},
 		{"金利+2%", 0.02, 0},
 		{"空室+10%", 0, 0.10},
 		{"空室+20%", 0, 0.20},
 		{"複合ストレス", 0.02, 0.10},
+		{"カスタム", input.LoanRateDelta, input.VacancyRateDelta},
 	}
-	stressScenarios := make([]StressScenarioResult, 0, 7)
-	for _, sc := range defaultScenarios {
-		stressScenarios = append(stressScenarios, calcStressScenario(input, sc.label, sc.rateDelta, sc.vacDelta))
+	hasCustom := input.LoanRateDelta != 0 || input.VacancyRateDelta != 0
+	scenarioCount := 6
+	if hasCustom {
+		scenarioCount = 7
 	}
-	if input.LoanRateDelta != 0 || input.VacancyRateDelta != 0 {
-		stressScenarios = append(stressScenarios, calcStressScenario(
-			input, "カスタム", input.LoanRateDelta, input.VacancyRateDelta,
-		))
+	scenarioResults := make([]StressScenarioResult, scenarioCount)
+	var wg sync.WaitGroup
+	for i := 0; i < scenarioCount; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			sc := allScenarioDefs[idx]
+			scenarioResults[idx] = calcStressScenario(input, sc.label, sc.rateDelta, sc.vacDelta)
+		}(i)
 	}
+	wg.Wait()
+	stressScenarios := scenarioResults
 
 	acquisitionCosts := CalcAcquisitionCosts(
 		input.LandPrice,


### PR DESCRIPTION
## 概要

バックエンドのパフォーマンス改善 Track B として、2つの変更を実装しました。

1. **ストレステスト7シナリオのgoroutine並列化（#346）**: `Analyze` 関数内で逐次実行していた7つのストレスシナリオを `sync.WaitGroup` と goroutine で並列実行するよう変更しました。インデックス固定のスライスに直書きするため mutex は不要です。
2. **heatmapエンドポイントのタイル数上限（#342）**: ズームレベルに応じたタイル数上限を追加しました（z=11-12: 20タイル、z=13-14: 30タイル、z=15: 50タイル）。上限超過時は `400 Bad Request` を返します。

## 変更内容

- `backend/internal/domain/investment.go`: ストレスシナリオ計算を `sync.WaitGroup` + goroutine で並列化
- `backend/internal/api/handler.go`: `GetInvestmentScoreHeatmap` にズームレベル別タイル数上限を追加、エラーメッセージを英語形式 `"too many tiles: max N for zoom level Z"` に変更

## 関連Issue

Closes #346
Closes #342

## テスト

- [x] 既存テストが通ること（`go test -race ./...` 全パッケージ PASS）
- [x] race detector でデータ競合なし

## 確認事項

- [x] コードレビュー観点での自己レビュー済み