### PR TITLE
feat(mobile): モバイルにシミュレーションモード切替を表示

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -14,7 +14,8 @@ import type { InvestmentInput, InvestmentResult, LandPriceComparison, Theoretica
 import { analyze as analyzeOnline, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks, fetchHazardInfo, fetchInvestmentScore, simulate } from "@/lib/api";
 import { analyze as analyzeOffline } from "@/lib/investment";
 import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
-import { ShieldAlert, Info, FileDown, Share2, Check, SlidersHorizontal, X, WifiOff, Zap } from "lucide-react";
+import { ShieldAlert, Info, FileDown, Share2, Check, SlidersHorizontal, X, WifiOff } from "lucide-react";
+import { SimulationModeToggle } from "@/components/SimulationModeToggle";
 import { Button } from "@/components/ui/button";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 import { downloadReportPDF } from "@/lib/generatePdf";
@@ -431,42 +432,11 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
 
             {/* Mobile: simulation mode toggle (PC は左サイドバーの InvestmentForm 内に表示) */}
             {activeTab === "simulation" && (
-              <div className="flex rounded-lg border bg-muted p-1 gap-1 lg:hidden" role="group" aria-label="シミュレーションモード">
-                <button
-                  type="button"
-                  role="radio"
-                  aria-checked={simulationMode === "quick"}
-                  onClick={() => handleModeChange("quick")}
-                  className={`flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-                    simulationMode === "quick"
-                      ? "bg-primary text-white shadow-sm"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  <span className="flex items-center gap-1.5">
-                    <Zap className="h-3.5 w-3.5" />
-                    クイック
-                  </span>
-                  <span className="text-xs font-normal opacity-75">内覧でサッと試す</span>
-                </button>
-                <button
-                  type="button"
-                  role="radio"
-                  aria-checked={simulationMode === "full"}
-                  onClick={() => handleModeChange("full")}
-                  className={`flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-                    simulationMode === "full"
-                      ? "bg-primary text-white shadow-sm"
-                      : "text-muted-foreground hover:text-foreground"
-                  }`}
-                >
-                  <span className="flex items-center gap-1.5">
-                    <SlidersHorizontal className="h-3.5 w-3.5" />
-                    詳細
-                  </span>
-                  <span className="text-xs font-normal opacity-75">じっくり分析する</span>
-                </button>
-              </div>
+              <SimulationModeToggle
+                mode={simulationMode}
+                onChange={handleModeChange}
+                className="lg:hidden"
+              />
             )}
 
             {activeTab === "area-discovery" && (
@@ -614,6 +584,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                 isOnline={isOnline}
                 externalLat={propertyLat}
                 externalLng={propertyLng}
+                showModeToggle={false}
               />
             </div>
           </div>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -14,7 +14,7 @@ import type { InvestmentInput, InvestmentResult, LandPriceComparison, Theoretica
 import { analyze as analyzeOnline, compareLandPrice, estimateLandPrice, fetchStationRidership, fetchPopulationForecast, fetchLandAppraisals, fetchUrbanRisks, fetchHazardInfo, fetchInvestmentScore, simulate } from "@/lib/api";
 import { analyze as analyzeOffline } from "@/lib/investment";
 import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
-import { ShieldAlert, Info, FileDown, Share2, Check, SlidersHorizontal, X, WifiOff } from "lucide-react";
+import { ShieldAlert, Info, FileDown, Share2, Check, SlidersHorizontal, X, WifiOff, Zap } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 import { downloadReportPDF } from "@/lib/generatePdf";
@@ -428,6 +428,46 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                 エリアを探す
               </button>
             </div>
+
+            {/* Mobile: simulation mode toggle (PC は左サイドバーの InvestmentForm 内に表示) */}
+            {activeTab === "simulation" && (
+              <div className="flex rounded-lg border bg-muted p-1 gap-1 lg:hidden" role="group" aria-label="シミュレーションモード">
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={simulationMode === "quick"}
+                  onClick={() => handleModeChange("quick")}
+                  className={`flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                    simulationMode === "quick"
+                      ? "bg-primary text-white shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <span className="flex items-center gap-1.5">
+                    <Zap className="h-3.5 w-3.5" />
+                    クイック
+                  </span>
+                  <span className="text-xs font-normal opacity-75">内覧でサッと試す</span>
+                </button>
+                <button
+                  type="button"
+                  role="radio"
+                  aria-checked={simulationMode === "full"}
+                  onClick={() => handleModeChange("full")}
+                  className={`flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+                    simulationMode === "full"
+                      ? "bg-primary text-white shadow-sm"
+                      : "text-muted-foreground hover:text-foreground"
+                  }`}
+                >
+                  <span className="flex items-center gap-1.5">
+                    <SlidersHorizontal className="h-3.5 w-3.5" />
+                    詳細
+                  </span>
+                  <span className="text-xs font-normal opacity-75">じっくり分析する</span>
+                </button>
+              </div>
+            )}
 
             {activeTab === "area-discovery" && (
               <>

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -17,7 +17,8 @@ import { DEFAULT_INPUT, QUICK_MODE_DEFAULTS } from "@/types/investment";
 import { formatPct } from "@/lib/utils";
 import { fetchMunicipalities, fetchRentDeclineHint, fetchGeocode, type Municipality } from "@/lib/api";
 import type { RentDeclineHint } from "@/types/investment";
-import { Search, Calculator, Info, AlertTriangle, ShieldCheck, Zap, SlidersHorizontal, ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
+import { Search, Calculator, Info, AlertTriangle, ShieldCheck, ChevronDown, ChevronUp, Plus, Trash2 } from "lucide-react";
+import { SimulationModeToggle } from "@/components/SimulationModeToggle";
 import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
 
 const QUICK_HISTORY_KEY = "yield-guard:quick-history";
@@ -109,6 +110,7 @@ interface Props {
   isOnline?: boolean | null;
   externalLat?: number;
   externalLng?: number;
+  showModeToggle?: boolean;
 }
 
 function getPeriodLabel(): string {
@@ -165,7 +167,7 @@ function validateQuick(quickTotalPriceMan: string, input: InvestmentInput): Form
   return e;
 }
 
-export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulationMode, onModeChange, initialInput, initialQuickTotalPriceMan, isOnline = null, externalLat, externalLng }: Props) {
+export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulationMode, onModeChange, initialInput, initialQuickTotalPriceMan, isOnline = null, externalLat, externalLng, showModeToggle = true }: Props) {
   const [input, setInput] = useState<InvestmentInput>({ ...DEFAULT_INPUT, ...initialInput });
   const [area, setArea] = useState("10");
   const [city, setCity] = useState("");
@@ -453,43 +455,9 @@ export function InvestmentForm({ onAnalyze, onFetchLandPrices, loading, simulati
 
   return (
     <div className="space-y-4">
-      {/* モード切替 */}
-      <div className="flex rounded-lg border bg-muted p-1 gap-1" role="group" aria-label="シミュレーションモード">
-        <button
-          type="button"
-          role="radio"
-          aria-checked={simulationMode === "quick"}
-          onClick={() => onModeChange("quick")}
-          className={`flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-            simulationMode === "quick"
-              ? "bg-primary text-white shadow-sm"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <span className="flex items-center gap-1.5">
-            <Zap className="h-3.5 w-3.5" />
-            クイック
-          </span>
-          <span className="text-xs font-normal opacity-75">内覧でサッと試す</span>
-        </button>
-        <button
-          type="button"
-          role="radio"
-          aria-checked={simulationMode === "full"}
-          onClick={() => onModeChange("full")}
-          className={`flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
-            simulationMode === "full"
-              ? "bg-primary text-white shadow-sm"
-              : "text-muted-foreground hover:text-foreground"
-          }`}
-        >
-          <span className="flex items-center gap-1.5">
-            <SlidersHorizontal className="h-3.5 w-3.5" />
-            詳細
-          </span>
-          <span className="text-xs font-normal opacity-75">じっくり分析する</span>
-        </button>
-      </div>
+      {showModeToggle && (
+        <SimulationModeToggle mode={simulationMode} onChange={onModeChange} />
+      )}
 
       {/* ─── クイックモード ─── */}
       {isQuick && (

--- a/frontend/src/components/SimulationModeToggle.tsx
+++ b/frontend/src/components/SimulationModeToggle.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { Zap, SlidersHorizontal } from "lucide-react";
+import type { SimulationMode } from "@/types/investment";
+
+interface Props {
+  mode: SimulationMode;
+  onChange: (mode: SimulationMode) => void;
+  className?: string;
+}
+
+export function SimulationModeToggle({ mode, onChange, className }: Props) {
+  return (
+    <div
+      className={`flex rounded-lg border bg-muted p-1 gap-1${className ? ` ${className}` : ""}`}
+      role="group"
+      aria-label="シミュレーションモード"
+    >
+      <button
+        type="button"
+        role="radio"
+        aria-checked={mode === "quick"}
+        onClick={() => onChange("quick")}
+        className={`flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+          mode === "quick"
+            ? "bg-primary text-white shadow-sm"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <span className="flex items-center gap-1.5">
+          <Zap className="h-3.5 w-3.5" />
+          クイック
+        </span>
+        <span className="text-xs font-normal opacity-75">内覧でサッと試す</span>
+      </button>
+      <button
+        type="button"
+        role="radio"
+        aria-checked={mode === "full"}
+        onClick={() => onChange("full")}
+        className={`flex flex-1 flex-col items-center justify-center gap-0.5 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
+          mode === "full"
+            ? "bg-primary text-white shadow-sm"
+            : "text-muted-foreground hover:text-foreground"
+        }`}
+      >
+        <span className="flex items-center gap-1.5">
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          詳細
+        </span>
+        <span className="text-xs font-normal opacity-75">じっくり分析する</span>
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

モバイルでクイック/詳細モード切替と物件・投資条件が見えない問題を修正しました。

## 問題

PC では左サイドバーに `InvestmentForm`（クイック/詳細モード切替 + フォーム）が常時表示されます。
一方モバイルでは `InvestmentForm` が `hidden lg:block` の `<aside>` に入っており、
「条件を編集」ボタンを押してボトムシートを開かないとモード切替すら見えない状態でした。

## 修正内容

`Dashboard.tsx` のシミュレーションタブ内に、モバイル専用（`lg:hidden`）のクイック/詳細モード切替 UI を追加しました。

- モバイルでボトムシートを開かずにモード切替できる
- 「条件を編集」ボタンからフォーム全体は引き続き編集可能
- PC（lg 以上）には影響なし

## 確認方法

- [ ] モバイル幅でシミュレーションタブを開き、クイック/詳細の切替ボタンが表示されることを確認
- [ ] クイック⇔詳細を切り替えるとモードが変わることを確認
- [ ] 「条件を編集」から開いたボトムシート内でも同様に切替可能なことを確認
- [ ] PC（lg 以上）ではモード切替が左サイドバーのみに表示されることを確認