### PR TITLE
security: 認証バイパス・タイミング攻撃・エラー漏洩の修正

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -28,6 +28,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	if os.Getenv("GIN_MODE") == "release" && os.Getenv("APP_INTERNAL_API_KEY") == "" {
+		slog.Error("APP_INTERNAL_API_KEY must be set in production (GIN_MODE=release)")
+		os.Exit(1)
+	}
+
 	ctx := context.Background()
 	otelShutdown, err := telemetry.Setup(ctx, "yield-guard-backend", "0.1.0")
 	if err != nil {

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -57,7 +57,8 @@ func (h *Handler) GetLandPrices(c *gin.Context) {
 
 	transactions, err := h.mlitClient.FetchLandPrices(c.Request.Context(), q)
 	if err != nil {
-		badGateway(c, "国交省APIからのデータ取得に失敗しました: "+err.Error())
+		slog.ErrorContext(c.Request.Context(), "FetchLandPrices failed", "err", err)
+		badGateway(c, "国交省APIからのデータ取得に失敗しました")
 		return
 	}
 
@@ -99,7 +100,8 @@ func (h *Handler) CompareLandPrice(c *gin.Context) {
 
 	transactions, err := h.mlitClient.FetchLandPrices(c.Request.Context(), q)
 	if err != nil {
-		badGateway(c, "国交省APIからのデータ取得に失敗しました: "+err.Error())
+		slog.ErrorContext(c.Request.Context(), "FetchLandPrices failed", "err", err)
+		badGateway(c, "国交省APIからのデータ取得に失敗しました")
 		return
 	}
 
@@ -310,7 +312,8 @@ func (h *Handler) EstimateLandPrice(c *gin.Context) {
 
 	transactions, err := h.mlitClient.FetchLandPrices(c.Request.Context(), q)
 	if err != nil {
-		badGateway(c, "国交省APIからのデータ取得に失敗しました: "+err.Error())
+		slog.ErrorContext(c.Request.Context(), "FetchLandPrices failed", "err", err)
+		badGateway(c, "国交省APIからのデータ取得に失敗しました")
 		return
 	}
 
@@ -346,7 +349,8 @@ func (h *Handler) GetStationRidership(c *gin.Context) {
 
 	stations, err := h.mlitClient.FetchStationRidership(c.Request.Context(), z, tx, ty)
 	if err != nil {
-		badGateway(c, "駅別乗降客数の取得に失敗しました: "+err.Error())
+		slog.ErrorContext(c.Request.Context(), "FetchStationRidership failed", "err", err)
+		badGateway(c, "駅別乗降客数の取得に失敗しました")
 		return
 	}
 
@@ -381,7 +385,8 @@ func (h *Handler) GetPopulationForecast(c *gin.Context) {
 
 	items, err := h.mlitClient.FetchPopulationForecast(c.Request.Context(), z, tx, ty)
 	if err != nil {
-		badGateway(c, "将来推計人口の取得に失敗しました: "+err.Error())
+		slog.ErrorContext(c.Request.Context(), "FetchPopulationForecast failed", "err", err)
+		badGateway(c, "将来推計人口の取得に失敗しました")
 		return
 	}
 
@@ -405,7 +410,8 @@ func (h *Handler) GetMunicipalities(c *gin.Context) {
 
 	municipalities, err := h.mlitClient.FetchMunicipalities(c.Request.Context(), area)
 	if err != nil {
-		badGateway(c, "市区町村一覧の取得に失敗しました: "+err.Error())
+		slog.ErrorContext(c.Request.Context(), "FetchMunicipalities failed", "err", err)
+		badGateway(c, "市区町村一覧の取得に失敗しました")
 		return
 	}
 
@@ -439,7 +445,8 @@ func (h *Handler) GetLandAppraisals(c *gin.Context) {
 
 	items, err := h.mlitClient.FetchLandAppraisals(c.Request.Context(), area, city, year, division)
 	if err != nil {
-		badGateway(c, "地価公示APIからのデータ取得に失敗しました: "+err.Error())
+		slog.ErrorContext(c.Request.Context(), "FetchLandAppraisals failed", "err", err)
+		badGateway(c, "地価公示APIからのデータ取得に失敗しました")
 		return
 	}
 
@@ -496,7 +503,7 @@ func (h *Handler) GetRentDeclineHint(c *gin.Context) {
 
 	// 全年エラーの場合のみ502を返す
 	if len(itemsByYear) == 0 && fetchErr != nil {
-		badGateway(c, "地価公示APIからのデータ取得に失敗しました: "+fetchErr.Error())
+		badGateway(c, "地価公示APIからのデータ取得に失敗しました")
 		return
 	}
 
@@ -748,7 +755,8 @@ func (h *Handler) GetInvestmentScore(c *gin.Context) {
 
 	score, err := h.calcScoreForTile(ctx, z, x, y)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		slog.ErrorContext(ctx, "calcScoreForTile failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "投資スコアの計算に失敗しました"})
 		return
 	}
 	c.JSON(http.StatusOK, score)

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -503,6 +503,7 @@ func (h *Handler) GetRentDeclineHint(c *gin.Context) {
 
 	// 全年エラーの場合のみ502を返す
 	if len(itemsByYear) == 0 && fetchErr != nil {
+		slog.ErrorContext(c.Request.Context(), "FetchLandAppraisals failed for all years", "err", fetchErr)
 		badGateway(c, "地価公示APIからのデータ取得に失敗しました")
 		return
 	}

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -1500,3 +1500,94 @@ func TestGetGeocode(t *testing.T) {
 		})
 	}
 }
+
+// TestUpstreamErrorNotExposed は上流APIエラーの詳細がレスポンスに漏洩しないことを検証する
+func TestUpstreamErrorNotExposed(t *testing.T) {
+	// 内部詳細を含む典型的な上流エラー（URLやネットワーク情報）
+	internalErr := errors.New(`Get "https://www.reinfolib.mlit.go.jp/ex-api/external/XIT001": dial tcp 203.0.113.1:443: connect: connection refused`)
+
+	tests := []struct {
+		name        string
+		path        string
+		client      *mockMLITClient
+		wantStatus  int
+		wantMessage string
+	}{
+		{
+			name: "GetLandPrices: 上流エラーが漏洩しない",
+			path: "/api/land-prices/stats?area=13&year=2024&quarter=1&to_year=2024&to_quarter=4",
+			client: &mockMLITClient{fetchFunc: func(_ context.Context, _ mlit.LandPriceQuery) ([]domain.LandTransaction, error) {
+				return nil, internalErr
+			}},
+			wantStatus:  http.StatusBadGateway,
+			wantMessage: "国交省APIからのデータ取得に失敗しました",
+		},
+		{
+			name: "GetMunicipalities: 上流エラーが漏洩しない",
+			path: "/api/municipalities?area=13",
+			client: &mockMLITClient{muniFunc: func(_ context.Context, _ string) ([]mlit.Municipality, error) {
+				return nil, internalErr
+			}},
+			wantStatus:  http.StatusBadGateway,
+			wantMessage: "市区町村一覧の取得に失敗しました",
+		},
+		{
+			name: "GetStationRidership: 上流エラーが漏洩しない",
+			path: "/api/station-ridership?lat=35.68&lng=139.69",
+			client: &mockMLITClient{ridershipFunc: func(_ context.Context, _, _, _ int) ([]mlit.StationRidership, error) {
+				return nil, internalErr
+			}},
+			wantStatus:  http.StatusBadGateway,
+			wantMessage: "駅別乗降客数の取得に失敗しました",
+		},
+		{
+			name: "GetPopulationForecast: 上流エラーが漏洩しない",
+			path: "/api/population-forecast?lat=35.68&lng=139.69",
+			client: &mockMLITClient{populationFunc: func(_ context.Context, _, _, _ int) ([]domain.PopulationForecastItem, error) {
+				return nil, internalErr
+			}},
+			wantStatus:  http.StatusBadGateway,
+			wantMessage: "将来推計人口の取得に失敗しました",
+		},
+		{
+			name: "GetLandAppraisals: 上流エラーが漏洩しない",
+			path: "/api/land-appraisals?area=13&year=2024",
+			client: &mockMLITClient{appraisalFunc: func(_ context.Context, _, _ string, _ int, _ string) ([]domain.LandAppraisalItem, error) {
+				return nil, internalErr
+			}},
+			wantStatus:  http.StatusBadGateway,
+			wantMessage: "地価公示APIからのデータ取得に失敗しました",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newTestRouter(tc.client, nil)
+			req := httptest.NewRequest(http.MethodGet, tc.path, nil)
+			w := httptest.NewRecorder()
+			r.ServeHTTP(w, req)
+
+			if w.Code != tc.wantStatus {
+				t.Errorf("status: want %d, got %d", tc.wantStatus, w.Code)
+			}
+
+			body := w.Body.String()
+
+			// 上流エラーの内部詳細がレスポンスに含まれていないことを確認
+			if strings.Contains(body, "reinfolib.mlit.go.jp") {
+				t.Errorf("response must not contain upstream URL: %s", body)
+			}
+			if strings.Contains(body, "dial tcp") {
+				t.Errorf("response must not contain network error details: %s", body)
+			}
+			if strings.Contains(body, "connect: connection refused") {
+				t.Errorf("response must not contain connection error details: %s", body)
+			}
+
+			// 汎用メッセージが返っていることを確認
+			if !strings.Contains(body, tc.wantMessage) {
+				t.Errorf("response body %q must contain %q", body, tc.wantMessage)
+			}
+		})
+	}
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"crypto/subtle"
 	"fmt"
 	"io"
 	"log/slog"
@@ -18,8 +19,9 @@ import (
 
 func internalKeyMiddleware() gin.HandlerFunc {
 	key := os.Getenv("APP_INTERNAL_API_KEY")
+	keyBytes := []byte(key)
 	return func(c *gin.Context) {
-		if key != "" && c.GetHeader("X-Internal-Key") != key {
+		if key != "" && subtle.ConstantTimeCompare([]byte(c.GetHeader("X-Internal-Key")), keyBytes) != 1 {
 			c.AbortWithStatus(http.StatusUnauthorized)
 			return
 		}


### PR DESCRIPTION
## 概要

セキュリティレビューで発見された本番環境で悪用可能な脆弱性3件を修正する。

## 変更内容

### 1. 認証完全バイパスの修正（HIGH）— `backend/cmd/server/main.go`

`APP_INTERNAL_API_KEY` が未設定の場合、`internalKeyMiddleware` の条件式が短絡評価で `false` になり、全 `/api/*` エンドポイントが認証なしで公開される問題。
`GIN_MODE=release` かつキーが空の場合に起動時 `os.Exit(1)` で拒否するチェックを追加した。

### 2. タイミング攻撃によるAPIキー漏洩の修正（HIGH）— `backend/internal/api/router.go`

Go の `!=` による文字列比較は非定数時間のため、応答時間の統計的分析でキーを1文字ずつ推定できる問題。
`crypto/subtle.ConstantTimeCompare` に置換した。キーバイト列はミドルウェア初期化時に1度だけ変換する。

### 3. 上流エラー詳細の外部漏洩修正（MEDIUM）— `backend/internal/api/handler.go`

502/500 レスポンスに `err.Error()` をそのまま含めており、国交省 API の URL・HTTPステータス・ネットワークエラーなどの内部情報がクライアントに露出する問題。
エラーは `slog.ErrorContext` でサーバーサイドにのみ記録し、クライアントへは汎用メッセージのみ返すよう変更した（9箇所）。
`GetRentDeclineHint` の全年エラーパスも同様に修正。

## 関連Issue

なし（セキュリティレビューによる自発的修正）

## テスト

- [x] 既存テストが通ること（`go test -race ./...` 全パッケージ PASS）
- [x] `go vet ./...` クリーン
- [x] ローカル起動確認：`GIN_MODE` 未設定（debug）ではキーなしで起動できること
- [x] `GIN_MODE=release` かつ `APP_INTERNAL_API_KEY=""` で起動拒否されること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み