### PR TITLE
fix(terraform): Artifact Registry クリーンアップポリシーが機能しない問題を修正

### DIFF
--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -9,8 +9,10 @@ resource "google_artifact_registry_repository" "backend" {
   # a 403 on repositories.update before the new IAM role has propagated.
   depends_on = [google_project_iam_member.deployer_ar_repo_admin]
 
-  # 評価順序: KEEP が優先され、最新5件は保護される。
-  # それ以外のタグ付きイメージは older_than を超えた時点で DELETE 対象となる。
+  # false にしないとドライラン扱いになり実際に削除されない。
+  cleanup_policy_dry_run = false
+
+  # KEEP が DELETE より優先される。最新5件は保護され、それ以外は削除対象になる。
   cleanup_policies {
     id     = "keep-5-most-recent"
     action = "KEEP"
@@ -19,12 +21,14 @@ resource "google_artifact_registry_repository" "backend" {
     }
   }
 
+  # older_than を長く設定すると「6枚目以降かつ期間内」のイメージが残り続ける。
+  # プッシュ直後の競合を避けるため 1 日のバッファのみ設ける。
   cleanup_policies {
-    id     = "delete-old"
+    id     = "delete-old-tagged"
     action = "DELETE"
     condition {
       tag_state  = "TAGGED"
-      older_than = "2592000s" # 30日
+      older_than = "86400s" # 1日
     }
   }
 
@@ -33,7 +37,7 @@ resource "google_artifact_registry_repository" "backend" {
     action = "DELETE"
     condition {
       tag_state  = "UNTAGGED"
-      older_than = "604800s" # 7日
+      older_than = "86400s" # 1日
     }
   }
 }


### PR DESCRIPTION
## 概要

Artifact Registry のクリーンアップポリシーが実際に動作しておらず、イメージが最新5件に絞られていなかった問題を修正します。

## 原因

2点の設定ミスが重なっていました。

1. **`cleanup_policy_dry_run` が未設定**
   - デフォルト値がドライランとして扱われるケースがあり、ポリシーは評価されるが実際の削除が実行されなかった。
   - `cleanup_policy_dry_run = false` を明示的に追加。

2. **`delete-old` の `older_than = 30日` が長すぎた**
   - 「最新5件に入らない、かつ30日以内のイメージ」は DELETE 対象外になっていた。
   - 例: 1ヶ月で10枚プッシュすると6〜10枚目が残り続ける。
   - `older_than` を 1日に短縮。KEEP ポリシーが上位5件を保護するため、DELETE 側は競合回避の短い猶予のみで十分。

## 変更内容

| ファイル | 変更 |
|----------|------|
| `terraform/artifact_registry.tf` | `cleanup_policy_dry_run = false` 追加、`delete-old` の `older_than` を 30日→1日、`delete-untagged` も 7日→1日に統一 |

## ポリシー評価フロー（変更後）

```
1. keep-5-most-recent (KEEP)  → 最新5件を保護（DELETEより優先）
2. delete-old-tagged  (DELETE) → TAGGED かつ 1日超 → 上位5件以外は翌日に削除
3. delete-untagged    (DELETE) → UNTAGGED かつ 1日超 → 同様に削除
```

## テスト計画

- [ ] `terraform plan` でドリフトなし・変更内容が想定通りであることを確認
- [ ] `terraform apply` 後、Artifact Registry コンソールで6件以上のイメージが存在する場合に翌日削除されることを確認