### PR TITLE
fix(dev): make dev のバックエンド起動確認をヘルスチェックループに改善

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,23 @@ dev:
 	echo "==> Starting backend..."; \
 	(cd backend && set -a; . ../.env; set +a; go run ./cmd/server) & \
 	BACKEND_PID=$$!; \
-	sleep 3; \
-	if ! kill -0 $$BACKEND_PID 2>/dev/null; then \
-	  echo "ERROR: バックエンドの起動に失敗しました。ログを確認してください。"; \
+	echo "==> Waiting for backend (up to 30s)..."; \
+	for i in $$(seq 1 30); do \
+	  if curl -sf http://localhost:8080/health > /dev/null 2>&1; then \
+	    echo "==> Backend ready (PID=$$BACKEND_PID)"; \
+	    break; \
+	  fi; \
+	  if ! kill -0 $$BACKEND_PID 2>/dev/null; then \
+	    echo "ERROR: バックエンドの起動に失敗しました。ログを確認してください。"; \
+	    exit 1; \
+	  fi; \
+	  sleep 1; \
+	done; \
+	if ! curl -sf http://localhost:8080/health > /dev/null 2>&1; then \
+	  echo "ERROR: バックエンドが 30 秒以内に応答しませんでした。"; \
+	  kill $$BACKEND_PID 2>/dev/null; \
 	  exit 1; \
 	fi; \
-	echo "==> Backend started (PID=$$BACKEND_PID)"; \
 	echo "==> Starting frontend..."; \
 	(cd frontend && npm run dev) & \
 	wait


### PR DESCRIPTION
## 概要

`make dev` のバックエンド起動確認を `sleep 3` + `kill -0` からヘルスチェックループに置き換えます。

## 背景

closes #272

PR #267 のレビューで指摘された課題への対応です。

## 変更内容

- `sleep 3` + `kill -0` を削除
- `/health` へのポーリングループ（1 秒ごと、最大 30 秒）に置き換え
- ループ内でも `kill -0` によるプロセス死活監視を継続し、クラッシュを即検知
- 30 秒以内に応答がなければタイムアウトエラーを出してプロセスを終了
- フロントエンドはバックエンドが実際にリクエストを受け付けた後に起動

## 動作確認

- [ ] `make dev` でバックエンドが起動完了後にフロントエンドが起動することを確認
- [ ] バックエンドが起動失敗した場合に `ERROR: バックエンドの起動に失敗しました。` が表示されることを確認
- [ ] 30 秒以内に応答しない場合に `ERROR: バックエンドが 30 秒以内に応答しませんでした。` が表示されることを確認

## 影響範囲

開発体験のみ（機能・本番影響なし）