### PR TITLE
perf: memoize chart components and consolidate Dashboard state

### DIFF
--- a/frontend/src/components/CashFlowChart.tsx
+++ b/frontend/src/components/CashFlowChart.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useMemo } from "react";
 import {
   ComposedChart, Bar, Line, XAxis, YAxis, CartesianGrid,
   Tooltip, Legend, ReferenceLine, ResponsiveContainer, Cell,
@@ -15,33 +15,42 @@ interface Props {
   equityInvested: number;
 }
 
-export function CashFlowChart({ result, equityInvested }: Props) {
+function CashFlowChart({ result, equityInvested }: Props) {
   const { yearlyResults, exitTotalEquity, exitSalePrice, exitNetProceeds } = result;
 
-  const data = yearlyResults.slice(0, 35).map((y) => ({
-    year: `${y.year}年`,
-    税引後CF: Math.round(y.afterTaxCashFlow / 10_000),
-    // 自己資金を初期コストとして加算した累積CF（ISSUE-22）
-    累積CF: Math.round((y.cumulativeCashFlow - equityInvested) / 10_000),
-    isDeadCrossZone: y.isInDeadCrossZone,
-    effectiveRate: y.effectiveRate,
-  }));
+  const data = useMemo(
+    () =>
+      yearlyResults.slice(0, 35).map((y) => ({
+        year: `${y.year}年`,
+        税引後CF: Math.round(y.afterTaxCashFlow / 10_000),
+        // 自己資金を初期コストとして加算した累積CF（ISSUE-22）
+        累積CF: Math.round((y.cumulativeCashFlow - equityInvested) / 10_000),
+        isDeadCrossZone: y.isInDeadCrossZone,
+        effectiveRate: y.effectiveRate,
+      })),
+    [yearlyResults, equityInvested],
+  );
 
   // 自己資金を回収した年（累積CF - 自己資金 >= 0）
-  const breakEvenYear = yearlyResults.find(
-    (y) => y.cumulativeCashFlow - equityInvested >= 0
-  )?.year ?? null;
+  const breakEvenYear = useMemo(
+    () =>
+      yearlyResults.find((y) => y.cumulativeCashFlow - equityInvested >= 0)?.year ?? null,
+    [yearlyResults, equityInvested],
+  );
 
   // 金利が変化した年のリスト（2年目以降で前年から変化した年）
-  const rateChangeYears: { year: string; rate: number }[] = [];
-  for (let i = 1; i < Math.min(yearlyResults.length, 35); i++) {
-    if (yearlyResults[i].effectiveRate !== yearlyResults[i - 1].effectiveRate) {
-      rateChangeYears.push({
-        year: `${yearlyResults[i].year}年`,
-        rate: yearlyResults[i].effectiveRate,
-      });
+  const rateChangeYears = useMemo(() => {
+    const changes: { year: string; rate: number }[] = [];
+    for (let i = 1; i < Math.min(yearlyResults.length, 35); i++) {
+      if (yearlyResults[i].effectiveRate !== yearlyResults[i - 1].effectiveRate) {
+        changes.push({
+          year: `${yearlyResults[i].year}年`,
+          rate: yearlyResults[i].effectiveRate,
+        });
+      }
     }
-  }
+    return changes;
+  }, [yearlyResults]);
 
   return (
     <Card>
@@ -132,3 +141,5 @@ export function CashFlowChart({ result, equityInvested }: Props) {
     </Card>
   );
 }
+
+export default React.memo(CashFlowChart);

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -216,19 +216,18 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
       const comp = await compareLandPrice(baseParams);
       setAnalysisResult((prev) => ({ ...prev, comparison: comp }));
 
-      let est: TheoreticalPriceResult | null = null;
       if (lastInput && lastInput.landArea > 0) {
         try {
-          est = await estimateLandPrice({
+          const est = await estimateLandPrice({
             ...baseParams,
             buildingAge: lastInput.buildingAge,
             stationMinutes: lastInput.stationMinutes,
           });
+          setAnalysisResult((prev) => ({ ...prev, theoreticalPrice: est }));
         } catch {
-          est = null;
+          setAnalysisResult((prev) => ({ ...prev, theoreticalPrice: null }));
         }
       }
-      setAnalysisResult((prev) => ({ ...prev, theoreticalPrice: est }));
 
       const [appraisal] = await Promise.allSettled([
         fetchLandAppraisals({ area, year: toYear, city: city || undefined }),

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -4,8 +4,8 @@ import { useRouter } from "next/navigation";
 import { encodeUrlParams, decodeUrlParams } from "@/lib/urlParams";
 import { InvestmentForm } from "@/components/InvestmentForm";
 import { YieldAnalysis } from "@/components/YieldAnalysis";
-import { CashFlowChart } from "@/components/CashFlowChart";
-import { DeadCrossChart } from "@/components/DeadCrossChart";
+import CashFlowChart from "@/components/CashFlowChart";
+import DeadCrossChart from "@/components/DeadCrossChart";
 import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
 import CostBreakdown from "@/components/CostBreakdown";
 import { LoanOptimizationPanel } from "@/components/LoanOptimizationPanel";
@@ -32,6 +32,31 @@ function getCurrentPeriods(): { year: number; quarter: number; toYear: number; t
   return { year: toYear - 2, quarter: 1, toYear, toQuarter };
 }
 
+/** 分析結果系のstateをまとめたオブジェクト型 */
+interface AnalysisResult {
+  result: InvestmentResult | null;
+  comparison: LandPriceComparison | null;
+  theoreticalPrice: TheoreticalPriceResult | null;
+  stationRidership: StationRidershipResult[] | null;
+  populationForecast: PopulationForecastResult | null;
+  landAppraisal: AppraisalComparisonResult | null;
+  externalUrbanRisks: UrbanRisk[] | null;
+  investmentScore: InvestmentScoreResult | null;
+  hazardRisks: UrbanRisk[] | null;
+}
+
+const INITIAL_ANALYSIS_RESULT: AnalysisResult = {
+  result: null,
+  comparison: null,
+  theoreticalPrice: null,
+  stationRidership: null,
+  populationForecast: null,
+  landAppraisal: null,
+  externalUrbanRisks: null,
+  investmentScore: null,
+  hazardRisks: null,
+};
+
 interface DashboardProps {
   initialParams?: URLSearchParams | null;
 }
@@ -42,18 +67,13 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   // Decode URL params once on mount
   const decoded = initialParams ? decodeUrlParams(initialParams) : null;
 
-  const [result, setResult] = useState<InvestmentResult | null>(null);
-  const [comparison, setComparison] = useState<LandPriceComparison | null>(null);
-  const [theoreticalPrice, setTheoreticalPrice] = useState<TheoreticalPriceResult | null>(null);
+  // Analysis results consolidated into a single state object to avoid cascading re-renders
+  const [analysisResult, setAnalysisResult] = useState<AnalysisResult>(INITIAL_ANALYSIS_RESULT);
+
+  // UI states remain as individual useState calls
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
   const [lastInput, setLastInput] = useState<InvestmentInput | null>(null);
-  const [stationRidership, setStationRidership] = useState<StationRidershipResult[] | null>(null);
-  const [populationForecast, setPopulationForecast] = useState<PopulationForecastResult | null>(null);
-  const [landAppraisal, setLandAppraisal] = useState<AppraisalComparisonResult | null>(null);
-  const [externalUrbanRisks, setExternalUrbanRisks] = useState<UrbanRisk[] | null>(null);
-  const [investmentScore, setInvestmentScore] = useState<InvestmentScoreResult | null>(null);
-  const [hazardRisks, setHazardRisks] = useState<UrbanRisk[] | null>(null);
   const [propertyLat, setPropertyLat] = useState<number | undefined>(undefined);
   const [propertyLng, setPropertyLng] = useState<number | undefined>(undefined);
   const [simulationMode, setSimulationMode] = useState<SimulationMode>(
@@ -70,6 +90,9 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Destructure for ergonomic use in JSX
+  const { result, comparison, theoreticalPrice, stationRidership, populationForecast, landAppraisal, externalUrbanRisks, investmentScore, hazardRisks } = analysisResult;
 
   // Network status detection
   useEffect(() => {
@@ -102,7 +125,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
       noticeTimer.current = setTimeout(() => setModeNotice(false), 4000);
     }
     setSimulationMode(mode);
-    setResult(null);
+    setAnalysisResult((prev) => ({ ...prev, result: null }));
   };
 
   const handleAnalyze = async (input: InvestmentInput, quickTotalMan?: string) => {
@@ -115,7 +138,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
       const res = isOnline === false
         ? analyzeOffline(inputWithMethod)
         : await analyzeOnline(inputWithMethod);
-      setResult(res);
+      setAnalysisResult((prev) => ({ ...prev, result: res }));
       setLastInput(inputWithMethod);
 
       // Update URL with current simulation conditions
@@ -153,7 +176,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
       const res = isOnline === false
         ? analyzeOffline(updatedInput)
         : await analyzeOnline(updatedInput);
-      setResult(res);
+      setAnalysisResult((prev) => ({ ...prev, result: res }));
       setLastInput((prev) => prev ? { ...prev, loanMethod: method } : prev);
     } catch (e) {
       setError(e instanceof Error ? e.message : "シミュレーションに失敗しました");
@@ -165,12 +188,15 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   const handleFetchLandPrices = async (area: string, city: string, lat?: number, lng?: number) => {
     setLoading(true);
     setError(null);
-    setStationRidership(null);
-    setPopulationForecast(null);
-    setLandAppraisal(null);
-    setExternalUrbanRisks(null);
-    setInvestmentScore(null);
-    setHazardRisks(null);
+    setAnalysisResult((prev) => ({
+      ...prev,
+      stationRidership: null,
+      populationForecast: null,
+      landAppraisal: null,
+      externalUrbanRisks: null,
+      investmentScore: null,
+      hazardRisks: null,
+    }));
     if (lat !== undefined && lng !== undefined) {
       setPropertyLat(lat);
       setPropertyLng(lng);
@@ -188,24 +214,29 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
         areaSqm: lastInput?.landArea ?? 0,
       };
       const comp = await compareLandPrice(baseParams);
-      setComparison(comp);
+      setAnalysisResult((prev) => ({ ...prev, comparison: comp }));
 
+      let est: TheoreticalPriceResult | null = null;
       if (lastInput && lastInput.landArea > 0) {
         try {
-          const est = await estimateLandPrice({
+          est = await estimateLandPrice({
             ...baseParams,
             buildingAge: lastInput.buildingAge,
             stationMinutes: lastInput.stationMinutes,
           });
-          setTheoreticalPrice(est);
         } catch {
-          setTheoreticalPrice(null);
+          est = null;
         }
       }
+      setAnalysisResult((prev) => ({ ...prev, theoreticalPrice: est }));
+
       const [appraisal] = await Promise.allSettled([
         fetchLandAppraisals({ area, year: toYear, city: city || undefined }),
       ]);
-      setLandAppraisal(appraisal.status === "fulfilled" ? appraisal.value : null);
+      setAnalysisResult((prev) => ({
+        ...prev,
+        landAppraisal: appraisal.status === "fulfilled" ? appraisal.value : null,
+      }));
 
       if (lat !== undefined && lng !== undefined) {
         const [ridership, population, urbanRisks, scoreResult, hazard] = await Promise.allSettled([
@@ -215,11 +246,14 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
           fetchInvestmentScore({ lat, lng }),
           fetchHazardInfo(lat, lng),
         ]);
-        setStationRidership(ridership.status === "fulfilled" ? ridership.value : null);
-        setPopulationForecast(population.status === "fulfilled" ? population.value : null);
-        setExternalUrbanRisks(urbanRisks.status === "fulfilled" ? urbanRisks.value : null);
-        setInvestmentScore(scoreResult.status === "fulfilled" ? scoreResult.value : null);
-        setHazardRisks(hazard.status === "fulfilled" ? hazard.value : null);
+        setAnalysisResult((prev) => ({
+          ...prev,
+          stationRidership: ridership.status === "fulfilled" ? ridership.value : null,
+          populationForecast: population.status === "fulfilled" ? population.value : null,
+          externalUrbanRisks: urbanRisks.status === "fulfilled" ? urbanRisks.value : null,
+          investmentScore: scoreResult.status === "fulfilled" ? scoreResult.value : null,
+          hazardRisks: hazard.status === "fulfilled" ? hazard.value : null,
+        }));
       }
     } catch (e) {
       setError(e instanceof Error ? e.message : "相場データの取得に失敗しました。しばらく後に再試行してください");

--- a/frontend/src/components/DeadCrossChart.tsx
+++ b/frontend/src/components/DeadCrossChart.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useMemo } from "react";
 import {
   ComposedChart, Line, XAxis, YAxis, CartesianGrid,
   Tooltip, Legend, ReferenceLine, ReferenceArea, ResponsiveContainer,
@@ -14,22 +14,30 @@ interface Props {
   result: InvestmentResult;
 }
 
-export function DeadCrossChart({ result }: Props) {
+function DeadCrossChart({ result }: Props) {
   const { deadCrossYear, yearlyResults } = result;
 
-  const data = yearlyResults.slice(0, 35).map((y) => ({
-    year: `${y.year}年`,
-    元金返済: Math.round(y.annualPrincipal / 10_000),
-    減価償却費: Math.round(y.annualDepreciation / 10_000),
-    isDeadCrossZone: y.isInDeadCrossZone,
-  }));
+  const data = useMemo(
+    () =>
+      yearlyResults.slice(0, 35).map((y) => ({
+        year: `${y.year}年`,
+        元金返済: Math.round(y.annualPrincipal / 10_000),
+        減価償却費: Math.round(y.annualDepreciation / 10_000),
+        isDeadCrossZone: y.isInDeadCrossZone,
+      })),
+    [yearlyResults],
+  );
 
   const hasDeadCross = deadCrossYear > 0 && deadCrossYear <= 35;
 
   // デッドクロスゾーンの終了年（ローン完済またはデータ終端）
-  const deadCrossEndYear = hasDeadCross
-    ? ([...yearlyResults.slice(0, 35)].reverse().find((y) => y.isInDeadCrossZone)?.year ?? deadCrossYear)
-    : null;
+  const deadCrossEndYear = useMemo(
+    () =>
+      hasDeadCross
+        ? ([...yearlyResults.slice(0, 35)].reverse().find((y) => y.isInDeadCrossZone)?.year ?? deadCrossYear)
+        : null,
+    [hasDeadCross, yearlyResults, deadCrossYear],
+  );
 
   return (
     <Card>
@@ -93,3 +101,5 @@ export function DeadCrossChart({ result }: Props) {
     </Card>
   );
 }
+
+export default React.memo(DeadCrossChart);

--- a/frontend/src/components/__tests__/CashFlowChart.test.tsx
+++ b/frontend/src/components/__tests__/CashFlowChart.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { CashFlowChart } from "@/components/CashFlowChart";
+import CashFlowChart from "@/components/CashFlowChart";
 import { makeResult, makeYearlyResult } from "./helpers";
 
 describe("CashFlowChart", () => {

--- a/frontend/src/components/__tests__/DeadCrossChart.test.tsx
+++ b/frontend/src/components/__tests__/DeadCrossChart.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { render, screen } from "@testing-library/react";
-import { DeadCrossChart } from "@/components/DeadCrossChart";
+import DeadCrossChart from "@/components/DeadCrossChart";
 import { makeResult } from "./helpers";
 
 describe("DeadCrossChart", () => {


### PR DESCRIPTION
## 概要

フロントエンドのパフォーマンス改善 Track C として、2つの変更を実装しました。

1. **チャートコンポーネントのメモ化（#347）**: `DeadCrossChart` と `CashFlowChart` を `React.memo` でラップし、データ変換処理を `useMemo` でメモ化しました。props（`result` / `equityInvested`）が変わらない限り35年分のデータ再計算・再描画が発生しなくなります。

2. **Dashboard 分析結果stateの一元化（#344）**: 9個の個別 `useState`（`result`, `comparison`, `theoreticalPrice`, `stationRidership`, `populationForecast`, `landAppraisal`, `externalUrbanRisks`, `investmentScore`, `hazardRisks`）を単一の `analysisResult` オブジェクトstateに統合しました。API応答ごとに連鎖していた再レンダリングが削減されます。

## 変更内容

- `frontend/src/components/DeadCrossChart.tsx`: `React.memo` + `useMemo` 適用、default export に変更
- `frontend/src/components/CashFlowChart.tsx`: `React.memo` + `useMemo` 適用、default export に変更
- `frontend/src/components/Dashboard.tsx`: 分析結果9stateを `AnalysisResult` 型オブジェクトに統合
- `frontend/src/components/__tests__/DeadCrossChart.test.tsx`: default import に更新
- `frontend/src/components/__tests__/CashFlowChart.test.tsx`: default import に更新

## 関連Issue

Closes #347
Closes #344

## テスト

- [x] 既存テストが通ること（vitest 225件 全PASS）
- [x] TypeScript型チェック通過（`tsc --noEmit`）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み