### PR TITLE
feat(frontend): ウォッチリストへの投資指標スナップショット保存

### DIFF
--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -222,7 +222,7 @@ export function ResultsSection({
             </>
           )}
           <RenovationPanel />
-          <WatchlistPanel />
+          <WatchlistPanel currentResult={result ?? undefined} />
         </>
       )}
     </section>

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Trash2, ClipboardList } from "lucide-react";
-import type { WatchlistItem, WatchlistStatus } from "@/types/investment";
+import type { WatchlistItem, WatchlistStatus, InvestmentResult } from "@/types/investment";
 
 const STORAGE_KEY = "yg_watchlist";
 
@@ -40,7 +40,17 @@ function formatDate(iso: string): string {
   return d.toLocaleDateString("ja-JP", { year: "numeric", month: "2-digit", day: "2-digit" });
 }
 
-export default function WatchlistPanel() {
+function getDscrColor(dscr: number): string {
+  if (dscr >= 1.2) return "text-green-600";
+  if (dscr >= 1.0) return "text-yellow-600";
+  return "text-red-600";
+}
+
+interface WatchlistPanelProps {
+  currentResult?: InvestmentResult;
+}
+
+export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
   const [items, setItems] = useState<WatchlistItem[]>(loadItems);
   const [nameInput, setNameInput] = useState("");
   const [memoInput, setMemoInput] = useState("");
@@ -66,6 +76,18 @@ export default function WatchlistPanel() {
       memo: memoInput.trim(),
       status: "検討中",
       addedAt: new Date().toISOString(),
+      ...(currentResult
+        ? {
+            metrics: {
+              grossYield: currentResult.grossYield,
+              netYield: currentResult.netYield,
+              dscr: currentResult.dscr,
+              irr: currentResult.irr ?? null,
+              totalInvestment: currentResult.totalInvestment,
+              exitTotalEquity: currentResult.exitTotalEquity,
+            },
+          }
+        : {}),
     };
     setItems((prev) => [newItem, ...prev]);
     setNameInput("");
@@ -148,6 +170,19 @@ export default function WatchlistPanel() {
                       {item.status}
                     </span>
                   </div>
+                  {item.metrics && (
+                    <div className="flex flex-wrap gap-2 pt-0.5">
+                      <span className="text-xs text-blue-600">
+                        表面利回り: {(item.metrics.grossYield * 100).toFixed(1)}%
+                      </span>
+                      <span className={`text-xs ${getDscrColor(item.metrics.dscr)}`}>
+                        DSCR: {item.metrics.dscr.toFixed(2)}
+                      </span>
+                      <span className="text-xs text-purple-600">
+                        IRR: {item.metrics.irr !== null ? `${(item.metrics.irr * 100).toFixed(1)}%` : "-"}
+                      </span>
+                    </div>
+                  )}
                   {item.memo && (
                     <p className="truncate text-xs text-muted-foreground">{item.memo}</p>
                   )}

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -418,12 +418,22 @@ export interface HeatmapResponse {
 
 export type WatchlistStatus = "検討中" | "見送り" | "購入済み";
 
+export interface WatchlistMetrics {
+  grossYield: number;
+  netYield: number;
+  dscr: number;
+  irr: number | null;
+  totalInvestment: number;
+  exitTotalEquity: number;
+}
+
 export interface WatchlistItem {
   id: string;
   name: string;
   memo: string;
   status: WatchlistStatus;
   addedAt: string; // ISO 8601
+  metrics?: WatchlistMetrics;
 }
 
 export interface GeocodeResult {


### PR DESCRIPTION
## 概要
ウォッチリストへ物件を登録する際に、その時点の投資指標（表面利回り・DSCR・IRR等）を自動保存する機能を追加。複数物件候補を並列検討する際の比較を可能にする。

## 変更内容
- `WatchlistMetrics` インターフェースを新規追加（`grossYield`, `netYield`, `dscr`, `irr`, `totalInvestment`, `exitTotalEquity`）
- `WatchlistItem` に `metrics?: WatchlistMetrics` フィールドを追加（既存データは後方互換を維持）
- `WatchlistPanel` に `currentResult?: InvestmentResult` propsを追加し、登録時にメトリクスを自動保存
- 登録済みアイテムの表示に表面利回り・DSCR（色分け）・IRRのバッジを追加
- `ResultsSection` から分析結果を `WatchlistPanel` に連携

## 関連Issue
Closes #376

## テスト
- [ ] 既存テストが通ること

## 確認事項
- [ ] コードレビュー観点での自己レビュー済み