### PR TITLE
feat: 住所入力からジオコーディングで座標を自動取得する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,6 +6,11 @@ ALLOW_ORIGINS=http://localhost:3000
 # 申請: https://www.reinfolib.mlit.go.jp/api/request/
 MLIT_API_KEY=your_api_key_here
 
+# Google Maps Geocoding API キー（住所→座標変換に使用）
+# https://console.cloud.google.com/apis/library/geocoding-backend.googleapis.com
+# 未設定でも他機能は動作する（/api/geocode が 503 を返すのみ）
+GOOGLE_MAPS_API_KEY=your_google_maps_api_key_here
+
 # ログ設定
 # LOG_LEVEL: DEBUG / INFO / WARN / ERROR（デフォルト: INFO）
 LOG_LEVEL=INFO

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -36,7 +36,8 @@ func main() {
 	}
 
 	mlitClient := mlit.NewClient()
-	handler := api.NewHandler(mlitClient)
+	geocodeClient := api.NewGoogleGeocodeClient(os.Getenv("GOOGLE_MAPS_API_KEY"))
+	handler := api.NewHandler(mlitClient, geocodeClient)
 	router := api.NewRouter(handler)
 
 	srv := &http.Server{

--- a/backend/internal/api/geocode_client.go
+++ b/backend/internal/api/geocode_client.go
@@ -1,0 +1,102 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+var (
+	errGeocodeNotConfigured = errors.New("geocode: API key not configured")
+	errGeocodeNotFound      = errors.New("geocode: address not found")
+	errGeocodeUpstream      = errors.New("geocode: upstream error")
+)
+
+// GeocodeResult はジオコーディング結果を表す
+type GeocodeResult struct {
+	Lat          float64 `json:"lat"`
+	Lng          float64 `json:"lng"`
+	LocationType string  `json:"locationType"`
+}
+
+// GeocodeClient は住所→座標変換のインターフェース（テスト時にモック注入可能）
+type GeocodeClient interface {
+	Geocode(ctx context.Context, address string) (*GeocodeResult, error)
+}
+
+type googleGeocodeClient struct {
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewGoogleGeocodeClient は Google Maps Geocoding API クライアントを返す
+func NewGoogleGeocodeClient(apiKey string) GeocodeClient {
+	return &googleGeocodeClient{
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// googleGeocodeResponse は Google Maps Geocoding API のレスポンス構造体
+type googleGeocodeResponse struct {
+	Status  string `json:"status"`
+	Results []struct {
+		Geometry struct {
+			Location struct {
+				Lat float64 `json:"lat"`
+				Lng float64 `json:"lng"`
+			} `json:"location"`
+			LocationType string `json:"location_type"`
+		} `json:"geometry"`
+	} `json:"results"`
+}
+
+func (c *googleGeocodeClient) Geocode(ctx context.Context, address string) (*GeocodeResult, error) {
+	if c.apiKey == "" {
+		return nil, errGeocodeNotConfigured
+	}
+
+	q := url.Values{}
+	q.Set("address", address)
+	q.Set("language", "ja")
+	q.Set("key", c.apiKey)
+	endpoint := "https://maps.googleapis.com/maps/api/geocode/json?" + q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errGeocodeUpstream, err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", errGeocodeUpstream, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: HTTP %d", errGeocodeUpstream, resp.StatusCode)
+	}
+
+	var gr googleGeocodeResponse
+	if err := json.NewDecoder(resp.Body).Decode(&gr); err != nil {
+		return nil, fmt.Errorf("%w: %w", errGeocodeUpstream, err)
+	}
+
+	switch gr.Status {
+	case "OK":
+		loc := gr.Results[0].Geometry
+		return &GeocodeResult{
+			Lat:          loc.Location.Lat,
+			Lng:          loc.Location.Lng,
+			LocationType: loc.LocationType,
+		}, nil
+	case "ZERO_RESULTS":
+		return nil, errGeocodeNotFound
+	default:
+		return nil, fmt.Errorf("%w: status=%s", errGeocodeUpstream, gr.Status)
+	}
+}

--- a/backend/internal/api/geocode_client.go
+++ b/backend/internal/api/geocode_client.go
@@ -88,6 +88,9 @@ func (c *googleGeocodeClient) Geocode(ctx context.Context, address string) (*Geo
 
 	switch gr.Status {
 	case "OK":
+		if len(gr.Results) == 0 {
+			return nil, fmt.Errorf("%w: empty results", errGeocodeUpstream)
+		}
 		loc := gr.Results[0].Geometry
 		return &GeocodeResult{
 			Lat:          loc.Location.Lat,

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"sort"
 	"strconv"
 	"sync"
@@ -1208,12 +1209,19 @@ func (h *Handler) GetGeocode(c *gin.Context) {
 		return
 	}
 
-	// 住所はPIIになりうるため先頭10文字のみログに記録する
+	// 住所はPIIになりうるため、accessLogMiddleware が記録するクエリ文字列をマスクする
+	// nil ガードより先に実行することで、全パスでマスクが適用される
 	masked := address
 	if len([]rune(address)) > 10 {
 		masked = string([]rune(address)[:10]) + "***"
 	}
+	c.Request.URL.RawQuery = "address=" + url.QueryEscape(masked)
 	slog.InfoContext(c.Request.Context(), "geocode request", "address_masked", masked)
+
+	if h.geocodeClient == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "ジオコーディングが設定されていません"})
+		return
+	}
 
 	result, err := h.geocodeClient.Geocode(c.Request.Context(), address)
 	if err != nil {

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -37,11 +37,12 @@ type MLITClient interface {
 }
 
 type Handler struct {
-	mlitClient MLITClient
+	mlitClient    MLITClient
+	geocodeClient GeocodeClient
 }
 
-func NewHandler(mlitClient MLITClient) *Handler {
-	return &Handler{mlitClient: mlitClient}
+func NewHandler(mlitClient MLITClient, geocodeClient GeocodeClient) *Handler {
+	return &Handler{mlitClient: mlitClient, geocodeClient: geocodeClient}
 }
 
 // GetLandPrices は国交省APIから土地取引価格を取得して統計を返す
@@ -1194,5 +1195,39 @@ func (h *Handler) HandleRenovationAnalyze(c *gin.Context) {
 		return
 	}
 	result := domain.CalcRenovationROI(input)
+	c.JSON(http.StatusOK, result)
+}
+
+// GetGeocode は住所文字列から緯度・経度を返す
+// GET /api/geocode?address=<住所>
+// APIキーはサーバーサイドのみで保持し、フロントには露出しない
+func (h *Handler) GetGeocode(c *gin.Context) {
+	address := c.Query("address")
+	if address == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "address パラメータは必須です"})
+		return
+	}
+
+	// 住所はPIIになりうるため先頭10文字のみログに記録する
+	masked := address
+	if len([]rune(address)) > 10 {
+		masked = string([]rune(address)[:10]) + "***"
+	}
+	slog.InfoContext(c.Request.Context(), "geocode request", "address_masked", masked)
+
+	result, err := h.geocodeClient.Geocode(c.Request.Context(), address)
+	if err != nil {
+		switch {
+		case errors.Is(err, errGeocodeNotConfigured):
+			c.JSON(http.StatusServiceUnavailable, gin.H{"error": "ジオコーディングが設定されていません"})
+		case errors.Is(err, errGeocodeNotFound):
+			c.JSON(http.StatusBadRequest, gin.H{"error": "住所が見つかりませんでした。丁目・番地まで入力してください"})
+		default:
+			slog.WarnContext(c.Request.Context(), "geocode upstream error", "error", err)
+			c.JSON(http.StatusBadGateway, gin.H{"error": "座標取得に失敗しました"})
+		}
+		return
+	}
+
 	c.JSON(http.StatusOK, result)
 }

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -271,8 +271,8 @@ func (m *mockMLITClient) FetchLandslideHazard(ctx context.Context, z, x, y int) 
 }
 
 // newTestRouter はモッククライアントを使ったテスト用ルーターを返す
-func newTestRouter(client MLITClient) *gin.Engine {
-	h := NewHandler(client)
+func newTestRouter(client MLITClient, geocodeClient GeocodeClient) *gin.Engine {
+	h := NewHandler(client, geocodeClient)
 	return NewRouter(h)
 }
 
@@ -410,7 +410,7 @@ func TestDomainValidate_Combinations(t *testing.T) {
 }
 
 func TestAnalyze_ValidInput(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 
 	body, _ := json.Marshal(validBase)
 	req := httptest.NewRequest(http.MethodPost, "/api/investment/analyze", bytes.NewReader(body))
@@ -431,7 +431,7 @@ func TestAnalyze_ValidInput(t *testing.T) {
 }
 
 func TestAnalyze_InvalidJSON(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 
 	req := httptest.NewRequest(http.MethodPost, "/api/investment/analyze", bytes.NewBufferString("not-json"))
 	req.Header.Set("Content-Type", "application/json")
@@ -444,7 +444,7 @@ func TestAnalyze_InvalidJSON(t *testing.T) {
 }
 
 func TestAnalyze_ValidationError(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 
 	invalid := validBase
 	invalid.LandPrice = -1
@@ -465,7 +465,7 @@ func TestAnalyze_ValidationError(t *testing.T) {
 }
 
 func TestGetLandPrices_MissingArea(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/stats?year=2024&quarter=1&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -476,7 +476,7 @@ func TestGetLandPrices_MissingArea(t *testing.T) {
 }
 
 func TestGetLandPrices_InvalidYear(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/stats?area=13&year=2000&quarter=1&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -487,7 +487,7 @@ func TestGetLandPrices_InvalidYear(t *testing.T) {
 }
 
 func TestGetLandPrices_InvalidQuarter(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/stats?area=13&year=2024&quarter=5&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -498,7 +498,7 @@ func TestGetLandPrices_InvalidQuarter(t *testing.T) {
 }
 
 func TestHandleRenovationAnalyze_ValidInput(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	body := `{
 		"propertyPrice": 10000000,
 		"annualBaseRent": 1200000,
@@ -533,7 +533,7 @@ func TestHandleRenovationAnalyze_ValidInput(t *testing.T) {
 }
 
 func TestHandleRenovationAnalyze_EmptyItems(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	body := `{"propertyPrice": 10000000, "annualBaseRent": 1200000, "annualExpenses": 0, "effectiveTaxRate": 0.3, "selfLaborRatePerHour": 0, "items": []}`
 	req := httptest.NewRequest(http.MethodPost, "/api/renovation/analyze", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -546,7 +546,7 @@ func TestHandleRenovationAnalyze_EmptyItems(t *testing.T) {
 }
 
 func TestHandleRenovationAnalyze_ZeroPropertyPrice(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	body := `{"propertyPrice": 0, "items": [{"name": "A", "cost": 100000}]}`
 	req := httptest.NewRequest(http.MethodPost, "/api/renovation/analyze", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -559,7 +559,7 @@ func TestHandleRenovationAnalyze_ZeroPropertyPrice(t *testing.T) {
 }
 
 func TestHandleRenovationAnalyze_InvalidTaxRate(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	body := `{"propertyPrice": 10000000, "effectiveTaxRate": 1.5, "items": [{"name": "A", "cost": 100000}]}`
 	req := httptest.NewRequest(http.MethodPost, "/api/renovation/analyze", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
@@ -577,7 +577,7 @@ func TestGetLandPrices_APIError(t *testing.T) {
 			return nil, errors.New("upstream error")
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/stats?area=13&year=2024&quarter=1&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -595,7 +595,7 @@ func TestGetLandPrices_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/stats?area=13&year=2024&quarter=1&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -613,7 +613,7 @@ func TestGetLandPrices_Success(t *testing.T) {
 }
 
 func TestCompareLandPrice_MissingPrice(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/compare?area=13&year=2024&quarter=1&to_year=2024&to_quarter=4", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -624,7 +624,7 @@ func TestCompareLandPrice_MissingPrice(t *testing.T) {
 }
 
 func TestCompareLandPrice_InvalidPrice(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/compare?area=13&year=2024&quarter=1&to_year=2024&to_quarter=4&price=-1", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -642,7 +642,7 @@ func TestCompareLandPrice_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-prices/compare?area=13&year=2024&quarter=1&to_year=2024&to_quarter=4&price=10000000&area_sqm=100", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -660,7 +660,7 @@ func TestCompareLandPrice_Success(t *testing.T) {
 }
 
 func TestGetMunicipalities_MissingArea(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/municipalities", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -676,7 +676,7 @@ func TestGetMunicipalities_APIError(t *testing.T) {
 			return nil, errors.New("upstream error")
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/municipalities?area=13", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -695,7 +695,7 @@ func TestGetMunicipalities_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/municipalities?area=13", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -716,7 +716,7 @@ func TestGetMunicipalities_Success(t *testing.T) {
 }
 
 func TestGetStationRidership_MissingLatLng(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -727,7 +727,7 @@ func TestGetStationRidership_MissingLatLng(t *testing.T) {
 }
 
 func TestGetStationRidership_InvalidLatLng(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership?lat=999&lng=139.6503", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -738,7 +738,7 @@ func TestGetStationRidership_InvalidLatLng(t *testing.T) {
 }
 
 func TestGetStationRidership_InvalidZ(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership?lat=35.6762&lng=139.6503&z=16", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -761,7 +761,7 @@ func TestGetStationRidership_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership?lat=35.6762&lng=139.6503", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -793,7 +793,7 @@ func TestGetStationRidership_APIError(t *testing.T) {
 			return nil, fmt.Errorf("upstream error")
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/station-ridership?lat=35.6762&lng=139.6503", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -811,7 +811,7 @@ func TestEstimateLandPrice_InvalidRidershipScore(t *testing.T) {
 			}, nil
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet,
 		"/api/land-prices/estimate?area=10&year=2024&quarter=1&to_year=2024&to_quarter=4&price=5000000&area_sqm=100&building_age=10&ridership_score=Z",
 		nil)
@@ -824,7 +824,7 @@ func TestEstimateLandPrice_InvalidRidershipScore(t *testing.T) {
 }
 
 func TestHealthCheck(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -840,7 +840,7 @@ func TestHealthCheck(t *testing.T) {
 }
 
 func TestGetPopulationForecast_MissingLatLng(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/population-forecast", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -864,7 +864,7 @@ func TestGetPopulationForecast_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/population-forecast?lat=35.6762&lng=139.6503", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -890,7 +890,7 @@ func TestGetPopulationForecast_UpstreamError(t *testing.T) {
 			return nil, errors.New("upstream error")
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/population-forecast?lat=35.6762&lng=139.6503", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -903,7 +903,7 @@ func TestGetPopulationForecast_UpstreamError(t *testing.T) {
 // ---- GetLandAppraisals ----
 
 func TestGetLandAppraisals_MissingArea(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-appraisals?year=2024", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -914,7 +914,7 @@ func TestGetLandAppraisals_MissingArea(t *testing.T) {
 }
 
 func TestGetLandAppraisals_InvalidYear(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-appraisals?area=13&year=2010", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -933,7 +933,7 @@ func TestGetLandAppraisals_Success(t *testing.T) {
 			}, nil
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-appraisals?area=13&year=2024", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -959,7 +959,7 @@ func TestGetLandAppraisals_NoData(t *testing.T) {
 			return []domain.LandAppraisalItem{}, nil
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-appraisals?area=13&year=2024", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -975,7 +975,7 @@ func TestGetLandAppraisals_UpstreamError(t *testing.T) {
 			return nil, errors.New("upstream error")
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-appraisals?area=13&year=2024", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -986,7 +986,7 @@ func TestGetLandAppraisals_UpstreamError(t *testing.T) {
 }
 
 func TestGetLandAppraisals_InvalidDivision(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/land-appraisals?area=13&year=2024&division=99", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -998,7 +998,7 @@ func TestGetLandAppraisals_InvalidDivision(t *testing.T) {
 
 func TestInternalKeyMiddleware_NoKeySet(t *testing.T) {
 	t.Setenv("APP_INTERNAL_API_KEY", "")
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1009,7 +1009,7 @@ func TestInternalKeyMiddleware_NoKeySet(t *testing.T) {
 
 func TestInternalKeyMiddleware_HealthSkipped(t *testing.T) {
 	t.Setenv("APP_INTERNAL_API_KEY", "secret")
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/health", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1020,7 +1020,7 @@ func TestInternalKeyMiddleware_HealthSkipped(t *testing.T) {
 
 func TestInternalKeyMiddleware_Unauthorized(t *testing.T) {
 	t.Setenv("APP_INTERNAL_API_KEY", "secret")
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/municipalities", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1031,7 +1031,7 @@ func TestInternalKeyMiddleware_Unauthorized(t *testing.T) {
 
 func TestInternalKeyMiddleware_WrongKey(t *testing.T) {
 	t.Setenv("APP_INTERNAL_API_KEY", "secret")
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/municipalities", nil)
 	req.Header.Set("X-Internal-Key", "wrong")
 	w := httptest.NewRecorder()
@@ -1043,7 +1043,7 @@ func TestInternalKeyMiddleware_WrongKey(t *testing.T) {
 
 func TestInternalKeyMiddleware_CorrectKey(t *testing.T) {
 	t.Setenv("APP_INTERNAL_API_KEY", "secret")
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/municipalities?area=13", nil)
 	req.Header.Set("X-Internal-Key", "secret")
 	w := httptest.NewRecorder()
@@ -1054,7 +1054,7 @@ func TestInternalKeyMiddleware_CorrectKey(t *testing.T) {
 }
 
 func TestGetUrbanRisks_MissingParams(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	for _, url := range []string{
 		"/api/urban-risks",
 		"/api/urban-risks?lat=35.68",
@@ -1069,7 +1069,7 @@ func TestGetUrbanRisks_MissingParams(t *testing.T) {
 }
 
 func TestGetUrbanRisks_InvalidRange(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	for _, url := range []string{
 		"/api/urban-risks?lat=10&lng=139.69",  // lat 範囲外（< 20）
 		"/api/urban-risks?lat=35.68&lng=200",  // lng 範囲外（> 154）
@@ -1084,7 +1084,7 @@ func TestGetUrbanRisks_InvalidRange(t *testing.T) {
 }
 
 func TestGetUrbanRisks_EmptyResult(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/urban-risks?lat=35.68&lng=139.69", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1112,7 +1112,7 @@ func TestGetUrbanRisks_WithRisks(t *testing.T) {
 			return []domain.DisasterHistoryItem{{Name: "浸水域", Year: 2019}}, nil
 		},
 	}
-	r := newTestRouter(mock)
+	r := newTestRouter(mock, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/urban-risks?lat=35.68&lng=139.69", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1143,7 +1143,7 @@ func TestGetUrbanRisks_PartialAPIFailure(t *testing.T) {
 			return []domain.DisasterHistoryItem{{Name: "がけ崩れ", Year: 2011}}, nil
 		},
 	}
-	r := newTestRouter(mock)
+	r := newTestRouter(mock, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/urban-risks?lat=35.68&lng=139.69", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1168,7 +1168,7 @@ func TestGetUrbanRisks_PartialAPIFailure(t *testing.T) {
 // ---- /api/investment-score テスト ----
 
 func TestGetInvestmentScore_MissingParams(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	for _, url := range []string{
 		"/api/investment-score",
 		"/api/investment-score?lat=35.68",
@@ -1183,7 +1183,7 @@ func TestGetInvestmentScore_MissingParams(t *testing.T) {
 }
 
 func TestGetInvestmentScore_InvalidRange(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	for _, url := range []string{
 		"/api/investment-score?lat=10&lng=139.69",   // lat 範囲外（< 20）
 		"/api/investment-score?lat=35.68&lng=200",   // lng 範囲外（> 154）
@@ -1198,7 +1198,7 @@ func TestGetInvestmentScore_InvalidRange(t *testing.T) {
 }
 
 func TestGetInvestmentScore_EmptyResult(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/investment-score?lat=35.68&lng=139.69", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1229,7 +1229,7 @@ func TestGetInvestmentScore_WithData(t *testing.T) {
 			return []domain.FloodHazardItem{{DepthRank: 3, RiverName: "多摩川"}}, nil
 		},
 	}
-	r := newTestRouter(mock)
+	r := newTestRouter(mock, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/investment-score?lat=35.68&lng=139.69", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1261,7 +1261,7 @@ func TestGetInvestmentScore_PartialAPIFailure(t *testing.T) {
 			return []domain.UrbanZoningItem{{AreaClassificationJa: "市街化区域"}}, nil
 		},
 	}
-	r := newTestRouter(mock)
+	r := newTestRouter(mock, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/investment-score?lat=35.68&lng=139.69", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1280,7 +1280,7 @@ func TestGetInvestmentScore_PartialAPIFailure(t *testing.T) {
 }
 
 func TestGetHazardInfo_MissingLatLng(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	for _, url := range []string{"/api/hazard", "/api/hazard?lat=35.68", "/api/hazard?lng=139.69"} {
 		req := httptest.NewRequest(http.MethodGet, url, nil)
 		w := httptest.NewRecorder()
@@ -1292,7 +1292,7 @@ func TestGetHazardInfo_MissingLatLng(t *testing.T) {
 }
 
 func TestGetHazardInfo_InvalidLatLng(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	cases := []string{
 		"/api/hazard?lat=999&lng=139.69",  // lat 範囲外
 		"/api/hazard?lat=35.68&lng=200",   // lng 範囲外
@@ -1317,7 +1317,7 @@ func TestGetHazardInfo_Success(t *testing.T) {
 			return []domain.TsunamiHazardItem{{DepthJa: "3m以上"}}, nil
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/hazard?lat=35.68&lng=139.69", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1353,7 +1353,7 @@ func TestGetHazardInfo_PartialAPIFailure(t *testing.T) {
 			return []domain.LandslideHazardItem{{PhenomenonType: 2, ZoneCode: 1}}, nil
 		},
 	}
-	r := newTestRouter(client)
+	r := newTestRouter(client, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/hazard?lat=35.68&lng=139.69", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
@@ -1372,7 +1372,7 @@ func TestGetHazardInfo_PartialAPIFailure(t *testing.T) {
 }
 
 func TestGetHazardInfo_EmptyResult(t *testing.T) {
-	r := newTestRouter(&mockMLITClient{})
+	r := newTestRouter(&mockMLITClient{}, nil)
 	req := httptest.NewRequest(http.MethodGet, "/api/hazard?lat=35.68&lng=139.69", nil)
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -1392,3 +1392,111 @@ func TestGetHazardInfo_EmptyResult(t *testing.T) {
 		t.Errorf("expected 0 risks, got %d", len(risks))
 	}
 }
+
+// mockGeocodeClient は GeocodeClient インターフェースのテスト用モック
+type mockGeocodeClient struct {
+	geocodeFunc func(ctx context.Context, address string) (*GeocodeResult, error)
+}
+
+func (m *mockGeocodeClient) Geocode(ctx context.Context, address string) (*GeocodeResult, error) {
+	if m.geocodeFunc == nil {
+		return &GeocodeResult{Lat: 35.6762, Lng: 139.6503, LocationType: "ROOFTOP"}, nil
+	}
+	return m.geocodeFunc(ctx, address)
+}
+
+func TestGetGeocode(t *testing.T) {
+	tests := []struct {
+		name          string
+		query         string
+		geocodeClient GeocodeClient
+		wantStatus    int
+		wantLat       float64
+		wantLocType   string
+	}{
+		{
+			name:  "正常系 ROOFTOP",
+			query: "address=東京都渋谷区道玄坂1-2",
+			geocodeClient: &mockGeocodeClient{geocodeFunc: func(_ context.Context, _ string) (*GeocodeResult, error) {
+				return &GeocodeResult{Lat: 35.6585, Lng: 139.7013, LocationType: "ROOFTOP"}, nil
+			}},
+			wantStatus:  http.StatusOK,
+			wantLat:     35.6585,
+			wantLocType: "ROOFTOP",
+		},
+		{
+			name:  "正常系 APPROXIMATE",
+			query: "address=東京都",
+			geocodeClient: &mockGeocodeClient{geocodeFunc: func(_ context.Context, _ string) (*GeocodeResult, error) {
+				return &GeocodeResult{Lat: 35.6895, Lng: 139.6917, LocationType: "APPROXIMATE"}, nil
+			}},
+			wantStatus:  http.StatusOK,
+			wantLocType: "APPROXIMATE",
+		},
+		{
+			name:          "address パラメータ欠落 → 400",
+			query:         "",
+			geocodeClient: &mockGeocodeClient{},
+			wantStatus:    http.StatusBadRequest,
+		},
+		{
+			name:  "ZERO_RESULTS（住所未発見） → 400",
+			query: "address=存在しない住所99999",
+			geocodeClient: &mockGeocodeClient{geocodeFunc: func(_ context.Context, _ string) (*GeocodeResult, error) {
+				return nil, errGeocodeNotFound
+			}},
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:  "上流APIエラー → 502",
+			query: "address=東京都渋谷区",
+			geocodeClient: &mockGeocodeClient{geocodeFunc: func(_ context.Context, _ string) (*GeocodeResult, error) {
+				return nil, errGeocodeUpstream
+			}},
+			wantStatus: http.StatusBadGateway,
+		},
+		{
+			name:  "APIキー未設定 → 503",
+			query: "address=東京都渋谷区",
+			geocodeClient: &mockGeocodeClient{geocodeFunc: func(_ context.Context, _ string) (*GeocodeResult, error) {
+				return nil, errGeocodeNotConfigured
+			}},
+			wantStatus: http.StatusServiceUnavailable,
+		},
+		{
+			name:          "geocodeClient nil → 503",
+			query:         "address=東京都渋谷区",
+			geocodeClient: nil,
+			wantStatus:    http.StatusServiceUnavailable,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newTestRouter(&mockMLITClient{}, tc.geocodeClient)
+			apiURL := "/api/geocode"
+			if tc.query != "" {
+				apiURL += "?" + tc.query
+			}
+			req := httptest.NewRequest(http.MethodGet, apiURL, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Errorf("status: want %d, got %d (body: %s)", tc.wantStatus, w.Code, w.Body.String())
+			}
+			if tc.wantStatus == http.StatusOK && tc.wantLat != 0 {
+				var result GeocodeResult
+				if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+					t.Fatalf("failed to decode response: %v", err)
+				}
+				if result.Lat != tc.wantLat {
+					t.Errorf("lat: want %f, got %f", tc.wantLat, result.Lat)
+				}
+				if tc.wantLocType != "" && result.LocationType != tc.wantLocType {
+					t.Errorf("locationType: want %s, got %s", tc.wantLocType, result.LocationType)
+				}
+			}
+		})
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -133,6 +133,7 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/investment-score", h.GetInvestmentScore)
 		api.GET("/investment-score-heatmap", analyzeRL.middleware(), h.GetInvestmentScoreHeatmap)
 		api.GET("/area-discovery", analyzeRL.middleware(), h.HandleAreaDiscovery)
+		api.GET("/geocode", h.GetGeocode)
 	}
 
 	return r

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -1,5 +1,12 @@
 "use client";
 import React, { useState, useEffect, useCallback, useMemo } from "react";
+
+const LOCATION_TYPE_LABEL: Record<string, string> = {
+  ROOFTOP: "番地レベルで取得",
+  RANGE_INTERPOLATED: "住所レベルで取得",
+  GEOMETRIC_CENTER: "地点レベルで取得",
+  APPROXIMATE: "近似位置で取得（精度低）",
+};
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
@@ -319,13 +326,6 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   };
   const setStr = (key: keyof InvestmentInput, value: string) =>
     setInput((prev) => ({ ...prev, [key]: value }));
-
-  const locationTypeLabel: Record<string, string> = {
-    ROOFTOP: "番地レベルで取得",
-    RANGE_INTERPOLATED: "住所レベルで取得",
-    GEOMETRIC_CENTER: "地点レベルで取得",
-    APPROXIMATE: "近似位置で取得（精度低）",
-  };
 
   const handleGeocode = useCallback(async () => {
     if (!addressInput.trim()) return;
@@ -739,6 +739,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                         setPropertyLat("");
                         setPropertyLng("");
                       }}
+                      onKeyDown={(e) => { if (e.key === "Enter") handleGeocode(); }}
                       className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
                       aria-label="物件住所"
                     />
@@ -754,7 +755,7 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   </div>
                   {geocodeStatus === "success" && (
                     <p className="text-xs text-green-600">
-                      ✓ {locationTypeLabel[geocodeLocationType] ?? "座標を取得しました"}
+                      ✓ {LOCATION_TYPE_LABEL[geocodeLocationType] ?? "座標を取得しました"}
                     </p>
                   )}
                   {geocodeStatus === "error" && (

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -8,7 +8,7 @@ import { Slider } from "@/components/ui/slider";
 import type { InvestmentInput, BuildingType, SimulationMode, RateAdjustment } from "@/types/investment";
 import { DEFAULT_INPUT, QUICK_MODE_DEFAULTS } from "@/types/investment";
 import { formatPct } from "@/lib/utils";
-import { fetchMunicipalities, fetchRentDeclineHint, type Municipality } from "@/lib/api";
+import { fetchMunicipalities, fetchRentDeclineHint, fetchGeocode, type Municipality } from "@/lib/api";
 import type { RentDeclineHint } from "@/types/investment";
 import { Search, Calculator, Info, AlertTriangle, ShieldCheck, Zap, SlidersHorizontal, ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
 import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
@@ -164,6 +164,11 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   const [city, setCity] = useState("");
   const [propertyLat, setPropertyLat] = useState("");
   const [propertyLng, setPropertyLng] = useState("");
+  const [addressInput, setAddressInput] = useState("");
+  const [geocodeStatus, setGeocodeStatus] = useState<"idle" | "loading" | "success" | "error">("idle");
+  const [geocodeError, setGeocodeError] = useState("");
+  const [geocodeLocationType, setGeocodeLocationType] = useState("");
+  const [showManualCoords, setShowManualCoords] = useState(false);
 
   useEffect(() => {
     if (externalLat !== undefined && externalLng !== undefined) {
@@ -314,6 +319,31 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
   };
   const setStr = (key: keyof InvestmentInput, value: string) =>
     setInput((prev) => ({ ...prev, [key]: value }));
+
+  const locationTypeLabel: Record<string, string> = {
+    ROOFTOP: "番地レベルで取得",
+    RANGE_INTERPOLATED: "住所レベルで取得",
+    GEOMETRIC_CENTER: "地点レベルで取得",
+    APPROXIMATE: "近似位置で取得（精度低）",
+  };
+
+  const handleGeocode = useCallback(async () => {
+    if (!addressInput.trim()) return;
+    setGeocodeStatus("loading");
+    setGeocodeError("");
+    try {
+      const result = await fetchGeocode(addressInput.trim());
+      setPropertyLat(result.lat.toFixed(6));
+      setPropertyLng(result.lng.toFixed(6));
+      setGeocodeLocationType(result.locationType);
+      setGeocodeStatus("success");
+      setShowManualCoords(false);
+    } catch (e) {
+      setGeocodeError(e instanceof Error ? e.message : "座標取得に失敗しました");
+      setGeocodeStatus("error");
+      setShowManualCoords(true);
+    }
+  }, [addressInput]);
 
   const handleFetchRentHint = useCallback(async () => {
     setRentHintLoading(true);
@@ -693,33 +723,74 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
                   )}
                 </div>
               </div>
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="flex flex-col gap-2">
                 <div className="flex flex-col gap-1">
-                  <label className="text-sm font-medium text-foreground">緯度（任意）</label>
-                  <input
-                    type="number"
-                    inputMode="decimal"
-                    placeholder="例: 35.6762"
-                    step="0.0001"
-                    value={propertyLat}
-                    onChange={(e) => setPropertyLat(e.target.value)}
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                    aria-label="物件の緯度"
-                  />
+                  <label className="text-sm font-medium text-foreground">物件住所（任意）</label>
+                  <p className="text-xs text-muted-foreground">丁目・番地まで入力してください（建物名・部屋番号は不要）</p>
+                  <div className="flex gap-2">
+                    <input
+                      type="text"
+                      placeholder="例: 東京都渋谷区道玄坂1-2"
+                      value={addressInput}
+                      onChange={(e) => {
+                        setAddressInput(e.target.value);
+                        setGeocodeStatus("idle");
+                        setGeocodeLocationType("");
+                        setPropertyLat("");
+                        setPropertyLng("");
+                      }}
+                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                      aria-label="物件住所"
+                    />
+                    <Button
+                      variant="outline"
+                      loading={geocodeStatus === "loading"}
+                      disabled={!addressInput.trim() || geocodeStatus === "loading"}
+                      onClick={handleGeocode}
+                      className="shrink-0"
+                    >
+                      座標を取得
+                    </Button>
+                  </div>
+                  {geocodeStatus === "success" && (
+                    <p className="text-xs text-green-600">
+                      ✓ {locationTypeLabel[geocodeLocationType] ?? "座標を取得しました"}
+                    </p>
+                  )}
+                  {geocodeStatus === "error" && (
+                    <p className="text-xs text-destructive">{geocodeError}</p>
+                  )}
                 </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-sm font-medium text-foreground">経度（任意）</label>
-                  <input
-                    type="number"
-                    inputMode="decimal"
-                    placeholder="例: 139.6503"
-                    step="0.0001"
-                    value={propertyLng}
-                    onChange={(e) => setPropertyLng(e.target.value)}
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                    aria-label="物件の経度"
-                  />
-                </div>
+                {showManualCoords && (
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-medium text-foreground">緯度（手動入力）</label>
+                      <input
+                        type="number"
+                        inputMode="decimal"
+                        placeholder="例: 35.6762"
+                        step="0.0001"
+                        value={propertyLat}
+                        onChange={(e) => setPropertyLat(e.target.value)}
+                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                        aria-label="物件の緯度"
+                      />
+                    </div>
+                    <div className="flex flex-col gap-1">
+                      <label className="text-sm font-medium text-foreground">経度（手動入力）</label>
+                      <input
+                        type="number"
+                        inputMode="decimal"
+                        placeholder="例: 139.6503"
+                        step="0.0001"
+                        value={propertyLng}
+                        onChange={(e) => setPropertyLng(e.target.value)}
+                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                        aria-label="物件の経度"
+                      />
+                    </div>
+                  </div>
+                )}
               </div>
               <p className="text-xs text-muted-foreground">
                 {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します。緯度・経度を入力すると周辺駅の需要スコアも取得します

--- a/frontend/src/components/__tests__/InvestmentForm.test.tsx
+++ b/frontend/src/components/__tests__/InvestmentForm.test.tsx
@@ -8,6 +8,7 @@ import type { SimulationMode } from "@/types/investment";
 vi.mock("@/lib/api", () => ({
   fetchMunicipalities: vi.fn().mockResolvedValue([]),
   fetchRentDeclineHint: vi.fn(),
+  fetchGeocode: vi.fn(),
 }));
 
 import * as api from "@/lib/api";
@@ -321,6 +322,72 @@ describe("InvestmentForm", () => {
       await waitFor(() => {
         expect(screen.queryByText("ネットワークエラー")).not.toBeInTheDocument();
       });
+    });
+  });
+
+  describe("住所ジオコーディング", () => {
+    it("住所入力後「座標を取得」ボタン押下で精度ラベルが表示される", async () => {
+      vi.mocked(api.fetchGeocode).mockResolvedValueOnce({
+        lat: 35.6585,
+        lng: 139.7013,
+        locationType: "ROOFTOP",
+      });
+      renderForm("full");
+
+      await userEvent.type(screen.getByLabelText("物件住所"), "東京都渋谷区道玄坂1-2");
+      await userEvent.click(screen.getByRole("button", { name: "座標を取得" }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/番地レベルで取得/)).toBeInTheDocument();
+      });
+      expect(api.fetchGeocode).toHaveBeenCalledWith("東京都渋谷区道玄坂1-2");
+    });
+
+    it("ZERO_RESULTS エラー時にエラーメッセージと手動入力フォールバックが表示される", async () => {
+      vi.mocked(api.fetchGeocode).mockRejectedValueOnce(new Error("住所が見つかりませんでした。丁目・番地まで入力してください"));
+      renderForm("full");
+
+      await userEvent.type(screen.getByLabelText("物件住所"), "存在しない住所99999");
+      await userEvent.click(screen.getByRole("button", { name: "座標を取得" }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/住所が見つかりませんでした/)).toBeInTheDocument();
+        expect(screen.getByLabelText("物件の緯度")).toBeInTheDocument();
+        expect(screen.getByLabelText("物件の経度")).toBeInTheDocument();
+      });
+    });
+
+    it("上流エラー時にエラーメッセージと手動入力フォールバックが表示される", async () => {
+      vi.mocked(api.fetchGeocode).mockRejectedValueOnce(new Error("座標取得に失敗しました"));
+      renderForm("full");
+
+      await userEvent.type(screen.getByLabelText("物件住所"), "東京都渋谷区");
+      await userEvent.click(screen.getByRole("button", { name: "座標を取得" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("座標取得に失敗しました")).toBeInTheDocument();
+        expect(screen.getByLabelText("物件の緯度")).toBeInTheDocument();
+      });
+    });
+
+    it("住所書き換え後に精度ラベルが消えて座標がクリアされる", async () => {
+      vi.mocked(api.fetchGeocode).mockResolvedValueOnce({
+        lat: 35.6585,
+        lng: 139.7013,
+        locationType: "ROOFTOP",
+      });
+      renderForm("full");
+
+      await userEvent.type(screen.getByLabelText("物件住所"), "東京都渋谷区道玄坂1-2");
+      await userEvent.click(screen.getByRole("button", { name: "座標を取得" }));
+      await waitFor(() => {
+        expect(screen.getByText(/番地レベルで取得/)).toBeInTheDocument();
+      });
+
+      await userEvent.clear(screen.getByLabelText("物件住所"));
+      await userEvent.type(screen.getByLabelText("物件住所"), "東京都新宿区");
+
+      expect(screen.queryByText(/番地レベルで取得/)).not.toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -16,6 +16,7 @@ import type {
   InvestmentScoreResult,
   RentDeclineHint,
   HeatmapResponse,
+  GeocodeResult,
 } from "@/types/investment";
 
 const BASE = "/api";
@@ -277,4 +278,11 @@ export async function simulate(input: MonteCarloInput): Promise<MonteCarloResult
     body: JSON.stringify(input),
   });
   return handleResponse<MonteCarloResult>(res);
+}
+
+/** 住所文字列から緯度・経度を取得（バックエンド経由でGoogle Maps Geocoding API を呼び出す） */
+export async function fetchGeocode(address: string): Promise<GeocodeResult> {
+  const q = new URLSearchParams({ address });
+  const res = await fetch(`${BASE}/geocode?${q}`);
+  return handleResponse<GeocodeResult>(res);
 }

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -425,3 +425,9 @@ export interface WatchlistItem {
   status: WatchlistStatus;
   addedAt: string; // ISO 8601
 }
+
+export interface GeocodeResult {
+  lat: number;
+  lng: number;
+  locationType: "ROOFTOP" | "RANGE_INTERPOLATED" | "GEOMETRIC_CENTER" | "APPROXIMATE";
+}

--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -10,6 +10,7 @@ locals {
     "serviceusage.googleapis.com",
     "cloudtrace.googleapis.com",
     "monitoring.googleapis.com",
+    "geocoding-backend.googleapis.com",
   ])
 }
 

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -65,6 +65,16 @@ resource "google_cloud_run_v2_service" "backend" {
         }
       }
 
+      env {
+        name = "GOOGLE_MAPS_API_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.google_maps_api_key.secret_id
+            version = "latest"
+          }
+        }
+      }
+
       liveness_probe {
         http_get {
           path = "/health"
@@ -95,6 +105,7 @@ resource "google_cloud_run_v2_service" "backend" {
     google_project_service.apis,
     google_secret_manager_secret_iam_member.mlit_accessor,
     google_secret_manager_secret_iam_member.internal_key_accessor,
+    google_secret_manager_secret_iam_member.google_maps_accessor,
     google_project_iam_member.backend_trace_agent,
     google_project_iam_member.backend_metric_writer,
   ]

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -123,6 +123,12 @@ resource "google_secret_manager_secret_iam_member" "internal_key_accessor" {
   member    = "serviceAccount:${google_service_account.backend.email}"
 }
 
+resource "google_secret_manager_secret_iam_member" "google_maps_accessor" {
+  secret_id = google_secret_manager_secret.google_maps_api_key.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.backend.email}"
+}
+
 resource "google_project_iam_member" "backend_trace_agent" {
   project = var.project_id
   role    = "roles/cloudtrace.agent"

--- a/terraform/secret_manager.tf
+++ b/terraform/secret_manager.tf
@@ -23,3 +23,16 @@ resource "google_secret_manager_secret_version" "app_internal_api_key" {
   secret      = google_secret_manager_secret.app_internal_api_key.id
   secret_data = var.app_internal_api_key
 }
+
+resource "google_secret_manager_secret" "google_maps_api_key" {
+  secret_id = "google-maps-api-key-${var.env}"
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret_version" "google_maps_api_key" {
+  secret      = google_secret_manager_secret.google_maps_api_key.id
+  secret_data = var.google_maps_api_key
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -9,6 +9,7 @@
 #   GCP_PROJECT_ID            = var.project_id
 #   MLIT_API_KEY              = var.mlit_api_key
 #   APP_INTERNAL_API_KEY      = var.app_internal_api_key
+#   GOOGLE_MAPS_API_KEY       = var.google_maps_api_key
 #
 # GitHub Variables（Settings → Secrets and variables → Actions → Variables）:
 #   VERCEL_FRONTEND_URL       = var.vercel_frontend_url
@@ -30,6 +31,12 @@ region               = "asia-northeast1"
 env                  = "prod"
 mlit_api_key         = "your-mlit-api-key"
 app_internal_api_key = "generate with: openssl rand -hex 32"
+google_maps_api_key  = "your-google-maps-api-key"
+# Google Maps Geocoding API: 課金リスク管理
+#   1. Google Cloud Console → API とサービス → 割り当て
+#      → "Geocoding API" → 日次上限を設定（推奨: 1000件/日）
+#   2. Google Cloud Console → お支払い → 予算とアラート
+#      → 予算 $1 を作成し、notification_email に通知
 vercel_frontend_url  = "https://your-app.vercel.app"
 notification_email   = "your@email.com"
 billing_account_id   = "XXXXXX-XXXXXX-XXXXXX"  # gcloud billing accounts list で確認

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,6 +31,12 @@ variable "vercel_frontend_url" {
   type        = string
 }
 
+variable "google_maps_api_key" {
+  description = "Google Maps Geocoding API key for server-side address geocoding"
+  type        = string
+  sensitive   = true
+}
+
 variable "billing_account_id" {
   description = "GCP billing account ID for budget alerts (format: XXXXXX-XXXXXX-XXXXXX)"
   type        = string


### PR DESCRIPTION
## 概要

緯度・経度の数値直接入力はユーザーには実質不能だった。住所テキストを入力して「座標を取得」ボタンを押すと、バックエンド経由で Google Maps Geocoding API を呼び出し、座標を自動取得できるようになった。APIキーはサーバーサイドのみで保持し、フロントへの露出なし。

## 変更内容

### Terraform
- `terraform/apis.tf`: `geocoding-backend.googleapis.com` を有効化
- `terraform/secret_manager.tf`: `GOOGLE_MAPS_API_KEY` 用 Secret リソース追加
- `terraform/iam.tf`: Cloud Run の runtime SA に Secret Accessor 権限付与
- `terraform/cloud_run.tf`: Secret Manager 経由で env 注入、`depends_on` 追加
- `terraform/variables.tf`: `google_maps_api_key` 変数追加（sensitive）
- `terraform/terraform.tfvars.example`: 変数・GitHub Secret・クォータ/予算アラート手順を記載

### バックエンド
- `backend/internal/api/geocode_client.go`（新規）: `GeocodeClient` インターフェース + Google 実装。sentinel errors でステータスコードを分岐（ZERO_RESULTS→400、upstream error→502、APIキー未設定→503）
- `backend/internal/api/handler.go`: `Handler` struct に `geocodeClient` 追加、`GetGeocode` ハンドラ追加（住所PII はログマスク処理）
- `backend/internal/api/router.go`: `GET /api/geocode` を `generalRL` グループに追加
- `backend/cmd/server/main.go`: `GOOGLE_MAPS_API_KEY` を読み込み DI
- `.env.example`: `GOOGLE_MAPS_API_KEY` を追記

### フロントエンド
- `frontend/src/types/investment.ts`: `GeocodeResult` 型追加
- `frontend/src/lib/api.ts`: `fetchGeocode` 関数追加
- `frontend/src/components/InvestmentForm.tsx`: 緯度・経度の数値入力を住所テキスト入力 + 「座標を取得」ボタンに置換。精度ラベル表示（ROOFTOP/RANGE_INTERPOLATED/GEOMETRIC_CENTER/APPROXIMATE）、エラー時の手動入力フォールバック、住所変更時の座標リセット処理を実装

## 関連Issue

Closes #355

## テスト

- [x] 既存テストが通ること（backend: race detector 付き全パス / frontend: 232テスト全パス）
- [x] 新規テストを追加した場合、全ケースがPASSすること
  - `TestGetGeocode`: 正常系2ケース・ZERO_RESULTS・上流エラー・APIキー未設定 計6ケース
  - `InvestmentForm` ジオコーディング: 精度ラベル表示・エラーフォールバック・住所書き換えリセット 計4ケース

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] `GOOGLE_MAPS_API_KEY` がブラウザの DevTools ネットワークタブに露出しないことを設計上確認
- [x] APIキー未設定でも他の API エンドポイントが正常動作する（`/api/geocode` のみ 503 を返す）
- [x] Terraform `google_maps_api_key` は `sensitive = true` で tfstate への平文記録を抑制