### PR TITLE
feat(ci): lefthook による pre-commit / pre-push フックの導入

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev backend frontend install logs test lint build clean help \
+.PHONY: dev backend frontend install install-hooks logs test lint build clean help \
         mlit-land-prices mlit-municipalities mlit-station-ridership mlit-population-forecast mlit-land-appraisals \
         mlit-urban-zoning mlit-liquefaction mlit-flood-hazard mlit-storm-hazard mlit-tsunami-hazard mlit-landslide-hazard \
         api-station-ridership api-estimate-ridership api-population-forecast api-land-appraisals api-investment-score \
@@ -36,6 +36,11 @@ frontend:
 ## install: フロントエンド依存関係をインストール
 install:
 	cd frontend && npm install
+
+## install-hooks: lefthook git フックをインストール
+install-hooks:
+	brew install lefthook || true
+	lefthook install
 
 ## logs: Dockerコンテナのログを表示（未起動の場合は案内）
 logs:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,19 @@
+pre-commit:
+  parallel: true
+  commands:
+    go-lint:
+      glob: "backend/**/*.go"
+      run: cd backend && golangci-lint run ./...
+    frontend-lint:
+      glob: "frontend/src/**/*.{ts,tsx}"
+      run: cd frontend && npm run lint
+    frontend-typecheck:
+      glob: "frontend/src/**/*.{ts,tsx}"
+      run: cd frontend && npm run type-check
+
+pre-push:
+  commands:
+    go-test:
+      run: cd backend && go test -race ./... -timeout 120s
+    frontend-test:
+      run: cd frontend && npm test


### PR DESCRIPTION
## 背景・目的

Issue #285 の対応。現在 pre-commit フックが存在しないため、lint エラー・型エラーがあってもコミットでき、CI（約15分）が失敗して初めて気づく状況を改善する。

## 変更内容

### `lefthook.yml`（新規）

| フェーズ | コマンド名 | 実行内容 |
|---------|-----------|---------|
| pre-commit（並列） | go-lint | `cd backend && golangci-lint run ./...` |
| pre-commit（並列） | frontend-lint | `cd frontend && npm run lint` |
| pre-commit（並列） | frontend-typecheck | `cd frontend && npm run type-check` |
| pre-push | go-test | `cd backend && go test -race ./... -timeout 120s` |
| pre-push | frontend-test | `cd frontend && npm test` |

- `golangci-lint` のパスは issue 案（`./backend/...`）から `cd backend && ./...` に修正 → CI の `working-directory: backend` と一致し `.golangci.yml` を確実に読み込む

### `Makefile`

- `.PHONY` に `install-hooks` を追加
- `install-hooks` ターゲットを追加（`make help` に表示される行頭 `## ` 形式）

```bash
make install-hooks  # brew install lefthook && lefthook install
```

## 動作確認

```bash
# フック登録
make install-hooks

# pre-commit を手動実行（変更なしでも全コマンド動作確認）
lefthook run pre-commit

# pre-push を手動実行
lefthook run pre-push
```

## 関連 Issue

Closes #285