### PR TITLE
refactor(cache): Go generics でキャッシュ実装を統一する

### DIFF
--- a/backend/internal/mlit/cache.go
+++ b/backend/internal/mlit/cache.go
@@ -10,11 +10,13 @@ import (
 
 const cacheTTL = 24 * time.Hour
 
+// genericEntry はキャッシュの1エントリ。E は格納する要素の型。
 type genericEntry[E any] struct {
 	data      []E
 	expiresAt time.Time
 }
 
+// genericCache は TTL・スレッドセーフ・コピーオンリードを提供する汎用インメモリキャッシュ。
 type genericCache[E any] struct {
 	mu      sync.RWMutex
 	entries map[string]genericEntry[E]
@@ -36,7 +38,10 @@ func (c *genericCache[E]) get(key string) ([]E, bool) {
 	}
 	if time.Now().After(entry.expiresAt) {
 		c.mu.Lock()
-		delete(c.entries, key)
+		// RUnlock から Lock 取得までの間に set() で新しいエントリが書き込まれた場合は削除しない
+		if current, exists := c.entries[key]; exists && time.Now().After(current.expiresAt) {
+			delete(c.entries, key)
+		}
 		c.mu.Unlock()
 		return nil, false
 	}

--- a/backend/internal/mlit/cache.go
+++ b/backend/internal/mlit/cache.go
@@ -10,555 +10,86 @@ import (
 
 const cacheTTL = 24 * time.Hour
 
-// cacheEntry はキャッシュの1エントリ
-type cacheEntry struct {
-	data      []domain.LandTransaction
+type genericEntry[E any] struct {
+	data      []E
 	expiresAt time.Time
 }
 
-// landPriceGroup は土地価格系・市区町村・地価公示 のキャッシュグループ
-type landPriceGroup struct {
-	mu              sync.RWMutex
-	entries         map[string]cacheEntry
-	muniEntries     map[string]muniCacheEntry
-	appraisalEntries map[string]appraisalCacheEntry
+type genericCache[E any] struct {
+	mu      sync.RWMutex
+	entries map[string]genericEntry[E]
 }
 
-// tileGroup は駅別乗降客数・将来推計人口・立地適正化・大規模盛土・都市計画道路・
-// 災害履歴・都市計画区域・液状化 のキャッシュグループ
-type tileGroup struct {
-	mu                          sync.RWMutex
-	ridershipEntries            map[string]ridershipCacheEntry
-	populationEntries           map[string]populationCacheEntry
-	locationOptimizationEntries map[string]locationOptimizationCacheEntry
-	embankmentEntries           map[string]embankmentCacheEntry
-	urbanRoadEntries            map[string]urbanRoadCacheEntry
-	disasterEntries             map[string]disasterCacheEntry
-	urbanZoningEntries          map[string]urbanZoningCacheEntry
-	liquefactionEntries         map[string]liquefactionCacheEntry
-}
-
-// hazardGroup は洪水・高潮・津波・土砂災害 のキャッシュグループ
-type hazardGroup struct {
-	mu                     sync.RWMutex
-	floodHazardEntries     map[string]floodHazardCacheEntry
-	stormHazardEntries     map[string]stormHazardCacheEntry
-	tsunamiHazardEntries   map[string]tsunamiHazardCacheEntry
-	landslideHazardEntries map[string]landslideHazardCacheEntry
-}
-
-// cache は TTL 付きインメモリキャッシュ
-type cache struct {
-	land   landPriceGroup
-	tile   tileGroup
-	hazard hazardGroup
-}
-
-func newCache() *cache {
-	c := &cache{}
-	c.land.entries = make(map[string]cacheEntry)
-	c.land.muniEntries = make(map[string]muniCacheEntry)
-	c.land.appraisalEntries = make(map[string]appraisalCacheEntry)
-
-	c.tile.ridershipEntries = make(map[string]ridershipCacheEntry)
-	c.tile.populationEntries = make(map[string]populationCacheEntry)
-	c.tile.locationOptimizationEntries = make(map[string]locationOptimizationCacheEntry)
-	c.tile.embankmentEntries = make(map[string]embankmentCacheEntry)
-	c.tile.urbanRoadEntries = make(map[string]urbanRoadCacheEntry)
-	c.tile.disasterEntries = make(map[string]disasterCacheEntry)
-	c.tile.urbanZoningEntries = make(map[string]urbanZoningCacheEntry)
-	c.tile.liquefactionEntries = make(map[string]liquefactionCacheEntry)
-
-	c.hazard.floodHazardEntries = make(map[string]floodHazardCacheEntry)
-	c.hazard.stormHazardEntries = make(map[string]stormHazardCacheEntry)
-	c.hazard.tsunamiHazardEntries = make(map[string]tsunamiHazardCacheEntry)
-	c.hazard.landslideHazardEntries = make(map[string]landslideHazardCacheEntry)
-	return c
+func newGenericCache[E any]() *genericCache[E] {
+	return &genericCache[E]{entries: make(map[string]genericEntry[E])}
 }
 
 // get はキャッシュを取得する。TTL 切れの場合はエントリを削除して (nil, false) を返す。
 // 呼び出し元がスライスを変更してもキャッシュが汚染されないようコピーを返す。
-func (c *cache) get(key string) ([]domain.LandTransaction, bool) {
-	c.land.mu.RLock()
-	entry, ok := c.land.entries[key]
-	c.land.mu.RUnlock()
+func (c *genericCache[E]) get(key string) ([]E, bool) {
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
 
 	if !ok {
 		return nil, false
 	}
 	if time.Now().After(entry.expiresAt) {
-		c.land.mu.Lock()
-		delete(c.land.entries, key)
-		c.land.mu.Unlock()
+		c.mu.Lock()
+		delete(c.entries, key)
+		c.mu.Unlock()
 		return nil, false
 	}
 
-	copied := make([]domain.LandTransaction, len(entry.data))
+	copied := make([]E, len(entry.data))
 	copy(copied, entry.data)
 	return copied, true
 }
 
 // set はキャッシュに保存する。
-func (c *cache) set(key string, data []domain.LandTransaction) {
-	c.land.mu.Lock()
-	defer c.land.mu.Unlock()
+func (c *genericCache[E]) set(key string, data []E) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = genericEntry[E]{data: data, expiresAt: time.Now().Add(cacheTTL)}
+}
 
-	c.land.entries[key] = cacheEntry{
-		data:      data,
-		expiresAt: time.Now().Add(cacheTTL),
+// cache は TTL 付きインメモリキャッシュ。各フィールドが独立した mutex を持つ。
+type cache struct {
+	landPrices           *genericCache[domain.LandTransaction]
+	municipalities       *genericCache[Municipality]
+	appraisals           *genericCache[domain.LandAppraisalItem]
+	ridership            *genericCache[StationRidership]
+	population           *genericCache[domain.PopulationForecastItem]
+	locationOptimization *genericCache[domain.LocationOptimizationItem]
+	embankment           *genericCache[domain.EmbankmentItem]
+	urbanRoad            *genericCache[domain.UrbanRoadItem]
+	disaster             *genericCache[domain.DisasterHistoryItem]
+	urbanZoning          *genericCache[domain.UrbanZoningItem]
+	liquefaction         *genericCache[domain.LiquefactionRiskItem]
+	floodHazard          *genericCache[domain.FloodHazardItem]
+	stormHazard          *genericCache[domain.StormHazardItem]
+	tsunamiHazard        *genericCache[domain.TsunamiHazardItem]
+	landslideHazard      *genericCache[domain.LandslideHazardItem]
+}
+
+func newCache() *cache {
+	return &cache{
+		landPrices:           newGenericCache[domain.LandTransaction](),
+		municipalities:       newGenericCache[Municipality](),
+		appraisals:           newGenericCache[domain.LandAppraisalItem](),
+		ridership:            newGenericCache[StationRidership](),
+		population:           newGenericCache[domain.PopulationForecastItem](),
+		locationOptimization: newGenericCache[domain.LocationOptimizationItem](),
+		embankment:           newGenericCache[domain.EmbankmentItem](),
+		urbanRoad:            newGenericCache[domain.UrbanRoadItem](),
+		disaster:             newGenericCache[domain.DisasterHistoryItem](),
+		urbanZoning:          newGenericCache[domain.UrbanZoningItem](),
+		liquefaction:         newGenericCache[domain.LiquefactionRiskItem](),
+		floodHazard:          newGenericCache[domain.FloodHazardItem](),
+		stormHazard:          newGenericCache[domain.StormHazardItem](),
+		tsunamiHazard:        newGenericCache[domain.TsunamiHazardItem](),
+		landslideHazard:      newGenericCache[domain.LandslideHazardItem](),
 	}
-}
-
-// muniCacheEntry は市区町村キャッシュの1エントリ
-type muniCacheEntry struct {
-	data      []Municipality
-	expiresAt time.Time
-}
-
-// getMuni は市区町村キャッシュを取得する。TTL 切れの場合はエントリを削除して (nil, false) を返す。
-func (c *cache) getMuni(area string) ([]Municipality, bool) {
-	c.land.mu.RLock()
-	entry, ok := c.land.muniEntries[area]
-	c.land.mu.RUnlock()
-
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.land.mu.Lock()
-		delete(c.land.muniEntries, area)
-		c.land.mu.Unlock()
-		return nil, false
-	}
-
-	copied := make([]Municipality, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-// setMuni は市区町村キャッシュに保存する。
-func (c *cache) setMuni(area string, data []Municipality) {
-	c.land.mu.Lock()
-	defer c.land.mu.Unlock()
-
-	c.land.muniEntries[area] = muniCacheEntry{
-		data:      data,
-		expiresAt: time.Now().Add(cacheTTL),
-	}
-}
-
-// ridershipCacheEntry は駅別乗降客数キャッシュの1エントリ
-type ridershipCacheEntry struct {
-	data      []StationRidership
-	expiresAt time.Time
-}
-
-// getRidership は駅別乗降客数キャッシュを取得する。
-func (c *cache) getRidership(key string) ([]StationRidership, bool) {
-	c.tile.mu.RLock()
-	entry, ok := c.tile.ridershipEntries[key]
-	c.tile.mu.RUnlock()
-
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.tile.mu.Lock()
-		delete(c.tile.ridershipEntries, key)
-		c.tile.mu.Unlock()
-		return nil, false
-	}
-
-	copied := make([]StationRidership, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-// setRidership は駅別乗降客数キャッシュに保存する。
-func (c *cache) setRidership(key string, data []StationRidership) {
-	c.tile.mu.Lock()
-	defer c.tile.mu.Unlock()
-
-	c.tile.ridershipEntries[key] = ridershipCacheEntry{
-		data:      data,
-		expiresAt: time.Now().Add(cacheTTL),
-	}
-}
-
-// populationCacheEntry は将来推計人口キャッシュの1エントリ
-type populationCacheEntry struct {
-	data      []domain.PopulationForecastItem
-	expiresAt time.Time
-}
-
-// getPopulation は将来推計人口キャッシュを取得する。
-func (c *cache) getPopulation(key string) ([]domain.PopulationForecastItem, bool) {
-	c.tile.mu.RLock()
-	entry, ok := c.tile.populationEntries[key]
-	c.tile.mu.RUnlock()
-
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.tile.mu.Lock()
-		delete(c.tile.populationEntries, key)
-		c.tile.mu.Unlock()
-		return nil, false
-	}
-
-	copied := make([]domain.PopulationForecastItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-// setPopulation は将来推計人口キャッシュに保存する。
-func (c *cache) setPopulation(key string, data []domain.PopulationForecastItem) {
-	c.tile.mu.Lock()
-	defer c.tile.mu.Unlock()
-
-	c.tile.populationEntries[key] = populationCacheEntry{
-		data:      data,
-		expiresAt: time.Now().Add(cacheTTL),
-	}
-}
-
-// appraisalCacheEntry は地価公示キャッシュの1エントリ
-type appraisalCacheEntry struct {
-	data      []domain.LandAppraisalItem
-	expiresAt time.Time
-}
-
-// getAppraisals は地価公示キャッシュを取得する。
-func (c *cache) getAppraisals(key string) ([]domain.LandAppraisalItem, bool) {
-	c.land.mu.RLock()
-	entry, ok := c.land.appraisalEntries[key]
-	c.land.mu.RUnlock()
-
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.land.mu.Lock()
-		delete(c.land.appraisalEntries, key)
-		c.land.mu.Unlock()
-		return nil, false
-	}
-
-	copied := make([]domain.LandAppraisalItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-// setAppraisals は地価公示キャッシュに保存する。
-func (c *cache) setAppraisals(key string, data []domain.LandAppraisalItem) {
-	c.land.mu.Lock()
-	defer c.land.mu.Unlock()
-
-	c.land.appraisalEntries[key] = appraisalCacheEntry{
-		data:      data,
-		expiresAt: time.Now().Add(cacheTTL),
-	}
-}
-
-// locationOptimizationCacheEntry は立地適正化計画キャッシュの1エントリ
-type locationOptimizationCacheEntry struct {
-	data      []domain.LocationOptimizationItem
-	expiresAt time.Time
-}
-
-func (c *cache) getLocationOptimization(key string) ([]domain.LocationOptimizationItem, bool) {
-	c.tile.mu.RLock()
-	entry, ok := c.tile.locationOptimizationEntries[key]
-	c.tile.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.tile.mu.Lock()
-		delete(c.tile.locationOptimizationEntries, key)
-		c.tile.mu.Unlock()
-		return nil, false
-	}
-	copied := make([]domain.LocationOptimizationItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-func (c *cache) setLocationOptimization(key string, data []domain.LocationOptimizationItem) {
-	c.tile.mu.Lock()
-	defer c.tile.mu.Unlock()
-	c.tile.locationOptimizationEntries[key] = locationOptimizationCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
-}
-
-// embankmentCacheEntry は大規模盛土造成地キャッシュの1エントリ
-type embankmentCacheEntry struct {
-	data      []domain.EmbankmentItem
-	expiresAt time.Time
-}
-
-func (c *cache) getEmbankment(key string) ([]domain.EmbankmentItem, bool) {
-	c.tile.mu.RLock()
-	entry, ok := c.tile.embankmentEntries[key]
-	c.tile.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.tile.mu.Lock()
-		delete(c.tile.embankmentEntries, key)
-		c.tile.mu.Unlock()
-		return nil, false
-	}
-	copied := make([]domain.EmbankmentItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-func (c *cache) setEmbankment(key string, data []domain.EmbankmentItem) {
-	c.tile.mu.Lock()
-	defer c.tile.mu.Unlock()
-	c.tile.embankmentEntries[key] = embankmentCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
-}
-
-// urbanRoadCacheEntry は都市計画道路キャッシュの1エントリ
-type urbanRoadCacheEntry struct {
-	data      []domain.UrbanRoadItem
-	expiresAt time.Time
-}
-
-func (c *cache) getUrbanRoad(key string) ([]domain.UrbanRoadItem, bool) {
-	c.tile.mu.RLock()
-	entry, ok := c.tile.urbanRoadEntries[key]
-	c.tile.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.tile.mu.Lock()
-		delete(c.tile.urbanRoadEntries, key)
-		c.tile.mu.Unlock()
-		return nil, false
-	}
-	copied := make([]domain.UrbanRoadItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-func (c *cache) setUrbanRoad(key string, data []domain.UrbanRoadItem) {
-	c.tile.mu.Lock()
-	defer c.tile.mu.Unlock()
-	c.tile.urbanRoadEntries[key] = urbanRoadCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
-}
-
-// disasterCacheEntry は災害履歴キャッシュの1エントリ
-type disasterCacheEntry struct {
-	data      []domain.DisasterHistoryItem
-	expiresAt time.Time
-}
-
-func (c *cache) getDisaster(key string) ([]domain.DisasterHistoryItem, bool) {
-	c.tile.mu.RLock()
-	entry, ok := c.tile.disasterEntries[key]
-	c.tile.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.tile.mu.Lock()
-		delete(c.tile.disasterEntries, key)
-		c.tile.mu.Unlock()
-		return nil, false
-	}
-	copied := make([]domain.DisasterHistoryItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-func (c *cache) setDisaster(key string, data []domain.DisasterHistoryItem) {
-	c.tile.mu.Lock()
-	defer c.tile.mu.Unlock()
-	c.tile.disasterEntries[key] = disasterCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
-}
-
-// urbanZoningCacheEntry は都市計画区域/区域区分キャッシュの1エントリ
-type urbanZoningCacheEntry struct {
-	data      []domain.UrbanZoningItem
-	expiresAt time.Time
-}
-
-func (c *cache) getUrbanZoning(key string) ([]domain.UrbanZoningItem, bool) {
-	c.tile.mu.RLock()
-	entry, ok := c.tile.urbanZoningEntries[key]
-	c.tile.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.tile.mu.Lock()
-		delete(c.tile.urbanZoningEntries, key)
-		c.tile.mu.Unlock()
-		return nil, false
-	}
-	copied := make([]domain.UrbanZoningItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-func (c *cache) setUrbanZoning(key string, data []domain.UrbanZoningItem) {
-	c.tile.mu.Lock()
-	defer c.tile.mu.Unlock()
-	c.tile.urbanZoningEntries[key] = urbanZoningCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
-}
-
-// liquefactionCacheEntry は液状化発生傾向図キャッシュの1エントリ
-type liquefactionCacheEntry struct {
-	data      []domain.LiquefactionRiskItem
-	expiresAt time.Time
-}
-
-func (c *cache) getLiquefaction(key string) ([]domain.LiquefactionRiskItem, bool) {
-	c.tile.mu.RLock()
-	entry, ok := c.tile.liquefactionEntries[key]
-	c.tile.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.tile.mu.Lock()
-		delete(c.tile.liquefactionEntries, key)
-		c.tile.mu.Unlock()
-		return nil, false
-	}
-	copied := make([]domain.LiquefactionRiskItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-func (c *cache) setLiquefaction(key string, data []domain.LiquefactionRiskItem) {
-	c.tile.mu.Lock()
-	defer c.tile.mu.Unlock()
-	c.tile.liquefactionEntries[key] = liquefactionCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
-}
-
-// floodHazardCacheEntry は洪水浸水想定区域キャッシュの1エントリ
-type floodHazardCacheEntry struct {
-	data      []domain.FloodHazardItem
-	expiresAt time.Time
-}
-
-func (c *cache) getFloodHazard(key string) ([]domain.FloodHazardItem, bool) {
-	c.hazard.mu.RLock()
-	entry, ok := c.hazard.floodHazardEntries[key]
-	c.hazard.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.hazard.mu.Lock()
-		delete(c.hazard.floodHazardEntries, key)
-		c.hazard.mu.Unlock()
-		return nil, false
-	}
-	copied := make([]domain.FloodHazardItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-func (c *cache) setFloodHazard(key string, data []domain.FloodHazardItem) {
-	c.hazard.mu.Lock()
-	defer c.hazard.mu.Unlock()
-	c.hazard.floodHazardEntries[key] = floodHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
-}
-
-// stormHazardCacheEntry は高潮浸水想定区域キャッシュの1エントリ
-type stormHazardCacheEntry struct {
-	data      []domain.StormHazardItem
-	expiresAt time.Time
-}
-
-func (c *cache) getStormHazard(key string) ([]domain.StormHazardItem, bool) {
-	c.hazard.mu.RLock()
-	entry, ok := c.hazard.stormHazardEntries[key]
-	c.hazard.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.hazard.mu.Lock()
-		delete(c.hazard.stormHazardEntries, key)
-		c.hazard.mu.Unlock()
-		return nil, false
-	}
-	copied := make([]domain.StormHazardItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-func (c *cache) setStormHazard(key string, data []domain.StormHazardItem) {
-	c.hazard.mu.Lock()
-	defer c.hazard.mu.Unlock()
-	c.hazard.stormHazardEntries[key] = stormHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
-}
-
-// tsunamiHazardCacheEntry は津波浸水想定キャッシュの1エントリ
-type tsunamiHazardCacheEntry struct {
-	data      []domain.TsunamiHazardItem
-	expiresAt time.Time
-}
-
-func (c *cache) getTsunamiHazard(key string) ([]domain.TsunamiHazardItem, bool) {
-	c.hazard.mu.RLock()
-	entry, ok := c.hazard.tsunamiHazardEntries[key]
-	c.hazard.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.hazard.mu.Lock()
-		delete(c.hazard.tsunamiHazardEntries, key)
-		c.hazard.mu.Unlock()
-		return nil, false
-	}
-	copied := make([]domain.TsunamiHazardItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-func (c *cache) setTsunamiHazard(key string, data []domain.TsunamiHazardItem) {
-	c.hazard.mu.Lock()
-	defer c.hazard.mu.Unlock()
-	c.hazard.tsunamiHazardEntries[key] = tsunamiHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
-}
-
-// landslideHazardCacheEntry は土砂災害警戒区域キャッシュの1エントリ
-type landslideHazardCacheEntry struct {
-	data      []domain.LandslideHazardItem
-	expiresAt time.Time
-}
-
-func (c *cache) getLandslideHazard(key string) ([]domain.LandslideHazardItem, bool) {
-	c.hazard.mu.RLock()
-	entry, ok := c.hazard.landslideHazardEntries[key]
-	c.hazard.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if time.Now().After(entry.expiresAt) {
-		c.hazard.mu.Lock()
-		delete(c.hazard.landslideHazardEntries, key)
-		c.hazard.mu.Unlock()
-		return nil, false
-	}
-	copied := make([]domain.LandslideHazardItem, len(entry.data))
-	copy(copied, entry.data)
-	return copied, true
-}
-
-func (c *cache) setLandslideHazard(key string, data []domain.LandslideHazardItem) {
-	c.hazard.mu.Lock()
-	defer c.hazard.mu.Unlock()
-	c.hazard.landslideHazardEntries[key] = landslideHazardCacheEntry{data: data, expiresAt: time.Now().Add(cacheTTL)}
 }
 
 // cacheKey は LandPriceQuery からキャッシュキーを生成する。

--- a/backend/internal/mlit/cache_test.go
+++ b/backend/internal/mlit/cache_test.go
@@ -27,22 +27,22 @@ func TestCacheKey_UniquePerQuery(t *testing.T) {
 	}
 }
 
-// --- getMuni / setMuni (landPriceGroup) ---
+// --- municipalities ---
 
 func TestCacheMuni_HitMiss(t *testing.T) {
 	c := newCache()
 
-	_, ok := c.getMuni("13")
+	_, ok := c.municipalities.get("13")
 	if ok {
 		t.Fatal("expected miss on empty cache")
 	}
 
 	data := []Municipality{{ID: "13101", Name: "千代田区"}}
-	c.setMuni("13", data)
+	c.municipalities.set("13", data)
 
-	got, ok := c.getMuni("13")
+	got, ok := c.municipalities.get("13")
 	if !ok {
-		t.Fatal("expected hit after setMuni")
+		t.Fatal("expected hit after set")
 	}
 	if len(got) != 1 || got[0].ID != "13101" {
 		t.Errorf("unexpected data: %+v", got)
@@ -51,22 +51,22 @@ func TestCacheMuni_HitMiss(t *testing.T) {
 
 func TestCacheMuni_TTLExpiry(t *testing.T) {
 	c := newCache()
-	c.land.mu.Lock()
-	c.land.muniEntries["13"] = muniCacheEntry{
+	c.municipalities.mu.Lock()
+	c.municipalities.entries["13"] = genericEntry[Municipality]{
 		data:      []Municipality{{ID: "13101", Name: "千代田区"}},
 		expiresAt: time.Now().Add(-1 * time.Second), // 期限切れ
 	}
-	c.land.mu.Unlock()
+	c.municipalities.mu.Unlock()
 
-	_, ok := c.getMuni("13")
+	_, ok := c.municipalities.get("13")
 	if ok {
 		t.Error("expected miss after TTL expiry")
 	}
 
 	// 期限切れエントリが削除されていること
-	c.land.mu.RLock()
-	_, stillExists := c.land.muniEntries["13"]
-	c.land.mu.RUnlock()
+	c.municipalities.mu.RLock()
+	_, stillExists := c.municipalities.entries["13"]
+	c.municipalities.mu.RUnlock()
 	if stillExists {
 		t.Error("expired muni entry was not deleted from map")
 	}
@@ -75,34 +75,34 @@ func TestCacheMuni_TTLExpiry(t *testing.T) {
 func TestCacheMuni_ReturnsCopy(t *testing.T) {
 	c := newCache()
 	original := []Municipality{{ID: "13101", Name: "千代田区"}}
-	c.setMuni("13", original)
+	c.municipalities.set("13", original)
 
-	got, _ := c.getMuni("13")
+	got, _ := c.municipalities.get("13")
 	got[0].Name = "MODIFIED"
 
-	got2, _ := c.getMuni("13")
+	got2, _ := c.municipalities.get("13")
 	if got2[0].Name != "千代田区" {
 		t.Errorf("cache was mutated by caller: got %q, want '千代田区'", got2[0].Name)
 	}
 }
 
-// --- getRidership / setRidership (tileGroup) ---
+// --- ridership ---
 
 func TestCacheRidership_HitMiss(t *testing.T) {
 	c := newCache()
 	key := "14/2/2"
 
-	_, ok := c.getRidership(key)
+	_, ok := c.ridership.get(key)
 	if ok {
 		t.Fatal("expected miss on empty cache")
 	}
 
 	data := []StationRidership{{StationName: "横浜", Passengers: 100_000}}
-	c.setRidership(key, data)
+	c.ridership.set(key, data)
 
-	got, ok := c.getRidership(key)
+	got, ok := c.ridership.get(key)
 	if !ok {
-		t.Fatal("expected hit after setRidership")
+		t.Fatal("expected hit after set")
 	}
 	if len(got) != 1 || got[0].StationName != "横浜" {
 		t.Errorf("unexpected data: %+v", got)
@@ -112,66 +112,66 @@ func TestCacheRidership_HitMiss(t *testing.T) {
 func TestCacheRidership_TTLExpiry(t *testing.T) {
 	c := newCache()
 	key := "14/2/2"
-	c.tile.mu.Lock()
-	c.tile.ridershipEntries[key] = ridershipCacheEntry{
+	c.ridership.mu.Lock()
+	c.ridership.entries[key] = genericEntry[StationRidership]{
 		data:      []StationRidership{{StationName: "横浜", Passengers: 100_000}},
 		expiresAt: time.Now().Add(-1 * time.Second),
 	}
-	c.tile.mu.Unlock()
+	c.ridership.mu.Unlock()
 
-	_, ok := c.getRidership(key)
+	_, ok := c.ridership.get(key)
 	if ok {
 		t.Error("expected miss after TTL expiry")
 	}
 
-	c.tile.mu.RLock()
-	_, stillExists := c.tile.ridershipEntries[key]
-	c.tile.mu.RUnlock()
+	c.ridership.mu.RLock()
+	_, stillExists := c.ridership.entries[key]
+	c.ridership.mu.RUnlock()
 	if stillExists {
 		t.Error("expired ridership entry was not deleted from map")
 	}
 }
 
-// --- getPopulation / setPopulation (tileGroup) ---
+// --- population ---
 
 func TestCachePopulation_HitMiss(t *testing.T) {
 	c := newCache()
 	key := "14/5/5"
 
-	_, ok := c.getPopulation(key)
+	_, ok := c.population.get(key)
 	if ok {
 		t.Fatal("expected miss on empty cache")
 	}
 
 	data := []domain.PopulationForecastItem{{Year: 2020, Pop: 50000}}
-	c.setPopulation(key, data)
+	c.population.set(key, data)
 
-	got, ok := c.getPopulation(key)
+	got, ok := c.population.get(key)
 	if !ok {
-		t.Fatal("expected hit after setPopulation")
+		t.Fatal("expected hit after set")
 	}
 	if len(got) != 1 || got[0].Year != 2020 {
 		t.Errorf("unexpected data: %+v", got)
 	}
 }
 
-// --- getFloodHazard / setFloodHazard (hazardGroup) ---
+// --- floodHazard ---
 
 func TestCacheFloodHazard_HitMiss(t *testing.T) {
 	c := newCache()
 	key := "15/3/3"
 
-	_, ok := c.getFloodHazard(key)
+	_, ok := c.floodHazard.get(key)
 	if ok {
 		t.Fatal("expected miss on empty cache")
 	}
 
 	data := []domain.FloodHazardItem{{DepthRank: 3, RiverName: "多摩川"}}
-	c.setFloodHazard(key, data)
+	c.floodHazard.set(key, data)
 
-	got, ok := c.getFloodHazard(key)
+	got, ok := c.floodHazard.get(key)
 	if !ok {
-		t.Fatal("expected hit after setFloodHazard")
+		t.Fatal("expected hit after set")
 	}
 	if len(got) != 1 || got[0].RiverName != "多摩川" {
 		t.Errorf("unexpected data: %+v", got)
@@ -181,27 +181,27 @@ func TestCacheFloodHazard_HitMiss(t *testing.T) {
 func TestCacheFloodHazard_TTLExpiry(t *testing.T) {
 	c := newCache()
 	key := "15/3/3"
-	c.hazard.mu.Lock()
-	c.hazard.floodHazardEntries[key] = floodHazardCacheEntry{
+	c.floodHazard.mu.Lock()
+	c.floodHazard.entries[key] = genericEntry[domain.FloodHazardItem]{
 		data:      []domain.FloodHazardItem{{DepthRank: 3}},
 		expiresAt: time.Now().Add(-1 * time.Second),
 	}
-	c.hazard.mu.Unlock()
+	c.floodHazard.mu.Unlock()
 
-	_, ok := c.getFloodHazard(key)
+	_, ok := c.floodHazard.get(key)
 	if ok {
 		t.Error("expected miss after TTL expiry")
 	}
 
-	c.hazard.mu.RLock()
-	_, stillExists := c.hazard.floodHazardEntries[key]
-	c.hazard.mu.RUnlock()
+	c.floodHazard.mu.RLock()
+	_, stillExists := c.floodHazard.entries[key]
+	c.floodHazard.mu.RUnlock()
 	if stillExists {
 		t.Error("expired flood entry was not deleted from map")
 	}
 }
 
-// --- 並行アクセス (tileGroup / hazardGroup) ---
+// --- 並行アクセス ---
 
 func TestCacheTileGroup_ConcurrentAccess(t *testing.T) {
 	c := newCache()
@@ -215,9 +215,9 @@ func TestCacheTileGroup_ConcurrentAccess(t *testing.T) {
 			key := "14/5/5"
 			data := []domain.PopulationForecastItem{{Year: 2020, Pop: float64(idx * 1000)}}
 			if idx%2 == 0 {
-				c.setPopulation(key, data)
+				c.population.set(key, data)
 			} else {
-				c.getPopulation(key)
+				c.population.get(key)
 			}
 		}(i)
 	}
@@ -236,9 +236,9 @@ func TestCacheHazardGroup_ConcurrentAccess(t *testing.T) {
 			key := "15/3/3"
 			data := []domain.FloodHazardItem{{DepthRank: idx % 5}}
 			if idx%2 == 0 {
-				c.setFloodHazard(key, data)
+				c.floodHazard.set(key, data)
 			} else {
-				c.getFloodHazard(key)
+				c.floodHazard.get(key)
 			}
 		}(i)
 	}

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -90,7 +90,7 @@ func (c *Client) FetchLandPrices(ctx context.Context, q LandPriceQuery) ([]domai
 	)
 
 	key := cacheKey(q)
-	if cached, ok := c.cache.get(key); ok {
+	if cached, ok := c.cache.landPrices.get(key); ok {
 		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT001")))
 		return cached, nil
@@ -125,7 +125,7 @@ func (c *Client) FetchLandPrices(ctx context.Context, q LandPriceQuery) ([]domai
 
 		if err == nil {
 			span.SetAttributes(attribute.Int("mlit.retry.count", attempt))
-			c.cache.set(key, result)
+			c.cache.landPrices.set(key, result)
 			return result, nil
 		}
 		lastErr = err
@@ -163,7 +163,7 @@ func (c *Client) FetchMunicipalities(ctx context.Context, area string) ([]Munici
 		return nil, err
 	}
 
-	if cached, ok := c.cache.getMuni(area); ok {
+	if cached, ok := c.cache.municipalities.get(area); ok {
 		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT002")))
 		return cached, nil
@@ -224,7 +224,7 @@ func (c *Client) FetchMunicipalities(ctx context.Context, area string) ([]Munici
 	}
 
 	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
-	c.cache.setMuni(area, apiResp.Data)
+	c.cache.municipalities.set(area, apiResp.Data)
 	return apiResp.Data, nil
 }
 
@@ -264,7 +264,7 @@ func (c *Client) FetchStationRidership(ctx context.Context, z, x, y int) ([]Stat
 	)
 
 	key := fmt.Sprintf("ridership:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getRidership(key); ok {
+	if cached, ok := c.cache.ridership.get(key); ok {
 		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT015")))
 		return cached, nil
@@ -323,7 +323,7 @@ func (c *Client) FetchStationRidership(ctx context.Context, z, x, y int) ([]Stat
 
 	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
 	result := parseStationRiderships(geoResp.Features)
-	c.cache.setRidership(key, result)
+	c.cache.ridership.set(key, result)
 	return result, nil
 }
 
@@ -384,7 +384,7 @@ func (c *Client) FetchPopulationForecast(ctx context.Context, z, x, y int) ([]do
 	)
 
 	key := fmt.Sprintf("population:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getPopulation(key); ok {
+	if cached, ok := c.cache.population.get(key); ok {
 		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT013")))
 		return cached, nil
@@ -443,7 +443,7 @@ func (c *Client) FetchPopulationForecast(ctx context.Context, z, x, y int) ([]do
 
 	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
 	result := parsePopulationForecasts(geoResp.Features)
-	c.cache.setPopulation(key, result)
+	c.cache.population.set(key, result)
 	return result, nil
 }
 
@@ -496,7 +496,7 @@ func (c *Client) FetchLandAppraisals(ctx context.Context, area, city string, yea
 	)
 
 	key := fmt.Sprintf("appraisals:%s:%s:%d:%s", area, city, year, division)
-	if cached, ok := c.cache.getAppraisals(key); ok {
+	if cached, ok := c.cache.appraisals.get(key); ok {
 		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XCT001")))
 		return cached, nil
@@ -529,7 +529,7 @@ func (c *Client) FetchLandAppraisals(ctx context.Context, area, city string, yea
 
 		if err == nil {
 			span.SetAttributes(attribute.Int("mlit.retry.count", attempt))
-			c.cache.setAppraisals(key, result)
+			c.cache.appraisals.set(key, result)
 			return result, nil
 		}
 		lastErr = err
@@ -802,7 +802,7 @@ func (c *Client) fetchTileGeoJSON(ctx context.Context, endpoint string, z, x, y 
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchLocationOptimization(ctx context.Context, z, x, y int) ([]domain.LocationOptimizationItem, error) {
 	key := fmt.Sprintf("location_optimization:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getLocationOptimization(key); ok {
+	if cached, ok := c.cache.locationOptimization.get(key); ok {
 		return cached, nil
 	}
 
@@ -815,7 +815,7 @@ func (c *Client) FetchLocationOptimization(ctx context.Context, z, x, y int) ([]
 	for _, f := range geoResp.Features {
 		result = append(result, domain.LocationOptimizationItem{KubunNameJa: f.Properties.KubunNameJa})
 	}
-	c.cache.setLocationOptimization(key, result)
+	c.cache.locationOptimization.set(key, result)
 	return result, nil
 }
 
@@ -823,7 +823,7 @@ func (c *Client) FetchLocationOptimization(ctx context.Context, z, x, y int) ([]
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchEmbankment(ctx context.Context, z, x, y int) ([]domain.EmbankmentItem, error) {
 	key := fmt.Sprintf("embankment:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getEmbankment(key); ok {
+	if cached, ok := c.cache.embankment.get(key); ok {
 		return cached, nil
 	}
 
@@ -836,7 +836,7 @@ func (c *Client) FetchEmbankment(ctx context.Context, z, x, y int) ([]domain.Emb
 	for _, f := range geoResp.Features {
 		result = append(result, domain.EmbankmentItem{Classification: f.Properties.EmbankmentClassification})
 	}
-	c.cache.setEmbankment(key, result)
+	c.cache.embankment.set(key, result)
 	return result, nil
 }
 
@@ -844,7 +844,7 @@ func (c *Client) FetchEmbankment(ctx context.Context, z, x, y int) ([]domain.Emb
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchUrbanRoad(ctx context.Context, z, x, y int) ([]domain.UrbanRoadItem, error) {
 	key := fmt.Sprintf("urban_road:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getUrbanRoad(key); ok {
+	if cached, ok := c.cache.urbanRoad.get(key); ok {
 		return cached, nil
 	}
 
@@ -860,7 +860,7 @@ func (c *Client) FetchUrbanRoad(ctx context.Context, z, x, y int) ([]domain.Urba
 			KubunID:        f.Properties.KubunID,
 		})
 	}
-	c.cache.setUrbanRoad(key, result)
+	c.cache.urbanRoad.set(key, result)
 	return result, nil
 }
 
@@ -868,7 +868,7 @@ func (c *Client) FetchUrbanRoad(ctx context.Context, z, x, y int) ([]domain.Urba
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domain.DisasterHistoryItem, error) {
 	key := fmt.Sprintf("disaster:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getDisaster(key); ok {
+	if cached, ok := c.cache.disaster.get(key); ok {
 		return cached, nil
 	}
 
@@ -888,7 +888,7 @@ func (c *Client) FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domai
 			Year: year,
 		})
 	}
-	c.cache.setDisaster(key, result)
+	c.cache.disaster.set(key, result)
 	return result, nil
 }
 
@@ -896,7 +896,7 @@ func (c *Client) FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domai
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.UrbanZoningItem, error) {
 	key := fmt.Sprintf("urban_zoning:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getUrbanZoning(key); ok {
+	if cached, ok := c.cache.urbanZoning.get(key); ok {
 		return cached, nil
 	}
 	var geoResp UrbanZoningGeoJSON
@@ -910,7 +910,7 @@ func (c *Client) FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.Ur
 			KubunID:              f.Properties.KubunID,
 		})
 	}
-	c.cache.setUrbanZoning(key, result)
+	c.cache.urbanZoning.set(key, result)
 	return result, nil
 }
 
@@ -918,7 +918,7 @@ func (c *Client) FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.Ur
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.LiquefactionRiskItem, error) {
 	key := fmt.Sprintf("liquefaction:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getLiquefaction(key); ok {
+	if cached, ok := c.cache.liquefaction.get(key); ok {
 		return cached, nil
 	}
 	var geoResp LiquefactionGeoJSON
@@ -932,7 +932,7 @@ func (c *Client) FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.L
 			Note:          f.Properties.Note,
 		})
 	}
-	c.cache.setLiquefaction(key, result)
+	c.cache.liquefaction.set(key, result)
 	return result, nil
 }
 
@@ -940,7 +940,7 @@ func (c *Client) FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.L
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchFloodHazard(ctx context.Context, z, x, y int) ([]domain.FloodHazardItem, error) {
 	key := fmt.Sprintf("flood_hazard:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getFloodHazard(key); ok {
+	if cached, ok := c.cache.floodHazard.get(key); ok {
 		return cached, nil
 	}
 	var geoResp FloodHazardGeoJSON
@@ -954,7 +954,7 @@ func (c *Client) FetchFloodHazard(ctx context.Context, z, x, y int) ([]domain.Fl
 			RiverName: f.Properties.RiverName,
 		})
 	}
-	c.cache.setFloodHazard(key, result)
+	c.cache.floodHazard.set(key, result)
 	return result, nil
 }
 
@@ -962,7 +962,7 @@ func (c *Client) FetchFloodHazard(ctx context.Context, z, x, y int) ([]domain.Fl
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.StormHazardItem, error) {
 	key := fmt.Sprintf("storm_hazard:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getStormHazard(key); ok {
+	if cached, ok := c.cache.stormHazard.get(key); ok {
 		return cached, nil
 	}
 	var geoResp StormHazardGeoJSON
@@ -973,7 +973,7 @@ func (c *Client) FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.St
 	for _, f := range geoResp.Features {
 		result = append(result, domain.StormHazardItem{DepthJa: f.Properties.DepthJa})
 	}
-	c.cache.setStormHazard(key, result)
+	c.cache.stormHazard.set(key, result)
 	return result, nil
 }
 
@@ -981,7 +981,7 @@ func (c *Client) FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.St
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.TsunamiHazardItem, error) {
 	key := fmt.Sprintf("tsunami_hazard:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getTsunamiHazard(key); ok {
+	if cached, ok := c.cache.tsunamiHazard.get(key); ok {
 		return cached, nil
 	}
 	var geoResp TsunamiHazardGeoJSON
@@ -992,7 +992,7 @@ func (c *Client) FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.
 	for _, f := range geoResp.Features {
 		result = append(result, domain.TsunamiHazardItem{DepthJa: f.Properties.DepthJa})
 	}
-	c.cache.setTsunamiHazard(key, result)
+	c.cache.tsunamiHazard.set(key, result)
 	return result, nil
 }
 
@@ -1000,7 +1000,7 @@ func (c *Client) FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domain.LandslideHazardItem, error) {
 	key := fmt.Sprintf("landslide_hazard:%d:%d:%d", z, x, y)
-	if cached, ok := c.cache.getLandslideHazard(key); ok {
+	if cached, ok := c.cache.landslideHazard.get(key); ok {
 		return cached, nil
 	}
 	var geoResp LandslideHazardGeoJSON
@@ -1014,7 +1014,7 @@ func (c *Client) FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domai
 			ZoneCode:       f.Properties.ZoneCode,
 		})
 	}
-	c.cache.setLandslideHazard(key, result)
+	c.cache.landslideHazard.set(key, result)
 	return result, nil
 }
 

--- a/backend/internal/mlit/client_test.go
+++ b/backend/internal/mlit/client_test.go
@@ -391,22 +391,22 @@ func TestCache_TTLExpiry(t *testing.T) {
 	data := []domain.LandTransaction{{Period: "2024年第1四半期", TradePrice: 10_000_000}}
 
 	// 有効期限を過去に設定して直接注入
-	c.land.mu.Lock()
-	c.land.entries[key] = cacheEntry{
+	c.landPrices.mu.Lock()
+	c.landPrices.entries[key] = genericEntry[domain.LandTransaction]{
 		data:      data,
 		expiresAt: time.Now().Add(-1 * time.Second), // 1秒前に期限切れ
 	}
-	c.land.mu.Unlock()
+	c.landPrices.mu.Unlock()
 
-	_, ok := c.get(key)
+	_, ok := c.landPrices.get(key)
 	if ok {
 		t.Error("expected cache miss after TTL expiry, got hit")
 	}
 
 	// TTL切れエントリは get 後に削除されていること（メモリリーク対策）
-	c.land.mu.RLock()
-	_, stillExists := c.land.entries[key]
-	c.land.mu.RUnlock()
+	c.landPrices.mu.RLock()
+	_, stillExists := c.landPrices.entries[key]
+	c.landPrices.mu.RUnlock()
 	if stillExists {
 		t.Error("expected expired entry to be deleted from map, but it still exists")
 	}
@@ -416,9 +416,9 @@ func TestCache_ReturnsCopy(t *testing.T) {
 	c := newCache()
 	key := "test-key"
 	original := []domain.LandTransaction{{Period: "2024年第1四半期", TradePrice: 10_000_000}}
-	c.set(key, original)
+	c.landPrices.set(key, original)
 
-	result, ok := c.get(key)
+	result, ok := c.landPrices.get(key)
 	if !ok {
 		t.Fatal("expected cache hit")
 	}
@@ -426,7 +426,7 @@ func TestCache_ReturnsCopy(t *testing.T) {
 	// 返されたスライスを変更してもキャッシュが汚染されないこと
 	result[0].TradePrice = 999
 
-	result2, ok := c.get(key)
+	result2, ok := c.landPrices.get(key)
 	if !ok {
 		t.Fatal("expected cache hit on 2nd get")
 	}
@@ -448,7 +448,7 @@ func TestCache_ConcurrentAccess(t *testing.T) {
 	// 書き込みゴルーチン
 	go func() {
 		for i := 0; i < goroutines; i++ {
-			c.set(key, data)
+			c.landPrices.set(key, data)
 		}
 		close(done)
 	}()
@@ -456,7 +456,7 @@ func TestCache_ConcurrentAccess(t *testing.T) {
 	// 読み取りゴルーチン群（書き込みと並行）
 	for i := 0; i < goroutines; i++ {
 		go func() {
-			c.get(key)
+			c.landPrices.get(key)
 		}()
 	}
 


### PR DESCRIPTION
## 概要

`backend/internal/mlit/cache.go` に散在していた15種類のほぼ同一キャッシュ型と30個の get/set メソッドを、Go generics の `genericCache[E any]` 一型に統一した。

- **before**: 567行（15エントリ型・3グループ struct・30メソッド）
- **after**: 約100行（`genericEntry[E]` + `genericCache[E]` + `cache` struct）

## 変更内容

- `cache.go` 全面書き直し: `genericEntry[E any]` / `genericCache[E any]` / `newGenericCache[E]()` を定義し、旧 `landPriceGroup` / `tileGroup` / `hazardGroup` および15エントリ型を削除
- `client.go` 30箇所置換: `c.cache.getMuni(area)` → `c.cache.municipalities.get(area)` 形式に統一
- `client_test.go` 3テスト更新: `TestCache_TTLExpiry` / `TestCache_ReturnsCopy` / `TestCache_ConcurrentAccess`

## 設計上の改善点

- 各 `genericCache[E]` が独立した `sync.RWMutex` を持つため、旧来の「複数データ型が1つの mutex を共有する」設計よりロック競合が減少
- TTL・コピーオンリード・期限切れエントリ削除の挙動は変更なし

## 確認事項

- [x] `go test -race ./... -timeout 120s` 全パス
- [x] `go vet ./...` 問題なし
- [x] `go build ./...` 成功

## 関連

Closes #324