### PR TITLE
refactor(api): タイル座標バリデーションを parseLatLng/parseZoom に共通化

### DIFF
--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -140,6 +140,13 @@ func parseLandPriceQuery(c *gin.Context) (mlit.LandPriceQuery, error) {
 	}, nil
 }
 
+// coordsGlobal and coordsJapanOnly are used as the japanOnly argument of parseLatLng
+// to make call sites self-documenting.
+const (
+	coordsGlobal    = false
+	coordsJapanOnly = true
+)
+
 // parseLatLng parses lat and lng query params with range validation.
 // If japanOnly is true, validates Japan domestic range (lat 20-46, lng 122-154).
 // Otherwise validates global range (lat -90~90, lng -180~180).
@@ -382,7 +389,7 @@ func (h *Handler) EstimateLandPrice(c *gin.Context) {
 // GetStationRidership は物件の緯度経度からタイル座標を計算し、駅別乗降客数と需要スコアを返す（XKT015）
 // GET /api/station-ridership?lat=35.6762&lng=139.6503[&z=14]
 func (h *Handler) GetStationRidership(c *gin.Context) {
-	lat, lng, ok := parseLatLng(c, false)
+	lat, lng, ok := parseLatLng(c, coordsGlobal)
 	if !ok {
 		return
 	}
@@ -417,7 +424,7 @@ func (h *Handler) GetStationRidership(c *gin.Context) {
 // GetPopulationForecast は物件の緯度経度からタイル座標を計算し、将来推計人口と人口減少シナリオを返す（XKT013）
 // GET /api/population-forecast?lat=35.6762&lng=139.6503[&z=14]
 func (h *Handler) GetPopulationForecast(c *gin.Context) {
-	lat, lng, ok := parseLatLng(c, false)
+	lat, lng, ok := parseLatLng(c, coordsGlobal)
 	if !ok {
 		return
 	}
@@ -556,7 +563,7 @@ func (h *Handler) GetRentDeclineHint(c *gin.Context) {
 // GetUrbanRisks は緯度経度から都市計画リスクを一括取得する
 // GET /api/urban-risks?lat=35.68&lng=139.69
 func (h *Handler) GetUrbanRisks(c *gin.Context) {
-	lat, lng, ok := parseLatLng(c, true)
+	lat, lng, ok := parseLatLng(c, coordsJapanOnly)
 	if !ok {
 		return
 	}
@@ -631,7 +638,7 @@ func (h *Handler) GetUrbanRisks(c *gin.Context) {
 // GetHazardInfo は物件の緯度経度から洪水・高潮・津波・土砂災害のハザード情報を返す。
 // GET /api/hazard?lat=35.6895&lng=139.6917
 func (h *Handler) GetHazardInfo(c *gin.Context) {
-	lat, lng, ok := parseLatLng(c, true)
+	lat, lng, ok := parseLatLng(c, coordsJapanOnly)
 	if !ok {
 		return
 	}
@@ -845,7 +852,7 @@ func (h *Handler) calcScoreForTile(ctx context.Context, z, x, y int) (domain.Inv
 // GetInvestmentScore は物件の緯度経度から複数 API を並列呼び出しし、投資適地スコアを算出して返す。
 // GET /api/investment-score?lat=35.6762&lng=139.6503
 func (h *Handler) GetInvestmentScore(c *gin.Context) {
-	lat, lng, ok := parseLatLng(c, true)
+	lat, lng, ok := parseLatLng(c, coordsJapanOnly)
 	if !ok {
 		return
 	}

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -140,6 +140,57 @@ func parseLandPriceQuery(c *gin.Context) (mlit.LandPriceQuery, error) {
 	}, nil
 }
 
+// parseLatLng parses lat and lng query params with range validation.
+// If japanOnly is true, validates Japan domestic range (lat 20-46, lng 122-154).
+// Otherwise validates global range (lat -90~90, lng -180~180).
+func parseLatLng(c *gin.Context, japanOnly bool) (lat, lng float64, ok bool) {
+	latStr := c.Query("lat")
+	lngStr := c.Query("lng")
+	if latStr == "" || lngStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "lat と lng は必須パラメータです"})
+		return 0, 0, false
+	}
+	lat, err := strconv.ParseFloat(latStr, 64)
+	if japanOnly {
+		if err != nil || lat < 20 || lat > 46 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "lat は日本国内の緯度（20〜46）で指定してください"})
+			return 0, 0, false
+		}
+	} else {
+		if err != nil || lat < -90 || lat > 90 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "lat は -90〜90 の数値で指定してください"})
+			return 0, 0, false
+		}
+	}
+	lng, err = strconv.ParseFloat(lngStr, 64)
+	if japanOnly {
+		if err != nil || lng < 122 || lng > 154 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "lng は日本国内の経度（122〜154）で指定してください"})
+			return 0, 0, false
+		}
+	} else {
+		if err != nil || lng < -180 || lng > 180 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "lng は -180〜180 の数値で指定してください"})
+			return 0, 0, false
+		}
+	}
+	return lat, lng, true
+}
+
+// parseZoom parses the optional z query param (11-15). Returns defaultZ if absent.
+func parseZoom(c *gin.Context, defaultZ int) (z int, ok bool) {
+	zStr := c.Query("z")
+	if zStr == "" {
+		return defaultZ, true
+	}
+	zv, err := strconv.Atoi(zStr)
+	if err != nil || zv < 11 || zv > 15 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "z は 11〜15 の整数で指定してください"})
+		return 0, false
+	}
+	return zv, true
+}
+
 // Analyze は投資シミュレーションを実行する
 // POST /api/analyze
 func (h *Handler) Analyze(c *gin.Context) {
@@ -331,31 +382,13 @@ func (h *Handler) EstimateLandPrice(c *gin.Context) {
 // GetStationRidership は物件の緯度経度からタイル座標を計算し、駅別乗降客数と需要スコアを返す（XKT015）
 // GET /api/station-ridership?lat=35.6762&lng=139.6503[&z=14]
 func (h *Handler) GetStationRidership(c *gin.Context) {
-	latStr := c.Query("lat")
-	lngStr := c.Query("lng")
-	if latStr == "" || lngStr == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lat と lng は必須パラメータです"})
+	lat, lng, ok := parseLatLng(c, false)
+	if !ok {
 		return
 	}
-	lat, err := strconv.ParseFloat(latStr, 64)
-	if err != nil || lat < -90 || lat > 90 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lat は -90〜90 の数値で指定してください"})
+	z, ok := parseZoom(c, 14)
+	if !ok {
 		return
-	}
-	lng, err := strconv.ParseFloat(lngStr, 64)
-	if err != nil || lng < -180 || lng > 180 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lng は -180〜180 の数値で指定してください"})
-		return
-	}
-
-	z := 14
-	if zStr := c.Query("z"); zStr != "" {
-		zv, err := strconv.Atoi(zStr)
-		if err != nil || zv < 11 || zv > 15 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "z は 11〜15 の整数で指定してください"})
-			return
-		}
-		z = zv
 	}
 
 	tx, ty := mlit.LatLngToTile(lat, lng, z)
@@ -384,31 +417,13 @@ func (h *Handler) GetStationRidership(c *gin.Context) {
 // GetPopulationForecast は物件の緯度経度からタイル座標を計算し、将来推計人口と人口減少シナリオを返す（XKT013）
 // GET /api/population-forecast?lat=35.6762&lng=139.6503[&z=14]
 func (h *Handler) GetPopulationForecast(c *gin.Context) {
-	latStr := c.Query("lat")
-	lngStr := c.Query("lng")
-	if latStr == "" || lngStr == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lat と lng は必須パラメータです"})
+	lat, lng, ok := parseLatLng(c, false)
+	if !ok {
 		return
 	}
-	lat, err := strconv.ParseFloat(latStr, 64)
-	if err != nil || lat < -90 || lat > 90 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lat は -90〜90 の数値で指定してください"})
+	z, ok := parseZoom(c, 14)
+	if !ok {
 		return
-	}
-	lng, err := strconv.ParseFloat(lngStr, 64)
-	if err != nil || lng < -180 || lng > 180 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lng は -180〜180 の数値で指定してください"})
-		return
-	}
-
-	z := 14
-	if zStr := c.Query("z"); zStr != "" {
-		zv, err := strconv.Atoi(zStr)
-		if err != nil || zv < 11 || zv > 15 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "z は 11〜15 の整数で指定してください"})
-			return
-		}
-		z = zv
 	}
 
 	tx, ty := mlit.LatLngToTile(lat, lng, z)
@@ -541,20 +556,8 @@ func (h *Handler) GetRentDeclineHint(c *gin.Context) {
 // GetUrbanRisks は緯度経度から都市計画リスクを一括取得する
 // GET /api/urban-risks?lat=35.68&lng=139.69
 func (h *Handler) GetUrbanRisks(c *gin.Context) {
-	latStr := c.Query("lat")
-	lngStr := c.Query("lng")
-	if latStr == "" || lngStr == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lat と lng は必須パラメータです"})
-		return
-	}
-	lat, err := strconv.ParseFloat(latStr, 64)
-	if err != nil || lat < 20 || lat > 46 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lat は日本国内の緯度（20〜46）で指定してください"})
-		return
-	}
-	lng, err := strconv.ParseFloat(lngStr, 64)
-	if err != nil || lng < 122 || lng > 154 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lng は日本国内の経度（122〜154）で指定してください"})
+	lat, lng, ok := parseLatLng(c, true)
+	if !ok {
 		return
 	}
 
@@ -628,20 +631,8 @@ func (h *Handler) GetUrbanRisks(c *gin.Context) {
 // GetHazardInfo は物件の緯度経度から洪水・高潮・津波・土砂災害のハザード情報を返す。
 // GET /api/hazard?lat=35.6895&lng=139.6917
 func (h *Handler) GetHazardInfo(c *gin.Context) {
-	latStr := c.Query("lat")
-	lngStr := c.Query("lng")
-	if latStr == "" || lngStr == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lat と lng は必須パラメータです"})
-		return
-	}
-	lat, err := strconv.ParseFloat(latStr, 64)
-	if err != nil || lat < 20 || lat > 46 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lat は日本国内の緯度（20〜46）で指定してください"})
-		return
-	}
-	lng, err := strconv.ParseFloat(lngStr, 64)
-	if err != nil || lng < 122 || lng > 154 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lng は日本国内の経度（122〜154）で指定してください"})
+	lat, lng, ok := parseLatLng(c, true)
+	if !ok {
 		return
 	}
 
@@ -854,20 +845,8 @@ func (h *Handler) calcScoreForTile(ctx context.Context, z, x, y int) (domain.Inv
 // GetInvestmentScore は物件の緯度経度から複数 API を並列呼び出しし、投資適地スコアを算出して返す。
 // GET /api/investment-score?lat=35.6762&lng=139.6503
 func (h *Handler) GetInvestmentScore(c *gin.Context) {
-	latStr := c.Query("lat")
-	lngStr := c.Query("lng")
-	if latStr == "" || lngStr == "" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lat と lng は必須パラメータです"})
-		return
-	}
-	lat, err := strconv.ParseFloat(latStr, 64)
-	if err != nil || lat < 20 || lat > 46 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lat は日本国内の緯度（20〜46）で指定してください"})
-		return
-	}
-	lng, err := strconv.ParseFloat(lngStr, 64)
-	if err != nil || lng < 122 || lng > 154 {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "lng は日本国内の経度（122〜154）で指定してください"})
+	lat, lng, ok := parseLatLng(c, true)
+	if !ok {
 		return
 	}
 
@@ -935,14 +914,9 @@ func (h *Handler) GetInvestmentScoreHeatmap(c *gin.Context) {
 		return
 	}
 
-	z := 13
-	if zStr := c.Query("z"); zStr != "" {
-		zVal, err := strconv.Atoi(zStr)
-		if err != nil || zVal < 11 || zVal > 15 {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "z は 11〜15 の整数で指定してください"})
-			return
-		}
-		z = zVal
+	z, ok := parseZoom(c, 13)
+	if !ok {
+		return
 	}
 
 	// ズームレベルに応じてタイル数上限を決定

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -47,7 +48,14 @@ func TestParseLatLng_Global(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(w)
-			c.Request, _ = http.NewRequest("GET", "/?lat="+tc.lat+"&lng="+tc.lng, nil)
+			q := url.Values{}
+			if tc.lat != "" {
+				q.Set("lat", tc.lat)
+			}
+			if tc.lng != "" {
+				q.Set("lng", tc.lng)
+			}
+			c.Request, _ = http.NewRequest("GET", "/?"+q.Encode(), nil)
 			lat, lng, ok := parseLatLng(c, coordsGlobal)
 			if ok != tc.wantOK {
 				t.Errorf("ok = %v, want %v (status %d)", ok, tc.wantOK, w.Code)
@@ -64,29 +72,37 @@ func TestParseLatLng_Global(t *testing.T) {
 
 func TestParseLatLng_JapanOnly(t *testing.T) {
 	cases := []struct {
-		name   string
-		lat    string
-		lng    string
-		wantOK bool
+		name    string
+		lat     string
+		lng     string
+		wantOK  bool
+		wantLat float64
+		wantLng float64
 	}{
-		{"valid tokyo", "35.6762", "139.6503", true},
-		{"lat below japan", "19", "139.6503", false},
-		{"lat above japan", "47", "139.6503", false},
-		{"lng below japan", "35.6762", "121", false},
-		{"lng above japan", "35.6762", "155", false},
-		{"boundary lat min", "20", "139", true},
-		{"boundary lat max", "46", "139", true},
-		{"boundary lng min", "35", "122", true},
-		{"boundary lng max", "35", "154", true},
+		{"valid tokyo", "35.6762", "139.6503", true, 35.6762, 139.6503},
+		{"lat below japan", "19", "139.6503", false, 0, 0},
+		{"lat above japan", "47", "139.6503", false, 0, 0},
+		{"lng below japan", "35.6762", "121", false, 0, 0},
+		{"lng above japan", "35.6762", "155", false, 0, 0},
+		{"boundary lat min", "20", "139", true, 20, 139},
+		{"boundary lat max", "46", "139", true, 46, 139},
+		{"boundary lng min", "35", "122", true, 35, 122},
+		{"boundary lng max", "35", "154", true, 35, 154},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			w := httptest.NewRecorder()
 			c, _ := gin.CreateTestContext(w)
-			c.Request, _ = http.NewRequest("GET", "/?lat="+tc.lat+"&lng="+tc.lng, nil)
-			_, _, ok := parseLatLng(c, coordsJapanOnly)
+			q := url.Values{}
+			q.Set("lat", tc.lat)
+			q.Set("lng", tc.lng)
+			c.Request, _ = http.NewRequest("GET", "/?"+q.Encode(), nil)
+			lat, lng, ok := parseLatLng(c, coordsJapanOnly)
 			if ok != tc.wantOK {
 				t.Errorf("ok = %v, want %v (status %d)", ok, tc.wantOK, w.Code)
+			}
+			if ok && (lat != tc.wantLat || lng != tc.wantLng) {
+				t.Errorf("lat/lng = %v/%v, want %v/%v", lat, lng, tc.wantLat, tc.wantLng)
 			}
 			if !ok && w.Code != http.StatusBadRequest {
 				t.Errorf("status = %d, want 400", w.Code)

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -20,6 +20,121 @@ func init() {
 	gin.SetMode(gin.TestMode)
 }
 
+func TestParseLatLng_Global(t *testing.T) {
+	cases := []struct {
+		name    string
+		lat     string
+		lng     string
+		wantOK  bool
+		wantLat float64
+		wantLng float64
+	}{
+		{"valid", "35.6762", "139.6503", true, 35.6762, 139.6503},
+		{"missing lat", "", "139.6503", false, 0, 0},
+		{"missing lng", "35.6762", "", false, 0, 0},
+		{"lat out of range high", "91", "139.6503", false, 0, 0},
+		{"lat out of range low", "-91", "139.6503", false, 0, 0},
+		{"lng out of range high", "35.6762", "181", false, 0, 0},
+		{"lng out of range low", "35.6762", "-181", false, 0, 0},
+		{"lat not a number", "abc", "139.6503", false, 0, 0},
+		{"lng not a number", "35.6762", "abc", false, 0, 0},
+		{"lat boundary min", "-90", "0", true, -90, 0},
+		{"lat boundary max", "90", "0", true, 90, 0},
+		{"lng boundary min", "0", "-180", true, 0, -180},
+		{"lng boundary max", "0", "180", true, 0, 180},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest("GET", "/?lat="+tc.lat+"&lng="+tc.lng, nil)
+			lat, lng, ok := parseLatLng(c, coordsGlobal)
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v (status %d)", ok, tc.wantOK, w.Code)
+			}
+			if ok && (lat != tc.wantLat || lng != tc.wantLng) {
+				t.Errorf("lat/lng = %v/%v, want %v/%v", lat, lng, tc.wantLat, tc.wantLng)
+			}
+			if !ok && w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", w.Code)
+			}
+		})
+	}
+}
+
+func TestParseLatLng_JapanOnly(t *testing.T) {
+	cases := []struct {
+		name   string
+		lat    string
+		lng    string
+		wantOK bool
+	}{
+		{"valid tokyo", "35.6762", "139.6503", true},
+		{"lat below japan", "19", "139.6503", false},
+		{"lat above japan", "47", "139.6503", false},
+		{"lng below japan", "35.6762", "121", false},
+		{"lng above japan", "35.6762", "155", false},
+		{"boundary lat min", "20", "139", true},
+		{"boundary lat max", "46", "139", true},
+		{"boundary lng min", "35", "122", true},
+		{"boundary lng max", "35", "154", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			c.Request, _ = http.NewRequest("GET", "/?lat="+tc.lat+"&lng="+tc.lng, nil)
+			_, _, ok := parseLatLng(c, coordsJapanOnly)
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v (status %d)", ok, tc.wantOK, w.Code)
+			}
+			if !ok && w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", w.Code)
+			}
+		})
+	}
+}
+
+func TestParseZoom(t *testing.T) {
+	cases := []struct {
+		name     string
+		z        string
+		defaultZ int
+		wantOK   bool
+		wantZ    int
+	}{
+		{"omitted uses default 14", "", 14, true, 14},
+		{"omitted uses default 13", "", 13, true, 13},
+		{"explicit valid", "12", 14, true, 12},
+		{"boundary min", "11", 14, true, 11},
+		{"boundary max", "15", 14, true, 15},
+		{"below range", "10", 14, false, 0},
+		{"above range", "16", 14, false, 0},
+		{"not a number", "abc", 14, false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(w)
+			url := "/"
+			if tc.z != "" {
+				url += "?z=" + tc.z
+			}
+			c.Request, _ = http.NewRequest("GET", url, nil)
+			z, ok := parseZoom(c, tc.defaultZ)
+			if ok != tc.wantOK {
+				t.Errorf("ok = %v, want %v (status %d)", ok, tc.wantOK, w.Code)
+			}
+			if ok && z != tc.wantZ {
+				t.Errorf("z = %d, want %d", z, tc.wantZ)
+			}
+			if !ok && w.Code != http.StatusBadRequest {
+				t.Errorf("status = %d, want 400", w.Code)
+			}
+		})
+	}
+}
+
 // mockMLITClient は MLITClient インターフェースのテスト用モック
 type mockMLITClient struct {
 	fetchFunc            func(ctx context.Context, q mlit.LandPriceQuery) ([]domain.LandTransaction, error)


### PR DESCRIPTION
## 概要

`handler.go` で 5〜6 ハンドラに重複していたタイル座標パース・バリデーションを 2 つのヘルパーに共通化した。

## 変更内容

### 追加したヘルパー

| 関数 | 役割 |
|---|---|
| `parseLatLng(c, japanOnly bool)` | lat/lng の必須チェック・型チェック・範囲チェック（グローバル or 日本国内） |
| `parseZoom(c, defaultZ int)` | z の省略可能パース（デフォルト値対応、範囲 11〜15） |

### 適用したハンドラ

| ハンドラ | parseLatLng | parseZoom |
|---|---|---|
| GetStationRidership | ✅ `japanOnly=false` | ✅ `default=14` |
| GetPopulationForecast | ✅ `japanOnly=false` | ✅ `default=14` |
| GetUrbanRisks | ✅ `japanOnly=true` | — |
| GetHazardInfo | ✅ `japanOnly=true` | — |
| GetInvestmentScore | ✅ `japanOnly=true` | — |
| GetInvestmentScoreHeatmap | — (別パラメータ体系) | ✅ `default=13` |

## 動作確認

- 既存テスト 56 件すべてパス（`go test -race ./internal/api/...`）
- バリデーション挙動・エラーメッセージに変更なし
- z の省略可能な挙動を維持（デフォルト値をヘルパーに委譲）

## 関連

Closes #356