### PR TITLE
perf: distribute cache mutex and add timeout to GetRentDeclineHint

### DIFF
--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/yield-guard/backend/internal/domain"
@@ -493,7 +494,8 @@ func (h *Handler) GetRentDeclineHint(c *gin.Context) {
 	}
 
 	municipality := c.Query("municipality")
-	ctx := c.Request.Context()
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 30*time.Second)
+	defer cancel()
 
 	// XCT001 の対応年（2022〜2026）を並列取得
 	years := []int{2022, 2023, 2024, 2025, 2026}

--- a/backend/internal/mlit/cache.go
+++ b/backend/internal/mlit/cache.go
@@ -16,66 +16,83 @@ type cacheEntry struct {
 	expiresAt time.Time
 }
 
+// landPriceGroup は土地価格系・市区町村・地価公示 のキャッシュグループ
+type landPriceGroup struct {
+	mu              sync.RWMutex
+	entries         map[string]cacheEntry
+	muniEntries     map[string]muniCacheEntry
+	appraisalEntries map[string]appraisalCacheEntry
+}
+
+// tileGroup は駅別乗降客数・将来推計人口・立地適正化・大規模盛土・都市計画道路・
+// 災害履歴・都市計画区域・液状化 のキャッシュグループ
+type tileGroup struct {
+	mu                          sync.RWMutex
+	ridershipEntries            map[string]ridershipCacheEntry
+	populationEntries           map[string]populationCacheEntry
+	locationOptimizationEntries map[string]locationOptimizationCacheEntry
+	embankmentEntries           map[string]embankmentCacheEntry
+	urbanRoadEntries            map[string]urbanRoadCacheEntry
+	disasterEntries             map[string]disasterCacheEntry
+	urbanZoningEntries          map[string]urbanZoningCacheEntry
+	liquefactionEntries         map[string]liquefactionCacheEntry
+}
+
+// hazardGroup は洪水・高潮・津波・土砂災害 のキャッシュグループ
+type hazardGroup struct {
+	mu                     sync.RWMutex
+	floodHazardEntries     map[string]floodHazardCacheEntry
+	stormHazardEntries     map[string]stormHazardCacheEntry
+	tsunamiHazardEntries   map[string]tsunamiHazardCacheEntry
+	landslideHazardEntries map[string]landslideHazardCacheEntry
+}
+
 // cache は TTL 付きインメモリキャッシュ
 type cache struct {
-	mu                         sync.RWMutex
-	entries                    map[string]cacheEntry
-	muniEntries                map[string]muniCacheEntry
-	ridershipEntries           map[string]ridershipCacheEntry
-	populationEntries          map[string]populationCacheEntry
-	appraisalEntries           map[string]appraisalCacheEntry
-	locationOptimizationEntries map[string]locationOptimizationCacheEntry
-	embankmentEntries          map[string]embankmentCacheEntry
-	urbanRoadEntries           map[string]urbanRoadCacheEntry
-	disasterEntries            map[string]disasterCacheEntry
-	urbanZoningEntries         map[string]urbanZoningCacheEntry
-	liquefactionEntries        map[string]liquefactionCacheEntry
-	floodHazardEntries         map[string]floodHazardCacheEntry
-	stormHazardEntries         map[string]stormHazardCacheEntry
-	tsunamiHazardEntries       map[string]tsunamiHazardCacheEntry
-	landslideHazardEntries     map[string]landslideHazardCacheEntry
+	land   landPriceGroup
+	tile   tileGroup
+	hazard hazardGroup
 }
 
 func newCache() *cache {
-	return &cache{
-		entries:                    make(map[string]cacheEntry),
-		muniEntries:                make(map[string]muniCacheEntry),
-		ridershipEntries:           make(map[string]ridershipCacheEntry),
-		populationEntries:          make(map[string]populationCacheEntry),
-		appraisalEntries:           make(map[string]appraisalCacheEntry),
-		locationOptimizationEntries: make(map[string]locationOptimizationCacheEntry),
-		embankmentEntries:          make(map[string]embankmentCacheEntry),
-		urbanRoadEntries:           make(map[string]urbanRoadCacheEntry),
-		disasterEntries:            make(map[string]disasterCacheEntry),
-		urbanZoningEntries:         make(map[string]urbanZoningCacheEntry),
-		liquefactionEntries:        make(map[string]liquefactionCacheEntry),
-		floodHazardEntries:         make(map[string]floodHazardCacheEntry),
-		stormHazardEntries:         make(map[string]stormHazardCacheEntry),
-		tsunamiHazardEntries:       make(map[string]tsunamiHazardCacheEntry),
-		landslideHazardEntries:     make(map[string]landslideHazardCacheEntry),
-	}
+	c := &cache{}
+	c.land.entries = make(map[string]cacheEntry)
+	c.land.muniEntries = make(map[string]muniCacheEntry)
+	c.land.appraisalEntries = make(map[string]appraisalCacheEntry)
+
+	c.tile.ridershipEntries = make(map[string]ridershipCacheEntry)
+	c.tile.populationEntries = make(map[string]populationCacheEntry)
+	c.tile.locationOptimizationEntries = make(map[string]locationOptimizationCacheEntry)
+	c.tile.embankmentEntries = make(map[string]embankmentCacheEntry)
+	c.tile.urbanRoadEntries = make(map[string]urbanRoadCacheEntry)
+	c.tile.disasterEntries = make(map[string]disasterCacheEntry)
+	c.tile.urbanZoningEntries = make(map[string]urbanZoningCacheEntry)
+	c.tile.liquefactionEntries = make(map[string]liquefactionCacheEntry)
+
+	c.hazard.floodHazardEntries = make(map[string]floodHazardCacheEntry)
+	c.hazard.stormHazardEntries = make(map[string]stormHazardCacheEntry)
+	c.hazard.tsunamiHazardEntries = make(map[string]tsunamiHazardCacheEntry)
+	c.hazard.landslideHazardEntries = make(map[string]landslideHazardCacheEntry)
+	return c
 }
 
 // get はキャッシュを取得する。TTL 切れの場合はエントリを削除して (nil, false) を返す。
 // 呼び出し元がスライスを変更してもキャッシュが汚染されないようコピーを返す。
 func (c *cache) get(key string) ([]domain.LandTransaction, bool) {
-	// まず読み取りロックで存在・有効期限を確認
-	c.mu.RLock()
-	entry, ok := c.entries[key]
-	c.mu.RUnlock()
+	c.land.mu.RLock()
+	entry, ok := c.land.entries[key]
+	c.land.mu.RUnlock()
 
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		// TTL 切れ: 書き込みロックに昇格してエントリを削除
-		c.mu.Lock()
-		delete(c.entries, key)
-		c.mu.Unlock()
+		c.land.mu.Lock()
+		delete(c.land.entries, key)
+		c.land.mu.Unlock()
 		return nil, false
 	}
 
-	// キャッシュヒット: コピーを返して呼び出し元による変更からキャッシュを保護する
 	copied := make([]domain.LandTransaction, len(entry.data))
 	copy(copied, entry.data)
 	return copied, true
@@ -83,10 +100,10 @@ func (c *cache) get(key string) ([]domain.LandTransaction, bool) {
 
 // set はキャッシュに保存する。
 func (c *cache) set(key string, data []domain.LandTransaction) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.land.mu.Lock()
+	defer c.land.mu.Unlock()
 
-	c.entries[key] = cacheEntry{
+	c.land.entries[key] = cacheEntry{
 		data:      data,
 		expiresAt: time.Now().Add(cacheTTL),
 	}
@@ -100,17 +117,17 @@ type muniCacheEntry struct {
 
 // getMuni は市区町村キャッシュを取得する。TTL 切れの場合はエントリを削除して (nil, false) を返す。
 func (c *cache) getMuni(area string) ([]Municipality, bool) {
-	c.mu.RLock()
-	entry, ok := c.muniEntries[area]
-	c.mu.RUnlock()
+	c.land.mu.RLock()
+	entry, ok := c.land.muniEntries[area]
+	c.land.mu.RUnlock()
 
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.muniEntries, area)
-		c.mu.Unlock()
+		c.land.mu.Lock()
+		delete(c.land.muniEntries, area)
+		c.land.mu.Unlock()
 		return nil, false
 	}
 
@@ -121,10 +138,10 @@ func (c *cache) getMuni(area string) ([]Municipality, bool) {
 
 // setMuni は市区町村キャッシュに保存する。
 func (c *cache) setMuni(area string, data []Municipality) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.land.mu.Lock()
+	defer c.land.mu.Unlock()
 
-	c.muniEntries[area] = muniCacheEntry{
+	c.land.muniEntries[area] = muniCacheEntry{
 		data:      data,
 		expiresAt: time.Now().Add(cacheTTL),
 	}
@@ -138,17 +155,17 @@ type ridershipCacheEntry struct {
 
 // getRidership は駅別乗降客数キャッシュを取得する。
 func (c *cache) getRidership(key string) ([]StationRidership, bool) {
-	c.mu.RLock()
-	entry, ok := c.ridershipEntries[key]
-	c.mu.RUnlock()
+	c.tile.mu.RLock()
+	entry, ok := c.tile.ridershipEntries[key]
+	c.tile.mu.RUnlock()
 
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.ridershipEntries, key)
-		c.mu.Unlock()
+		c.tile.mu.Lock()
+		delete(c.tile.ridershipEntries, key)
+		c.tile.mu.Unlock()
 		return nil, false
 	}
 
@@ -159,10 +176,10 @@ func (c *cache) getRidership(key string) ([]StationRidership, bool) {
 
 // setRidership は駅別乗降客数キャッシュに保存する。
 func (c *cache) setRidership(key string, data []StationRidership) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.tile.mu.Lock()
+	defer c.tile.mu.Unlock()
 
-	c.ridershipEntries[key] = ridershipCacheEntry{
+	c.tile.ridershipEntries[key] = ridershipCacheEntry{
 		data:      data,
 		expiresAt: time.Now().Add(cacheTTL),
 	}
@@ -176,17 +193,17 @@ type populationCacheEntry struct {
 
 // getPopulation は将来推計人口キャッシュを取得する。
 func (c *cache) getPopulation(key string) ([]domain.PopulationForecastItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.populationEntries[key]
-	c.mu.RUnlock()
+	c.tile.mu.RLock()
+	entry, ok := c.tile.populationEntries[key]
+	c.tile.mu.RUnlock()
 
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.populationEntries, key)
-		c.mu.Unlock()
+		c.tile.mu.Lock()
+		delete(c.tile.populationEntries, key)
+		c.tile.mu.Unlock()
 		return nil, false
 	}
 
@@ -197,10 +214,10 @@ func (c *cache) getPopulation(key string) ([]domain.PopulationForecastItem, bool
 
 // setPopulation は将来推計人口キャッシュに保存する。
 func (c *cache) setPopulation(key string, data []domain.PopulationForecastItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.tile.mu.Lock()
+	defer c.tile.mu.Unlock()
 
-	c.populationEntries[key] = populationCacheEntry{
+	c.tile.populationEntries[key] = populationCacheEntry{
 		data:      data,
 		expiresAt: time.Now().Add(cacheTTL),
 	}
@@ -214,17 +231,17 @@ type appraisalCacheEntry struct {
 
 // getAppraisals は地価公示キャッシュを取得する。
 func (c *cache) getAppraisals(key string) ([]domain.LandAppraisalItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.appraisalEntries[key]
-	c.mu.RUnlock()
+	c.land.mu.RLock()
+	entry, ok := c.land.appraisalEntries[key]
+	c.land.mu.RUnlock()
 
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.appraisalEntries, key)
-		c.mu.Unlock()
+		c.land.mu.Lock()
+		delete(c.land.appraisalEntries, key)
+		c.land.mu.Unlock()
 		return nil, false
 	}
 
@@ -235,10 +252,10 @@ func (c *cache) getAppraisals(key string) ([]domain.LandAppraisalItem, bool) {
 
 // setAppraisals は地価公示キャッシュに保存する。
 func (c *cache) setAppraisals(key string, data []domain.LandAppraisalItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
+	c.land.mu.Lock()
+	defer c.land.mu.Unlock()
 
-	c.appraisalEntries[key] = appraisalCacheEntry{
+	c.land.appraisalEntries[key] = appraisalCacheEntry{
 		data:      data,
 		expiresAt: time.Now().Add(cacheTTL),
 	}
@@ -251,16 +268,16 @@ type locationOptimizationCacheEntry struct {
 }
 
 func (c *cache) getLocationOptimization(key string) ([]domain.LocationOptimizationItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.locationOptimizationEntries[key]
-	c.mu.RUnlock()
+	c.tile.mu.RLock()
+	entry, ok := c.tile.locationOptimizationEntries[key]
+	c.tile.mu.RUnlock()
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.locationOptimizationEntries, key)
-		c.mu.Unlock()
+		c.tile.mu.Lock()
+		delete(c.tile.locationOptimizationEntries, key)
+		c.tile.mu.Unlock()
 		return nil, false
 	}
 	copied := make([]domain.LocationOptimizationItem, len(entry.data))
@@ -269,9 +286,9 @@ func (c *cache) getLocationOptimization(key string) ([]domain.LocationOptimizati
 }
 
 func (c *cache) setLocationOptimization(key string, data []domain.LocationOptimizationItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.locationOptimizationEntries[key] = locationOptimizationCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+	c.tile.mu.Lock()
+	defer c.tile.mu.Unlock()
+	c.tile.locationOptimizationEntries[key] = locationOptimizationCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // embankmentCacheEntry は大規模盛土造成地キャッシュの1エントリ
@@ -281,16 +298,16 @@ type embankmentCacheEntry struct {
 }
 
 func (c *cache) getEmbankment(key string) ([]domain.EmbankmentItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.embankmentEntries[key]
-	c.mu.RUnlock()
+	c.tile.mu.RLock()
+	entry, ok := c.tile.embankmentEntries[key]
+	c.tile.mu.RUnlock()
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.embankmentEntries, key)
-		c.mu.Unlock()
+		c.tile.mu.Lock()
+		delete(c.tile.embankmentEntries, key)
+		c.tile.mu.Unlock()
 		return nil, false
 	}
 	copied := make([]domain.EmbankmentItem, len(entry.data))
@@ -299,9 +316,9 @@ func (c *cache) getEmbankment(key string) ([]domain.EmbankmentItem, bool) {
 }
 
 func (c *cache) setEmbankment(key string, data []domain.EmbankmentItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.embankmentEntries[key] = embankmentCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+	c.tile.mu.Lock()
+	defer c.tile.mu.Unlock()
+	c.tile.embankmentEntries[key] = embankmentCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // urbanRoadCacheEntry は都市計画道路キャッシュの1エントリ
@@ -311,16 +328,16 @@ type urbanRoadCacheEntry struct {
 }
 
 func (c *cache) getUrbanRoad(key string) ([]domain.UrbanRoadItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.urbanRoadEntries[key]
-	c.mu.RUnlock()
+	c.tile.mu.RLock()
+	entry, ok := c.tile.urbanRoadEntries[key]
+	c.tile.mu.RUnlock()
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.urbanRoadEntries, key)
-		c.mu.Unlock()
+		c.tile.mu.Lock()
+		delete(c.tile.urbanRoadEntries, key)
+		c.tile.mu.Unlock()
 		return nil, false
 	}
 	copied := make([]domain.UrbanRoadItem, len(entry.data))
@@ -329,9 +346,9 @@ func (c *cache) getUrbanRoad(key string) ([]domain.UrbanRoadItem, bool) {
 }
 
 func (c *cache) setUrbanRoad(key string, data []domain.UrbanRoadItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.urbanRoadEntries[key] = urbanRoadCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+	c.tile.mu.Lock()
+	defer c.tile.mu.Unlock()
+	c.tile.urbanRoadEntries[key] = urbanRoadCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // disasterCacheEntry は災害履歴キャッシュの1エントリ
@@ -341,16 +358,16 @@ type disasterCacheEntry struct {
 }
 
 func (c *cache) getDisaster(key string) ([]domain.DisasterHistoryItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.disasterEntries[key]
-	c.mu.RUnlock()
+	c.tile.mu.RLock()
+	entry, ok := c.tile.disasterEntries[key]
+	c.tile.mu.RUnlock()
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.disasterEntries, key)
-		c.mu.Unlock()
+		c.tile.mu.Lock()
+		delete(c.tile.disasterEntries, key)
+		c.tile.mu.Unlock()
 		return nil, false
 	}
 	copied := make([]domain.DisasterHistoryItem, len(entry.data))
@@ -359,9 +376,9 @@ func (c *cache) getDisaster(key string) ([]domain.DisasterHistoryItem, bool) {
 }
 
 func (c *cache) setDisaster(key string, data []domain.DisasterHistoryItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.disasterEntries[key] = disasterCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+	c.tile.mu.Lock()
+	defer c.tile.mu.Unlock()
+	c.tile.disasterEntries[key] = disasterCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // urbanZoningCacheEntry は都市計画区域/区域区分キャッシュの1エントリ
@@ -371,16 +388,16 @@ type urbanZoningCacheEntry struct {
 }
 
 func (c *cache) getUrbanZoning(key string) ([]domain.UrbanZoningItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.urbanZoningEntries[key]
-	c.mu.RUnlock()
+	c.tile.mu.RLock()
+	entry, ok := c.tile.urbanZoningEntries[key]
+	c.tile.mu.RUnlock()
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.urbanZoningEntries, key)
-		c.mu.Unlock()
+		c.tile.mu.Lock()
+		delete(c.tile.urbanZoningEntries, key)
+		c.tile.mu.Unlock()
 		return nil, false
 	}
 	copied := make([]domain.UrbanZoningItem, len(entry.data))
@@ -389,9 +406,9 @@ func (c *cache) getUrbanZoning(key string) ([]domain.UrbanZoningItem, bool) {
 }
 
 func (c *cache) setUrbanZoning(key string, data []domain.UrbanZoningItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.urbanZoningEntries[key] = urbanZoningCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+	c.tile.mu.Lock()
+	defer c.tile.mu.Unlock()
+	c.tile.urbanZoningEntries[key] = urbanZoningCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // liquefactionCacheEntry は液状化発生傾向図キャッシュの1エントリ
@@ -401,16 +418,16 @@ type liquefactionCacheEntry struct {
 }
 
 func (c *cache) getLiquefaction(key string) ([]domain.LiquefactionRiskItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.liquefactionEntries[key]
-	c.mu.RUnlock()
+	c.tile.mu.RLock()
+	entry, ok := c.tile.liquefactionEntries[key]
+	c.tile.mu.RUnlock()
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.liquefactionEntries, key)
-		c.mu.Unlock()
+		c.tile.mu.Lock()
+		delete(c.tile.liquefactionEntries, key)
+		c.tile.mu.Unlock()
 		return nil, false
 	}
 	copied := make([]domain.LiquefactionRiskItem, len(entry.data))
@@ -419,9 +436,9 @@ func (c *cache) getLiquefaction(key string) ([]domain.LiquefactionRiskItem, bool
 }
 
 func (c *cache) setLiquefaction(key string, data []domain.LiquefactionRiskItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.liquefactionEntries[key] = liquefactionCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+	c.tile.mu.Lock()
+	defer c.tile.mu.Unlock()
+	c.tile.liquefactionEntries[key] = liquefactionCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // floodHazardCacheEntry は洪水浸水想定区域キャッシュの1エントリ
@@ -431,16 +448,16 @@ type floodHazardCacheEntry struct {
 }
 
 func (c *cache) getFloodHazard(key string) ([]domain.FloodHazardItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.floodHazardEntries[key]
-	c.mu.RUnlock()
+	c.hazard.mu.RLock()
+	entry, ok := c.hazard.floodHazardEntries[key]
+	c.hazard.mu.RUnlock()
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.floodHazardEntries, key)
-		c.mu.Unlock()
+		c.hazard.mu.Lock()
+		delete(c.hazard.floodHazardEntries, key)
+		c.hazard.mu.Unlock()
 		return nil, false
 	}
 	copied := make([]domain.FloodHazardItem, len(entry.data))
@@ -449,9 +466,9 @@ func (c *cache) getFloodHazard(key string) ([]domain.FloodHazardItem, bool) {
 }
 
 func (c *cache) setFloodHazard(key string, data []domain.FloodHazardItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.floodHazardEntries[key] = floodHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+	c.hazard.mu.Lock()
+	defer c.hazard.mu.Unlock()
+	c.hazard.floodHazardEntries[key] = floodHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // stormHazardCacheEntry は高潮浸水想定区域キャッシュの1エントリ
@@ -461,16 +478,16 @@ type stormHazardCacheEntry struct {
 }
 
 func (c *cache) getStormHazard(key string) ([]domain.StormHazardItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.stormHazardEntries[key]
-	c.mu.RUnlock()
+	c.hazard.mu.RLock()
+	entry, ok := c.hazard.stormHazardEntries[key]
+	c.hazard.mu.RUnlock()
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.stormHazardEntries, key)
-		c.mu.Unlock()
+		c.hazard.mu.Lock()
+		delete(c.hazard.stormHazardEntries, key)
+		c.hazard.mu.Unlock()
 		return nil, false
 	}
 	copied := make([]domain.StormHazardItem, len(entry.data))
@@ -479,9 +496,9 @@ func (c *cache) getStormHazard(key string) ([]domain.StormHazardItem, bool) {
 }
 
 func (c *cache) setStormHazard(key string, data []domain.StormHazardItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.stormHazardEntries[key] = stormHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+	c.hazard.mu.Lock()
+	defer c.hazard.mu.Unlock()
+	c.hazard.stormHazardEntries[key] = stormHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // tsunamiHazardCacheEntry は津波浸水想定キャッシュの1エントリ
@@ -491,16 +508,16 @@ type tsunamiHazardCacheEntry struct {
 }
 
 func (c *cache) getTsunamiHazard(key string) ([]domain.TsunamiHazardItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.tsunamiHazardEntries[key]
-	c.mu.RUnlock()
+	c.hazard.mu.RLock()
+	entry, ok := c.hazard.tsunamiHazardEntries[key]
+	c.hazard.mu.RUnlock()
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.tsunamiHazardEntries, key)
-		c.mu.Unlock()
+		c.hazard.mu.Lock()
+		delete(c.hazard.tsunamiHazardEntries, key)
+		c.hazard.mu.Unlock()
 		return nil, false
 	}
 	copied := make([]domain.TsunamiHazardItem, len(entry.data))
@@ -509,9 +526,9 @@ func (c *cache) getTsunamiHazard(key string) ([]domain.TsunamiHazardItem, bool) 
 }
 
 func (c *cache) setTsunamiHazard(key string, data []domain.TsunamiHazardItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.tsunamiHazardEntries[key] = tsunamiHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+	c.hazard.mu.Lock()
+	defer c.hazard.mu.Unlock()
+	c.hazard.tsunamiHazardEntries[key] = tsunamiHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // landslideHazardCacheEntry は土砂災害警戒区域キャッシュの1エントリ
@@ -521,16 +538,16 @@ type landslideHazardCacheEntry struct {
 }
 
 func (c *cache) getLandslideHazard(key string) ([]domain.LandslideHazardItem, bool) {
-	c.mu.RLock()
-	entry, ok := c.landslideHazardEntries[key]
-	c.mu.RUnlock()
+	c.hazard.mu.RLock()
+	entry, ok := c.hazard.landslideHazardEntries[key]
+	c.hazard.mu.RUnlock()
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.mu.Lock()
-		delete(c.landslideHazardEntries, key)
-		c.mu.Unlock()
+		c.hazard.mu.Lock()
+		delete(c.hazard.landslideHazardEntries, key)
+		c.hazard.mu.Unlock()
 		return nil, false
 	}
 	copied := make([]domain.LandslideHazardItem, len(entry.data))
@@ -539,9 +556,9 @@ func (c *cache) getLandslideHazard(key string) ([]domain.LandslideHazardItem, bo
 }
 
 func (c *cache) setLandslideHazard(key string, data []domain.LandslideHazardItem) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.landslideHazardEntries[key] = landslideHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
+	c.hazard.mu.Lock()
+	defer c.hazard.mu.Unlock()
+	c.hazard.landslideHazardEntries[key] = landslideHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // cacheKey は LandPriceQuery からキャッシュキーを生成する。

--- a/backend/internal/mlit/client_test.go
+++ b/backend/internal/mlit/client_test.go
@@ -391,12 +391,12 @@ func TestCache_TTLExpiry(t *testing.T) {
 	data := []domain.LandTransaction{{Period: "2024年第1四半期", TradePrice: 10_000_000}}
 
 	// 有効期限を過去に設定して直接注入
-	c.mu.Lock()
-	c.entries[key] = cacheEntry{
+	c.land.mu.Lock()
+	c.land.entries[key] = cacheEntry{
 		data:      data,
 		expiresAt: time.Now().Add(-1 * time.Second), // 1秒前に期限切れ
 	}
-	c.mu.Unlock()
+	c.land.mu.Unlock()
 
 	_, ok := c.get(key)
 	if ok {
@@ -404,9 +404,9 @@ func TestCache_TTLExpiry(t *testing.T) {
 	}
 
 	// TTL切れエントリは get 後に削除されていること（メモリリーク対策）
-	c.mu.RLock()
-	_, stillExists := c.entries[key]
-	c.mu.RUnlock()
+	c.land.mu.RLock()
+	_, stillExists := c.land.entries[key]
+	c.land.mu.RUnlock()
 	if stillExists {
 		t.Error("expected expired entry to be deleted from map, but it still exists")
 	}


### PR DESCRIPTION
## 概要

パフォーマンス改善 Track A として、キャッシュの Mutex 分散化と `GetRentDeclineHint` へのタイムアウト追加を実施しました。

## 変更内容

- **cache.go（issue #343）**: 16 個のキャッシュ map を保護していた単一の `sync.RWMutex` を 3 つの独立したグループに分散
  - `landPriceGroup`（土地価格・市区町村・地価公示）
  - `tileGroup`（乗降客数・将来推計人口・立地適正化・大規模盛土・都市計画道路・災害履歴・都市計画区域・液状化）
  - `hazardGroup`（洪水・高潮・津波・土砂災害）
  - 無関係なグループへの並列アクセスが同一ロックで直列化されなくなる
  - `TestCache_TTLExpiry` を新構造体に合わせ `c.land.mu` / `c.land.entries` へ更新

- **handler.go（issue #345）**: `GetRentDeclineHint` の冒頭に `context.WithTimeout(30s)` を追加
  - 5 並列の `FetchLandAppraisals` ゴルーチンが時間無制限でぶら下がる問題を解消
  - エラーログは既存の `slog.WarnContext` で記録済み（サイレント箇所なし）

## 関連Issue

Closes #343
Closes #345

## テスト
- [x] 既存テストが通ること（`go test -race ./... -timeout 120s` — all PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み