### PR TITLE
fix: #349マージで壊れたTooltipProviderとテストスイートを修復

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -126,8 +126,12 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   }, [mobileFormOpen]);
 
   useEffect(() => {
-    if (!localStorage.getItem(ONBOARDING_KEY)) {
-      setShowGuide(true);
+    try {
+      if (!localStorage.getItem(ONBOARDING_KEY)) {
+        setShowGuide(true);
+      }
+    } catch {
+      // localStorage unavailable (e.g. test environment or private browsing)
     }
   }, []);
 

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -19,6 +19,10 @@ vi.mock("next/dynamic", () => ({
   default: () => () => null,
 }));
 
+// WatchlistPanel and AreaDiscovery use localStorage/external APIs not needed for Dashboard unit tests
+vi.mock("@/components/WatchlistPanel", () => ({ default: () => null }));
+vi.mock("@/components/AreaDiscovery", () => ({ AreaDiscovery: () => null }));
+
 // Mock next/navigation for useRouter
 const mockReplace = vi.fn();
 vi.mock("next/navigation", () => ({

--- a/frontend/src/components/__tests__/DeadCrossChart.test.tsx
+++ b/frontend/src/components/__tests__/DeadCrossChart.test.tsx
@@ -6,20 +6,21 @@ import { makeResult } from "./helpers";
 describe("DeadCrossChart", () => {
   it("デッドクロスがない場合は成功バッジを表示する", () => {
     const result = makeResult({ deadCrossYear: 0 });
-    render(<DeadCrossChart result={result} />);
-    expect(screen.getByText(/デッドクロス.*なし（35年以内）/)).toBeInTheDocument();
+    const { container } = render(<DeadCrossChart result={result} />);
+    expect(container.textContent).toContain("デッドクロスなし（35年以内）");
   });
 
   it("デッドクロスがある場合は警告バッジを表示する", () => {
     const result = makeResult({ deadCrossYear: 10 });
-    render(<DeadCrossChart result={result} />);
-    expect(screen.getByText(/10年目〜.*デッドクロス.*ゾーン/)).toBeInTheDocument();
+    const { container } = render(<DeadCrossChart result={result} />);
+    expect(container.textContent).toContain("10年目〜");
+    expect(container.textContent).toContain("デッドクロスゾーン");
   });
 
   it("35年超のデッドクロス年はデッドクロスなしとして扱う", () => {
     const result = makeResult({ deadCrossYear: 40 });
-    render(<DeadCrossChart result={result} />);
-    expect(screen.getByText(/デッドクロス.*なし（35年以内）/)).toBeInTheDocument();
+    const { container } = render(<DeadCrossChart result={result} />);
+    expect(container.textContent).toContain("デッドクロスなし（35年以内）");
   });
 
   it("デッドクロスがある場合は警告テキストを表示する", () => {

--- a/frontend/src/components/ui/TermTooltip.tsx
+++ b/frontend/src/components/ui/TermTooltip.tsx
@@ -1,6 +1,6 @@
 "use client";
 import React, { useState } from "react";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { Info } from "lucide-react";
 import { GLOSSARY } from "@/lib/glossary";
 
@@ -15,7 +15,7 @@ export function TermTooltip({ term, children }: Props) {
   if (!entry) return <>{children}</>;
 
   return (
-    <>
+    <TooltipProvider>
       <Tooltip open={open} onOpenChange={setOpen}>
         <TooltipTrigger asChild>
           <span
@@ -39,6 +39,6 @@ export function TermTooltip({ term, children }: Props) {
           <p className="mt-0.5 text-muted-foreground">💡 {entry.tip}</p>
         </div>
       )}
-    </>
+    </TooltipProvider>
   );
 }

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -8,3 +8,8 @@ class ResizeObserverMock {
   disconnect() {}
 }
 global.ResizeObserver = ResizeObserverMock;
+
+// Restore any vi.stubGlobal overrides between tests to prevent cross-test pollution
+afterEach(() => {
+  vi.unstubAllGlobals();
+});


### PR DESCRIPTION
## 概要

PR #349 のマージ（`abf418b`: TooltipProvider を layout に移動）によって、テスト環境で `TooltipProvider` コンテキストが失われ、複数のテストが壊れた問題を修正。

## 修正内容

### TermTooltip.tsx — TooltipProvider を自己完結型に戻す
- `abf418b` で `TooltipProvider` が `layout.tsx` に移動されたが、テスト環境ではレイアウトが描画されないためエラーが発生していた
- 各 `TermTooltip` インスタンスが自前で `TooltipProvider` を持つ形式に復元
- `Error: 'Tooltip' must be used within 'TooltipProvider'` を解消

### DeadCrossChart.test.tsx — `container.textContent` アサーションに変更
- TermTooltip がテキストを複数 DOM ノードに分割するため `getByText` が失敗していた
- `container.textContent.toContain()` に変更して確実に動作するよう修正

### Dashboard.test.tsx — WatchlistPanel/AreaDiscovery をモック
- `WatchlistPanel` の localStorage 使用がテスト環境でエラーを引き起こしていた
- Dashboard ユニットテストに不要なコンポーネントをモックして分離

### Dashboard.tsx — localStorage アクセスを try-catch で保護
- テスト環境でも安全に動作するよう `localStorage.getItem` を try-catch で保護

### vitest.setup.ts — `afterEach(() => vi.unstubAllGlobals())` 追加
- テスト間の `vi.stubGlobal` 汚染を防止

## テスト

- `npm test` で 228/228 通過確認

## 関連
- 修正対象: #349 (`feature/term-tooltip-yield-benchmark`) のマージによる副作用