### PR TITLE
test(backend): investment_score / cache / router のユニットテスト追加 (#327)

### DIFF
--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -1,0 +1,171 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// --- CORS ヘッダー ---
+
+func TestRouter_CORS_DefaultOrigin(t *testing.T) {
+	// ALLOW_ORIGINS 未設定 → デフォルト http://localhost:3000 が許可される
+	t.Setenv("ALLOW_ORIGINS", "")
+
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	got := w.Header().Get("Access-Control-Allow-Origin")
+	if got != "http://localhost:3000" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "http://localhost:3000")
+	}
+}
+
+func TestRouter_CORS_CustomOrigin(t *testing.T) {
+	// ALLOW_ORIGINS に設定したオリジンが許可される
+	t.Setenv("ALLOW_ORIGINS", "http://app.example.com")
+
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "http://app.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	got := w.Header().Get("Access-Control-Allow-Origin")
+	if got != "http://app.example.com" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "http://app.example.com")
+	}
+}
+
+func TestRouter_CORS_UnknownOriginNotReflected(t *testing.T) {
+	// 許可リストにないオリジンはヘッダーに反映されない
+	t.Setenv("ALLOW_ORIGINS", "http://app.example.com")
+
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	req.Header.Set("Origin", "http://evil.example.com")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	got := w.Header().Get("Access-Control-Allow-Origin")
+	if got == "http://evil.example.com" {
+		t.Errorf("unlisted origin was reflected in Access-Control-Allow-Origin")
+	}
+}
+
+func TestRouter_CORS_Preflight(t *testing.T) {
+	// OPTIONS プリフライトリクエストに対して許可メソッドが返る
+	t.Setenv("ALLOW_ORIGINS", "http://localhost:3000")
+
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	req := httptest.NewRequest(http.MethodOptions, "/health", nil)
+	req.Header.Set("Origin", "http://localhost:3000")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	methods := w.Header().Get("Access-Control-Allow-Methods")
+	if methods == "" {
+		t.Error("Access-Control-Allow-Methods header is missing in preflight response")
+	}
+}
+
+func TestRouter_CORS_MultipleOrigins(t *testing.T) {
+	// カンマ区切りで複数オリジンを許可できる
+	t.Setenv("ALLOW_ORIGINS", "http://a.example.com,http://b.example.com")
+
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	for _, origin := range []string{"http://a.example.com", "http://b.example.com"} {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Header.Set("Origin", origin)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		got := w.Header().Get("Access-Control-Allow-Origin")
+		if got != origin {
+			t.Errorf("origin %q: Access-Control-Allow-Origin = %q, want %q", origin, got, origin)
+		}
+	}
+}
+
+// --- ルート登録 ---
+
+func TestRouter_HealthEndpoint(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("GET /health status = %d, want 200", w.Code)
+	}
+}
+
+func TestRouter_UnknownRoute_Returns404(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/no-such-route", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("unknown route status = %d, want 404", w.Code)
+	}
+}
+
+// --- 認証ミドルウェア ---
+
+func TestRouter_InternalKey_Required_WhenSet(t *testing.T) {
+	// APP_INTERNAL_API_KEY が設定されているとき、キーなしリクエストは 401
+	t.Setenv("APP_INTERNAL_API_KEY", "secret-key")
+
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/municipalities?area=13", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 when key is missing", w.Code)
+	}
+}
+
+func TestRouter_InternalKey_Accepted_WhenCorrect(t *testing.T) {
+	// 正しいキーを付けると認証を通過する
+	t.Setenv("APP_INTERNAL_API_KEY", "secret-key")
+
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/municipalities?area=13", nil)
+	req.Header.Set("X-Internal-Key", "secret-key")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Error("correct key was rejected")
+	}
+}
+
+func TestRouter_InternalKey_NotRequired_WhenUnset(t *testing.T) {
+	// APP_INTERNAL_API_KEY 未設定のときはキーなしでも通過する
+	t.Setenv("APP_INTERNAL_API_KEY", "")
+
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	req := httptest.NewRequest(http.MethodGet, "/api/municipalities?area=13", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code == http.StatusUnauthorized {
+		t.Error("request was rejected even though APP_INTERNAL_API_KEY is not set")
+	}
+}

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -140,7 +140,7 @@ func TestRouter_InternalKey_Required_WhenSet(t *testing.T) {
 }
 
 func TestRouter_InternalKey_Accepted_WhenCorrect(t *testing.T) {
-	// 正しいキーを付けると認証を通過する
+	// 正しいキーを付けると認証を通過して 200 が返る
 	t.Setenv("APP_INTERNAL_API_KEY", "secret-key")
 
 	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
@@ -150,13 +150,13 @@ func TestRouter_InternalKey_Accepted_WhenCorrect(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	if w.Code == http.StatusUnauthorized {
-		t.Error("correct key was rejected")
+	if w.Code != http.StatusOK {
+		t.Errorf("correct key: status = %d, want 200", w.Code)
 	}
 }
 
 func TestRouter_InternalKey_NotRequired_WhenUnset(t *testing.T) {
-	// APP_INTERNAL_API_KEY 未設定のときはキーなしでも通過する
+	// APP_INTERNAL_API_KEY 未設定のときはキーなしでも 200 が返る
 	t.Setenv("APP_INTERNAL_API_KEY", "")
 
 	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
@@ -165,7 +165,7 @@ func TestRouter_InternalKey_NotRequired_WhenUnset(t *testing.T) {
 	w := httptest.NewRecorder()
 	r.ServeHTTP(w, req)
 
-	if w.Code == http.StatusUnauthorized {
-		t.Error("request was rejected even though APP_INTERNAL_API_KEY is not set")
+	if w.Code != http.StatusOK {
+		t.Errorf("no key set: status = %d, want 200", w.Code)
 	}
 }

--- a/backend/internal/domain/investment_score_test.go
+++ b/backend/internal/domain/investment_score_test.go
@@ -1,0 +1,449 @@
+package domain
+
+import (
+	"testing"
+	"time"
+)
+
+// --- gradeFromScore ---
+
+func TestGradeFromScore_Boundaries(t *testing.T) {
+	tests := []struct {
+		score int
+		want  string
+	}{
+		{100, "優良"},
+		{80, "優良"},
+		{79, "良好"},
+		{65, "良好"},
+		{64, "普通"},
+		{50, "普通"},
+		{49, "注意"},
+		{35, "注意"},
+		{34, "要注意"},
+		{0, "要注意"},
+	}
+	for _, tc := range tests {
+		got := gradeFromScore(tc.score)
+		if got != tc.want {
+			t.Errorf("gradeFromScore(%d) = %q, want %q", tc.score, got, tc.want)
+		}
+	}
+}
+
+// --- calcPopulationScore ---
+
+func TestCalcPopulationScore_Empty(t *testing.T) {
+	s := calcPopulationScore(nil)
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+	if s.Description != "データなし" {
+		t.Errorf("description = %q, want 'データなし'", s.Description)
+	}
+}
+
+func TestCalcPopulationScore_Growth30pct(t *testing.T) {
+	// CalcPopulationForecast は Year=2020 を base、Year=2050 を future として変化率を計算する
+	// 2020=100, 2050=130 → +30% → スコア +15
+	items := []PopulationForecastItem{
+		{Year: 2020, Pop: 100},
+		{Year: 2050, Pop: 130},
+	}
+	s := calcPopulationScore(items)
+	if s.Score != 15 {
+		t.Errorf("score = %d, want 15", s.Score)
+	}
+}
+
+func TestCalcPopulationScore_Decline50pct(t *testing.T) {
+	// 2020=100, 2050=50 → -50% → スコア -15
+	items := []PopulationForecastItem{
+		{Year: 2020, Pop: 100},
+		{Year: 2050, Pop: 50},
+	}
+	s := calcPopulationScore(items)
+	if s.Score != -15 {
+		t.Errorf("score = %d, want -15", s.Score)
+	}
+}
+
+func TestCalcPopulationScore_NoChange(t *testing.T) {
+	// 変化なし → スコア 0
+	items := []PopulationForecastItem{
+		{Year: 2020, Pop: 100},
+		{Year: 2050, Pop: 100},
+	}
+	s := calcPopulationScore(items)
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+}
+
+// --- calcRidershipScore ---
+
+func TestCalcRidershipScore_Empty(t *testing.T) {
+	s := calcRidershipScore(nil)
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+	if s.Description != "駅データなし" {
+		t.Errorf("description = %q, want '駅データなし'", s.Description)
+	}
+}
+
+func TestCalcRidershipScore_FullScore(t *testing.T) {
+	// 200,000 人/日 → 上限 +20
+	s := calcRidershipScore([]StationRidershipResult{
+		{StationName: "渋谷", Passengers: 200_000},
+	})
+	if s.Score != 20 {
+		t.Errorf("score = %d, want 20", s.Score)
+	}
+}
+
+func TestCalcRidershipScore_CappedAt20(t *testing.T) {
+	// 200,000 超でも 20 を超えない
+	s := calcRidershipScore([]StationRidershipResult{
+		{StationName: "新宿", Passengers: 500_000},
+	})
+	if s.Score != 20 {
+		t.Errorf("score = %d, want 20 (capped)", s.Score)
+	}
+}
+
+func TestCalcRidershipScore_BestStationChosen(t *testing.T) {
+	// 複数駅のうち最大乗降客数の駅が採用される
+	s := calcRidershipScore([]StationRidershipResult{
+		{StationName: "A駅", Passengers: 50_000},
+		{StationName: "B駅", Passengers: 200_000},
+	})
+	if s.Score != 20 {
+		t.Errorf("score = %d, want 20", s.Score)
+	}
+}
+
+// --- calcUrbanAreaScore ---
+
+func TestCalcUrbanAreaScore_Empty(t *testing.T) {
+	s := calcUrbanAreaScore(nil)
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+}
+
+func TestCalcUrbanAreaScore_InMarketArea(t *testing.T) {
+	// 市街化区域 → +10
+	s := calcUrbanAreaScore([]UrbanZoningItem{
+		{AreaClassificationJa: "市街化区域"},
+	})
+	if s.Score != 10 {
+		t.Errorf("score = %d, want 10", s.Score)
+	}
+}
+
+func TestCalcUrbanAreaScore_AdjustedArea(t *testing.T) {
+	// 市街化調整区域（"調整" を含む） → 0
+	s := calcUrbanAreaScore([]UrbanZoningItem{
+		{AreaClassificationJa: "市街化調整区域"},
+	})
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+}
+
+// --- calcLocationOptScore ---
+
+func TestCalcLocationOptScore_NotPlanned(t *testing.T) {
+	// 立地適正化計画未策定（空） → 0
+	s := calcLocationOptScore(nil)
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+}
+
+func TestCalcLocationOptScore_InResidenceZone(t *testing.T) {
+	// 居住誘導区域内 → +10
+	s := calcLocationOptScore([]LocationOptimizationItem{
+		{KubunNameJa: "居住誘導区域"},
+	})
+	if s.Score != 10 {
+		t.Errorf("score = %d, want 10", s.Score)
+	}
+}
+
+func TestCalcLocationOptScore_OutsideZone(t *testing.T) {
+	// 策定済みだが居住誘導区域外 → -5
+	s := calcLocationOptScore([]LocationOptimizationItem{
+		{KubunNameJa: "都市機能誘導区域"},
+	})
+	if s.Score != -5 {
+		t.Errorf("score = %d, want -5", s.Score)
+	}
+}
+
+// --- calcHazardScore ---
+
+func TestCalcHazardScore_AllEmpty(t *testing.T) {
+	s := calcHazardScore(nil, nil, nil, nil)
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+}
+
+func TestCalcHazardScore_FloodHighRank(t *testing.T) {
+	// 浸水深ランク >= 3 → -5
+	s := calcHazardScore([]FloodHazardItem{{DepthRank: 3}}, nil, nil, nil)
+	if s.Score != -5 {
+		t.Errorf("score = %d, want -5", s.Score)
+	}
+}
+
+func TestCalcHazardScore_FloodLowRank(t *testing.T) {
+	// 浸水深ランク 1 → -3
+	s := calcHazardScore([]FloodHazardItem{{DepthRank: 1}}, nil, nil, nil)
+	if s.Score != -3 {
+		t.Errorf("score = %d, want -3", s.Score)
+	}
+}
+
+func TestCalcHazardScore_Storm(t *testing.T) {
+	// 高潮リスク → -5
+	s := calcHazardScore(nil, []StormHazardItem{{DepthJa: "0.5m未満"}}, nil, nil)
+	if s.Score != -5 {
+		t.Errorf("score = %d, want -5", s.Score)
+	}
+}
+
+func TestCalcHazardScore_Tsunami(t *testing.T) {
+	// 津波リスク → -5
+	s := calcHazardScore(nil, nil, []TsunamiHazardItem{{DepthJa: "0.3m未満"}}, nil)
+	if s.Score != -5 {
+		t.Errorf("score = %d, want -5", s.Score)
+	}
+}
+
+func TestCalcHazardScore_LandslideSpecialZone(t *testing.T) {
+	// 特別警戒区域（ZoneCode=1）→ -5
+	s := calcHazardScore(nil, nil, nil, []LandslideHazardItem{{ZoneCode: 1}})
+	if s.Score != -5 {
+		t.Errorf("score = %d, want -5", s.Score)
+	}
+}
+
+func TestCalcHazardScore_LandslideWarningZone(t *testing.T) {
+	// 警戒区域（ZoneCode=2）→ -3
+	s := calcHazardScore(nil, nil, nil, []LandslideHazardItem{{ZoneCode: 2}})
+	if s.Score != -3 {
+		t.Errorf("score = %d, want -3", s.Score)
+	}
+}
+
+func TestCalcHazardScore_ClampedToMinus20(t *testing.T) {
+	// 全ハザード重複 → -20 を下回らない
+	flood := []FloodHazardItem{{DepthRank: 5}}
+	storm := []StormHazardItem{{DepthJa: "1m"}}
+	tsunami := []TsunamiHazardItem{{DepthJa: "1m"}}
+	landslide := []LandslideHazardItem{{ZoneCode: 1}}
+	s := calcHazardScore(flood, storm, tsunami, landslide)
+	if s.Score < -20 {
+		t.Errorf("score %d is below minimum -20", s.Score)
+	}
+}
+
+// --- calcLiquefactionScore ---
+
+func TestCalcLiquefactionScore_Empty(t *testing.T) {
+	s := calcLiquefactionScore(nil)
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+}
+
+func TestCalcLiquefactionScore_HighRisk(t *testing.T) {
+	// TendencyLevel <= 2 → -10
+	s := calcLiquefactionScore([]LiquefactionRiskItem{{TendencyLevel: 1}})
+	if s.Score != -10 {
+		t.Errorf("score = %d, want -10", s.Score)
+	}
+}
+
+func TestCalcLiquefactionScore_MediumRisk(t *testing.T) {
+	// TendencyLevel 3-4 → -5
+	s := calcLiquefactionScore([]LiquefactionRiskItem{{TendencyLevel: 3}})
+	if s.Score != -5 {
+		t.Errorf("score = %d, want -5", s.Score)
+	}
+}
+
+func TestCalcLiquefactionScore_LowRisk(t *testing.T) {
+	// TendencyLevel > 4 → 0
+	s := calcLiquefactionScore([]LiquefactionRiskItem{{TendencyLevel: 5}})
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+}
+
+// --- calcEmbankmentScore ---
+
+func TestCalcEmbankmentScore_Empty(t *testing.T) {
+	// 大規模盛土造成地に非該当 → 0
+	s := calcEmbankmentScore(nil)
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+}
+
+func TestCalcEmbankmentScore_HasItem(t *testing.T) {
+	// 該当あり → -5
+	s := calcEmbankmentScore([]EmbankmentItem{{Classification: "谷埋め型"}})
+	if s.Score != -5 {
+		t.Errorf("score = %d, want -5", s.Score)
+	}
+}
+
+// --- disasterScoreByYear ---
+
+func TestDisasterScoreByYear_Table(t *testing.T) {
+	cur := time.Now().Year()
+	tests := []struct {
+		label string
+		year  int
+		want  int
+	}{
+		{"年不明(0)", 0, -10},
+		{"5年前", cur - 5, -10},
+		{"ちょうど10年前", cur - 10, -10},
+		{"11年前", cur - 11, -5},
+		{"ちょうど30年前", cur - 30, -5},
+		{"31年前", cur - 31, -2},
+		{"50年前", cur - 50, -2},
+	}
+	for _, tc := range tests {
+		got := disasterScoreByYear(tc.year, cur)
+		if got != tc.want {
+			t.Errorf("[%s] disasterScoreByYear(%d, %d) = %d, want %d",
+				tc.label, tc.year, cur, got, tc.want)
+		}
+	}
+}
+
+func TestCalcDisasterScore_Empty(t *testing.T) {
+	s := calcDisasterScore(nil)
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0", s.Score)
+	}
+}
+
+func TestCalcDisasterScore_RecentDisaster(t *testing.T) {
+	cur := time.Now().Year()
+	s := calcDisasterScore([]DisasterHistoryItem{
+		{Name: "浸水域", Year: cur - 3},
+	})
+	if s.Score != -10 {
+		t.Errorf("score = %d, want -10", s.Score)
+	}
+}
+
+func TestCalcDisasterScore_Deduplication(t *testing.T) {
+	// 同名の災害は重複カウントしない
+	cur := time.Now().Year()
+	items := []DisasterHistoryItem{
+		{Name: "浸水域", Year: cur - 3},
+		{Name: "浸水域", Year: cur - 3}, // 重複
+	}
+	s1 := calcDisasterScore(items[:1])
+	s2 := calcDisasterScore(items)
+	if s1.Score != s2.Score {
+		t.Errorf("duplicate disaster items changed score: s1=%d s2=%d", s1.Score, s2.Score)
+	}
+}
+
+// --- CalcInvestmentScore 統合 ---
+
+func TestCalcInvestmentScore_AllEmpty_BaseScore(t *testing.T) {
+	// 全データ空 → baseScore=50 から加減なしで 0〜100 の範囲内
+	result := CalcInvestmentScore(InvestmentScoreInput{})
+	if result.TotalScore < 0 || result.TotalScore > 100 {
+		t.Errorf("TotalScore %d out of [0, 100]", result.TotalScore)
+	}
+	if result.Grade == "" {
+		t.Error("Grade must not be empty")
+	}
+}
+
+func TestCalcInvestmentScore_ScoreNotExceed100(t *testing.T) {
+	// 全有利条件でも 100 を超えない
+	input := InvestmentScoreInput{
+		StationRiderships: []StationRidershipResult{
+			{StationName: "渋谷", Passengers: 500_000},
+		},
+		UrbanZoningItems: []UrbanZoningItem{
+			{AreaClassificationJa: "市街化区域"},
+		},
+		LocationItems: []LocationOptimizationItem{
+			{KubunNameJa: "居住誘導区域"},
+		},
+		HasLandPriceTrend:   true,
+		LandPriceChangeRate: 0.20,
+		PopulationItems: []PopulationForecastItem{
+			{Year: 2020, Pop: 100},
+			{Year: 2050, Pop: 130},
+		},
+	}
+	result := CalcInvestmentScore(input)
+	if result.TotalScore > 100 {
+		t.Errorf("TotalScore %d exceeds 100", result.TotalScore)
+	}
+}
+
+func TestCalcInvestmentScore_ScoreNotBelow0(t *testing.T) {
+	// 全リスク最大でも 0 を下回らない
+	cur := time.Now().Year()
+	input := InvestmentScoreInput{
+		FloodItems:        []FloodHazardItem{{DepthRank: 5}},
+		StormItems:        []StormHazardItem{{DepthJa: "1m"}},
+		TsunamiItems:      []TsunamiHazardItem{{DepthJa: "1m"}},
+		LandslideItems:    []LandslideHazardItem{{ZoneCode: 1}},
+		LiquefactionItems: []LiquefactionRiskItem{{TendencyLevel: 1}},
+		EmbankmentItems:   []EmbankmentItem{{Classification: "腹付け型"}},
+		DisasterItems:     []DisasterHistoryItem{{Name: "浸水域", Year: cur - 1}},
+		HasLandPriceTrend:   true,
+		LandPriceChangeRate: -0.20,
+	}
+	result := CalcInvestmentScore(input)
+	if result.TotalScore < 0 {
+		t.Errorf("TotalScore %d is below 0", result.TotalScore)
+	}
+}
+
+func TestCalcInvestmentScore_RadarDataHas5Points(t *testing.T) {
+	// レーダーチャートは常に5カテゴリ
+	result := CalcInvestmentScore(InvestmentScoreInput{})
+	if len(result.Breakdown.RadarData) != 5 {
+		t.Errorf("RadarData len = %d, want 5", len(result.Breakdown.RadarData))
+	}
+}
+
+func TestCalcInvestmentScore_RadarScoreInRange(t *testing.T) {
+	// 各レーダースコアは 0〜100 の範囲
+	result := CalcInvestmentScore(InvestmentScoreInput{})
+	for _, p := range result.Breakdown.RadarData {
+		if p.Score < 0 || p.Score > 100 {
+			t.Errorf("RadarData[%q].Score = %.1f, want [0, 100]", p.Category, p.Score)
+		}
+	}
+}
+
+func TestCalcInvestmentScore_LandPriceTrend_Ignored_WhenNoData(t *testing.T) {
+	// HasLandPriceTrend=false の場合、LandPriceChangeRate は無視される
+	base := CalcInvestmentScore(InvestmentScoreInput{})
+	withRate := CalcInvestmentScore(InvestmentScoreInput{
+		LandPriceChangeRate: 0.50,
+		HasLandPriceTrend:   false,
+	})
+	if base.TotalScore != withRate.TotalScore {
+		t.Errorf("HasLandPriceTrend=false なのにスコアが変化: base=%d, withRate=%d",
+			base.TotalScore, withRate.TotalScore)
+	}
+}

--- a/backend/internal/domain/investment_score_test.go
+++ b/backend/internal/domain/investment_score_test.go
@@ -362,10 +362,10 @@ func TestCalcDisasterScore_Deduplication(t *testing.T) {
 // --- CalcInvestmentScore 統合 ---
 
 func TestCalcInvestmentScore_AllEmpty_BaseScore(t *testing.T) {
-	// 全データ空 → baseScore=50 から加減なしで 0〜100 の範囲内
+	// 全データ空 → 加減算なしで baseScore=50 が返る
 	result := CalcInvestmentScore(InvestmentScoreInput{})
-	if result.TotalScore < 0 || result.TotalScore > 100 {
-		t.Errorf("TotalScore %d out of [0, 100]", result.TotalScore)
+	if result.TotalScore != 50 {
+		t.Errorf("TotalScore = %d, want 50 (base score)", result.TotalScore)
 	}
 	if result.Grade == "" {
 		t.Error("Grade must not be empty")
@@ -431,6 +431,39 @@ func TestCalcInvestmentScore_RadarScoreInRange(t *testing.T) {
 	for _, p := range result.Breakdown.RadarData {
 		if p.Score < 0 || p.Score > 100 {
 			t.Errorf("RadarData[%q].Score = %.1f, want [0, 100]", p.Category, p.Score)
+		}
+	}
+}
+
+// --- calcLandPriceTrendScore ---
+
+func TestCalcLandPriceTrendScore_NoData(t *testing.T) {
+	s := calcLandPriceTrendScore(0, false)
+	if s.Score != 0 {
+		t.Errorf("score = %d, want 0 when hasData=false", s.Score)
+	}
+}
+
+func TestCalcLandPriceTrendScore_Boundaries(t *testing.T) {
+	tests := []struct {
+		label      string
+		changeRate float64
+		want       int
+	}{
+		{">10%", 0.11, 10},
+		{"ちょうど10%", 0.10, 5},  // pct=10 は >10 に入らず >5 に入る
+		{">5%", 0.06, 5},
+		{"ちょうど5%", 0.05, 0},   // pct=5 は >5 に入らず >=-5 に入る
+		{"0%（横ばい）", 0.00, 0},
+		{"-5%（下限境界）", -0.05, 0}, // pct=-5 は >=-5 に入る
+		{"-6%", -0.06, -5},
+		{"-10%", -0.10, -5},       // pct=-10 は >=-10 に入る
+		{"<-10%", -0.11, -10},
+	}
+	for _, tc := range tests {
+		got := calcLandPriceTrendScore(tc.changeRate, true)
+		if got.Score != tc.want {
+			t.Errorf("[%s] changeRate=%.2f: score = %d, want %d", tc.label, tc.changeRate, got.Score, tc.want)
 		}
 	}
 }

--- a/backend/internal/mlit/cache_test.go
+++ b/backend/internal/mlit/cache_test.go
@@ -1,0 +1,246 @@
+package mlit
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/yield-guard/backend/internal/domain"
+)
+
+// --- cacheKey ---
+
+func TestCacheKey_Deterministic(t *testing.T) {
+	q := LandPriceQuery{Area: "13", City: "101", Year: 2024, Quarter: 1, ToYear: 2024, ToQuarter: 4}
+	k1 := cacheKey(q)
+	k2 := cacheKey(q)
+	if k1 != k2 {
+		t.Errorf("cacheKey is not deterministic: %q != %q", k1, k2)
+	}
+}
+
+func TestCacheKey_UniquePerQuery(t *testing.T) {
+	q1 := LandPriceQuery{Area: "13", Year: 2024, Quarter: 1}
+	q2 := LandPriceQuery{Area: "14", Year: 2024, Quarter: 1}
+	if cacheKey(q1) == cacheKey(q2) {
+		t.Errorf("different queries produced the same cache key: %q", cacheKey(q1))
+	}
+}
+
+// --- getMuni / setMuni (landPriceGroup) ---
+
+func TestCacheMuni_HitMiss(t *testing.T) {
+	c := newCache()
+
+	_, ok := c.getMuni("13")
+	if ok {
+		t.Fatal("expected miss on empty cache")
+	}
+
+	data := []Municipality{{ID: "13101", Name: "千代田区"}}
+	c.setMuni("13", data)
+
+	got, ok := c.getMuni("13")
+	if !ok {
+		t.Fatal("expected hit after setMuni")
+	}
+	if len(got) != 1 || got[0].ID != "13101" {
+		t.Errorf("unexpected data: %+v", got)
+	}
+}
+
+func TestCacheMuni_TTLExpiry(t *testing.T) {
+	c := newCache()
+	c.land.mu.Lock()
+	c.land.muniEntries["13"] = muniCacheEntry{
+		data:      []Municipality{{ID: "13101", Name: "千代田区"}},
+		expiresAt: time.Now().Add(-1 * time.Second), // 期限切れ
+	}
+	c.land.mu.Unlock()
+
+	_, ok := c.getMuni("13")
+	if ok {
+		t.Error("expected miss after TTL expiry")
+	}
+
+	// 期限切れエントリが削除されていること
+	c.land.mu.RLock()
+	_, stillExists := c.land.muniEntries["13"]
+	c.land.mu.RUnlock()
+	if stillExists {
+		t.Error("expired muni entry was not deleted from map")
+	}
+}
+
+func TestCacheMuni_ReturnsCopy(t *testing.T) {
+	c := newCache()
+	original := []Municipality{{ID: "13101", Name: "千代田区"}}
+	c.setMuni("13", original)
+
+	got, _ := c.getMuni("13")
+	got[0].Name = "MODIFIED"
+
+	got2, _ := c.getMuni("13")
+	if got2[0].Name != "千代田区" {
+		t.Errorf("cache was mutated by caller: got %q, want '千代田区'", got2[0].Name)
+	}
+}
+
+// --- getRidership / setRidership (tileGroup) ---
+
+func TestCacheRidership_HitMiss(t *testing.T) {
+	c := newCache()
+	key := "14/2/2"
+
+	_, ok := c.getRidership(key)
+	if ok {
+		t.Fatal("expected miss on empty cache")
+	}
+
+	data := []StationRidership{{StationName: "横浜", Passengers: 100_000}}
+	c.setRidership(key, data)
+
+	got, ok := c.getRidership(key)
+	if !ok {
+		t.Fatal("expected hit after setRidership")
+	}
+	if len(got) != 1 || got[0].StationName != "横浜" {
+		t.Errorf("unexpected data: %+v", got)
+	}
+}
+
+func TestCacheRidership_TTLExpiry(t *testing.T) {
+	c := newCache()
+	key := "14/2/2"
+	c.tile.mu.Lock()
+	c.tile.ridershipEntries[key] = ridershipCacheEntry{
+		data:      []StationRidership{{StationName: "横浜", Passengers: 100_000}},
+		expiresAt: time.Now().Add(-1 * time.Second),
+	}
+	c.tile.mu.Unlock()
+
+	_, ok := c.getRidership(key)
+	if ok {
+		t.Error("expected miss after TTL expiry")
+	}
+
+	c.tile.mu.RLock()
+	_, stillExists := c.tile.ridershipEntries[key]
+	c.tile.mu.RUnlock()
+	if stillExists {
+		t.Error("expired ridership entry was not deleted from map")
+	}
+}
+
+// --- getPopulation / setPopulation (tileGroup) ---
+
+func TestCachePopulation_HitMiss(t *testing.T) {
+	c := newCache()
+	key := "14/5/5"
+
+	_, ok := c.getPopulation(key)
+	if ok {
+		t.Fatal("expected miss on empty cache")
+	}
+
+	data := []domain.PopulationForecastItem{{Year: 2020, Pop: 50000}}
+	c.setPopulation(key, data)
+
+	got, ok := c.getPopulation(key)
+	if !ok {
+		t.Fatal("expected hit after setPopulation")
+	}
+	if len(got) != 1 || got[0].Year != 2020 {
+		t.Errorf("unexpected data: %+v", got)
+	}
+}
+
+// --- getFloodHazard / setFloodHazard (hazardGroup) ---
+
+func TestCacheFloodHazard_HitMiss(t *testing.T) {
+	c := newCache()
+	key := "15/3/3"
+
+	_, ok := c.getFloodHazard(key)
+	if ok {
+		t.Fatal("expected miss on empty cache")
+	}
+
+	data := []domain.FloodHazardItem{{DepthRank: 3, RiverName: "多摩川"}}
+	c.setFloodHazard(key, data)
+
+	got, ok := c.getFloodHazard(key)
+	if !ok {
+		t.Fatal("expected hit after setFloodHazard")
+	}
+	if len(got) != 1 || got[0].RiverName != "多摩川" {
+		t.Errorf("unexpected data: %+v", got)
+	}
+}
+
+func TestCacheFloodHazard_TTLExpiry(t *testing.T) {
+	c := newCache()
+	key := "15/3/3"
+	c.hazard.mu.Lock()
+	c.hazard.floodHazardEntries[key] = floodHazardCacheEntry{
+		data:      []domain.FloodHazardItem{{DepthRank: 3}},
+		expiresAt: time.Now().Add(-1 * time.Second),
+	}
+	c.hazard.mu.Unlock()
+
+	_, ok := c.getFloodHazard(key)
+	if ok {
+		t.Error("expected miss after TTL expiry")
+	}
+
+	c.hazard.mu.RLock()
+	_, stillExists := c.hazard.floodHazardEntries[key]
+	c.hazard.mu.RUnlock()
+	if stillExists {
+		t.Error("expired flood entry was not deleted from map")
+	}
+}
+
+// --- 並行アクセス (tileGroup / hazardGroup) ---
+
+func TestCacheTileGroup_ConcurrentAccess(t *testing.T) {
+	c := newCache()
+	const goroutines = 50
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			key := "14/5/5"
+			data := []domain.PopulationForecastItem{{Year: 2020, Pop: float64(idx * 1000)}}
+			if idx%2 == 0 {
+				c.setPopulation(key, data)
+			} else {
+				c.getPopulation(key)
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+func TestCacheHazardGroup_ConcurrentAccess(t *testing.T) {
+	c := newCache()
+	const goroutines = 50
+
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			key := "15/3/3"
+			data := []domain.FloodHazardItem{{DepthRank: idx % 5}}
+			if idx%2 == 0 {
+				c.setFloodHazard(key, data)
+			} else {
+				c.getFloodHazard(key)
+			}
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## 概要

テストが存在しなかった3ファイルに対して、ユニットテストを新規追加した。

## 追加ファイルと内容

### `backend/internal/domain/investment_score_test.go`（26テスト）

| 対象 | テスト内容 |
|---|---|
| `gradeFromScore` | 5グレードの境界値（80/65/50/35） |
| `calcPopulationScore` | 空データ・+30%成長・-50%減少・変化なし |
| `calcRidershipScore` | 空データ・20万人満点・上限クランプ・最大駅選択 |
| `calcUrbanAreaScore` | 空データ・市街化区域・調整区域 |
| `calcLocationOptScore` | 未策定・居住誘導区域内・区域外 |
| `calcHazardScore` | 全空・洪水高/低ランク・高潮・津波・土砂特別/警戒・-20クランプ |
| `calcLiquefactionScore` | 空データ・レベル高/中/低リスク |
| `calcEmbankmentScore` | 空データ・該当あり |
| `disasterScoreByYear` | 年不明・10年以内・30年以内・30年超（境界値） |
| `CalcInvestmentScore` | 全空入力・スコア上限100・下限0・レーダー5点・地価トレンド無視 |

### `backend/internal/mlit/cache_test.go`（11テスト）

既存の `client_test.go` は land prices (`get`/`set`) のみカバー。本 PR は他のキャッシュメソッドを直接テスト。

| 対象 | テスト内容 |
|---|---|
| `cacheKey` | 決定論的・クエリ差異でユニーク |
| `getMuni`/`setMuni` | ヒット・ミス・TTL期限切れ・コピー防御 |
| `getRidership`/`setRidership` | ヒット・ミス・TTL期限切れ |
| `getPopulation`/`setPopulation` | ヒット・ミス |
| `getFloodHazard`/`setFloodHazard` | ヒット・ミス・TTL期限切れ |
| 並行アクセス | tileGroup・hazardGroup で `go test -race` 対応 |

### `backend/internal/api/router_test.go`（11テスト）

既存の `handler_test.go` / `ratelimit_test.go` はハンドラ・レートリミットをカバー済み。本 PR は CORS が主な追加範囲。

| 対象 | テスト内容 |
|---|---|
| CORS デフォルト | `ALLOW_ORIGINS` 未設定 → `http://localhost:3000` が許可される |
| CORS カスタム | `ALLOW_ORIGINS` 設定 → そのオリジンが許可される |
| CORS 拒否 | リストにないオリジンはヘッダーに反映されない |
| CORS プリフライト | OPTIONS リクエストに `Access-Control-Allow-Methods` が返る |
| CORS 複数オリジン | カンマ区切りで複数オリジンを許可 |
| ルート登録 | `/health` → 200、未知ルート → 404 |
| 認証ミドルウェア | キーなし→401・正しいキー→通過・未設定→通過 |

## テスト結果

```
ok  github.com/yield-guard/backend/internal/domain  1.958s
ok  github.com/yield-guard/backend/internal/mlit    13.984s
ok  github.com/yield-guard/backend/internal/api     1.548s
```

`go test -race ./...` 全件パス確認済み。

## 関連

- Closes #327