### PR TITLE
fix(mobile): SimulationModeToggle をボトムシート内に移動

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -249,7 +249,6 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
             selectedMunicipalityMsg={selectedMunicipalityMsg}
             setSelectedMunicipalityMsg={setSelectedMunicipalityMsg}
             simulationMode={simulationMode}
-            onModeChange={handleModeChange}
             result={result}
             comparison={comparison}
             theoreticalPrice={theoreticalPrice}
@@ -304,7 +303,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
           isOnline={isOnline}
           externalLat={propertyLat}
           externalLng={propertyLng}
-          showModeToggle={false}
+          showModeToggle={true}
         />
       </FormSheet>
     </div>

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -32,9 +32,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
 
   const isOnline = useNetworkStatus();
 
-  const [simulationMode, setSimulationMode] = useState<SimulationMode>(
-    decoded?.mode ?? "quick"
-  );
+  const [simulationMode, setSimulationMode] = useState<SimulationMode>(decoded?.mode ?? "quick");
   const [modeNotice, setModeNotice] = useState(false);
   const [pdfGenerating, setPdfGenerating] = useState(false);
   const [pdfError, setPdfError] = useState<string | null>(null);

--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -16,15 +16,7 @@ import {
   getPeriodLabel,
 } from "@/lib/investmentFormConstants";
 import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
-import {
-  Search,
-  Calculator,
-  Info,
-  AlertTriangle,
-  ShieldCheck,
-  Plus,
-  Trash2,
-} from "lucide-react";
+import { Search, Calculator, Info, AlertTriangle, ShieldCheck, Plus, Trash2 } from "lucide-react";
 
 const LOCATION_TYPE_LABEL: Record<string, string> = {
   ROOFTOP: "番地レベルで取得",
@@ -203,7 +195,9 @@ export function FullModeForm({
               </select>
               {muniError && <p className="text-xs text-destructive">{muniError}</p>}
               {muniFilter.trim() && filteredMunicipalities.length > 0 && (
-                <p className="text-xs text-muted-foreground">{filteredMunicipalities.length}件該当</p>
+                <p className="text-xs text-muted-foreground">
+                  {filteredMunicipalities.length}件該当
+                </p>
               )}
             </div>
           </div>
@@ -297,7 +291,12 @@ export function FullModeForm({
               const lat = parseFloat(propertyLat);
               const lng = parseFloat(propertyLng);
               const hasCoords = !isNaN(lat) && !isNaN(lng);
-              onFetchLandPrices(area, city, hasCoords ? lat : undefined, hasCoords ? lng : undefined);
+              onFetchLandPrices(
+                area,
+                city,
+                hasCoords ? lat : undefined,
+                hasCoords ? lng : undefined
+              );
             }}
           >
             <Search className="h-4 w-4" />
@@ -389,7 +388,9 @@ export function FullModeForm({
                           適用
                         </Button>
                       </div>
-                      <p className="text-xs text-muted-foreground mt-1">建物価格 = 消費税額 ÷ 0.1</p>
+                      <p className="text-xs text-muted-foreground mt-1">
+                        建物価格 = 消費税額 ÷ 0.1
+                      </p>
                     </div>
                     <div>
                       <p className="font-medium text-xs mb-1">② 固定資産税評価額の比率で按分</p>

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -1,11 +1,7 @@
 "use client";
 import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { SimulationModeToggle } from "@/components/SimulationModeToggle";
-import type {
-  InvestmentInput,
-  SimulationMode,
-  RateAdjustment,
-} from "@/types/investment";
+import type { InvestmentInput, SimulationMode, RateAdjustment } from "@/types/investment";
 import { DEFAULT_INPUT, QUICK_MODE_DEFAULTS } from "@/types/investment";
 import { fetchGeocode } from "@/lib/api";
 import { type ZoningType } from "@/lib/zoning";

--- a/frontend/src/components/QuickModeForm.tsx
+++ b/frontend/src/components/QuickModeForm.tsx
@@ -152,7 +152,12 @@ export function QuickModeForm({
                 const lat = parseFloat(propertyLat);
                 const lng = parseFloat(propertyLng);
                 const hasCoords = !isNaN(lat) && !isNaN(lng);
-                onFetchLandPrices(area, city, hasCoords ? lat : undefined, hasCoords ? lng : undefined);
+                onFetchLandPrices(
+                  area,
+                  city,
+                  hasCoords ? lat : undefined,
+                  hasCoords ? lng : undefined
+                );
               }}
             >
               <Search className="h-4 w-4" />

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -113,7 +113,6 @@ export function ResultsSection({
         </button>
       </div>
 
-
       {activeTab === "area-discovery" && (
         <>
           {selectedMunicipalityMsg && (

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -13,7 +13,6 @@ import { MonteCarloChart } from "@/components/MonteCarloChart";
 import NegotiationPanel from "@/components/NegotiationPanel";
 import WatchlistPanel from "@/components/WatchlistPanel";
 import { AreaDiscovery } from "@/components/AreaDiscovery";
-import { SimulationModeToggle } from "@/components/SimulationModeToggle";
 import { Button } from "@/components/ui/button";
 import dynamic from "next/dynamic";
 import { ShieldAlert } from "lucide-react";
@@ -40,7 +39,6 @@ interface ResultsSectionProps {
   selectedMunicipalityMsg: string | null;
   setSelectedMunicipalityMsg: (msg: string | null) => void;
   simulationMode: SimulationMode;
-  onModeChange: (mode: SimulationMode) => void;
   result: InvestmentResult | null;
   comparison: LandPriceComparison | null;
   theoreticalPrice: TheoreticalPriceResult | null;
@@ -67,7 +65,6 @@ export function ResultsSection({
   selectedMunicipalityMsg,
   setSelectedMunicipalityMsg,
   simulationMode,
-  onModeChange,
   result,
   comparison,
   theoreticalPrice,
@@ -116,10 +113,6 @@ export function ResultsSection({
         </button>
       </div>
 
-      {/* Mobile: simulation mode toggle */}
-      {activeTab === "simulation" && (
-        <SimulationModeToggle mode={simulationMode} onChange={onModeChange} className="lg:hidden" />
-      )}
 
       {activeTab === "area-discovery" && (
         <>

--- a/frontend/src/hooks/useInvestmentSimulation.ts
+++ b/frontend/src/hooks/useInvestmentSimulation.ts
@@ -223,14 +223,15 @@ export function useInvestmentSimulation(
         }));
 
         if (lat !== undefined && lng !== undefined) {
-          const [ridership, population, urbanRisks, scoreResult, hazard] =
-            await Promise.allSettled([
+          const [ridership, population, urbanRisks, scoreResult, hazard] = await Promise.allSettled(
+            [
               fetchStationRidership({ lat, lng }),
               fetchPopulationForecast({ lat, lng }),
               fetchUrbanRisks(lat, lng),
               fetchInvestmentScore({ lat, lng }),
               fetchHazardInfo(lat, lng),
-            ]);
+            ]
+          );
           setAnalysisResult((prev) => ({
             ...prev,
             stationRidership: ridership.status === "fulfilled" ? ridership.value : null,

--- a/frontend/src/hooks/useMunicipalitiesLoader.ts
+++ b/frontend/src/hooks/useMunicipalitiesLoader.ts
@@ -14,9 +14,7 @@ export interface UseMunicipalitiesLoaderResult {
   loadMunicipalities: (areaCode: string) => Promise<void>;
 }
 
-export function useMunicipalitiesLoader(
-  initialAreaCode = "10"
-): UseMunicipalitiesLoaderResult {
+export function useMunicipalitiesLoader(initialAreaCode = "10"): UseMunicipalitiesLoaderResult {
   const [municipalities, setMunicipalities] = useState<Municipality[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);


### PR DESCRIPTION
## 概要

モバイルでクイック/詳細のモード切り替えが機能していないように見える問題を修正します。

## 問題の背景

`SimulationModeToggle`（クイック/詳細切替UI）がメインコンテンツ領域に表示されていたものの、実際にそのモードが影響するフォームフィールドはボトムシート（下から引き出すモーダル）の中に隠れていました。

モバイルでトグルをタップすると：
- ボタンのハイライトは変わる（React state は正しく更新される）
- しかしコンテンツ領域には何も変化がない（フォームがボトムシートに隠れているため）

この UX の断絶が「タブ切り替えが機能していない」という印象を与えていました。

## 対応方針

デスクトップでは `InvestmentForm` サイドバー内にトグルを表示するパターンを採用しており、モバイルも同じパターンに揃えます。

- トグルをメインコンテンツ領域から削除
- ボトムシートの `InvestmentForm` でトグルを有効化（`showModeToggle={true}`）

これによりトグルとフォームフィールドが同一画面内に並び、切り替えの効果が即座に確認できます。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `frontend/src/components/ResultsSection.tsx` | `SimulationModeToggle` 配置・import・`onModeChange` prop を削除 |
| `frontend/src/components/Dashboard.tsx` | ボトムシートの `InvestmentForm` に `showModeToggle={true}` を設定、`ResultsSection` への `onModeChange` prop を削除 |

## 動作確認

- [ ] モバイル幅（< 1024px）でボトムシートを開き、クイック/詳細トグルが表示される
- [ ] 詳細モードに切り替えると詳細フォームフィールドが表示される
- [ ] クイックモードに切り替えると簡易フォームが表示される
- [ ] デスクトップ幅でサイドバーのトグルが引き続き動作する

## テスト

```
Tests: 232 passed (232)
```