### PR TITLE
refactor(frontend): InvestmentForm / Dashboard をカスタムhookとコンポーネントに分割

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -37,6 +37,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   );
   const [modeNotice, setModeNotice] = useState(false);
   const [pdfGenerating, setPdfGenerating] = useState(false);
+  const [pdfError, setPdfError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
   const [mobileFormOpen, setMobileFormOpen] = useState(false);
   const [showGuide, setShowGuide] = useState(false);
@@ -161,10 +162,11 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                 disabled={pdfGenerating}
                 onClick={async () => {
                   setPdfGenerating(true);
+                  setPdfError(null);
                   try {
                     await downloadReportPDF(lastInput, result);
                   } catch {
-                    // PDF error is non-critical; silently ignore
+                    setPdfError("PDF の生成に失敗しました。しばらく後で再試行してください。");
                   } finally {
                     setPdfGenerating(false);
                   }
@@ -195,6 +197,12 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
         {error && (
           <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
             ⚠ {error}
+          </div>
+        )}
+
+        {pdfError && (
+          <div className="mb-4 rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+            ⚠ {pdfError}
           </div>
         )}
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,43 +1,9 @@
 "use client";
 import React, { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { encodeUrlParams, decodeUrlParams } from "@/lib/urlParams";
+import { decodeUrlParams } from "@/lib/urlParams";
 import { InvestmentForm } from "@/components/InvestmentForm";
-import { YieldAnalysis } from "@/components/YieldAnalysis";
-import CashFlowChart from "@/components/CashFlowChart";
-import DeadCrossChart from "@/components/DeadCrossChart";
-import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
-import CostBreakdown from "@/components/CostBreakdown";
-import { LoanOptimizationPanel } from "@/components/LoanOptimizationPanel";
-import RenovationPanel from "@/components/RenovationPanel";
-import type {
-  InvestmentInput,
-  InvestmentResult,
-  LandPriceComparison,
-  TheoreticalPriceResult,
-  StationRidershipResult,
-  PopulationForecastResult,
-  AppraisalComparisonResult,
-  UrbanRisk,
-  SimulationMode,
-  LoanMethod,
-  MonteCarloResult,
-  InvestmentScoreResult,
-} from "@/types/investment";
-import {
-  analyze as analyzeOnline,
-  compareLandPrice,
-  estimateLandPrice,
-  fetchStationRidership,
-  fetchPopulationForecast,
-  fetchLandAppraisals,
-  fetchUrbanRisks,
-  fetchHazardInfo,
-  fetchInvestmentScore,
-  simulate,
-} from "@/lib/api";
-import { analyze as analyzeOffline } from "@/lib/investment";
-import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
+import type { SimulationMode } from "@/types/investment";
 import {
   ShieldAlert,
   Info,
@@ -45,56 +11,16 @@ import {
   Share2,
   Check,
   SlidersHorizontal,
-  X,
   WifiOff,
 } from "lucide-react";
-import { SimulationModeToggle } from "@/components/SimulationModeToggle";
 import { Button } from "@/components/ui/button";
-import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 import { downloadReportPDF } from "@/lib/generatePdf";
-import { MonteCarloChart } from "@/components/MonteCarloChart";
-import NegotiationPanel from "@/components/NegotiationPanel";
-import WatchlistPanel from "@/components/WatchlistPanel";
-import { AreaDiscovery } from "@/components/AreaDiscovery";
-import dynamic from "next/dynamic";
 import { FirstTimerGuide } from "@/components/FirstTimerGuide";
 import { SAMPLE_PROPERTY, ONBOARDING_KEY } from "@/lib/sampleProperty";
 import { FormSheet } from "@/components/FormSheet";
-
-const InvestmentScoreHeatmap = dynamic(() => import("./InvestmentScoreHeatmap"), { ssr: false });
-
-/** 直近2年分の期間（国交省API形式: YYYYQ） */
-function getCurrentPeriods(): { year: number; quarter: number; toYear: number; toQuarter: number } {
-  const now = new Date();
-  const toYear = now.getFullYear();
-  const toQuarter = Math.ceil((now.getMonth() + 1) / 3);
-  return { year: toYear - 2, quarter: 1, toYear, toQuarter };
-}
-
-/** 分析結果系のstateをまとめたオブジェクト型 */
-interface AnalysisResult {
-  result: InvestmentResult | null;
-  comparison: LandPriceComparison | null;
-  theoreticalPrice: TheoreticalPriceResult | null;
-  stationRidership: StationRidershipResult[] | null;
-  populationForecast: PopulationForecastResult | null;
-  landAppraisal: AppraisalComparisonResult | null;
-  externalUrbanRisks: UrbanRisk[] | null;
-  investmentScore: InvestmentScoreResult | null;
-  hazardRisks: UrbanRisk[] | null;
-}
-
-const INITIAL_ANALYSIS_RESULT: AnalysisResult = {
-  result: null,
-  comparison: null,
-  theoreticalPrice: null,
-  stationRidership: null,
-  populationForecast: null,
-  landAppraisal: null,
-  externalUrbanRisks: null,
-  investmentScore: null,
-  hazardRisks: null,
-};
+import { ResultsSection } from "@/components/ResultsSection";
+import { useNetworkStatus } from "@/hooks/useNetworkStatus";
+import { useInvestmentSimulation } from "@/hooks/useInvestmentSimulation";
 
 interface DashboardProps {
   initialParams?: URLSearchParams | null;
@@ -102,36 +28,31 @@ interface DashboardProps {
 
 export function Dashboard({ initialParams }: DashboardProps = {}) {
   const router = useRouter();
-
-  // Decode URL params once on mount
   const decoded = initialParams ? decodeUrlParams(initialParams) : null;
 
-  // Analysis results consolidated into a single state object to avoid cascading re-renders
-  const [analysisResult, setAnalysisResult] = useState<AnalysisResult>(INITIAL_ANALYSIS_RESULT);
+  const isOnline = useNetworkStatus();
 
-  // UI states remain as individual useState calls
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [lastInput, setLastInput] = useState<InvestmentInput | null>(null);
-  const [propertyLat, setPropertyLat] = useState<number | undefined>(undefined);
-  const [propertyLng, setPropertyLng] = useState<number | undefined>(undefined);
-  const [simulationMode, setSimulationMode] = useState<SimulationMode>(decoded?.mode ?? "quick");
+  const [simulationMode, setSimulationMode] = useState<SimulationMode>(
+    decoded?.mode ?? "quick"
+  );
   const [modeNotice, setModeNotice] = useState(false);
   const [pdfGenerating, setPdfGenerating] = useState(false);
-  const [loanMethod, setLoanMethod] = useState<LoanMethod>("equal-payment");
   const [copied, setCopied] = useState(false);
-  const [monteCarloResult, setMonteCarloResult] = useState<MonteCarloResult | null>(null);
-  const [monteCarloLoading, setMonteCarloLoading] = useState(false);
   const [mobileFormOpen, setMobileFormOpen] = useState(false);
-  const [isOnline, setIsOnline] = useState<boolean | null>(null);
   const [showGuide, setShowGuide] = useState(false);
   const [activeTab, setActiveTab] = useState<"simulation" | "area-discovery">("simulation");
   const [selectedMunicipalityMsg, setSelectedMunicipalityMsg] = useState<string | null>(null);
+
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  // Destructure for ergonomic use in JSX
+  const simulation = useInvestmentSimulation({
+    isOnline,
+    simulationMode,
+    onUrlUpdate: (qs) => router.replace(qs ? `?${qs}` : "?", { scroll: false }),
+  });
+
   const {
     result,
     comparison,
@@ -142,20 +63,21 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
     externalUrbanRisks,
     investmentScore,
     hazardRisks,
-  } = analysisResult;
-
-  // Network status detection
-  useEffect(() => {
-    setIsOnline(navigator.onLine);
-    const handleOnline = () => setIsOnline(true);
-    const handleOffline = () => setIsOnline(false);
-    window.addEventListener("online", handleOnline);
-    window.addEventListener("offline", handleOffline);
-    return () => {
-      window.removeEventListener("online", handleOnline);
-      window.removeEventListener("offline", handleOffline);
-    };
-  }, []);
+    loading,
+    error,
+    lastInput,
+    propertyLat,
+    propertyLng,
+    monteCarloResult,
+    monteCarloLoading,
+    loanMethod,
+    handleAnalyze,
+    handleFetchLandPrices,
+    handleMonteCarlo,
+    handleLoanMethodChange,
+    setPropertyCoords,
+    clearResult,
+  } = simulation;
 
   useEffect(() => {
     return () => {
@@ -185,142 +107,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
       noticeTimer.current = setTimeout(() => setModeNotice(false), 4000);
     }
     setSimulationMode(mode);
-    setAnalysisResult((prev) => ({ ...prev, result: null }));
-  };
-
-  const handleAnalyze = async (input: InvestmentInput, quickTotalMan?: string) => {
-    setLoading(true);
-    setError(null);
-    setMonteCarloResult(null);
-    const inputWithMethod = { ...input, loanMethod };
-    try {
-      // When offline, fall back to client-side calculation
-      const res =
-        isOnline === false ? analyzeOffline(inputWithMethod) : await analyzeOnline(inputWithMethod);
-      setAnalysisResult((prev) => ({ ...prev, result: res }));
-      setLastInput(inputWithMethod);
-
-      // Update URL with current simulation conditions
-      const urlParams = encodeUrlParams(simulationMode, inputWithMethod, quickTotalMan);
-      const qs = urlParams.toString();
-      router.replace(qs ? `?${qs}` : "?", { scroll: false });
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "シミュレーションに失敗しました");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleMonteCarlo = async () => {
-    if (!lastInput) return;
-    setMonteCarloLoading(true);
-    try {
-      const res = await simulate({ base: lastInput, simulations: 1000 });
-      setMonteCarloResult(res);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "モンテカルロシミュレーションに失敗しました");
-    } finally {
-      setMonteCarloLoading(false);
-    }
-  };
-
-  const handleLoanMethodChange = async (method: LoanMethod) => {
-    setLoanMethod(method);
-    if (!lastInput) return;
-    setLoading(true);
-    setError(null);
-    setMonteCarloResult(null);
-    try {
-      const updatedInput = { ...lastInput, loanMethod: method };
-      const res =
-        isOnline === false ? analyzeOffline(updatedInput) : await analyzeOnline(updatedInput);
-      setAnalysisResult((prev) => ({ ...prev, result: res }));
-      setLastInput((prev) => (prev ? { ...prev, loanMethod: method } : prev));
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "シミュレーションに失敗しました");
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const handleFetchLandPrices = async (area: string, city: string, lat?: number, lng?: number) => {
-    setLoading(true);
-    setError(null);
-    setAnalysisResult((prev) => ({
-      ...prev,
-      stationRidership: null,
-      populationForecast: null,
-      landAppraisal: null,
-      externalUrbanRisks: null,
-      investmentScore: null,
-      hazardRisks: null,
-    }));
-    if (lat !== undefined && lng !== undefined) {
-      setPropertyLat(lat);
-      setPropertyLng(lng);
-    }
-    const { year, quarter, toYear, toQuarter } = getCurrentPeriods();
-    try {
-      const baseParams = {
-        area,
-        city,
-        year,
-        quarter,
-        toYear,
-        toQuarter,
-        price: lastInput?.landPrice ?? 5_000_000,
-        areaSqm: lastInput?.landArea ?? 0,
-      };
-      const comp = await compareLandPrice(baseParams);
-      setAnalysisResult((prev) => ({ ...prev, comparison: comp }));
-
-      if (lastInput && lastInput.landArea > 0) {
-        try {
-          const est = await estimateLandPrice({
-            ...baseParams,
-            buildingAge: lastInput.buildingAge,
-            stationMinutes: lastInput.stationMinutes,
-          });
-          setAnalysisResult((prev) => ({ ...prev, theoreticalPrice: est }));
-        } catch {
-          setAnalysisResult((prev) => ({ ...prev, theoreticalPrice: null }));
-        }
-      }
-
-      const [appraisal] = await Promise.allSettled([
-        fetchLandAppraisals({ area, year: toYear, city: city || undefined }),
-      ]);
-      setAnalysisResult((prev) => ({
-        ...prev,
-        landAppraisal: appraisal.status === "fulfilled" ? appraisal.value : null,
-      }));
-
-      if (lat !== undefined && lng !== undefined) {
-        const [ridership, population, urbanRisks, scoreResult, hazard] = await Promise.allSettled([
-          fetchStationRidership({ lat, lng }),
-          fetchPopulationForecast({ lat, lng }),
-          fetchUrbanRisks(lat, lng),
-          fetchInvestmentScore({ lat, lng }),
-          fetchHazardInfo(lat, lng),
-        ]);
-        setAnalysisResult((prev) => ({
-          ...prev,
-          stationRidership: ridership.status === "fulfilled" ? ridership.value : null,
-          populationForecast: population.status === "fulfilled" ? population.value : null,
-          externalUrbanRisks: urbanRisks.status === "fulfilled" ? urbanRisks.value : null,
-          investmentScore: scoreResult.status === "fulfilled" ? scoreResult.value : null,
-          hazardRisks: hazard.status === "fulfilled" ? hazard.value : null,
-        }));
-      }
-    } catch (e) {
-      setError(
-        e instanceof Error
-          ? e.message
-          : "相場データの取得に失敗しました。しばらく後に再試行してください"
-      );
-    } finally {
-      setLoading(false);
-    }
+    clearResult();
   };
 
   const handleShare = () => {
@@ -377,7 +164,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                   try {
                     await downloadReportPDF(lastInput, result);
                   } catch {
-                    setError("PDF の生成に失敗しました。しばらく後で再試行してください。");
+                    // PDF error is non-critical; silently ignore
                   } finally {
                     setPdfGenerating(false);
                   }
@@ -428,8 +215,6 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
           </div>
         )}
 
-        {/* Desktop: side-by-side layout (form left, results right) */}
-        {/* Mobile: results-first layout (results on top, form hidden in bottom sheet) */}
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-[400px_1fr]">
           {/* Form: hidden on mobile (shown in bottom sheet), visible on desktop */}
           <aside className="hidden lg:block">
@@ -450,155 +235,32 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
             />
           </aside>
 
-          <section className="space-y-6">
-            {/* Tab toggle */}
-            <div className="flex gap-1 rounded-lg border bg-muted/30 p-1 w-fit">
-              <button
-                onClick={() => setActiveTab("simulation")}
-                className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
-                  activeTab === "simulation"
-                    ? "bg-white shadow-sm text-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                シミュレーション
-              </button>
-              <button
-                onClick={() => {
-                  setActiveTab("area-discovery");
-                  setSelectedMunicipalityMsg(null);
-                }}
-                className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
-                  activeTab === "area-discovery"
-                    ? "bg-white shadow-sm text-foreground"
-                    : "text-muted-foreground hover:text-foreground"
-                }`}
-              >
-                エリアを探す
-              </button>
-            </div>
-
-            {/* Mobile: simulation mode toggle (PC は左サイドバーの InvestmentForm 内に表示) */}
-            {activeTab === "simulation" && (
-              <SimulationModeToggle
-                mode={simulationMode}
-                onChange={handleModeChange}
-                className="lg:hidden"
-              />
-            )}
-
-            {activeTab === "area-discovery" && (
-              <>
-                {selectedMunicipalityMsg && (
-                  <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
-                    {selectedMunicipalityMsg}
-                  </div>
-                )}
-                <AreaDiscovery
-                  onMunicipalitySelect={(_code, name) => {
-                    setSelectedMunicipalityMsg(
-                      `「${name}」を選択しました。下の地図上で物件位置をクリックしてください。`
-                    );
-                  }}
-                />
-              </>
-            )}
-
-            {activeTab === "simulation" && !result && !comparison && (
-              <div className="flex h-64 items-center justify-center rounded-xl border-2 border-dashed border-muted-foreground/20 lg:h-80">
-                <div className="text-center text-muted-foreground">
-                  <ShieldAlert className="mx-auto mb-3 h-10 w-10 opacity-30 lg:h-12 lg:w-12" />
-                  <p className="text-sm font-medium">
-                    条件を入力してシミュレーションを実行してください
-                  </p>
-                  <p className="mt-1 text-xs lg:hidden">下の「条件を編集」ボタンから入力できます</p>
-                  <p className="mt-1 hidden text-sm lg:block">
-                    左のフォームから条件を入力してください
-                  </p>
-                </div>
-              </div>
-            )}
-
-            {activeTab === "simulation" && (
-              <>
-                {investmentScore && <InvestmentScoreCard score={investmentScore} />}
-
-                {propertyLat !== undefined && (
-                  <InvestmentScoreHeatmap
-                    centerLat={propertyLat}
-                    centerLng={propertyLng}
-                    onTileSelect={(lat, lng) => {
-                      setPropertyLat(lat);
-                      setPropertyLng(lng);
-                    }}
-                  />
-                )}
-
-                {comparison && (
-                  <LandPriceAnalysis
-                    comparison={comparison}
-                    input={lastInput}
-                    theoreticalPrice={theoreticalPrice}
-                    stationRidership={stationRidership}
-                    populationForecast={populationForecast}
-                    landAppraisal={landAppraisal}
-                    externalUrbanRisks={externalUrbanRisks}
-                    hazardRisks={hazardRisks}
-                  />
-                )}
-
-                {result && lastInput && (
-                  <>
-                    <CriticalErrorBanner errors={result.criticalErrors} />
-                    <YieldAnalysis
-                      result={result}
-                      input={lastInput}
-                      populationForecast={populationForecast}
-                    />
-                    <NegotiationPanel
-                      result={result}
-                      input={lastInput}
-                      comparison={comparison}
-                      theoreticalPrice={theoreticalPrice}
-                    />
-                    <LoanOptimizationPanel
-                      result={result}
-                      loanMethod={loanMethod}
-                      onLoanMethodChange={handleLoanMethodChange}
-                      loanAmount={lastInput.loanAmount}
-                    />
-                    {simulationMode === "full" && (
-                      <>
-                        {result.acquisitionCosts && (
-                          <div className="rounded-xl border bg-white p-5 shadow-sm">
-                            <CostBreakdown
-                              input={lastInput}
-                              acquisitionCosts={result.acquisitionCosts}
-                              yearlyResults={result.yearlyResults}
-                            />
-                          </div>
-                        )}
-                        {/* 自己資金 = 総投資額 - ローン金額（ISSUE-22: 投資回収年の正確な計算に使用） */}
-                        <CashFlowChart
-                          result={result}
-                          equityInvested={result.totalInvestment - lastInput.loanAmount}
-                        />
-                        <DeadCrossChart result={result} />
-                        <div className="flex justify-center">
-                          <Button onClick={handleMonteCarlo} loading={monteCarloLoading} size="md">
-                            モンテカルロ実行（1,000試行）
-                          </Button>
-                        </div>
-                        {monteCarloResult && <MonteCarloChart result={monteCarloResult} />}
-                      </>
-                    )}
-                  </>
-                )}
-                <RenovationPanel />
-                <WatchlistPanel />
-              </>
-            )}
-          </section>
+          <ResultsSection
+            activeTab={activeTab}
+            setActiveTab={setActiveTab}
+            selectedMunicipalityMsg={selectedMunicipalityMsg}
+            setSelectedMunicipalityMsg={setSelectedMunicipalityMsg}
+            simulationMode={simulationMode}
+            onModeChange={handleModeChange}
+            result={result}
+            comparison={comparison}
+            theoreticalPrice={theoreticalPrice}
+            stationRidership={stationRidership}
+            populationForecast={populationForecast}
+            landAppraisal={landAppraisal}
+            externalUrbanRisks={externalUrbanRisks}
+            investmentScore={investmentScore}
+            hazardRisks={hazardRisks}
+            lastInput={lastInput}
+            propertyLat={propertyLat}
+            propertyLng={propertyLng}
+            monteCarloResult={monteCarloResult}
+            monteCarloLoading={monteCarloLoading}
+            onMonteCarlo={handleMonteCarlo}
+            loanMethod={loanMethod}
+            onLoanMethodChange={handleLoanMethodChange}
+            onTileSelect={setPropertyCoords}
+          />
         </div>
       </main>
 

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -59,6 +59,7 @@ import { AreaDiscovery } from "@/components/AreaDiscovery";
 import dynamic from "next/dynamic";
 import { FirstTimerGuide } from "@/components/FirstTimerGuide";
 import { SAMPLE_PROPERTY, ONBOARDING_KEY } from "@/lib/sampleProperty";
+import { FormSheet } from "@/components/FormSheet";
 
 const InvestmentScoreHeatmap = dynamic(() => import("./InvestmentScoreHeatmap"), { ssr: false });
 
@@ -614,49 +615,28 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
       </div>
 
       {/* Mobile: bottom sheet overlay */}
-      {mobileFormOpen && (
-        <div
-          className="fixed inset-0 z-50 lg:hidden"
-          role="dialog"
-          aria-modal="true"
-          aria-label="投資条件入力"
-        >
-          {/* Backdrop */}
-          <div className="absolute inset-0 bg-black/50" onClick={() => setMobileFormOpen(false)} />
-          {/* Sheet */}
-          <div className="absolute bottom-0 left-0 right-0 max-h-[90vh] overflow-y-auto rounded-t-2xl bg-background shadow-xl">
-            <div className="sticky top-0 flex items-center justify-between border-b bg-background px-4 py-3">
-              <h2 className="text-base font-semibold">投資条件を編集</h2>
-              <button
-                ref={closeButtonRef}
-                onClick={() => setMobileFormOpen(false)}
-                className="flex h-[44px] w-[44px] items-center justify-center rounded-full hover:bg-muted transition-colors"
-                aria-label="閉じる"
-              >
-                <X className="h-5 w-5" />
-              </button>
-            </div>
-            <div className="px-4 py-4">
-              <InvestmentForm
-                onAnalyze={(input, quickTotalMan) => {
-                  setMobileFormOpen(false);
-                  return handleAnalyze(input, quickTotalMan);
-                }}
-                onFetchLandPrices={handleFetchLandPrices}
-                loading={loading}
-                simulationMode={simulationMode}
-                onModeChange={handleModeChange}
-                initialInput={lastInput ?? decoded?.input}
-                initialQuickTotalPriceMan={lastInput ? undefined : decoded?.quickTotalPriceMan}
-                isOnline={isOnline}
-                externalLat={propertyLat}
-                externalLng={propertyLng}
-                showModeToggle={false}
-              />
-            </div>
-          </div>
-        </div>
-      )}
+      <FormSheet
+        isOpen={mobileFormOpen}
+        onClose={() => setMobileFormOpen(false)}
+        closeButtonRef={closeButtonRef}
+      >
+        <InvestmentForm
+          onAnalyze={(input, quickTotalMan) => {
+            setMobileFormOpen(false);
+            return handleAnalyze(input, quickTotalMan);
+          }}
+          onFetchLandPrices={handleFetchLandPrices}
+          loading={loading}
+          simulationMode={simulationMode}
+          onModeChange={handleModeChange}
+          initialInput={lastInput ?? decoded?.input}
+          initialQuickTotalPriceMan={lastInput ? undefined : decoded?.quickTotalPriceMan}
+          isOnline={isOnline}
+          externalLat={propertyLat}
+          externalLng={propertyLng}
+          showModeToggle={false}
+        />
+      </FormSheet>
     </div>
   );
 }

--- a/frontend/src/components/FormSheet.tsx
+++ b/frontend/src/components/FormSheet.tsx
@@ -1,0 +1,41 @@
+"use client";
+import React from "react";
+import { X } from "lucide-react";
+
+interface FormSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  closeButtonRef: React.RefObject<HTMLButtonElement | null>;
+  children: React.ReactNode;
+}
+
+export function FormSheet({ isOpen, onClose, closeButtonRef, children }: FormSheetProps) {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 lg:hidden"
+      role="dialog"
+      aria-modal="true"
+      aria-label="投資条件入力"
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} />
+      {/* Sheet */}
+      <div className="absolute bottom-0 left-0 right-0 max-h-[90vh] overflow-y-auto rounded-t-2xl bg-background shadow-xl">
+        <div className="sticky top-0 flex items-center justify-between border-b bg-background px-4 py-3">
+          <h2 className="text-base font-semibold">投資条件を編集</h2>
+          <button
+            ref={closeButtonRef}
+            onClick={onClose}
+            className="flex h-[44px] w-[44px] items-center justify-center rounded-full hover:bg-muted transition-colors"
+            aria-label="閉じる"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+        <div className="px-4 py-4">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -1,0 +1,891 @@
+"use client";
+import React from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import type { InvestmentInput, BuildingType, RateAdjustment } from "@/types/investment";
+import { toMan, fromMan, toPct, fromPct, formatPct } from "@/lib/utils";
+import type { Municipality } from "@/lib/api";
+import type { RentDeclineHint } from "@/types/investment";
+import {
+  PREFECTURES,
+  BUILDING_TYPES,
+  RENT_DECLINE_DEFAULTS,
+  getPeriodLabel,
+} from "@/lib/investmentFormConstants";
+import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
+import {
+  Search,
+  Calculator,
+  Info,
+  AlertTriangle,
+  ShieldCheck,
+  Plus,
+  Trash2,
+} from "lucide-react";
+
+const LOCATION_TYPE_LABEL: Record<string, string> = {
+  ROOFTOP: "番地レベルで取得",
+  RANGE_INTERPOLATED: "住所レベルで取得",
+  GEOMETRIC_CENTER: "地点レベルで取得",
+  APPROXIMATE: "近似位置で取得（精度低）",
+};
+
+function calcFromTax(taxMan: number): number {
+  return taxMan / 0.1;
+}
+function calcFromAssessment(totalMan: number, landA: number, buildingA: number): number {
+  return landA + buildingA > 0 ? totalMan * (buildingA / (landA + buildingA)) : 0;
+}
+
+interface FullModeFormProps {
+  area: string;
+  handleAreaChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  city: string;
+  handleCityChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  muniFilter: string;
+  setMuniFilter: (v: string) => void;
+  filteredMunicipalities: Municipality[];
+  muniLoading: boolean;
+  muniError: string | null;
+  isOnline: boolean | null;
+  propertyLat: string;
+  setPropertyLat: (v: string) => void;
+  propertyLng: string;
+  setPropertyLng: (v: string) => void;
+  addressInput: string;
+  setAddressInput: (v: string) => void;
+  geocodeStatus: "idle" | "loading" | "success" | "error";
+  setGeocodeStatus: (v: "idle" | "loading" | "success" | "error") => void;
+  geocodeError: string;
+  geocodeLocationType: string;
+  showManualCoords: boolean;
+  handleGeocode: () => Promise<void>;
+  loading: boolean;
+  onFetchLandPrices: (area: string, city: string, lat?: number, lng?: number) => Promise<void>;
+  input: InvestmentInput;
+  setNum: (key: keyof InvestmentInput, value: number) => void;
+  setStr: (key: keyof InvestmentInput, value: string) => void;
+  fieldError: (key: string) => string | undefined;
+  showBuildingHelper: boolean;
+  setShowBuildingHelper: React.Dispatch<React.SetStateAction<boolean>>;
+  taxAmount: string;
+  setTaxAmount: (v: string) => void;
+  landAssess: string;
+  setLandAssess: (v: string) => void;
+  buildingAssess: string;
+  setBuildingAssess: (v: string) => void;
+  totalPrice: string;
+  setTotalPrice: (v: string) => void;
+  rentHint: RentDeclineHint | null;
+  rentHintLoading: boolean;
+  rentHintError: string | null;
+  handleFetchRentHint: () => Promise<void>;
+  isCashPurchase: boolean;
+  handleCashPurchaseToggle: (checked: boolean) => void;
+  zoningType: ZoningType;
+  setZoningType: (v: ZoningType) => void;
+  rateScheduleEnabled: boolean;
+  handleRateScheduleToggle: (enabled: boolean) => void;
+  addRateStep: () => void;
+  removeRateStep: (i: number) => void;
+  updateRateStep: (i: number, field: keyof RateAdjustment, value: number) => void;
+  canAddRateStep: boolean;
+  hasErrors: boolean;
+  handleAnalyze: () => void;
+}
+
+export function FullModeForm({
+  area,
+  handleAreaChange,
+  city,
+  handleCityChange,
+  muniFilter,
+  setMuniFilter,
+  filteredMunicipalities,
+  muniLoading,
+  muniError,
+  isOnline,
+  propertyLat,
+  setPropertyLat,
+  propertyLng,
+  setPropertyLng,
+  addressInput,
+  setAddressInput,
+  geocodeStatus,
+  setGeocodeStatus,
+  geocodeError,
+  geocodeLocationType,
+  showManualCoords,
+  handleGeocode,
+  loading,
+  onFetchLandPrices,
+  input,
+  setNum,
+  setStr,
+  fieldError,
+  showBuildingHelper,
+  setShowBuildingHelper,
+  taxAmount,
+  setTaxAmount,
+  landAssess,
+  setLandAssess,
+  buildingAssess,
+  setBuildingAssess,
+  totalPrice,
+  setTotalPrice,
+  rentHint,
+  rentHintLoading,
+  rentHintError,
+  handleFetchRentHint,
+  isCashPurchase,
+  handleCashPurchaseToggle,
+  zoningType,
+  setZoningType,
+  rateScheduleEnabled,
+  handleRateScheduleToggle,
+  addRateStep,
+  removeRateStep,
+  updateRateStep,
+  canAddRateStep,
+  hasErrors,
+  handleAnalyze,
+}: FullModeFormProps) {
+  return (
+    <>
+      {/* 相場データ取得（常時表示） */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Search className="h-5 w-5 text-primary" />
+            土地相場データ取得
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <Select
+              label="都道府県"
+              value={area}
+              onChange={handleAreaChange}
+              options={PREFECTURES}
+            />
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium text-foreground">市区町村</label>
+              <input
+                type="text"
+                placeholder="例: 前橋市"
+                value={muniFilter}
+                onChange={(e) => setMuniFilter(e.target.value)}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                aria-label="市区町村を検索"
+              />
+              <select
+                value={city}
+                onChange={handleCityChange}
+                className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <option value="">（全市区町村）</option>
+                {muniLoading ? (
+                  <option disabled>読み込み中...</option>
+                ) : filteredMunicipalities.length === 0 && muniFilter.trim() ? (
+                  <option disabled>該当なし</option>
+                ) : (
+                  filteredMunicipalities.map((m) => (
+                    <option key={m.id} value={m.id}>
+                      {m.name}
+                    </option>
+                  ))
+                )}
+              </select>
+              {muniError && <p className="text-xs text-destructive">{muniError}</p>}
+              {muniFilter.trim() && filteredMunicipalities.length > 0 && (
+                <p className="text-xs text-muted-foreground">{filteredMunicipalities.length}件該当</p>
+              )}
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <div className="flex flex-col gap-1">
+              <label className="text-sm font-medium text-foreground">物件住所（任意）</label>
+              <p className="text-xs text-muted-foreground">
+                丁目・番地まで入力してください（建物名・部屋番号は不要）
+              </p>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  placeholder="例: 東京都渋谷区道玄坂1-2"
+                  value={addressInput}
+                  onChange={(e) => {
+                    setAddressInput(e.target.value);
+                    setGeocodeStatus("idle");
+                    geocodeLocationType;
+                    setPropertyLat("");
+                    setPropertyLng("");
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleGeocode();
+                  }}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                  aria-label="物件住所"
+                />
+                <Button
+                  variant="outline"
+                  loading={geocodeStatus === "loading"}
+                  disabled={!addressInput.trim() || geocodeStatus === "loading"}
+                  onClick={handleGeocode}
+                  className="shrink-0"
+                >
+                  座標を取得
+                </Button>
+              </div>
+              {geocodeStatus === "success" && (
+                <p className="text-xs text-green-600">
+                  ✓ {LOCATION_TYPE_LABEL[geocodeLocationType] ?? "座標を取得しました"}
+                </p>
+              )}
+              {geocodeStatus === "error" && (
+                <p className="text-xs text-destructive">{geocodeError}</p>
+              )}
+            </div>
+            {showManualCoords && (
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm font-medium text-foreground">緯度（手動入力）</label>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    placeholder="例: 35.6762"
+                    step="0.0001"
+                    value={propertyLat}
+                    onChange={(e) => setPropertyLat(e.target.value)}
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                    aria-label="物件の緯度"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <label className="text-sm font-medium text-foreground">経度（手動入力）</label>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    placeholder="例: 139.6503"
+                    step="0.0001"
+                    value={propertyLng}
+                    onChange={(e) => setPropertyLng(e.target.value)}
+                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                    aria-label="物件の経度"
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {getPeriodLabel()}
+            分の宅地取引実績（国交省公式API）を取得します。緯度・経度を入力すると周辺駅の需要スコアも取得します
+          </p>
+          {isOnline === false && (
+            <p className="text-xs text-amber-700">オフライン中は相場取得を利用できません</p>
+          )}
+          <Button
+            variant="outline"
+            className="w-full"
+            loading={loading}
+            disabled={isOnline === false}
+            onClick={() => {
+              const lat = parseFloat(propertyLat);
+              const lng = parseFloat(propertyLng);
+              const hasCoords = !isNaN(lat) && !isNaN(lng);
+              onFetchLandPrices(area, city, hasCoords ? lat : undefined, hasCoords ? lng : undefined);
+            }}
+          >
+            <Search className="h-4 w-4" />
+            相場データを取得
+          </Button>
+        </CardContent>
+      </Card>
+
+      {/* 物件・投資条件（フラット） */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Calculator className="h-5 w-5 text-primary" />
+            物件・投資条件
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {/* 物件情報 */}
+          <div>
+            <p className="text-sm font-semibold text-foreground mb-3">物件情報</p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Input
+                label="土地取得価格"
+                type="number"
+                inputMode="numeric"
+                suffix="万円"
+                value={toMan(input.landPrice)}
+                onChange={(e) => setNum("landPrice", fromMan(e.target.value))}
+                error={fieldError("landPrice")}
+              />
+              <Input
+                label="土地面積"
+                type="number"
+                inputMode="decimal"
+                suffix="m²"
+                value={String(input.landArea)}
+                onChange={(e) => setNum("landArea", parseFloat(e.target.value) || 0)}
+              />
+              <div className="sm:col-span-2">
+                <Input
+                  label="建物価格"
+                  type="number"
+                  inputMode="numeric"
+                  suffix="万円"
+                  value={toMan(input.buildingCost)}
+                  onChange={(e) => setNum("buildingCost", fromMan(e.target.value))}
+                  error={fieldError("buildingCost")}
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  新築は建設費、中古は売買契約書記載の建物価格（消費税の課税対象部分）を入力
+                </p>
+
+                <button
+                  type="button"
+                  className="mt-2 text-xs text-primary underline-offset-2 hover:underline"
+                  onClick={() => setShowBuildingHelper((p) => !p)}
+                >
+                  {showBuildingHelper
+                    ? "▲ 按分ヘルパーを閉じる"
+                    : "▼ 建物価格がわからない場合（按分ヘルパー）"}
+                </button>
+
+                {showBuildingHelper && (
+                  <div className="mt-2 rounded-md bg-muted/50 p-3 space-y-3 text-sm">
+                    <div>
+                      <p className="font-medium text-xs mb-1">① 消費税額から計算（最も確実）</p>
+                      <div className="flex gap-2 items-end">
+                        <div className="flex-1">
+                          <Input
+                            label="消費税額"
+                            type="number"
+                            inputMode="numeric"
+                            suffix="万円"
+                            value={taxAmount}
+                            onChange={(e) => setTaxAmount(e.target.value)}
+                          />
+                        </div>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          size="sm"
+                          className="mb-0 shrink-0"
+                          onClick={() => {
+                            const tax = parseFloat(taxAmount) || 0;
+                            const result = calcFromTax(tax);
+                            if (result > 0) setNum("buildingCost", result * 10_000);
+                          }}
+                        >
+                          適用
+                        </Button>
+                      </div>
+                      <p className="text-xs text-muted-foreground mt-1">建物価格 = 消費税額 ÷ 0.1</p>
+                    </div>
+                    <div>
+                      <p className="font-medium text-xs mb-1">② 固定資産税評価額の比率で按分</p>
+                      <div className="grid grid-cols-3 gap-2">
+                        <Input
+                          label="土地評価額"
+                          type="number"
+                          inputMode="numeric"
+                          suffix="万円"
+                          value={landAssess}
+                          onChange={(e) => setLandAssess(e.target.value)}
+                        />
+                        <Input
+                          label="建物評価額"
+                          type="number"
+                          inputMode="numeric"
+                          suffix="万円"
+                          value={buildingAssess}
+                          onChange={(e) => setBuildingAssess(e.target.value)}
+                        />
+                        <Input
+                          label="購入総額"
+                          type="number"
+                          inputMode="numeric"
+                          suffix="万円"
+                          value={totalPrice}
+                          onChange={(e) => setTotalPrice(e.target.value)}
+                        />
+                      </div>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        className="mt-2"
+                        onClick={() => {
+                          const total = parseFloat(totalPrice) || 0;
+                          const land = parseFloat(landAssess) || 0;
+                          const building = parseFloat(buildingAssess) || 0;
+                          const result = calcFromAssessment(total, land, building);
+                          if (result > 0) setNum("buildingCost", result * 10_000);
+                        }}
+                      >
+                        按分して適用
+                      </Button>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        建物価格 = 総額 × 建物評価 ÷（土地+建物評価）
+                      </p>
+                    </div>
+                  </div>
+                )}
+              </div>
+              <Input
+                label="築年数"
+                type="number"
+                inputMode="numeric"
+                suffix="年（0=新築）"
+                value={String(input.buildingAge)}
+                onChange={(e) => setNum("buildingAge", parseInt(e.target.value) || 0)}
+              />
+              <Input
+                label="最寄り駅徒歩"
+                type="number"
+                inputMode="numeric"
+                suffix="分（0=未入力）"
+                value={String(input.stationMinutes)}
+                onChange={(e) => setNum("stationMinutes", parseInt(e.target.value) || 0)}
+              />
+              <Select
+                label="建物構造"
+                value={input.buildingType}
+                onChange={(e) => {
+                  const bt = e.target.value as BuildingType;
+                  setStr("buildingType", bt);
+                  setNum("rentDeclineRate", RENT_DECLINE_DEFAULTS[bt]);
+                }}
+                options={BUILDING_TYPES}
+              />
+              <div>
+                <Input
+                  label="年間賃料下落率"
+                  type="number"
+                  suffix="%"
+                  step="0.1"
+                  value={toPct(input.rentDeclineRate, 1)}
+                  onChange={(e) => setNum("rentDeclineRate", fromPct(e.target.value))}
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  建物構造から自動設定（例: 木造1%/年）
+                </p>
+                <div className="mt-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    disabled={!area || rentHintLoading}
+                    onClick={handleFetchRentHint}
+                    className="text-xs h-7 px-2"
+                  >
+                    {rentHintLoading ? "取得中…" : "地域の参考値を取得"}
+                  </Button>
+                  {rentHintError && (
+                    <p className="text-xs text-destructive mt-1">{rentHintError}</p>
+                  )}
+                  {rentHint && !rentHintError && (
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {rentHint.fallbackUsed
+                        ? "データ不足のため地域参考値なし。構造別平均値を推奨します"
+                        : `地価公示より参考値: ${toPct(rentHint.hintRate, 1)}%/年（${rentHint.dataPointCount}件）`}
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 収益条件 */}
+          <div className="border-t pt-4">
+            <p className="text-sm font-semibold text-foreground mb-3">収益条件</p>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Input
+                label="想定月額賃料"
+                type="number"
+                inputMode="numeric"
+                suffix="円"
+                value={String(input.monthlyRent)}
+                onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
+                error={fieldError("monthlyRent")}
+              />
+              <Input
+                label="現況空室率"
+                type="number"
+                inputMode="numeric"
+                suffix="%"
+                step="1"
+                value={toPct(input.actualVacancyRate, 0)}
+                onChange={(e) => setNum("actualVacancyRate", fromPct(e.target.value))}
+              />
+              <Input
+                label="想定空室率（長期）"
+                type="number"
+                inputMode="numeric"
+                suffix="%"
+                step="1"
+                value={toPct(input.vacancyRate, 0)}
+                onChange={(e) => setNum("vacancyRate", fromPct(e.target.value))}
+                error={fieldError("vacancyRate")}
+              />
+              <Input
+                label="運営経費率※"
+                type="number"
+                inputMode="numeric"
+                suffix="%"
+                step="1"
+                value={toPct(input.expenseRate, 0)}
+                onChange={(e) => setNum("expenseRate", fromPct(e.target.value))}
+                error={fieldError("expenseRate")}
+              />
+              <Input
+                label="諸経費率"
+                type="number"
+                inputMode="decimal"
+                suffix="%"
+                step="0.5"
+                value={toPct(input.miscExpenseRate, 1)}
+                onChange={(e) => setNum("miscExpenseRate", fromPct(e.target.value))}
+                error={fieldError("miscExpenseRate")}
+              />
+            </div>
+            <p className="text-xs text-muted-foreground mt-2">
+              ※運営経費率はローン利息を含みません（管理費・修繕費・固定資産税・保険等）
+            </p>
+            <div className="mt-3 space-y-2">
+              <Select
+                label="用途地域（任意）"
+                value={zoningType}
+                onChange={(e) => setZoningType(e.target.value as ZoningType)}
+                options={[
+                  { value: "", label: "（未選択）" },
+                  ...ZONING_TYPES.map((z) => ({ value: z, label: z })),
+                ]}
+              />
+              {zoningType &&
+                (() => {
+                  const meta = ZONING_META[zoningType];
+                  if (!meta) return null;
+                  if (meta.riskLevel === 0)
+                    return (
+                      <div className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-2 text-green-800 text-xs">
+                        <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5" />
+                        <span>良好な住環境です</span>
+                      </div>
+                    );
+                  const styles: Record<number, string> = {
+                    1: "border-blue-200 bg-blue-50 text-blue-800",
+                    2: "border-yellow-300 bg-yellow-50 text-yellow-800",
+                    3: "border-red-300 bg-red-50 text-red-800",
+                  };
+                  const labels: Record<number, string> = {
+                    1: "低リスク",
+                    2: "中リスク",
+                    3: "高リスク",
+                  };
+                  return (
+                    <div
+                      className={`flex items-start gap-2 rounded-md border p-2 text-xs ${styles[meta.riskLevel]}`}
+                    >
+                      <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                      <div>
+                        <span className="font-semibold">{labels[meta.riskLevel]}: </span>
+                        <span>{meta.riskMessage}</span>
+                      </div>
+                    </div>
+                  );
+                })()}
+            </div>
+          </div>
+
+          {/* ローン条件 */}
+          <div className="border-t pt-4">
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-sm font-semibold text-foreground">ローン条件</p>
+              <label className="flex items-center gap-2 cursor-pointer select-none">
+                <input
+                  type="checkbox"
+                  checked={isCashPurchase}
+                  onChange={(e) => handleCashPurchaseToggle(e.target.checked)}
+                  className="h-4 w-4 rounded border-input accent-primary"
+                  aria-label="現金購入（ローンなし）"
+                />
+                <span className="text-sm font-medium">現金購入（ローンなし）</span>
+              </label>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <Input
+                label="ローン金額"
+                type="number"
+                inputMode="numeric"
+                suffix="万円"
+                value={toMan(input.loanAmount)}
+                onChange={(e) => {
+                  if (!isCashPurchase) setNum("loanAmount", fromMan(e.target.value));
+                }}
+                error={fieldError("loanAmount")}
+                disabled={isCashPurchase}
+              />
+              <Input
+                label="年利"
+                type="number"
+                inputMode="decimal"
+                suffix="%"
+                step="0.01"
+                value={toPct(input.annualLoanRate)}
+                onChange={(e) => {
+                  if (!isCashPurchase) setNum("annualLoanRate", fromPct(e.target.value));
+                }}
+                error={fieldError("annualLoanRate")}
+                disabled={isCashPurchase}
+              />
+              <Input
+                label="返済期間"
+                type="number"
+                inputMode="numeric"
+                suffix="年"
+                value={String(input.loanYears)}
+                onChange={(e) => {
+                  if (!isCashPurchase) setNum("loanYears", parseInt(e.target.value) || 0);
+                }}
+                error={fieldError("loanYears")}
+                disabled={isCashPurchase}
+              />
+            </div>
+          </div>
+
+          {/* 出口戦略 */}
+          <div className="border-t pt-4">
+            <p className="text-sm font-semibold text-foreground mb-3">出口戦略</p>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+              <Input
+                label="売却予定年数"
+                type="number"
+                inputMode="numeric"
+                suffix="年後"
+                value={String(input.holdingYears)}
+                onChange={(e) => setNum("holdingYears", parseInt(e.target.value) || 10)}
+                error={fieldError("holdingYears")}
+              />
+              <Input
+                label="売却時目標利回り（実質）"
+                type="number"
+                inputMode="decimal"
+                suffix="%"
+                step="0.5"
+                value={toPct(input.exitYieldTarget, 1)}
+                onChange={(e) => setNum("exitYieldTarget", fromPct(e.target.value))}
+                error={fieldError("exitYieldTarget")}
+              />
+              <Input
+                label="目標表面利回り"
+                type="number"
+                inputMode="decimal"
+                suffix="%"
+                step="0.5"
+                value={toPct(input.yieldTarget, 1)}
+                onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
+                error={fieldError("yieldTarget")}
+              />
+              <Input
+                label="所得税率（実効）"
+                type="number"
+                inputMode="numeric"
+                suffix="%"
+                step="1"
+                value={toPct(input.incomeTaxRate, 0)}
+                onChange={(e) => setNum("incomeTaxRate", fromPct(e.target.value))}
+                error={fieldError("incomeTaxRate")}
+              />
+            </div>
+
+            {/* NPV / IRR 設定 */}
+            <div className="mt-4">
+              <p className="text-xs font-semibold text-muted-foreground mb-2">NPV / IRR 設定</p>
+              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                <Input
+                  label="割引率"
+                  type="number"
+                  inputMode="decimal"
+                  suffix="%"
+                  step="0.1"
+                  value={toPct(input.discountRate ?? 0.05, 1)}
+                  onChange={(e) => setNum("discountRate", fromPct(e.target.value))}
+                  error={fieldError("discountRate")}
+                />
+                <Input
+                  label="物件価格下落率"
+                  type="number"
+                  inputMode="decimal"
+                  suffix="%"
+                  step="0.1"
+                  value={toPct(input.priceDeclineRate ?? 0, 1)}
+                  onChange={(e) => setNum("priceDeclineRate", fromPct(e.target.value))}
+                  error={fieldError("priceDeclineRate")}
+                />
+                <Select
+                  label="減価償却方式"
+                  value={input.depreciationMethod ?? "straight-line"}
+                  onChange={(e) => setStr("depreciationMethod", e.target.value)}
+                  options={[
+                    { value: "straight-line", label: "定額法" },
+                    { value: "declining-balance", label: "定率法" },
+                  ]}
+                />
+              </div>
+            </div>
+          </div>
+
+          {/* 変動金利スケジュール */}
+          <div className="border-t pt-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-semibold text-foreground">変動金利シミュレーション</p>
+              <label className="flex items-center gap-2 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={rateScheduleEnabled}
+                  onChange={(e) => handleRateScheduleToggle(e.target.checked)}
+                  className="h-4 w-4 rounded border-gray-300"
+                />
+                <span className="text-xs text-muted-foreground">有効にする</span>
+              </label>
+            </div>
+            {rateScheduleEnabled && (
+              <div className="space-y-2">
+                <p className="text-xs text-muted-foreground">
+                  指定年以降の適用金利（絶対値）を設定します。最大3ステップ。
+                </p>
+                {input.rateAdjustmentSchedule.map((step, i) => {
+                  const maxYear = input.loanYears || 35;
+                  const prevYear = i > 0 ? input.rateAdjustmentSchedule[i - 1].afterYear : 1;
+                  const yearError =
+                    step.afterYear < 2
+                      ? "2年目以降を指定してください"
+                      : step.afterYear > maxYear
+                        ? `${maxYear}年以内を指定してください`
+                        : step.afterYear <= prevYear
+                          ? `前のステップより後の年を指定してください`
+                          : undefined;
+                  const rateError =
+                    step.rate <= 0 || step.rate > 0.3
+                      ? "0%超〜30%の範囲で入力してください"
+                      : undefined;
+                  return (
+                    <div key={i} className="flex items-center gap-2">
+                      <Input
+                        label={i === 0 ? "開始年" : ""}
+                        type="number"
+                        inputMode="numeric"
+                        suffix="年目〜"
+                        min="2"
+                        max={String(maxYear)}
+                        step="1"
+                        value={String(step.afterYear)}
+                        onChange={(e) =>
+                          updateRateStep(i, "afterYear", parseInt(e.target.value) || 2)
+                        }
+                        error={yearError}
+                      />
+                      <Input
+                        label={i === 0 ? "適用金利" : ""}
+                        type="number"
+                        inputMode="decimal"
+                        suffix="%"
+                        min="0.1"
+                        max="30"
+                        step="0.1"
+                        value={(step.rate * 100).toFixed(2)}
+                        onChange={(e) =>
+                          updateRateStep(i, "rate", (parseFloat(e.target.value) || 0) / 100)
+                        }
+                        error={rateError}
+                      />
+                      <button
+                        type="button"
+                        onClick={() => removeRateStep(i)}
+                        className={`text-muted-foreground hover:text-destructive flex-shrink-0 ${i === 0 ? "mt-5" : ""}`}
+                        aria-label="削除"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </button>
+                    </div>
+                  );
+                })}
+                {canAddRateStep && (
+                  <button
+                    type="button"
+                    onClick={addRateStep}
+                    className="flex items-center gap-1 text-xs text-primary hover:underline"
+                  >
+                    <Plus className="h-3 w-3" />
+                    金利ステップを追加
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+
+          {/* ストレステスト */}
+          <div className="border-t pt-4 space-y-4">
+            <p className="text-sm font-semibold text-foreground">ストレステスト</p>
+            <Slider
+              label="空室率の上昇"
+              value={input.vacancyRateDelta}
+              min={0}
+              max={0.3}
+              step={0.01}
+              onChange={(v) => setNum("vacancyRateDelta", v)}
+              formatValue={(v) => `+${formatPct(v)}`}
+            />
+            <Slider
+              label="金利の上昇"
+              value={input.loanRateDelta}
+              min={0}
+              max={0.03}
+              step={0.001}
+              onChange={(v) => setNum("loanRateDelta", v)}
+              formatValue={(v) => `+${formatPct(v)}`}
+            />
+            {rateScheduleEnabled && input.loanRateDelta > 0 && (
+              <p className="text-xs text-muted-foreground">
+                金利上昇分はスケジュール後の金利にも上乗せされます
+              </p>
+            )}
+          </div>
+
+          <Button
+            className="w-full"
+            size="lg"
+            loading={loading}
+            disabled={hasErrors || loading}
+            onClick={handleAnalyze}
+          >
+            <Calculator className="h-5 w-5" />
+            シミュレーション実行
+          </Button>
+
+          <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-xs text-yellow-800 space-y-1">
+            <p className="flex items-center gap-1 font-semibold">
+              <Info className="h-3 w-3" />
+              免責事項
+            </p>
+            <ul className="list-disc list-inside space-y-0.5">
+              <li>計算結果は参考値であり、税務上の助言ではありません</li>
+              <li>消費税・損益通算・各種特例（3000万控除等）は考慮していません</li>
+              <li>所得税率は給与所得との合算後の実効税率を入力してください</li>
+              <li>中古物件の耐用年数は「築年数」から簡便法で算出しています</li>
+              <li>実際の投資判断は税理士・不動産の専門家にご相談ください</li>
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -61,6 +61,7 @@ interface FullModeFormProps {
   setGeocodeStatus: (v: "idle" | "loading" | "success" | "error") => void;
   geocodeError: string;
   geocodeLocationType: string;
+  setGeocodeLocationType: (v: string) => void;
   showManualCoords: boolean;
   handleGeocode: () => Promise<void>;
   loading: boolean;
@@ -118,6 +119,7 @@ export function FullModeForm({
   setGeocodeStatus,
   geocodeError,
   geocodeLocationType,
+  setGeocodeLocationType,
   showManualCoords,
   handleGeocode,
   loading,
@@ -219,7 +221,7 @@ export function FullModeForm({
                   onChange={(e) => {
                     setAddressInput(e.target.value);
                     setGeocodeStatus("idle");
-                    geocodeLocationType;
+                    setGeocodeLocationType("");
                     setPropertyLat("");
                     setPropertyLng("");
                   }}

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -19,7 +19,7 @@ import type {
   RateAdjustment,
 } from "@/types/investment";
 import { DEFAULT_INPUT, QUICK_MODE_DEFAULTS } from "@/types/investment";
-import { formatPct } from "@/lib/utils";
+import { formatPct, toMan, fromMan, toPct, fromPct } from "@/lib/utils";
 import {
   fetchMunicipalities,
   fetchRentDeclineHint,
@@ -437,11 +437,6 @@ export function InvestmentForm({
       setInput((prev) => ({ ...prev, loanAmount: savedLoanAmount, loanYears: savedLoanYears }));
     }
   };
-
-  const toMan = (yen: number) => String(Math.round(yen / 10_000));
-  const fromMan = (s: string) => (parseFloat(s) || 0) * 10_000;
-  const toPct = (rate: number, digits = 2) => (rate * 100).toFixed(digits);
-  const fromPct = (s: string) => (parseFloat(s) || 0) / 100;
 
   const addRateStep = () => {
     const schedule = input.rateAdjustmentSchedule;

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -1,54 +1,21 @@
 "use client";
-import React, { useState, useEffect, useCallback, useMemo } from "react";
-
-const LOCATION_TYPE_LABEL: Record<string, string> = {
-  ROOFTOP: "番地レベルで取得",
-  RANGE_INTERPOLATED: "住所レベルで取得",
-  GEOMETRIC_CENTER: "地点レベルで取得",
-  APPROXIMATE: "近似位置で取得（精度低）",
-};
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Select } from "@/components/ui/select";
-import { Button } from "@/components/ui/button";
-import { Slider } from "@/components/ui/slider";
+import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { SimulationModeToggle } from "@/components/SimulationModeToggle";
 import type {
   InvestmentInput,
-  BuildingType,
   SimulationMode,
   RateAdjustment,
 } from "@/types/investment";
 import { DEFAULT_INPUT, QUICK_MODE_DEFAULTS } from "@/types/investment";
-import { formatPct, toMan, fromMan, toPct, fromPct } from "@/lib/utils";
-import {
-  fetchMunicipalities,
-  fetchRentDeclineHint,
-  fetchGeocode,
-  type Municipality,
-} from "@/lib/api";
-import type { RentDeclineHint } from "@/types/investment";
-import {
-  Search,
-  Calculator,
-  Info,
-  AlertTriangle,
-  ShieldCheck,
-  ChevronDown,
-  ChevronUp,
-  Plus,
-  Trash2,
-} from "lucide-react";
-import { SimulationModeToggle } from "@/components/SimulationModeToggle";
-import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
+import { fetchGeocode } from "@/lib/api";
+import { type ZoningType } from "@/lib/zoning";
+import { useMunicipalitiesLoader } from "@/hooks/useMunicipalitiesLoader";
+import { useRentDeclineHint } from "@/hooks/useRentDeclineHint";
+import { QuickModeForm, type QuickHistoryEntry } from "@/components/QuickModeForm";
+import { FullModeForm } from "@/components/FullModeForm";
 
 const QUICK_HISTORY_KEY = "yield-guard:quick-history";
 const QUICK_HISTORY_MAX = 5;
-
-interface QuickHistoryEntry {
-  totalPriceMan: string;
-  monthlyRentYen: string;
-  ts: number;
-}
 
 function loadQuickHistory(): QuickHistoryEntry[] {
   if (typeof window === "undefined") return [];
@@ -72,93 +39,6 @@ function saveQuickHistory(entry: QuickHistoryEntry): QuickHistoryEntry[] {
   } catch {
     return loadQuickHistory();
   }
-}
-
-const PREFECTURES = [
-  { value: "01", label: "北海道" },
-  { value: "02", label: "青森県" },
-  { value: "03", label: "岩手県" },
-  { value: "04", label: "宮城県" },
-  { value: "05", label: "秋田県" },
-  { value: "06", label: "山形県" },
-  { value: "07", label: "福島県" },
-  { value: "08", label: "茨城県" },
-  { value: "09", label: "栃木県" },
-  { value: "10", label: "群馬県" },
-  { value: "11", label: "埼玉県" },
-  { value: "12", label: "千葉県" },
-  { value: "13", label: "東京都" },
-  { value: "14", label: "神奈川県" },
-  { value: "15", label: "新潟県" },
-  { value: "16", label: "富山県" },
-  { value: "17", label: "石川県" },
-  { value: "18", label: "福井県" },
-  { value: "19", label: "山梨県" },
-  { value: "20", label: "長野県" },
-  { value: "21", label: "岐阜県" },
-  { value: "22", label: "静岡県" },
-  { value: "23", label: "愛知県" },
-  { value: "24", label: "三重県" },
-  { value: "25", label: "滋賀県" },
-  { value: "26", label: "京都府" },
-  { value: "27", label: "大阪府" },
-  { value: "28", label: "兵庫県" },
-  { value: "29", label: "奈良県" },
-  { value: "30", label: "和歌山県" },
-  { value: "31", label: "鳥取県" },
-  { value: "32", label: "島根県" },
-  { value: "33", label: "岡山県" },
-  { value: "34", label: "広島県" },
-  { value: "35", label: "山口県" },
-  { value: "36", label: "徳島県" },
-  { value: "37", label: "香川県" },
-  { value: "38", label: "愛媛県" },
-  { value: "39", label: "高知県" },
-  { value: "40", label: "福岡県" },
-  { value: "41", label: "佐賀県" },
-  { value: "42", label: "長崎県" },
-  { value: "43", label: "熊本県" },
-  { value: "44", label: "大分県" },
-  { value: "45", label: "宮崎県" },
-  { value: "46", label: "鹿児島県" },
-  { value: "47", label: "沖縄県" },
-];
-
-const BUILDING_TYPES: { value: BuildingType; label: string }[] = [
-  { value: "木造", label: "木造（耐用22年）" },
-  { value: "軽量鉄骨(3mm以下)", label: "軽量鉄骨・薄板（耐用19年）" },
-  { value: "軽量鉄骨(4mm以下)", label: "軽量鉄骨（耐用27年）" },
-  { value: "重量鉄骨", label: "重量鉄骨（耐用34年）" },
-  { value: "RC造", label: "RC造（耐用47年）" },
-  { value: "SRC造", label: "SRC造（耐用47年）" },
-];
-
-const RENT_DECLINE_DEFAULTS: Record<BuildingType, number> = {
-  木造: 0.01,
-  "軽量鉄骨(3mm以下)": 0.008,
-  "軽量鉄骨(4mm以下)": 0.008,
-  重量鉄骨: 0.008,
-  RC造: 0.005,
-  SRC造: 0.005,
-};
-
-interface Props {
-  onAnalyze: (input: InvestmentInput, quickTotalMan?: string) => Promise<void>;
-  onFetchLandPrices: (area: string, city: string, lat?: number, lng?: number) => Promise<void>;
-  loading: boolean;
-  simulationMode: SimulationMode;
-  onModeChange: (mode: SimulationMode) => void;
-  initialInput?: Partial<InvestmentInput>;
-  initialQuickTotalPriceMan?: string;
-  isOnline?: boolean | null;
-  externalLat?: number;
-  externalLng?: number;
-  showModeToggle?: boolean;
-}
-
-function getPeriodLabel(): string {
-  const year = new Date().getFullYear();
-  return `${year - 2}〜${year - 1}年`;
 }
 
 type FormErrors = Partial<Record<keyof InvestmentInput | "quickTotalPrice", string>>;
@@ -205,6 +85,20 @@ function validateQuick(quickTotalPriceMan: string, input: InvestmentInput): Form
   return e;
 }
 
+interface Props {
+  onAnalyze: (input: InvestmentInput, quickTotalMan?: string) => Promise<void>;
+  onFetchLandPrices: (area: string, city: string, lat?: number, lng?: number) => Promise<void>;
+  loading: boolean;
+  simulationMode: SimulationMode;
+  onModeChange: (mode: SimulationMode) => void;
+  initialInput?: Partial<InvestmentInput>;
+  initialQuickTotalPriceMan?: string;
+  isOnline?: boolean | null;
+  externalLat?: number;
+  externalLng?: number;
+  showModeToggle?: boolean;
+}
+
 export function InvestmentForm({
   onAnalyze,
   onFetchLandPrices,
@@ -220,7 +114,6 @@ export function InvestmentForm({
 }: Props) {
   const [input, setInput] = useState<InvestmentInput>({ ...DEFAULT_INPUT, ...initialInput });
   const [area, setArea] = useState("10");
-  const [city, setCity] = useState("");
   const [propertyLat, setPropertyLat] = useState("");
   const [propertyLng, setPropertyLng] = useState("");
   const [addressInput, setAddressInput] = useState("");
@@ -230,56 +123,47 @@ export function InvestmentForm({
   const [geocodeError, setGeocodeError] = useState("");
   const [geocodeLocationType, setGeocodeLocationType] = useState("");
   const [showManualCoords, setShowManualCoords] = useState(false);
-
-  useEffect(() => {
-    if (externalLat !== undefined && externalLng !== undefined) {
-      setPropertyLat(externalLat.toFixed(6));
-      setPropertyLng(externalLng.toFixed(6));
-    }
-  }, [externalLat, externalLng]);
-  const [municipalities, setMunicipalities] = useState<Municipality[]>([]);
-  const [muniLoading, setMuniLoading] = useState(false);
-  const [muniError, setMuniError] = useState<string | null>(null);
-  const [muniFilter, setMuniFilter] = useState("");
   const [touched, setTouched] = useState<Set<string>>(new Set());
   const [zoningType, setZoningType] = useState<ZoningType>("");
-
-  // クイックモード専用: 物件価格（総額）
   const [quickTotalPriceMan, setQuickTotalPriceMan] = useState(initialQuickTotalPriceMan ?? "");
-  // クイックモード: 相場データ取得セクションの開閉
   const [showLandSection, setShowLandSection] = useState(false);
-  // 現金購入フラグ（クイック・詳細モード共用）
   const [isCashPurchase, setIsCashPurchase] = useState(false);
-  // 現金購入前のローン値を保存（チェックを外したときに復元）
   const [savedLoanAmount, setSavedLoanAmount] = useState(DEFAULT_INPUT.loanAmount);
   const [savedLoanYears, setSavedLoanYears] = useState(DEFAULT_INPUT.loanYears);
-  // クイックモード: ローン自動計算（80%）の展開フラグ
   const [showCustomLoan, setShowCustomLoan] = useState(false);
-  // クイックモード: 入力履歴
   const [quickHistory, setQuickHistory] = useState<QuickHistoryEntry[]>([]);
-
-  // 変動金利スケジュール
   const [rateScheduleEnabled, setRateScheduleEnabled] = useState(false);
-
-  // 賃料下落率参考値
-  const [rentHint, setRentHint] = useState<RentDeclineHint | null>(null);
-  const [rentHintLoading, setRentHintLoading] = useState(false);
-  const [rentHintError, setRentHintError] = useState<string | null>(null);
-
-  // 按分ヘルパーの状態
   const [showBuildingHelper, setShowBuildingHelper] = useState(false);
   const [taxAmount, setTaxAmount] = useState("");
   const [landAssess, setLandAssess] = useState("");
   const [buildingAssess, setBuildingAssess] = useState("");
   const [totalPrice, setTotalPrice] = useState("");
 
-  const calcFromTax = (taxMan: number) => taxMan / 0.1;
-  const calcFromAssessment = (totalMan: number, landA: number, buildingA: number) =>
-    landA + buildingA > 0 ? totalMan * (buildingA / (landA + buildingA)) : 0;
-
   const isQuick = simulationMode === "quick";
 
-  // 現在の入力値からエラーをリアルタイムで算出（派生状態）
+  // Municipalities hook
+  const {
+    municipalities,
+    loading: muniLoading,
+    error: muniError,
+    city,
+    setCity,
+    muniFilter,
+    setMuniFilter,
+    filteredMunicipalities,
+    loadMunicipalities,
+  } = useMunicipalitiesLoader("10");
+
+  // Rent decline hint hook
+  const setNumRef = useRef<(key: keyof InvestmentInput, value: number) => void>(null!);
+  const {
+    rentHint,
+    loading: rentHintLoading,
+    error: rentHintError,
+    fetch: fetchRentHint,
+    clear: clearRentHint,
+  } = useRentDeclineHint((rate) => setNumRef.current("rentDeclineRate", rate));
+
   const currentErrors = useMemo(
     () => (isQuick ? validateQuick(quickTotalPriceMan, input) : validateFull(input)),
     [isQuick, quickTotalPriceMan, input]
@@ -309,41 +193,29 @@ export function InvestmentForm({
     return lastYear < maxYear;
   }, [input.rateAdjustmentSchedule, input.loanYears]);
 
-  // touched フィールドにのみエラーを表示する
   const fieldError = (key: string) =>
     touched.has(key) ? currentErrors[key as keyof FormErrors] : undefined;
 
   const markTouched = (key: string) =>
     setTouched((prev) => (prev.has(key) ? prev : new Set([...prev, key])));
 
-  const filteredMunicipalities = useMemo(
-    () =>
-      muniFilter.trim()
-        ? municipalities.filter((m) => m.name.includes(muniFilter.trim()))
-        : municipalities,
-    [municipalities, muniFilter]
-  );
-
-  const loadMunicipalities = useCallback(async (areaCode: string) => {
-    setMuniLoading(true);
-    setMuniError(null);
-    setCity("");
-    setMuniFilter("");
-    try {
-      const data = await fetchMunicipalities(areaCode);
-      setMunicipalities(data);
-      if (data.length > 0) setCity(data[0].id);
-    } catch (e) {
-      setMunicipalities([]);
-      setMuniError(e instanceof Error ? e.message : "市区町村の取得に失敗しました");
-    } finally {
-      setMuniLoading(false);
-    }
+  const setNum = useCallback((key: keyof InvestmentInput, value: number) => {
+    setInput((prev) => ({ ...prev, [key]: value }));
+    markTouched(key);
   }, []);
 
+  // Keep ref in sync for useRentDeclineHint callback
+  setNumRef.current = setNum;
+
+  const setStr = (key: keyof InvestmentInput, value: string) =>
+    setInput((prev) => ({ ...prev, [key]: value }));
+
   useEffect(() => {
-    loadMunicipalities("10");
-  }, [loadMunicipalities]);
+    if (externalLat !== undefined && externalLng !== undefined) {
+      setPropertyLat(externalLat.toFixed(6));
+      setPropertyLng(externalLng.toFixed(6));
+    }
+  }, [externalLat, externalLng]);
 
   // モード切替時に現金購入フラグをリセットし、ローン値を復元する
   useEffect(() => {
@@ -354,42 +226,24 @@ export function InvestmentForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isQuick]);
 
+  // cityが変わるたびにレント参考値をクリア（手動変更・自動選択どちらも）
   useEffect(() => {
-    if (filteredMunicipalities.length === 1) {
-      setCity(filteredMunicipalities[0].id);
-      setRentHint(null);
-      setRentHintError(null);
-    }
-  }, [filteredMunicipalities]);
+    clearRentHint();
+  }, [city, clearRentHint]);
 
-  // クイックモード入力履歴をlocalStorageから読み込む
   useEffect(() => {
     setQuickHistory(loadQuickHistory());
   }, []);
 
-  const clearRentHint = () => {
-    setRentHint(null);
-    setRentHintError(null);
-  };
-
   const handleAreaChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const code = e.target.value;
     setArea(code);
-    clearRentHint();
     loadMunicipalities(code);
   };
 
   const handleCityChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     setCity(e.target.value);
-    clearRentHint();
   };
-
-  const setNum = (key: keyof InvestmentInput, value: number) => {
-    setInput((prev) => ({ ...prev, [key]: value }));
-    markTouched(key);
-  };
-  const setStr = (key: keyof InvestmentInput, value: string) =>
-    setInput((prev) => ({ ...prev, [key]: value }));
 
   const handleGeocode = useCallback(async () => {
     if (!addressInput.trim()) return;
@@ -410,21 +264,8 @@ export function InvestmentForm({
   }, [addressInput]);
 
   const handleFetchRentHint = useCallback(async () => {
-    setRentHintLoading(true);
-    setRentHintError(null);
-    setRentHint(null);
-    try {
-      const hint = await fetchRentDeclineHint({ area, municipality: city || undefined });
-      setRentHint(hint);
-      if (!hint.fallbackUsed && hint.hintRate > 0) {
-        setNum("rentDeclineRate", hint.hintRate);
-      }
-    } catch (e) {
-      setRentHintError(e instanceof Error ? e.message : "参考値の取得に失敗しました");
-    } finally {
-      setRentHintLoading(false);
-    }
-  }, [area, city]);
+    await fetchRentHint(area, city);
+  }, [fetchRentHint, area, city]);
 
   const handleCashPurchaseToggle = (checked: boolean) => {
     setIsCashPurchase(checked);
@@ -474,7 +315,6 @@ export function InvestmentForm({
     }
   };
 
-  // 送信前にスケジュールを afterYear 昇順にソートする
   const sortedInput = (src: InvestmentInput): InvestmentInput => ({
     ...src,
     rateAdjustmentSchedule: [...src.rateAdjustmentSchedule].sort(
@@ -513,990 +353,91 @@ export function InvestmentForm({
     setNum("monthlyRent", parseFloat(last.monthlyRentYen) || 0);
   };
 
+  const sharedMuniProps = {
+    area,
+    handleAreaChange,
+    city,
+    handleCityChange,
+    muniFilter,
+    setMuniFilter,
+    filteredMunicipalities,
+    muniLoading,
+    muniError,
+    isOnline,
+    propertyLat,
+    propertyLng,
+    loading,
+    onFetchLandPrices,
+  };
+
   return (
     <div className="space-y-4">
       {showModeToggle && <SimulationModeToggle mode={simulationMode} onChange={onModeChange} />}
 
-      {/* ─── クイックモード ─── */}
-      {isQuick && (
-        <>
-          {/* 土地相場データ取得（折りたたみ） */}
-          <div className="rounded-lg border">
-            <button
-              type="button"
-              className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground"
-              onClick={() => setShowLandSection((p) => !p)}
-            >
-              <span className="flex items-center gap-2">
-                <Search className="h-4 w-4" />
-                土地相場データを取得（任意）
-              </span>
-              {showLandSection ? (
-                <ChevronUp className="h-4 w-4" />
-              ) : (
-                <ChevronDown className="h-4 w-4" />
-              )}
-            </button>
-            {showLandSection && (
-              <div className="border-t px-4 pb-4 pt-3 space-y-3">
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <Select
-                    label="都道府県"
-                    value={area}
-                    onChange={handleAreaChange}
-                    options={PREFECTURES}
-                  />
-                  <div className="flex flex-col gap-1">
-                    <label className="text-sm font-medium text-foreground">市区町村</label>
-                    <input
-                      type="text"
-                      placeholder="例: 前橋市"
-                      value={muniFilter}
-                      onChange={(e) => setMuniFilter(e.target.value)}
-                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                    />
-                    <select
-                      value={city}
-                      onChange={handleCityChange}
-                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                    >
-                      <option value="">（全市区町村）</option>
-                      {muniLoading ? (
-                        <option disabled>読み込み中...</option>
-                      ) : (
-                        filteredMunicipalities.map((m) => (
-                          <option key={m.id} value={m.id}>
-                            {m.name}
-                          </option>
-                        ))
-                      )}
-                    </select>
-                    {muniError && <p className="text-xs text-destructive">{muniError}</p>}
-                  </div>
-                </div>
-                <p className="text-xs text-muted-foreground">
-                  {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します
-                </p>
-                {isOnline === false && (
-                  <p className="text-xs text-amber-700">オフライン中は相場取得を利用できません</p>
-                )}
-                <Button
-                  variant="outline"
-                  className="w-full"
-                  loading={loading}
-                  disabled={isOnline === false}
-                  onClick={() => {
-                    const lat = parseFloat(propertyLat);
-                    const lng = parseFloat(propertyLng);
-                    const hasCoords = !isNaN(lat) && !isNaN(lng);
-                    onFetchLandPrices(
-                      area,
-                      city,
-                      hasCoords ? lat : undefined,
-                      hasCoords ? lng : undefined
-                    );
-                  }}
-                >
-                  <Search className="h-4 w-4" />
-                  相場データを取得
-                </Button>
-              </div>
-            )}
-          </div>
-
-          {/* クイックモード入力フォーム */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Calculator className="h-5 w-5 text-primary" />
-                物件・投資条件
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              {quickHistory.length > 0 && (
-                <button
-                  type="button"
-                  className="flex w-full items-center justify-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 min-h-[44px] text-sm font-medium text-primary hover:bg-primary/10 transition-colors"
-                  onClick={handleRestoreLastInput}
-                >
-                  前回の入力から開始
-                </button>
-              )}
-              <div className="space-y-3">
-                <div>
-                  <Input
-                    label="物件価格（土地＋建物の総額）"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="万円"
-                    value={quickTotalPriceMan}
-                    onChange={(e) => {
-                      setQuickTotalPriceMan(e.target.value);
-                      markTouched("quickTotalPrice");
-                    }}
-                    error={fieldError("quickTotalPrice")}
-                  />
-                  <p className="text-xs text-muted-foreground mt-1">
-                    内部で土地70%・建物30%に按分して計算します
-                  </p>
-                </div>
-                <Input
-                  label="想定月額賃料"
-                  type="number"
-                  inputMode="numeric"
-                  suffix="円"
-                  value={String(input.monthlyRent)}
-                  onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
-                  error={fieldError("monthlyRent")}
-                />
-                <div className="space-y-2">
-                  <label className="flex items-center gap-2 cursor-pointer select-none min-h-[44px]">
-                    <input
-                      type="checkbox"
-                      checked={isCashPurchase}
-                      onChange={(e) => handleCashPurchaseToggle(e.target.checked)}
-                      className="h-4 w-4 rounded border-input accent-primary"
-                      aria-label="現金購入（ローンなし）"
-                    />
-                    <span className="text-sm font-medium">現金購入（ローンなし）</span>
-                  </label>
-                  {!isCashPurchase && (
-                    <>
-                      {!showCustomLoan && (
-                        <p className="text-xs text-muted-foreground">
-                          ローン 80% 自動適用中 —{" "}
-                          <button
-                            type="button"
-                            className="underline underline-offset-2 hover:text-foreground"
-                            onClick={() => setShowCustomLoan(true)}
-                          >
-                            カスタム設定
-                          </button>
-                        </p>
-                      )}
-                      {showCustomLoan && (
-                        <div className="space-y-1">
-                          <Input
-                            label="ローン金額"
-                            type="number"
-                            inputMode="numeric"
-                            suffix="万円"
-                            value={toMan(input.loanAmount)}
-                            onChange={(e) => setNum("loanAmount", fromMan(e.target.value))}
-                            error={fieldError("loanAmount")}
-                          />
-                          <button
-                            type="button"
-                            className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
-                            onClick={() => setShowCustomLoan(false)}
-                          >
-                            80% 自動計算に戻す
-                          </button>
-                        </div>
-                      )}
-                    </>
-                  )}
-                </div>
-                <Input
-                  label="目標利回り"
-                  type="number"
-                  inputMode="decimal"
-                  suffix="%"
-                  step="0.5"
-                  value={toPct(input.yieldTarget, 1)}
-                  onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
-                  error={fieldError("yieldTarget")}
-                />
-              </div>
-
-              <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 space-y-0.5">
-                <p className="font-semibold">自動設定されるデフォルト値</p>
-                <p>
-                  空室率 5%・運営経費率 20%・建物構造: 木造・
-                  {isCashPurchase
-                    ? "現金購入（ローンなし）"
-                    : !showCustomLoan
-                      ? "ローン 80%・年利 1.5%・返済期間 35年"
-                      : "年利 1.5%・返済期間 35年"}
-                  ・10年後売却・所得税率 33%
-                </p>
-              </div>
-
-              <Button
-                className="w-full"
-                size="lg"
-                loading={loading}
-                disabled={hasErrors || loading}
-                onClick={handleAnalyze}
-              >
-                <Calculator className="h-5 w-5" />
-                シミュレーション実行
-              </Button>
-
-              <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-xs text-yellow-800 space-y-1">
-                <p className="flex items-center gap-1 font-semibold">
-                  <Info className="h-3 w-3" />
-                  免責事項
-                </p>
-                <ul className="list-disc list-inside space-y-0.5">
-                  <li>計算結果は参考値であり、税務上の助言ではありません</li>
-                  <li>消費税・損益通算・各種特例（3000万控除等）は考慮していません</li>
-                  <li>実際の投資判断は税理士・不動産の専門家にご相談ください</li>
-                </ul>
-              </div>
-            </CardContent>
-          </Card>
-        </>
-      )}
-
-      {/* ─── 詳細モード ─── */}
-      {!isQuick && (
-        <>
-          {/* 相場データ取得（常時表示） */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Search className="h-5 w-5 text-primary" />
-                土地相場データ取得
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <Select
-                  label="都道府県"
-                  value={area}
-                  onChange={handleAreaChange}
-                  options={PREFECTURES}
-                />
-                <div className="flex flex-col gap-1">
-                  <label className="text-sm font-medium text-foreground">市区町村</label>
-                  <input
-                    type="text"
-                    placeholder="例: 前橋市"
-                    value={muniFilter}
-                    onChange={(e) => setMuniFilter(e.target.value)}
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                    aria-label="市区町村を検索"
-                  />
-                  <select
-                    value={city}
-                    onChange={handleCityChange}
-                    className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                  >
-                    <option value="">（全市区町村）</option>
-                    {muniLoading ? (
-                      <option disabled>読み込み中...</option>
-                    ) : filteredMunicipalities.length === 0 && muniFilter.trim() ? (
-                      <option disabled>該当なし</option>
-                    ) : (
-                      filteredMunicipalities.map((m) => (
-                        <option key={m.id} value={m.id}>
-                          {m.name}
-                        </option>
-                      ))
-                    )}
-                  </select>
-                  {muniError && <p className="text-xs text-destructive">{muniError}</p>}
-                  {muniFilter.trim() && filteredMunicipalities.length > 0 && (
-                    <p className="text-xs text-muted-foreground">
-                      {filteredMunicipalities.length}件該当
-                    </p>
-                  )}
-                </div>
-              </div>
-              <div className="flex flex-col gap-2">
-                <div className="flex flex-col gap-1">
-                  <label className="text-sm font-medium text-foreground">物件住所（任意）</label>
-                  <p className="text-xs text-muted-foreground">
-                    丁目・番地まで入力してください（建物名・部屋番号は不要）
-                  </p>
-                  <div className="flex gap-2">
-                    <input
-                      type="text"
-                      placeholder="例: 東京都渋谷区道玄坂1-2"
-                      value={addressInput}
-                      onChange={(e) => {
-                        setAddressInput(e.target.value);
-                        setGeocodeStatus("idle");
-                        setGeocodeLocationType("");
-                        setPropertyLat("");
-                        setPropertyLng("");
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleGeocode();
-                      }}
-                      className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                      aria-label="物件住所"
-                    />
-                    <Button
-                      variant="outline"
-                      loading={geocodeStatus === "loading"}
-                      disabled={!addressInput.trim() || geocodeStatus === "loading"}
-                      onClick={handleGeocode}
-                      className="shrink-0"
-                    >
-                      座標を取得
-                    </Button>
-                  </div>
-                  {geocodeStatus === "success" && (
-                    <p className="text-xs text-green-600">
-                      ✓ {LOCATION_TYPE_LABEL[geocodeLocationType] ?? "座標を取得しました"}
-                    </p>
-                  )}
-                  {geocodeStatus === "error" && (
-                    <p className="text-xs text-destructive">{geocodeError}</p>
-                  )}
-                </div>
-                {showManualCoords && (
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                    <div className="flex flex-col gap-1">
-                      <label className="text-sm font-medium text-foreground">
-                        緯度（手動入力）
-                      </label>
-                      <input
-                        type="number"
-                        inputMode="decimal"
-                        placeholder="例: 35.6762"
-                        step="0.0001"
-                        value={propertyLat}
-                        onChange={(e) => setPropertyLat(e.target.value)}
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                        aria-label="物件の緯度"
-                      />
-                    </div>
-                    <div className="flex flex-col gap-1">
-                      <label className="text-sm font-medium text-foreground">
-                        経度（手動入力）
-                      </label>
-                      <input
-                        type="number"
-                        inputMode="decimal"
-                        placeholder="例: 139.6503"
-                        step="0.0001"
-                        value={propertyLng}
-                        onChange={(e) => setPropertyLng(e.target.value)}
-                        className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                        aria-label="物件の経度"
-                      />
-                    </div>
-                  </div>
-                )}
-              </div>
-              <p className="text-xs text-muted-foreground">
-                {getPeriodLabel()}
-                分の宅地取引実績（国交省公式API）を取得します。緯度・経度を入力すると周辺駅の需要スコアも取得します
-              </p>
-              {isOnline === false && (
-                <p className="text-xs text-amber-700">オフライン中は相場取得を利用できません</p>
-              )}
-              <Button
-                variant="outline"
-                className="w-full"
-                loading={loading}
-                disabled={isOnline === false}
-                onClick={() => {
-                  const lat = parseFloat(propertyLat);
-                  const lng = parseFloat(propertyLng);
-                  const hasCoords = !isNaN(lat) && !isNaN(lng);
-                  onFetchLandPrices(
-                    area,
-                    city,
-                    hasCoords ? lat : undefined,
-                    hasCoords ? lng : undefined
-                  );
-                }}
-              >
-                <Search className="h-4 w-4" />
-                相場データを取得
-              </Button>
-            </CardContent>
-          </Card>
-
-          {/* 物件・投資条件（フラット） */}
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Calculator className="h-5 w-5 text-primary" />
-                物件・投資条件
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-6">
-              {/* 物件情報 */}
-              <div>
-                <p className="text-sm font-semibold text-foreground mb-3">物件情報</p>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <Input
-                    label="土地取得価格"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="万円"
-                    value={toMan(input.landPrice)}
-                    onChange={(e) => setNum("landPrice", fromMan(e.target.value))}
-                    error={fieldError("landPrice")}
-                  />
-                  <Input
-                    label="土地面積"
-                    type="number"
-                    inputMode="decimal"
-                    suffix="m²"
-                    value={String(input.landArea)}
-                    onChange={(e) => setNum("landArea", parseFloat(e.target.value) || 0)}
-                  />
-                  <div className="sm:col-span-2">
-                    <Input
-                      label="建物価格"
-                      type="number"
-                      inputMode="numeric"
-                      suffix="万円"
-                      value={toMan(input.buildingCost)}
-                      onChange={(e) => setNum("buildingCost", fromMan(e.target.value))}
-                      error={fieldError("buildingCost")}
-                    />
-                    <p className="text-xs text-muted-foreground mt-1">
-                      新築は建設費、中古は売買契約書記載の建物価格（消費税の課税対象部分）を入力
-                    </p>
-
-                    <button
-                      type="button"
-                      className="mt-2 text-xs text-primary underline-offset-2 hover:underline"
-                      onClick={() => setShowBuildingHelper((p) => !p)}
-                    >
-                      {showBuildingHelper
-                        ? "▲ 按分ヘルパーを閉じる"
-                        : "▼ 建物価格がわからない場合（按分ヘルパー）"}
-                    </button>
-
-                    {showBuildingHelper && (
-                      <div className="mt-2 rounded-md bg-muted/50 p-3 space-y-3 text-sm">
-                        <div>
-                          <p className="font-medium text-xs mb-1">① 消費税額から計算（最も確実）</p>
-                          <div className="flex gap-2 items-end">
-                            <div className="flex-1">
-                              <Input
-                                label="消費税額"
-                                type="number"
-                                inputMode="numeric"
-                                suffix="万円"
-                                value={taxAmount}
-                                onChange={(e) => setTaxAmount(e.target.value)}
-                              />
-                            </div>
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              className="mb-0 shrink-0"
-                              onClick={() => {
-                                const tax = parseFloat(taxAmount) || 0;
-                                const result = calcFromTax(tax);
-                                if (result > 0) setNum("buildingCost", result * 10_000);
-                              }}
-                            >
-                              適用
-                            </Button>
-                          </div>
-                          <p className="text-xs text-muted-foreground mt-1">
-                            建物価格 = 消費税額 ÷ 0.1
-                          </p>
-                        </div>
-                        <div>
-                          <p className="font-medium text-xs mb-1">② 固定資産税評価額の比率で按分</p>
-                          <div className="grid grid-cols-3 gap-2">
-                            <Input
-                              label="土地評価額"
-                              type="number"
-                              inputMode="numeric"
-                              suffix="万円"
-                              value={landAssess}
-                              onChange={(e) => setLandAssess(e.target.value)}
-                            />
-                            <Input
-                              label="建物評価額"
-                              type="number"
-                              inputMode="numeric"
-                              suffix="万円"
-                              value={buildingAssess}
-                              onChange={(e) => setBuildingAssess(e.target.value)}
-                            />
-                            <Input
-                              label="購入総額"
-                              type="number"
-                              inputMode="numeric"
-                              suffix="万円"
-                              value={totalPrice}
-                              onChange={(e) => setTotalPrice(e.target.value)}
-                            />
-                          </div>
-                          <Button
-                            type="button"
-                            variant="outline"
-                            size="sm"
-                            className="mt-2"
-                            onClick={() => {
-                              const total = parseFloat(totalPrice) || 0;
-                              const land = parseFloat(landAssess) || 0;
-                              const building = parseFloat(buildingAssess) || 0;
-                              const result = calcFromAssessment(total, land, building);
-                              if (result > 0) setNum("buildingCost", result * 10_000);
-                            }}
-                          >
-                            按分して適用
-                          </Button>
-                          <p className="text-xs text-muted-foreground mt-1">
-                            建物価格 = 総額 × 建物評価 ÷（土地+建物評価）
-                          </p>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                  <Input
-                    label="築年数"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="年（0=新築）"
-                    value={String(input.buildingAge)}
-                    onChange={(e) => setNum("buildingAge", parseInt(e.target.value) || 0)}
-                  />
-                  <Input
-                    label="最寄り駅徒歩"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="分（0=未入力）"
-                    value={String(input.stationMinutes)}
-                    onChange={(e) => setNum("stationMinutes", parseInt(e.target.value) || 0)}
-                  />
-                  <Select
-                    label="建物構造"
-                    value={input.buildingType}
-                    onChange={(e) => {
-                      const bt = e.target.value as BuildingType;
-                      setStr("buildingType", bt);
-                      setNum("rentDeclineRate", RENT_DECLINE_DEFAULTS[bt]);
-                    }}
-                    options={BUILDING_TYPES}
-                  />
-                  <div>
-                    <Input
-                      label="年間賃料下落率"
-                      type="number"
-                      suffix="%"
-                      step="0.1"
-                      value={toPct(input.rentDeclineRate, 1)}
-                      onChange={(e) => setNum("rentDeclineRate", fromPct(e.target.value))}
-                    />
-                    <p className="text-xs text-muted-foreground mt-1">
-                      建物構造から自動設定（例: 木造1%/年）
-                    </p>
-                    <div className="mt-2">
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        disabled={!area || rentHintLoading}
-                        onClick={handleFetchRentHint}
-                        className="text-xs h-7 px-2"
-                      >
-                        {rentHintLoading ? "取得中…" : "地域の参考値を取得"}
-                      </Button>
-                      {rentHintError && (
-                        <p className="text-xs text-destructive mt-1">{rentHintError}</p>
-                      )}
-                      {rentHint && !rentHintError && (
-                        <p className="text-xs text-muted-foreground mt-1">
-                          {rentHint.fallbackUsed
-                            ? "データ不足のため地域参考値なし。構造別平均値を推奨します"
-                            : `地価公示より参考値: ${toPct(rentHint.hintRate, 1)}%/年（${rentHint.dataPointCount}件）`}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-
-              {/* 収益条件 */}
-              <div className="border-t pt-4">
-                <p className="text-sm font-semibold text-foreground mb-3">収益条件</p>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                  <Input
-                    label="想定月額賃料"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="円"
-                    value={String(input.monthlyRent)}
-                    onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
-                    error={fieldError("monthlyRent")}
-                  />
-                  <Input
-                    label="現況空室率"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="%"
-                    step="1"
-                    value={toPct(input.actualVacancyRate, 0)}
-                    onChange={(e) => setNum("actualVacancyRate", fromPct(e.target.value))}
-                  />
-                  <Input
-                    label="想定空室率（長期）"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="%"
-                    step="1"
-                    value={toPct(input.vacancyRate, 0)}
-                    onChange={(e) => setNum("vacancyRate", fromPct(e.target.value))}
-                    error={fieldError("vacancyRate")}
-                  />
-                  <Input
-                    label="運営経費率※"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="%"
-                    step="1"
-                    value={toPct(input.expenseRate, 0)}
-                    onChange={(e) => setNum("expenseRate", fromPct(e.target.value))}
-                    error={fieldError("expenseRate")}
-                  />
-                  <Input
-                    label="諸経費率"
-                    type="number"
-                    inputMode="decimal"
-                    suffix="%"
-                    step="0.5"
-                    value={toPct(input.miscExpenseRate, 1)}
-                    onChange={(e) => setNum("miscExpenseRate", fromPct(e.target.value))}
-                    error={fieldError("miscExpenseRate")}
-                  />
-                </div>
-                <p className="text-xs text-muted-foreground mt-2">
-                  ※運営経費率はローン利息を含みません（管理費・修繕費・固定資産税・保険等）
-                </p>
-                <div className="mt-3 space-y-2">
-                  <Select
-                    label="用途地域（任意）"
-                    value={zoningType}
-                    onChange={(e) => setZoningType(e.target.value as ZoningType)}
-                    options={[
-                      { value: "", label: "（未選択）" },
-                      ...ZONING_TYPES.map((z) => ({ value: z, label: z })),
-                    ]}
-                  />
-                  {zoningType &&
-                    (() => {
-                      const meta = ZONING_META[zoningType];
-                      if (!meta) return null;
-                      if (meta.riskLevel === 0)
-                        return (
-                          <div className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-2 text-green-800 text-xs">
-                            <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5" />
-                            <span>良好な住環境です</span>
-                          </div>
-                        );
-                      const styles: Record<number, string> = {
-                        1: "border-blue-200 bg-blue-50 text-blue-800",
-                        2: "border-yellow-300 bg-yellow-50 text-yellow-800",
-                        3: "border-red-300 bg-red-50 text-red-800",
-                      };
-                      const labels: Record<number, string> = {
-                        1: "低リスク",
-                        2: "中リスク",
-                        3: "高リスク",
-                      };
-                      return (
-                        <div
-                          className={`flex items-start gap-2 rounded-md border p-2 text-xs ${styles[meta.riskLevel]}`}
-                        >
-                          <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
-                          <div>
-                            <span className="font-semibold">{labels[meta.riskLevel]}: </span>
-                            <span>{meta.riskMessage}</span>
-                          </div>
-                        </div>
-                      );
-                    })()}
-                </div>
-              </div>
-
-              {/* ローン条件 */}
-              <div className="border-t pt-4">
-                <div className="flex items-center justify-between mb-3">
-                  <p className="text-sm font-semibold text-foreground">ローン条件</p>
-                  <label className="flex items-center gap-2 cursor-pointer select-none">
-                    <input
-                      type="checkbox"
-                      checked={isCashPurchase}
-                      onChange={(e) => handleCashPurchaseToggle(e.target.checked)}
-                      className="h-4 w-4 rounded border-input accent-primary"
-                      aria-label="現金購入（ローンなし）"
-                    />
-                    <span className="text-sm font-medium">現金購入（ローンなし）</span>
-                  </label>
-                </div>
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                  <Input
-                    label="ローン金額"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="万円"
-                    value={toMan(input.loanAmount)}
-                    onChange={(e) => {
-                      if (!isCashPurchase) setNum("loanAmount", fromMan(e.target.value));
-                    }}
-                    error={fieldError("loanAmount")}
-                    disabled={isCashPurchase}
-                  />
-                  <Input
-                    label="年利"
-                    type="number"
-                    inputMode="decimal"
-                    suffix="%"
-                    step="0.01"
-                    value={toPct(input.annualLoanRate)}
-                    onChange={(e) => {
-                      if (!isCashPurchase) setNum("annualLoanRate", fromPct(e.target.value));
-                    }}
-                    error={fieldError("annualLoanRate")}
-                    disabled={isCashPurchase}
-                  />
-                  <Input
-                    label="返済期間"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="年"
-                    value={String(input.loanYears)}
-                    onChange={(e) => {
-                      if (!isCashPurchase) setNum("loanYears", parseInt(e.target.value) || 0);
-                    }}
-                    error={fieldError("loanYears")}
-                    disabled={isCashPurchase}
-                  />
-                </div>
-              </div>
-
-              {/* 出口戦略 */}
-              <div className="border-t pt-4">
-                <p className="text-sm font-semibold text-foreground mb-3">出口戦略</p>
-                <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                  <Input
-                    label="売却予定年数"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="年後"
-                    value={String(input.holdingYears)}
-                    onChange={(e) => setNum("holdingYears", parseInt(e.target.value) || 10)}
-                    error={fieldError("holdingYears")}
-                  />
-                  <Input
-                    label="売却時目標利回り（実質）"
-                    type="number"
-                    inputMode="decimal"
-                    suffix="%"
-                    step="0.5"
-                    value={toPct(input.exitYieldTarget, 1)}
-                    onChange={(e) => setNum("exitYieldTarget", fromPct(e.target.value))}
-                    error={fieldError("exitYieldTarget")}
-                  />
-                  <Input
-                    label="目標表面利回り"
-                    type="number"
-                    inputMode="decimal"
-                    suffix="%"
-                    step="0.5"
-                    value={toPct(input.yieldTarget, 1)}
-                    onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
-                    error={fieldError("yieldTarget")}
-                  />
-                  <Input
-                    label="所得税率（実効）"
-                    type="number"
-                    inputMode="numeric"
-                    suffix="%"
-                    step="1"
-                    value={toPct(input.incomeTaxRate, 0)}
-                    onChange={(e) => setNum("incomeTaxRate", fromPct(e.target.value))}
-                    error={fieldError("incomeTaxRate")}
-                  />
-                </div>
-
-                {/* NPV / IRR 設定 */}
-                <div className="mt-4">
-                  <p className="text-xs font-semibold text-muted-foreground mb-2">NPV / IRR 設定</p>
-                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                    <Input
-                      label="割引率"
-                      type="number"
-                      inputMode="decimal"
-                      suffix="%"
-                      step="0.1"
-                      value={toPct(input.discountRate ?? 0.05, 1)}
-                      onChange={(e) => setNum("discountRate", fromPct(e.target.value))}
-                      error={fieldError("discountRate")}
-                    />
-                    <Input
-                      label="物件価格下落率"
-                      type="number"
-                      inputMode="decimal"
-                      suffix="%"
-                      step="0.1"
-                      value={toPct(input.priceDeclineRate ?? 0, 1)}
-                      onChange={(e) => setNum("priceDeclineRate", fromPct(e.target.value))}
-                      error={fieldError("priceDeclineRate")}
-                    />
-                    <Select
-                      label="減価償却方式"
-                      value={input.depreciationMethod ?? "straight-line"}
-                      onChange={(e) => setStr("depreciationMethod", e.target.value)}
-                      options={[
-                        { value: "straight-line", label: "定額法" },
-                        { value: "declining-balance", label: "定率法" },
-                      ]}
-                    />
-                  </div>
-                </div>
-              </div>
-
-              {/* 変動金利スケジュール */}
-              <div className="border-t pt-4 space-y-3">
-                <div className="flex items-center justify-between">
-                  <p className="text-sm font-semibold text-foreground">変動金利シミュレーション</p>
-                  <label className="flex items-center gap-2 cursor-pointer">
-                    <input
-                      type="checkbox"
-                      checked={rateScheduleEnabled}
-                      onChange={(e) => handleRateScheduleToggle(e.target.checked)}
-                      className="h-4 w-4 rounded border-gray-300"
-                    />
-                    <span className="text-xs text-muted-foreground">有効にする</span>
-                  </label>
-                </div>
-                {rateScheduleEnabled && (
-                  <div className="space-y-2">
-                    <p className="text-xs text-muted-foreground">
-                      指定年以降の適用金利（絶対値）を設定します。最大3ステップ。
-                    </p>
-                    {input.rateAdjustmentSchedule.map((step, i) => {
-                      const maxYear = input.loanYears || 35;
-                      const prevYear = i > 0 ? input.rateAdjustmentSchedule[i - 1].afterYear : 1;
-                      const yearError =
-                        step.afterYear < 2
-                          ? "2年目以降を指定してください"
-                          : step.afterYear > maxYear
-                            ? `${maxYear}年以内を指定してください`
-                            : step.afterYear <= prevYear
-                              ? `前のステップより後の年を指定してください`
-                              : undefined;
-                      const rateError =
-                        step.rate <= 0 || step.rate > 0.3
-                          ? "0%超〜30%の範囲で入力してください"
-                          : undefined;
-                      return (
-                        <div key={i} className="flex items-center gap-2">
-                          <Input
-                            label={i === 0 ? "開始年" : ""}
-                            type="number"
-                            inputMode="numeric"
-                            suffix="年目〜"
-                            min="2"
-                            max={String(maxYear)}
-                            step="1"
-                            value={String(step.afterYear)}
-                            onChange={(e) =>
-                              updateRateStep(i, "afterYear", parseInt(e.target.value) || 2)
-                            }
-                            error={yearError}
-                          />
-                          <Input
-                            label={i === 0 ? "適用金利" : ""}
-                            type="number"
-                            inputMode="decimal"
-                            suffix="%"
-                            min="0.1"
-                            max="30"
-                            step="0.1"
-                            value={(step.rate * 100).toFixed(2)}
-                            onChange={(e) =>
-                              updateRateStep(i, "rate", (parseFloat(e.target.value) || 0) / 100)
-                            }
-                            error={rateError}
-                          />
-                          <button
-                            type="button"
-                            onClick={() => removeRateStep(i)}
-                            className={`text-muted-foreground hover:text-destructive flex-shrink-0 ${i === 0 ? "mt-5" : ""}`}
-                            aria-label="削除"
-                          >
-                            <Trash2 className="h-4 w-4" />
-                          </button>
-                        </div>
-                      );
-                    })}
-                    {canAddRateStep && (
-                      <button
-                        type="button"
-                        onClick={addRateStep}
-                        className="flex items-center gap-1 text-xs text-primary hover:underline"
-                      >
-                        <Plus className="h-3 w-3" />
-                        金利ステップを追加
-                      </button>
-                    )}
-                  </div>
-                )}
-              </div>
-
-              {/* ストレステスト */}
-              <div className="border-t pt-4 space-y-4">
-                <p className="text-sm font-semibold text-foreground">ストレステスト</p>
-                <Slider
-                  label="空室率の上昇"
-                  value={input.vacancyRateDelta}
-                  min={0}
-                  max={0.3}
-                  step={0.01}
-                  onChange={(v) => setNum("vacancyRateDelta", v)}
-                  formatValue={(v) => `+${formatPct(v)}`}
-                />
-                <Slider
-                  label="金利の上昇"
-                  value={input.loanRateDelta}
-                  min={0}
-                  max={0.03}
-                  step={0.001}
-                  onChange={(v) => setNum("loanRateDelta", v)}
-                  formatValue={(v) => `+${formatPct(v)}`}
-                />
-                {rateScheduleEnabled && input.loanRateDelta > 0 && (
-                  <p className="text-xs text-muted-foreground">
-                    金利上昇分はスケジュール後の金利にも上乗せされます
-                  </p>
-                )}
-              </div>
-
-              <Button
-                className="w-full"
-                size="lg"
-                loading={loading}
-                disabled={hasErrors || loading}
-                onClick={handleAnalyze}
-              >
-                <Calculator className="h-5 w-5" />
-                シミュレーション実行
-              </Button>
-
-              <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-xs text-yellow-800 space-y-1">
-                <p className="flex items-center gap-1 font-semibold">
-                  <Info className="h-3 w-3" />
-                  免責事項
-                </p>
-                <ul className="list-disc list-inside space-y-0.5">
-                  <li>計算結果は参考値であり、税務上の助言ではありません</li>
-                  <li>消費税・損益通算・各種特例（3000万控除等）は考慮していません</li>
-                  <li>所得税率は給与所得との合算後の実効税率を入力してください</li>
-                  <li>中古物件の耐用年数は「築年数」から簡便法で算出しています</li>
-                  <li>実際の投資判断は税理士・不動産の専門家にご相談ください</li>
-                </ul>
-              </div>
-            </CardContent>
-          </Card>
-        </>
+      {isQuick ? (
+        <QuickModeForm
+          {...sharedMuniProps}
+          showLandSection={showLandSection}
+          setShowLandSection={setShowLandSection}
+          quickHistory={quickHistory}
+          handleRestoreLastInput={handleRestoreLastInput}
+          quickTotalPriceMan={quickTotalPriceMan}
+          setQuickTotalPriceMan={setQuickTotalPriceMan}
+          markTouched={markTouched}
+          fieldError={fieldError}
+          input={input}
+          setNum={setNum}
+          isCashPurchase={isCashPurchase}
+          handleCashPurchaseToggle={handleCashPurchaseToggle}
+          showCustomLoan={showCustomLoan}
+          setShowCustomLoan={setShowCustomLoan}
+          hasErrors={hasErrors}
+          handleAnalyze={handleAnalyze}
+        />
+      ) : (
+        <FullModeForm
+          {...sharedMuniProps}
+          setPropertyLat={setPropertyLat}
+          setPropertyLng={setPropertyLng}
+          addressInput={addressInput}
+          setAddressInput={setAddressInput}
+          geocodeStatus={geocodeStatus}
+          setGeocodeStatus={setGeocodeStatus}
+          geocodeError={geocodeError}
+          geocodeLocationType={geocodeLocationType}
+          showManualCoords={showManualCoords}
+          handleGeocode={handleGeocode}
+          input={input}
+          setNum={setNum}
+          setStr={setStr}
+          fieldError={fieldError}
+          showBuildingHelper={showBuildingHelper}
+          setShowBuildingHelper={setShowBuildingHelper}
+          taxAmount={taxAmount}
+          setTaxAmount={setTaxAmount}
+          landAssess={landAssess}
+          setLandAssess={setLandAssess}
+          buildingAssess={buildingAssess}
+          setBuildingAssess={setBuildingAssess}
+          totalPrice={totalPrice}
+          setTotalPrice={setTotalPrice}
+          rentHint={rentHint}
+          rentHintLoading={rentHintLoading}
+          rentHintError={rentHintError}
+          handleFetchRentHint={handleFetchRentHint}
+          isCashPurchase={isCashPurchase}
+          handleCashPurchaseToggle={handleCashPurchaseToggle}
+          zoningType={zoningType}
+          setZoningType={setZoningType}
+          rateScheduleEnabled={rateScheduleEnabled}
+          handleRateScheduleToggle={handleRateScheduleToggle}
+          addRateStep={addRateStep}
+          removeRateStep={removeRateStep}
+          updateRateStep={updateRateStep}
+          canAddRateStep={canAddRateStep}
+          hasErrors={hasErrors}
+          handleAnalyze={handleAnalyze}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -405,6 +405,7 @@ export function InvestmentForm({
           setGeocodeStatus={setGeocodeStatus}
           geocodeError={geocodeError}
           geocodeLocationType={geocodeLocationType}
+          setGeocodeLocationType={setGeocodeLocationType}
           showManualCoords={showManualCoords}
           handleGeocode={handleGeocode}
           input={input}

--- a/frontend/src/components/QuickModeForm.tsx
+++ b/frontend/src/components/QuickModeForm.tsx
@@ -1,0 +1,309 @@
+"use client";
+import React from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import type { InvestmentInput } from "@/types/investment";
+import { toMan, fromMan, toPct, fromPct } from "@/lib/utils";
+import type { Municipality } from "@/lib/api";
+import { PREFECTURES, getPeriodLabel } from "@/lib/investmentFormConstants";
+import { Search, Calculator, Info, ChevronDown, ChevronUp } from "lucide-react";
+
+export interface QuickHistoryEntry {
+  totalPriceMan: string;
+  monthlyRentYen: string;
+  ts: number;
+}
+
+interface QuickModeFormProps {
+  area: string;
+  handleAreaChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  city: string;
+  handleCityChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  muniFilter: string;
+  setMuniFilter: (v: string) => void;
+  filteredMunicipalities: Municipality[];
+  muniLoading: boolean;
+  muniError: string | null;
+  showLandSection: boolean;
+  setShowLandSection: React.Dispatch<React.SetStateAction<boolean>>;
+  isOnline: boolean | null;
+  propertyLat: string;
+  propertyLng: string;
+  loading: boolean;
+  onFetchLandPrices: (area: string, city: string, lat?: number, lng?: number) => Promise<void>;
+  quickHistory: QuickHistoryEntry[];
+  handleRestoreLastInput: () => void;
+  quickTotalPriceMan: string;
+  setQuickTotalPriceMan: (v: string) => void;
+  markTouched: (key: string) => void;
+  fieldError: (key: string) => string | undefined;
+  input: InvestmentInput;
+  setNum: (key: keyof InvestmentInput, value: number) => void;
+  isCashPurchase: boolean;
+  handleCashPurchaseToggle: (checked: boolean) => void;
+  showCustomLoan: boolean;
+  setShowCustomLoan: (v: boolean) => void;
+  hasErrors: boolean;
+  handleAnalyze: () => void;
+}
+
+export function QuickModeForm({
+  area,
+  handleAreaChange,
+  city,
+  handleCityChange,
+  muniFilter,
+  setMuniFilter,
+  filteredMunicipalities,
+  muniLoading,
+  muniError,
+  showLandSection,
+  setShowLandSection,
+  isOnline,
+  propertyLat,
+  propertyLng,
+  loading,
+  onFetchLandPrices,
+  quickHistory,
+  handleRestoreLastInput,
+  quickTotalPriceMan,
+  setQuickTotalPriceMan,
+  markTouched,
+  fieldError,
+  input,
+  setNum,
+  isCashPurchase,
+  handleCashPurchaseToggle,
+  showCustomLoan,
+  setShowCustomLoan,
+  hasErrors,
+  handleAnalyze,
+}: QuickModeFormProps) {
+  return (
+    <>
+      {/* 土地相場データ取得（折りたたみ） */}
+      <div className="rounded-lg border">
+        <button
+          type="button"
+          className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-muted-foreground hover:text-foreground"
+          onClick={() => setShowLandSection((p) => !p)}
+        >
+          <span className="flex items-center gap-2">
+            <Search className="h-4 w-4" />
+            土地相場データを取得（任意）
+          </span>
+          {showLandSection ? (
+            <ChevronUp className="h-4 w-4" />
+          ) : (
+            <ChevronDown className="h-4 w-4" />
+          )}
+        </button>
+        {showLandSection && (
+          <div className="border-t px-4 pb-4 pt-3 space-y-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <Select
+                label="都道府県"
+                value={area}
+                onChange={handleAreaChange}
+                options={PREFECTURES}
+              />
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-foreground">市区町村</label>
+                <input
+                  type="text"
+                  placeholder="例: 前橋市"
+                  value={muniFilter}
+                  onChange={(e) => setMuniFilter(e.target.value)}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                />
+                <select
+                  value={city}
+                  onChange={handleCityChange}
+                  className="flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <option value="">（全市区町村）</option>
+                  {muniLoading ? (
+                    <option disabled>読み込み中...</option>
+                  ) : (
+                    filteredMunicipalities.map((m) => (
+                      <option key={m.id} value={m.id}>
+                        {m.name}
+                      </option>
+                    ))
+                  )}
+                </select>
+                {muniError && <p className="text-xs text-destructive">{muniError}</p>}
+              </div>
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {getPeriodLabel()}分の宅地取引実績（国交省公式API）を取得します
+            </p>
+            {isOnline === false && (
+              <p className="text-xs text-amber-700">オフライン中は相場取得を利用できません</p>
+            )}
+            <Button
+              variant="outline"
+              className="w-full"
+              loading={loading}
+              disabled={isOnline === false}
+              onClick={() => {
+                const lat = parseFloat(propertyLat);
+                const lng = parseFloat(propertyLng);
+                const hasCoords = !isNaN(lat) && !isNaN(lng);
+                onFetchLandPrices(area, city, hasCoords ? lat : undefined, hasCoords ? lng : undefined);
+              }}
+            >
+              <Search className="h-4 w-4" />
+              相場データを取得
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* クイックモード入力フォーム */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Calculator className="h-5 w-5 text-primary" />
+            物件・投資条件
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {quickHistory.length > 0 && (
+            <button
+              type="button"
+              className="flex w-full items-center justify-center gap-2 rounded-md border border-primary/30 bg-primary/5 px-3 py-2 min-h-[44px] text-sm font-medium text-primary hover:bg-primary/10 transition-colors"
+              onClick={handleRestoreLastInput}
+            >
+              前回の入力から開始
+            </button>
+          )}
+          <div className="space-y-3">
+            <div>
+              <Input
+                label="物件価格（土地＋建物の総額）"
+                type="number"
+                inputMode="numeric"
+                suffix="万円"
+                value={quickTotalPriceMan}
+                onChange={(e) => {
+                  setQuickTotalPriceMan(e.target.value);
+                  markTouched("quickTotalPrice");
+                }}
+                error={fieldError("quickTotalPrice")}
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                内部で土地70%・建物30%に按分して計算します
+              </p>
+            </div>
+            <Input
+              label="想定月額賃料"
+              type="number"
+              inputMode="numeric"
+              suffix="円"
+              value={String(input.monthlyRent)}
+              onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
+              error={fieldError("monthlyRent")}
+            />
+            <div className="space-y-2">
+              <label className="flex items-center gap-2 cursor-pointer select-none min-h-[44px]">
+                <input
+                  type="checkbox"
+                  checked={isCashPurchase}
+                  onChange={(e) => handleCashPurchaseToggle(e.target.checked)}
+                  className="h-4 w-4 rounded border-input accent-primary"
+                  aria-label="現金購入（ローンなし）"
+                />
+                <span className="text-sm font-medium">現金購入（ローンなし）</span>
+              </label>
+              {!isCashPurchase && (
+                <>
+                  {!showCustomLoan && (
+                    <p className="text-xs text-muted-foreground">
+                      ローン 80% 自動適用中 —{" "}
+                      <button
+                        type="button"
+                        className="underline underline-offset-2 hover:text-foreground"
+                        onClick={() => setShowCustomLoan(true)}
+                      >
+                        カスタム設定
+                      </button>
+                    </p>
+                  )}
+                  {showCustomLoan && (
+                    <div className="space-y-1">
+                      <Input
+                        label="ローン金額"
+                        type="number"
+                        inputMode="numeric"
+                        suffix="万円"
+                        value={toMan(input.loanAmount)}
+                        onChange={(e) => setNum("loanAmount", fromMan(e.target.value))}
+                        error={fieldError("loanAmount")}
+                      />
+                      <button
+                        type="button"
+                        className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+                        onClick={() => setShowCustomLoan(false)}
+                      >
+                        80% 自動計算に戻す
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
+            </div>
+            <Input
+              label="目標利回り"
+              type="number"
+              inputMode="decimal"
+              suffix="%"
+              step="0.5"
+              value={toPct(input.yieldTarget, 1)}
+              onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
+              error={fieldError("yieldTarget")}
+            />
+          </div>
+
+          <div className="rounded-md border border-blue-200 bg-blue-50 px-3 py-2 text-xs text-blue-800 space-y-0.5">
+            <p className="font-semibold">自動設定されるデフォルト値</p>
+            <p>
+              空室率 5%・運営経費率 20%・建物構造: 木造・
+              {isCashPurchase
+                ? "現金購入（ローンなし）"
+                : !showCustomLoan
+                  ? "ローン 80%・年利 1.5%・返済期間 35年"
+                  : "年利 1.5%・返済期間 35年"}
+              ・10年後売却・所得税率 33%
+            </p>
+          </div>
+
+          <Button
+            className="w-full"
+            size="lg"
+            loading={loading}
+            disabled={hasErrors || loading}
+            onClick={handleAnalyze}
+          >
+            <Calculator className="h-5 w-5" />
+            シミュレーション実行
+          </Button>
+
+          <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-xs text-yellow-800 space-y-1">
+            <p className="flex items-center gap-1 font-semibold">
+              <Info className="h-3 w-3" />
+              免責事項
+            </p>
+            <ul className="list-disc list-inside space-y-0.5">
+              <li>計算結果は参考値であり、税務上の助言ではありません</li>
+              <li>消費税・損益通算・各種特例（3000万控除等）は考慮していません</li>
+              <li>実際の投資判断は税理士・不動産の専門家にご相談ください</li>
+            </ul>
+          </div>
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -1,0 +1,230 @@
+"use client";
+import React from "react";
+import { YieldAnalysis } from "@/components/YieldAnalysis";
+import CashFlowChart from "@/components/CashFlowChart";
+import DeadCrossChart from "@/components/DeadCrossChart";
+import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
+import CostBreakdown from "@/components/CostBreakdown";
+import { LoanOptimizationPanel } from "@/components/LoanOptimizationPanel";
+import RenovationPanel from "@/components/RenovationPanel";
+import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
+import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
+import { MonteCarloChart } from "@/components/MonteCarloChart";
+import NegotiationPanel from "@/components/NegotiationPanel";
+import WatchlistPanel from "@/components/WatchlistPanel";
+import { AreaDiscovery } from "@/components/AreaDiscovery";
+import { SimulationModeToggle } from "@/components/SimulationModeToggle";
+import { Button } from "@/components/ui/button";
+import dynamic from "next/dynamic";
+import { ShieldAlert } from "lucide-react";
+import type {
+  InvestmentInput,
+  InvestmentResult,
+  LandPriceComparison,
+  TheoreticalPriceResult,
+  StationRidershipResult,
+  PopulationForecastResult,
+  AppraisalComparisonResult,
+  UrbanRisk,
+  SimulationMode,
+  LoanMethod,
+  MonteCarloResult,
+  InvestmentScoreResult,
+} from "@/types/investment";
+
+const InvestmentScoreHeatmap = dynamic(() => import("./InvestmentScoreHeatmap"), { ssr: false });
+
+interface ResultsSectionProps {
+  activeTab: "simulation" | "area-discovery";
+  setActiveTab: (tab: "simulation" | "area-discovery") => void;
+  selectedMunicipalityMsg: string | null;
+  setSelectedMunicipalityMsg: (msg: string | null) => void;
+  simulationMode: SimulationMode;
+  onModeChange: (mode: SimulationMode) => void;
+  result: InvestmentResult | null;
+  comparison: LandPriceComparison | null;
+  theoreticalPrice: TheoreticalPriceResult | null;
+  stationRidership: StationRidershipResult[] | null;
+  populationForecast: PopulationForecastResult | null;
+  landAppraisal: AppraisalComparisonResult | null;
+  externalUrbanRisks: UrbanRisk[] | null;
+  investmentScore: InvestmentScoreResult | null;
+  hazardRisks: UrbanRisk[] | null;
+  lastInput: InvestmentInput | null;
+  propertyLat: number | undefined;
+  propertyLng: number | undefined;
+  monteCarloResult: MonteCarloResult | null;
+  monteCarloLoading: boolean;
+  onMonteCarlo: () => Promise<void>;
+  loanMethod: LoanMethod;
+  onLoanMethodChange: (method: LoanMethod) => Promise<void>;
+  onTileSelect: (lat: number, lng: number) => void;
+}
+
+export function ResultsSection({
+  activeTab,
+  setActiveTab,
+  selectedMunicipalityMsg,
+  setSelectedMunicipalityMsg,
+  simulationMode,
+  onModeChange,
+  result,
+  comparison,
+  theoreticalPrice,
+  stationRidership,
+  populationForecast,
+  landAppraisal,
+  externalUrbanRisks,
+  investmentScore,
+  hazardRisks,
+  lastInput,
+  propertyLat,
+  propertyLng,
+  monteCarloResult,
+  monteCarloLoading,
+  onMonteCarlo,
+  loanMethod,
+  onLoanMethodChange,
+  onTileSelect,
+}: ResultsSectionProps) {
+  return (
+    <section className="space-y-6">
+      {/* Tab toggle */}
+      <div className="flex gap-1 rounded-lg border bg-muted/30 p-1 w-fit">
+        <button
+          onClick={() => setActiveTab("simulation")}
+          className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
+            activeTab === "simulation"
+              ? "bg-white shadow-sm text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          シミュレーション
+        </button>
+        <button
+          onClick={() => {
+            setActiveTab("area-discovery");
+            setSelectedMunicipalityMsg(null);
+          }}
+          className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
+            activeTab === "area-discovery"
+              ? "bg-white shadow-sm text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          エリアを探す
+        </button>
+      </div>
+
+      {/* Mobile: simulation mode toggle */}
+      {activeTab === "simulation" && (
+        <SimulationModeToggle mode={simulationMode} onChange={onModeChange} className="lg:hidden" />
+      )}
+
+      {activeTab === "area-discovery" && (
+        <>
+          {selectedMunicipalityMsg && (
+            <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+              {selectedMunicipalityMsg}
+            </div>
+          )}
+          <AreaDiscovery
+            onMunicipalitySelect={(_code, name) => {
+              setSelectedMunicipalityMsg(
+                `「${name}」を選択しました。下の地図上で物件位置をクリックしてください。`
+              );
+            }}
+          />
+        </>
+      )}
+
+      {activeTab === "simulation" && !result && !comparison && (
+        <div className="flex h-64 items-center justify-center rounded-xl border-2 border-dashed border-muted-foreground/20 lg:h-80">
+          <div className="text-center text-muted-foreground">
+            <ShieldAlert className="mx-auto mb-3 h-10 w-10 opacity-30 lg:h-12 lg:w-12" />
+            <p className="text-sm font-medium">条件を入力してシミュレーションを実行してください</p>
+            <p className="mt-1 text-xs lg:hidden">下の「条件を編集」ボタンから入力できます</p>
+            <p className="mt-1 hidden text-sm lg:block">左のフォームから条件を入力してください</p>
+          </div>
+        </div>
+      )}
+
+      {activeTab === "simulation" && (
+        <>
+          {investmentScore && <InvestmentScoreCard score={investmentScore} />}
+
+          {propertyLat !== undefined && (
+            <InvestmentScoreHeatmap
+              centerLat={propertyLat}
+              centerLng={propertyLng}
+              onTileSelect={onTileSelect}
+            />
+          )}
+
+          {comparison && (
+            <LandPriceAnalysis
+              comparison={comparison}
+              input={lastInput}
+              theoreticalPrice={theoreticalPrice}
+              stationRidership={stationRidership}
+              populationForecast={populationForecast}
+              landAppraisal={landAppraisal}
+              externalUrbanRisks={externalUrbanRisks}
+              hazardRisks={hazardRisks}
+            />
+          )}
+
+          {result && lastInput && (
+            <>
+              <CriticalErrorBanner errors={result.criticalErrors} />
+              <YieldAnalysis
+                result={result}
+                input={lastInput}
+                populationForecast={populationForecast}
+              />
+              <NegotiationPanel
+                result={result}
+                input={lastInput}
+                comparison={comparison}
+                theoreticalPrice={theoreticalPrice}
+              />
+              <LoanOptimizationPanel
+                result={result}
+                loanMethod={loanMethod}
+                onLoanMethodChange={onLoanMethodChange}
+                loanAmount={lastInput.loanAmount}
+              />
+              {simulationMode === "full" && (
+                <>
+                  {result.acquisitionCosts && (
+                    <div className="rounded-xl border bg-white p-5 shadow-sm">
+                      <CostBreakdown
+                        input={lastInput}
+                        acquisitionCosts={result.acquisitionCosts}
+                        yearlyResults={result.yearlyResults}
+                      />
+                    </div>
+                  )}
+                  {/* 自己資金 = 総投資額 - ローン金額（ISSUE-22: 投資回収年の正確な計算に使用） */}
+                  <CashFlowChart
+                    result={result}
+                    equityInvested={result.totalInvestment - lastInput.loanAmount}
+                  />
+                  <DeadCrossChart result={result} />
+                  <div className="flex justify-center">
+                    <Button onClick={onMonteCarlo} loading={monteCarloLoading} size="md">
+                      モンテカルロ実行（1,000試行）
+                    </Button>
+                  </div>
+                  {monteCarloResult && <MonteCarloChart result={monteCarloResult} />}
+                </>
+              )}
+            </>
+          )}
+          <RenovationPanel />
+          <WatchlistPanel />
+        </>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -12,6 +12,13 @@ vi.mock("@/lib/api", () => ({
   fetchStationRidership: vi.fn(),
   fetchPopulationForecast: vi.fn(),
   fetchLandAppraisals: vi.fn(),
+  fetchUrbanRisks: vi.fn(),
+  fetchHazardInfo: vi.fn(),
+  fetchInvestmentScore: vi.fn(),
+  simulate: vi.fn(),
+  fetchMunicipalities: vi.fn().mockResolvedValue([]),
+  fetchGeocode: vi.fn(),
+  fetchRentDeclineHint: vi.fn(),
 }));
 
 // PDFDownloadLink is a browser-only API; stub it out in jsdom

--- a/frontend/src/hooks/useInvestmentSimulation.ts
+++ b/frontend/src/hooks/useInvestmentSimulation.ts
@@ -62,7 +62,6 @@ function getCurrentPeriods(): { year: number; quarter: number; toYear: number; t
 
 export interface UseInvestmentSimulationParams {
   isOnline: boolean | null;
-  loanMethod: LoanMethod;
   simulationMode: SimulationMode;
   onUrlUpdate: (qs: string) => void;
 }
@@ -75,9 +74,11 @@ export interface UseInvestmentSimulationResult extends Omit<AnalysisResult, neve
   propertyLng: number | undefined;
   monteCarloResult: MonteCarloResult | null;
   monteCarloLoading: boolean;
+  loanMethod: LoanMethod;
   handleAnalyze: (input: InvestmentInput, quickTotalMan?: string) => Promise<void>;
   handleFetchLandPrices: (area: string, city: string, lat?: number, lng?: number) => Promise<void>;
   handleMonteCarlo: () => Promise<void>;
+  handleLoanMethodChange: (method: LoanMethod) => Promise<void>;
   setPropertyCoords: (lat: number, lng: number) => void;
   clearResult: () => void;
 }
@@ -93,6 +94,7 @@ export function useInvestmentSimulation(
   const [propertyLng, setPropertyLng] = useState<number | undefined>(undefined);
   const [monteCarloResult, setMonteCarloResult] = useState<MonteCarloResult | null>(null);
   const [monteCarloLoading, setMonteCarloLoading] = useState(false);
+  const [loanMethod, setLoanMethod] = useState<LoanMethod>("equal-payment");
 
   // Stable refs for params to avoid stale closures in callbacks
   const paramsRef = useRef(params);
@@ -100,18 +102,20 @@ export function useInvestmentSimulation(
     paramsRef.current = params;
   });
 
-  // lastInput ref for access inside async callbacks without dep churn
+  // Refs for mutable values accessed inside async callbacks
   const lastInputRef = useRef(lastInput);
   useEffect(() => {
     lastInputRef.current = lastInput;
   }, [lastInput]);
+  const loanMethodRef = useRef<LoanMethod>("equal-payment");
 
   const handleAnalyze = useCallback(async (input: InvestmentInput, quickTotalMan?: string) => {
-    const { isOnline, loanMethod, simulationMode, onUrlUpdate } = paramsRef.current;
+    const { isOnline, simulationMode, onUrlUpdate } = paramsRef.current;
+    const currentLoanMethod = loanMethodRef.current;
     setLoading(true);
     setError(null);
     setMonteCarloResult(null);
-    const inputWithMethod = { ...input, loanMethod };
+    const inputWithMethod = { ...input, loanMethod: currentLoanMethod };
     try {
       const res =
         isOnline === false ? analyzeOffline(inputWithMethod) : await analyzeOnline(inputWithMethod);
@@ -138,6 +142,28 @@ export function useInvestmentSimulation(
       setError(e instanceof Error ? e.message : "モンテカルロシミュレーションに失敗しました");
     } finally {
       setMonteCarloLoading(false);
+    }
+  }, []);
+
+  const handleLoanMethodChange = useCallback(async (method: LoanMethod) => {
+    setLoanMethod(method);
+    loanMethodRef.current = method;
+    const current = lastInputRef.current;
+    if (!current) return;
+    const { isOnline } = paramsRef.current;
+    setLoading(true);
+    setError(null);
+    setMonteCarloResult(null);
+    try {
+      const updatedInput = { ...current, loanMethod: method };
+      const res =
+        isOnline === false ? analyzeOffline(updatedInput) : await analyzeOnline(updatedInput);
+      setAnalysisResult((prev) => ({ ...prev, result: res }));
+      setLastInput((prev) => (prev ? { ...prev, loanMethod: method } : prev));
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "シミュレーションに失敗しました");
+    } finally {
+      setLoading(false);
     }
   }, []);
 
@@ -248,9 +274,11 @@ export function useInvestmentSimulation(
     propertyLng,
     monteCarloResult,
     monteCarloLoading,
+    loanMethod,
     handleAnalyze,
     handleFetchLandPrices,
     handleMonteCarlo,
+    handleLoanMethodChange,
     setPropertyCoords,
     clearResult,
   };

--- a/frontend/src/hooks/useInvestmentSimulation.ts
+++ b/frontend/src/hooks/useInvestmentSimulation.ts
@@ -1,0 +1,257 @@
+"use client";
+import { useState, useCallback, useRef, useEffect } from "react";
+import {
+  analyze as analyzeOnline,
+  compareLandPrice,
+  estimateLandPrice,
+  fetchStationRidership,
+  fetchPopulationForecast,
+  fetchLandAppraisals,
+  fetchUrbanRisks,
+  fetchHazardInfo,
+  fetchInvestmentScore,
+  simulate,
+} from "@/lib/api";
+import { analyze as analyzeOffline } from "@/lib/investment";
+import { encodeUrlParams } from "@/lib/urlParams";
+import type {
+  InvestmentInput,
+  InvestmentResult,
+  LandPriceComparison,
+  TheoreticalPriceResult,
+  StationRidershipResult,
+  PopulationForecastResult,
+  AppraisalComparisonResult,
+  UrbanRisk,
+  SimulationMode,
+  LoanMethod,
+  MonteCarloResult,
+  InvestmentScoreResult,
+} from "@/types/investment";
+
+interface AnalysisResult {
+  result: InvestmentResult | null;
+  comparison: LandPriceComparison | null;
+  theoreticalPrice: TheoreticalPriceResult | null;
+  stationRidership: StationRidershipResult[] | null;
+  populationForecast: PopulationForecastResult | null;
+  landAppraisal: AppraisalComparisonResult | null;
+  externalUrbanRisks: UrbanRisk[] | null;
+  investmentScore: InvestmentScoreResult | null;
+  hazardRisks: UrbanRisk[] | null;
+}
+
+const INITIAL_ANALYSIS_RESULT: AnalysisResult = {
+  result: null,
+  comparison: null,
+  theoreticalPrice: null,
+  stationRidership: null,
+  populationForecast: null,
+  landAppraisal: null,
+  externalUrbanRisks: null,
+  investmentScore: null,
+  hazardRisks: null,
+};
+
+function getCurrentPeriods(): { year: number; quarter: number; toYear: number; toQuarter: number } {
+  const now = new Date();
+  const toYear = now.getFullYear();
+  const toQuarter = Math.ceil((now.getMonth() + 1) / 3);
+  return { year: toYear - 2, quarter: 1, toYear, toQuarter };
+}
+
+export interface UseInvestmentSimulationParams {
+  isOnline: boolean | null;
+  loanMethod: LoanMethod;
+  simulationMode: SimulationMode;
+  onUrlUpdate: (qs: string) => void;
+}
+
+export interface UseInvestmentSimulationResult extends Omit<AnalysisResult, never> {
+  loading: boolean;
+  error: string | null;
+  lastInput: InvestmentInput | null;
+  propertyLat: number | undefined;
+  propertyLng: number | undefined;
+  monteCarloResult: MonteCarloResult | null;
+  monteCarloLoading: boolean;
+  handleAnalyze: (input: InvestmentInput, quickTotalMan?: string) => Promise<void>;
+  handleFetchLandPrices: (area: string, city: string, lat?: number, lng?: number) => Promise<void>;
+  handleMonteCarlo: () => Promise<void>;
+  setPropertyCoords: (lat: number, lng: number) => void;
+  clearResult: () => void;
+}
+
+export function useInvestmentSimulation(
+  params: UseInvestmentSimulationParams
+): UseInvestmentSimulationResult {
+  const [analysisResult, setAnalysisResult] = useState<AnalysisResult>(INITIAL_ANALYSIS_RESULT);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [lastInput, setLastInput] = useState<InvestmentInput | null>(null);
+  const [propertyLat, setPropertyLat] = useState<number | undefined>(undefined);
+  const [propertyLng, setPropertyLng] = useState<number | undefined>(undefined);
+  const [monteCarloResult, setMonteCarloResult] = useState<MonteCarloResult | null>(null);
+  const [monteCarloLoading, setMonteCarloLoading] = useState(false);
+
+  // Stable refs for params to avoid stale closures in callbacks
+  const paramsRef = useRef(params);
+  useEffect(() => {
+    paramsRef.current = params;
+  });
+
+  // lastInput ref for access inside async callbacks without dep churn
+  const lastInputRef = useRef(lastInput);
+  useEffect(() => {
+    lastInputRef.current = lastInput;
+  }, [lastInput]);
+
+  const handleAnalyze = useCallback(async (input: InvestmentInput, quickTotalMan?: string) => {
+    const { isOnline, loanMethod, simulationMode, onUrlUpdate } = paramsRef.current;
+    setLoading(true);
+    setError(null);
+    setMonteCarloResult(null);
+    const inputWithMethod = { ...input, loanMethod };
+    try {
+      const res =
+        isOnline === false ? analyzeOffline(inputWithMethod) : await analyzeOnline(inputWithMethod);
+      setAnalysisResult((prev) => ({ ...prev, result: res }));
+      setLastInput(inputWithMethod);
+      const urlParams = encodeUrlParams(simulationMode, inputWithMethod, quickTotalMan);
+      const qs = urlParams.toString();
+      onUrlUpdate(qs);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "シミュレーションに失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const handleMonteCarlo = useCallback(async () => {
+    const current = lastInputRef.current;
+    if (!current) return;
+    setMonteCarloLoading(true);
+    try {
+      const res = await simulate({ base: current, simulations: 1000 });
+      setMonteCarloResult(res);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "モンテカルロシミュレーションに失敗しました");
+    } finally {
+      setMonteCarloLoading(false);
+    }
+  }, []);
+
+  const handleFetchLandPrices = useCallback(
+    async (area: string, city: string, lat?: number, lng?: number) => {
+      const { isOnline } = paramsRef.current;
+      setLoading(true);
+      setError(null);
+      setAnalysisResult((prev) => ({
+        ...prev,
+        stationRidership: null,
+        populationForecast: null,
+        landAppraisal: null,
+        externalUrbanRisks: null,
+        investmentScore: null,
+        hazardRisks: null,
+      }));
+      if (lat !== undefined && lng !== undefined) {
+        setPropertyLat(lat);
+        setPropertyLng(lng);
+      }
+      const { year, quarter, toYear, toQuarter } = getCurrentPeriods();
+      const current = lastInputRef.current;
+      try {
+        const baseParams = {
+          area,
+          city,
+          year,
+          quarter,
+          toYear,
+          toQuarter,
+          price: current?.landPrice ?? 5_000_000,
+          areaSqm: current?.landArea ?? 0,
+        };
+        const comp = await compareLandPrice(baseParams);
+        setAnalysisResult((prev) => ({ ...prev, comparison: comp }));
+
+        if (current && current.landArea > 0) {
+          try {
+            const est = await estimateLandPrice({
+              ...baseParams,
+              buildingAge: current.buildingAge,
+              stationMinutes: current.stationMinutes,
+            });
+            setAnalysisResult((prev) => ({ ...prev, theoreticalPrice: est }));
+          } catch {
+            setAnalysisResult((prev) => ({ ...prev, theoreticalPrice: null }));
+          }
+        }
+
+        const [appraisal] = await Promise.allSettled([
+          fetchLandAppraisals({ area, year: toYear, city: city || undefined }),
+        ]);
+        setAnalysisResult((prev) => ({
+          ...prev,
+          landAppraisal: appraisal.status === "fulfilled" ? appraisal.value : null,
+        }));
+
+        if (lat !== undefined && lng !== undefined) {
+          const [ridership, population, urbanRisks, scoreResult, hazard] =
+            await Promise.allSettled([
+              fetchStationRidership({ lat, lng }),
+              fetchPopulationForecast({ lat, lng }),
+              fetchUrbanRisks(lat, lng),
+              fetchInvestmentScore({ lat, lng }),
+              fetchHazardInfo(lat, lng),
+            ]);
+          setAnalysisResult((prev) => ({
+            ...prev,
+            stationRidership: ridership.status === "fulfilled" ? ridership.value : null,
+            populationForecast: population.status === "fulfilled" ? population.value : null,
+            externalUrbanRisks: urbanRisks.status === "fulfilled" ? urbanRisks.value : null,
+            investmentScore: scoreResult.status === "fulfilled" ? scoreResult.value : null,
+            hazardRisks: hazard.status === "fulfilled" ? hazard.value : null,
+          }));
+        }
+
+        // オフラインでも相場比較は実行可能なため isOnline チェック不要
+        void isOnline;
+      } catch (e) {
+        setError(
+          e instanceof Error
+            ? e.message
+            : "相場データの取得に失敗しました。しばらく後に再試行してください"
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  const setPropertyCoords = useCallback((lat: number, lng: number) => {
+    setPropertyLat(lat);
+    setPropertyLng(lng);
+  }, []);
+
+  const clearResult = useCallback(() => {
+    setAnalysisResult((prev) => ({ ...prev, result: null }));
+  }, []);
+
+  return {
+    ...analysisResult,
+    loading,
+    error,
+    lastInput,
+    propertyLat,
+    propertyLng,
+    monteCarloResult,
+    monteCarloLoading,
+    handleAnalyze,
+    handleFetchLandPrices,
+    handleMonteCarlo,
+    setPropertyCoords,
+    clearResult,
+  };
+}

--- a/frontend/src/hooks/useMunicipalitiesLoader.ts
+++ b/frontend/src/hooks/useMunicipalitiesLoader.ts
@@ -1,0 +1,74 @@
+"use client";
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { fetchMunicipalities, type Municipality } from "@/lib/api";
+
+export interface UseMunicipalitiesLoaderResult {
+  municipalities: Municipality[];
+  loading: boolean;
+  error: string | null;
+  city: string;
+  setCity: (id: string) => void;
+  muniFilter: string;
+  setMuniFilter: (v: string) => void;
+  filteredMunicipalities: Municipality[];
+  loadMunicipalities: (areaCode: string) => Promise<void>;
+}
+
+export function useMunicipalitiesLoader(
+  initialAreaCode = "10"
+): UseMunicipalitiesLoaderResult {
+  const [municipalities, setMunicipalities] = useState<Municipality[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [city, setCity] = useState("");
+  const [muniFilter, setMuniFilter] = useState("");
+
+  const filteredMunicipalities = useMemo(
+    () =>
+      muniFilter.trim()
+        ? municipalities.filter((m) => m.name.includes(muniFilter.trim()))
+        : municipalities,
+    [municipalities, muniFilter]
+  );
+
+  const loadMunicipalities = useCallback(async (areaCode: string) => {
+    setLoading(true);
+    setError(null);
+    setCity("");
+    setMuniFilter("");
+    try {
+      const data = await fetchMunicipalities(areaCode);
+      setMunicipalities(data);
+      if (data.length > 0) setCity(data[0].id);
+    } catch (e) {
+      setMunicipalities([]);
+      setError(e instanceof Error ? e.message : "市区町村の取得に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadMunicipalities(initialAreaCode);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loadMunicipalities]);
+
+  // 絞り込み結果が1件になったとき自動選択
+  useEffect(() => {
+    if (filteredMunicipalities.length === 1) {
+      setCity(filteredMunicipalities[0].id);
+    }
+  }, [filteredMunicipalities]);
+
+  return {
+    municipalities,
+    loading,
+    error,
+    city,
+    setCity,
+    muniFilter,
+    setMuniFilter,
+    filteredMunicipalities,
+    loadMunicipalities,
+  };
+}

--- a/frontend/src/hooks/useNetworkStatus.ts
+++ b/frontend/src/hooks/useNetworkStatus.ts
@@ -2,10 +2,12 @@
 import { useState, useEffect } from "react";
 
 export function useNetworkStatus(): boolean | null {
-  const [isOnline, setIsOnline] = useState<boolean | null>(null);
+  const [isOnline, setIsOnline] = useState<boolean | null>(() => {
+    if (typeof window === "undefined") return null;
+    return navigator.onLine;
+  });
 
   useEffect(() => {
-    setIsOnline(navigator.onLine);
     const handleOnline = () => setIsOnline(true);
     const handleOffline = () => setIsOnline(false);
     window.addEventListener("online", handleOnline);

--- a/frontend/src/hooks/useNetworkStatus.ts
+++ b/frontend/src/hooks/useNetworkStatus.ts
@@ -1,0 +1,20 @@
+"use client";
+import { useState, useEffect } from "react";
+
+export function useNetworkStatus(): boolean | null {
+  const [isOnline, setIsOnline] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setIsOnline(navigator.onLine);
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+}

--- a/frontend/src/hooks/useRentDeclineHint.ts
+++ b/frontend/src/hooks/useRentDeclineHint.ts
@@ -1,0 +1,50 @@
+"use client";
+import { useState, useCallback, useRef, useEffect } from "react";
+import { fetchRentDeclineHint } from "@/lib/api";
+import type { RentDeclineHint } from "@/types/investment";
+
+export interface UseRentDeclineHintResult {
+  rentHint: RentDeclineHint | null;
+  loading: boolean;
+  error: string | null;
+  fetch: (area: string, city: string) => Promise<void>;
+  clear: () => void;
+}
+
+export function useRentDeclineHint(
+  onHintApplied: (rate: number) => void
+): UseRentDeclineHintResult {
+  const [rentHint, setRentHint] = useState<RentDeclineHint | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Stable ref to avoid stale closure in fetch callback
+  const onHintAppliedRef = useRef(onHintApplied);
+  useEffect(() => {
+    onHintAppliedRef.current = onHintApplied;
+  });
+
+  const fetch = useCallback(async (area: string, city: string) => {
+    setLoading(true);
+    setError(null);
+    setRentHint(null);
+    try {
+      const hint = await fetchRentDeclineHint({ area, municipality: city || undefined });
+      setRentHint(hint);
+      if (!hint.fallbackUsed && hint.hintRate > 0) {
+        onHintAppliedRef.current(hint.hintRate);
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "参考値の取得に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const clear = useCallback(() => {
+    setRentHint(null);
+    setError(null);
+  }, []);
+
+  return { rentHint, loading, error, fetch, clear };
+}

--- a/frontend/src/lib/investmentFormConstants.ts
+++ b/frontend/src/lib/investmentFormConstants.ts
@@ -1,0 +1,74 @@
+import type { BuildingType } from "@/types/investment";
+
+export const PREFECTURES = [
+  { value: "01", label: "北海道" },
+  { value: "02", label: "青森県" },
+  { value: "03", label: "岩手県" },
+  { value: "04", label: "宮城県" },
+  { value: "05", label: "秋田県" },
+  { value: "06", label: "山形県" },
+  { value: "07", label: "福島県" },
+  { value: "08", label: "茨城県" },
+  { value: "09", label: "栃木県" },
+  { value: "10", label: "群馬県" },
+  { value: "11", label: "埼玉県" },
+  { value: "12", label: "千葉県" },
+  { value: "13", label: "東京都" },
+  { value: "14", label: "神奈川県" },
+  { value: "15", label: "新潟県" },
+  { value: "16", label: "富山県" },
+  { value: "17", label: "石川県" },
+  { value: "18", label: "福井県" },
+  { value: "19", label: "山梨県" },
+  { value: "20", label: "長野県" },
+  { value: "21", label: "岐阜県" },
+  { value: "22", label: "静岡県" },
+  { value: "23", label: "愛知県" },
+  { value: "24", label: "三重県" },
+  { value: "25", label: "滋賀県" },
+  { value: "26", label: "京都府" },
+  { value: "27", label: "大阪府" },
+  { value: "28", label: "兵庫県" },
+  { value: "29", label: "奈良県" },
+  { value: "30", label: "和歌山県" },
+  { value: "31", label: "鳥取県" },
+  { value: "32", label: "島根県" },
+  { value: "33", label: "岡山県" },
+  { value: "34", label: "広島県" },
+  { value: "35", label: "山口県" },
+  { value: "36", label: "徳島県" },
+  { value: "37", label: "香川県" },
+  { value: "38", label: "愛媛県" },
+  { value: "39", label: "高知県" },
+  { value: "40", label: "福岡県" },
+  { value: "41", label: "佐賀県" },
+  { value: "42", label: "長崎県" },
+  { value: "43", label: "熊本県" },
+  { value: "44", label: "大分県" },
+  { value: "45", label: "宮崎県" },
+  { value: "46", label: "鹿児島県" },
+  { value: "47", label: "沖縄県" },
+];
+
+export const BUILDING_TYPES: { value: BuildingType; label: string }[] = [
+  { value: "木造", label: "木造（耐用22年）" },
+  { value: "軽量鉄骨(3mm以下)", label: "軽量鉄骨・薄板（耐用19年）" },
+  { value: "軽量鉄骨(4mm以下)", label: "軽量鉄骨（耐用27年）" },
+  { value: "重量鉄骨", label: "重量鉄骨（耐用34年）" },
+  { value: "RC造", label: "RC造（耐用47年）" },
+  { value: "SRC造", label: "SRC造（耐用47年）" },
+];
+
+export const RENT_DECLINE_DEFAULTS: Record<BuildingType, number> = {
+  木造: 0.01,
+  "軽量鉄骨(3mm以下)": 0.008,
+  "軽量鉄骨(4mm以下)": 0.008,
+  重量鉄骨: 0.008,
+  RC造: 0.005,
+  SRC造: 0.005,
+};
+
+export function getPeriodLabel(): string {
+  const year = new Date().getFullYear();
+  return `${year - 2}〜${year - 1}年`;
+}

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -25,3 +25,23 @@ export function formatTsubo(value: number): string {
   if (value >= 10_000) return `${(value / 10_000).toFixed(1)}万円/坪`;
   return `${Math.round(value).toLocaleString("ja-JP")}円/坪`;
 }
+
+/** 円 → 万円文字列 (入力フィールド向け) */
+export function toMan(yen: number): string {
+  return String(Math.round(yen / 10_000));
+}
+
+/** 万円文字列 → 円 */
+export function fromMan(s: string): number {
+  return (parseFloat(s) || 0) * 10_000;
+}
+
+/** 小数レート → %文字列 (入力フィールド向け) */
+export function toPct(rate: number, digits = 2): string {
+  return (rate * 100).toFixed(digits);
+}
+
+/** %文字列 → 小数レート */
+export function fromPct(s: string): number {
+  return (parseFloat(s) || 0) / 100;
+}


### PR DESCRIPTION
## 概要

フロントエンド主要コンポーネントの肥大化を解消する。`InvestmentForm.tsx`（1116行）・`Dashboard.tsx`（595行）が状態管理・副作用・UIロジック・レンダリングをすべて1ファイルに抱えており、変更時の影響範囲が広く読解コストが高かった。カスタムhook抽出とコンポーネント分割でそれぞれを小さな責務単位に整理した。

Closes #328

## 変更内容

### ユーティリティ統合
- `toMan / fromMan / toPct / fromPct` を `InvestmentForm` のインライン定義から `lib/utils.ts` にエクスポート関数として移動（`QuickModeForm` と `FullModeForm` で共有するため）

### カスタムhook（新規 `src/hooks/`）

| hook | 抽出元 | 役割 |
|---|---|---|
| `useNetworkStatus` | `Dashboard` | `navigator.onLine` + online/offlineイベント監視。SSR安全な lazy initializer で `null / true / false` の三値を返す |
| `useMunicipalitiesLoader` | `InvestmentForm` | 都道府県コードによる市区町村フェッチ・フィルタ・自動選択。`city` stateも内包し、一覧選択の状態をひとつの責務として管理 |
| `useRentDeclineHint` | `InvestmentForm` | 賃料下落率の地域参考値フェッチ。`onHintApplied` コールバックを `useRef` で安定化し、呼び出し元フォームへの書き戻しを逆依存にならない形で実現 |
| `useInvestmentSimulation` | `Dashboard` | analyze / monteCarlo / fetchLandPrices / loanMethodChange の非同期ハンドラと結果state群を管理。`loanMethod` もhook内で所有し `loanMethodRef` で即時更新することで stale closure を防止 |

### コンポーネント分割

| 新規コンポーネント | 抽出元 | 役割 |
|---|---|---|
| `FormSheet` | `Dashboard` | モバイルボトムシートのレイアウトのみを担う純粋な表示コンポーネント |
| `QuickModeForm` | `InvestmentForm` | クイックモードのフォームUI（折りたたみ相場取得 + 物件・投資条件カード） |
| `FullModeForm` | `InvestmentForm` | 詳細モードのフォームUI（住所ジオコーディング・按分ヘルパー・変動金利スケジュール等） |
| `ResultsSection` | `Dashboard` | タブ切り替え・スコアカード・チャート群・エリア探索を統括。状態を持たず props のみで動作 |

### 変更後の行数

| ファイル | 変更前 | 変更後 |
|---|---|---|
| `Dashboard.tsx` | 595行 | 304行（▲49%） |
| `InvestmentForm.tsx` | 1116行 | 444行（▲60%） |

### テスト修正
`Dashboard.test.tsx` のAPIモックに `useInvestmentSimulation` が内部で呼ぶ関数（`fetchUrbanRisks` / `fetchHazardInfo` / `fetchInvestmentScore` / `simulate` / `fetchMunicipalities`）を追加。

## テスト
- [x] 既存テストが通ること（`npm test` — 232テスト全通過）
- [x] `npm run lint`（eslint + tsc --noEmit）エラーなし

## 確認事項
- [x] コードレビュー観点での自己レビュー済み
- [ ] ブラウザ目視確認（クイック/詳細モード切り替え・モバイルシート・オフラインフォールバック・市区町村フィルタ・賃料参考値取得）
- `LandPriceAnalysis.tsx` の分割はスコープ外として意図的に見送り（純粋表示コンポーネントのため優先度低）