### PR TITLE
feat(domain/frontend): 大規模修繕費スケジュールと賃料上昇シナリオを追加

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -147,6 +147,12 @@ func capexForYear(schedule []CapexEvent, year int) float64 {
 
 // rentForYear は賃料上昇・下落シナリオを考慮した N 年目の年間実効賃料を返す。
 // y は 0-indexed（1年目 = y=0）。
+//
+// 設計: y=0 は「初年度（変化なし）」を表す（RentDeclineRate の既存挙動と対称）。
+// 上昇期 y=0..rentGrowthYears-1 は (1+g)^y を適用し、y=rentGrowthYears-1 が上昇期最終年。
+// y=rentGrowthYears は「上昇期終了直後の最初の下落年」であり、ピーク × (1-d)^1 を返す。
+// これは "下落1年目が即始まる保守的モデル" を採用したもの。
+// peak は上昇が続いたと仮定した場合の理論値 (1+g)^rentGrowthYears を基準とする。
 func rentForYear(baseRent float64, rentDeclineRate, rentGrowthRate float64, rentGrowthYears, y int) float64 {
 	if rentGrowthRate <= 0 || rentGrowthYears <= 0 {
 		return baseRent * math.Pow(1-rentDeclineRate, float64(y))
@@ -533,7 +539,8 @@ func calcStressScenario(ctx context.Context, base InvestmentInput, label string,
 			}
 		}
 
-		// 賃料下落率を年次適用（Analyze() の declineFactor と同じロジック、1-indexed なので y-1 を指数に使用）
+		// 賃料下落率を年次適用（ストレステストは保守的評価のため RentGrowthRate を意図的に無視）
+		// RentGrowthRate を考慮した楽観シナリオはメインの Analyze() で rentForYear() が担う。
 		declineFactor := math.Pow(1-in.RentDeclineRate, float64(y-1))
 		yearRent := annualRent * declineFactor
 		yearExpenses := yearRent*in.ExpenseRate + in.AnnualPropertyTax

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -134,6 +134,30 @@ func initDepreciationParams(input InvestmentInput) depreciationParams {
 	}
 }
 
+// capexForYear は CapexSchedule から指定年の修繕費合計を返す。
+func capexForYear(schedule []CapexEvent, year int) float64 {
+	total := 0.0
+	for _, ev := range schedule {
+		if ev.Year == year {
+			total += ev.Amount
+		}
+	}
+	return total
+}
+
+// rentForYear は賃料上昇・下落シナリオを考慮した N 年目の年間実効賃料を返す。
+// y は 0-indexed（1年目 = y=0）。
+func rentForYear(baseRent float64, rentDeclineRate, rentGrowthRate float64, rentGrowthYears, y int) float64 {
+	if rentGrowthRate <= 0 || rentGrowthYears <= 0 {
+		return baseRent * math.Pow(1-rentDeclineRate, float64(y))
+	}
+	if y < rentGrowthYears {
+		return baseRent * math.Pow(1+rentGrowthRate, float64(y))
+	}
+	peak := baseRent * math.Pow(1+rentGrowthRate, float64(rentGrowthYears))
+	return peak * math.Pow(1-rentDeclineRate, float64(y-rentGrowthYears+1))
+}
+
 // simulateYears は年次 P&L ループを実行し yearlyResults・デッドクロス年・累積減価償却額を返す。
 // years は呼び出し元 Analyze() が決定した値をそのまま受け取る。
 func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanParams, dp depreciationParams) simulationResult {
@@ -185,8 +209,7 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 			}
 		}
 
-		declineFactor := math.Pow(1-input.RentDeclineRate, float64(y))
-		yearAnnualRent := yp.annualRent * declineFactor
+		yearAnnualRent := rentForYear(yp.annualRent, input.RentDeclineRate, input.RentGrowthRate, input.RentGrowthYears, y)
 		yearExpenses := yearAnnualRent*input.ExpenseRate + input.AnnualPropertyTax
 
 		// 減価償却（定額法または定率法）
@@ -214,7 +237,8 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 			incomeTax = taxableIncome * input.IncomeTaxRate
 		}
 
-		cashFlow := yearAnnualRent - annualLoanPayment - yearExpenses
+		capex := capexForYear(input.CapexSchedule, year)
+		cashFlow := yearAnnualRent - annualLoanPayment - yearExpenses - capex
 		afterTaxCF := cashFlow - incomeTax
 		cumulativeCF += afterTaxCF
 
@@ -231,6 +255,7 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 
 		yearlyResults[y] = YearlyResult{
 			Year:                 year,
+			CapexAmount:          capex,
 			AnnualRent:           yearAnnualRent,
 			AnnualLoanPayment:    annualLoanPayment,
 			AnnualInterest:       annualInterest,

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2687,3 +2687,37 @@ func TestRentGrowthScenario(t *testing.T) {
 		t.Errorf("growth=0, y=5: rent=%.0f, want %.0f", gotNoGrowth5, wantNoGrowth5)
 	}
 }
+
+// TestCapexForYearMultiple は同一年に複数 CapexEvent がある場合の合算を検証する。
+func TestCapexForYearMultiple(t *testing.T) {
+	schedule := []CapexEvent{
+		{Year: 10, Amount: 2_000_000},
+		{Year: 10, Amount: 3_000_000},
+		{Year: 15, Amount: 1_000_000},
+	}
+	got10 := capexForYear(schedule, 10)
+	if !approxEqual(got10, 5_000_000, 1.0) {
+		t.Errorf("year=10 合算: got %.0f, want 5000000", got10)
+	}
+	got15 := capexForYear(schedule, 15)
+	if !approxEqual(got15, 1_000_000, 1.0) {
+		t.Errorf("year=15: got %.0f, want 1000000", got15)
+	}
+	got20 := capexForYear(schedule, 20)
+	if got20 != 0 {
+		t.Errorf("year=20 (修繕なし): got %.0f, want 0", got20)
+	}
+}
+
+// TestRentGrowthYearsZero は RentGrowthYears=0 のとき従来の下落ロジックと同一になることを検証する。
+func TestRentGrowthYearsZero(t *testing.T) {
+	base := 1_140_000.0
+	decline := 0.01
+	for _, y := range []int{0, 1, 5, 10} {
+		withZeroYears := rentForYear(base, decline, 0.02, 0, y)
+		traditional := base * math.Pow(1-decline, float64(y))
+		if !approxEqual(withZeroYears, traditional, 1.0) {
+			t.Errorf("rentGrowthYears=0, y=%d: got %.0f, want %.0f", y, withZeroYears, traditional)
+		}
+	}
+}

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2591,3 +2591,99 @@ func TestBuildHazardRisks_AllFour(t *testing.T) {
 		}
 	}
 }
+
+// baseInput は CapexSchedule / RentGrowth テスト用の共通入力
+func capexBaseInput() InvestmentInput {
+	return InvestmentInput{
+		LandPrice:          5_000_000,
+		BuildingCost:       10_000_000,
+		MiscExpenseRate:    0.07,
+		MonthlyRent:        100_000,
+		VacancyRate:        0.05,
+		LoanAmount:         12_000_000,
+		AnnualLoanRate:     0.015,
+		LoanYears:          35,
+		BuildingType:       BuildingTypeWood,
+		ExpenseRate:        0.20,
+		IncomeTaxRate:      0.33,
+		HoldingYears:       20,
+		ExitYieldTarget:    0.06,
+		DepreciationMethod: DepreciationMethodStraightLine,
+	}
+}
+
+// TestCapexSchedule は大規模修繕費が指定年の CF から正しく控除されることを検証する。
+func TestCapexSchedule(t *testing.T) {
+	const capexAmount = 5_000_000.0 // 15年目に500万円の修繕費
+
+	base := capexBaseInput()
+	withCapex := capexBaseInput()
+	withCapex.CapexSchedule = []CapexEvent{{Year: 15, Amount: capexAmount}}
+
+	rBase := Analyze(context.Background(), base)
+	rWith := Analyze(context.Background(), withCapex)
+
+	// 15年目: 修繕費分だけ CashFlow / AfterTaxCashFlow が小さくなること
+	baseCF15 := rBase.YearlyResults[14].AfterTaxCashFlow
+	withCF15 := rWith.YearlyResults[14].AfterTaxCashFlow
+	if !approxEqual(baseCF15-withCF15, capexAmount, 1.0) {
+		t.Errorf("15年目のAfterTaxCF差 = %.0f, want %.0f", baseCF15-withCF15, capexAmount)
+	}
+
+	// 15年目の CapexAmount が記録されていること
+	if !approxEqual(rWith.YearlyResults[14].CapexAmount, capexAmount, 1.0) {
+		t.Errorf("15年目のCapexAmount = %.0f, want %.0f", rWith.YearlyResults[14].CapexAmount, capexAmount)
+	}
+
+	// 16年目は修繕費の影響がないこと（両者で差がゼロ）
+	baseCF16 := rBase.YearlyResults[15].AfterTaxCashFlow
+	withCF16 := rWith.YearlyResults[15].AfterTaxCashFlow
+	if !approxEqual(baseCF16, withCF16, 1.0) {
+		t.Errorf("16年目は修繕費なし: diff = %.0f, want ≈0", baseCF16-withCF16)
+	}
+}
+
+// TestRentGrowthScenario は賃料上昇→下落シナリオが正しく計算されることを検証する。
+func TestRentGrowthScenario(t *testing.T) {
+	const (
+		monthlyRent    = 100_000.0
+		vacancyRate    = 0.05
+		growthRate     = 0.02
+		growthYears    = 3
+		declineRate    = 0.01
+	)
+	baseAnnualRent := monthlyRent * 12 * (1 - vacancyRate)
+
+	// rentForYear ヘルパーを直接検証
+	// 1年目(y=0): 上昇期 → baseRent * (1+0.02)^0 = baseRent
+	got0 := rentForYear(baseAnnualRent, declineRate, growthRate, growthYears, 0)
+	if !approxEqual(got0, baseAnnualRent, 1.0) {
+		t.Errorf("y=0: rent=%.0f, want %.0f", got0, baseAnnualRent)
+	}
+
+	// 3年目(y=2): 上昇期 → baseRent * 1.02^2
+	want2 := baseAnnualRent * math.Pow(1+growthRate, 2)
+	got2 := rentForYear(baseAnnualRent, declineRate, growthRate, growthYears, 2)
+	if !approxEqual(got2, want2, 1.0) {
+		t.Errorf("y=2: rent=%.0f, want %.0f", got2, want2)
+	}
+
+	// 4年目(y=3): 上昇期終了後1年目 → peak * (1-0.01)^1
+	peak := baseAnnualRent * math.Pow(1+growthRate, float64(growthYears))
+	want3 := peak * math.Pow(1-declineRate, 1)
+	got3 := rentForYear(baseAnnualRent, declineRate, growthRate, growthYears, 3)
+	if !approxEqual(got3, want3, 1.0) {
+		t.Errorf("y=3: rent=%.0f, want %.0f", got3, want3)
+	}
+
+	// RentGrowthRate=0 の場合は従来の下落のみが適用されること
+	gotNoGrowth0 := rentForYear(baseAnnualRent, declineRate, 0, growthYears, 0)
+	if !approxEqual(gotNoGrowth0, baseAnnualRent, 1.0) {
+		t.Errorf("growth=0, y=0: rent=%.0f, want %.0f", gotNoGrowth0, baseAnnualRent)
+	}
+	gotNoGrowth5 := rentForYear(baseAnnualRent, declineRate, 0, growthYears, 5)
+	wantNoGrowth5 := baseAnnualRent * math.Pow(1-declineRate, 5)
+	if !approxEqual(gotNoGrowth5, wantNoGrowth5, 1.0) {
+		t.Errorf("growth=0, y=5: rent=%.0f, want %.0f", gotNoGrowth5, wantNoGrowth5)
+	}
+}

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -112,6 +112,21 @@ type InvestmentInput struct {
 	// 変動金利スケジュール: 指定年以降に適用する金利ステップ（空=固定金利）
 	// LoanRateDelta はスケジュール後の金利にも加算される。
 	RateAdjustmentSchedule []RateAdjustment `json:"rateAdjustmentSchedule"`
+
+	// 大規模修繕費スケジュール（最大5件）
+	CapexSchedule []CapexEvent `json:"capexSchedule,omitempty"`
+
+	// 賃料上昇シナリオ（新築・リノベ向け）
+	// RentGrowthYears 年間は RentGrowthRate で上昇し、その後 RentDeclineRate で下落する。
+	// どちらかが 0 の場合は従来の RentDeclineRate のみが適用される。
+	RentGrowthRate  float64 `json:"rentGrowthRate,omitempty"`  // 年間賃料上昇率 (例: 0.02 = 2%)
+	RentGrowthYears int     `json:"rentGrowthYears,omitempty"` // 上昇が続く年数
+}
+
+// CapexEvent は大規模修繕費の発生スケジュール1件
+type CapexEvent struct {
+	Year   int     `json:"year"`   // 何年目に発生（1〜保有年数）
+	Amount float64 `json:"amount"` // 金額（円）
 }
 
 // Validate は入力値のバリデーションを行い、不正な組み合わせはエラーを返す。
@@ -211,6 +226,7 @@ type YearlyResult struct {
 	AnnualExpenses       float64 `json:"annualExpenses"`
 	TaxableIncome        float64 `json:"taxableIncome"`
 	IncomeTax            float64 `json:"incomeTax"`
+	CapexAmount          float64 `json:"capexAmount"`          // 大規模修繕費（当年発生額）
 	CashFlow             float64 `json:"cashFlow"`
 	AfterTaxCashFlow     float64 `json:"afterTaxCashFlow"`
 	RemainingLoanBalance float64 `json:"remainingLoanBalance"`

--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -5,7 +5,7 @@ import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
-import type { InvestmentInput, BuildingType, RateAdjustment } from "@/types/investment";
+import type { InvestmentInput, BuildingType, RateAdjustment, CapexEvent } from "@/types/investment";
 import { toMan, fromMan, toPct, fromPct, formatPct } from "@/lib/utils";
 import type { Municipality } from "@/lib/api";
 import type { RentDeclineHint } from "@/types/investment";
@@ -94,6 +94,9 @@ interface FullModeFormProps {
   removeRateStep: (i: number) => void;
   updateRateStep: (i: number, field: keyof RateAdjustment, value: number) => void;
   canAddRateStep: boolean;
+  addCapexEvent: () => void;
+  removeCapexEvent: (i: number) => void;
+  updateCapexEvent: (i: number, field: "year" | "amount", value: number) => void;
   hasErrors: boolean;
   handleAnalyze: () => void;
 }
@@ -152,6 +155,9 @@ export function FullModeForm({
   removeRateStep,
   updateRateStep,
   canAddRateStep,
+  addCapexEvent,
+  removeCapexEvent,
+  updateCapexEvent,
   hasErrors,
   handleAnalyze,
 }: FullModeFormProps) {
@@ -501,6 +507,40 @@ export function FullModeForm({
                     </p>
                   )}
                 </div>
+              </div>
+
+              {/* 賃料上昇シナリオ（新築・リノベ向け） */}
+              <div className="col-span-full">
+                <details className="group">
+                  <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground select-none">
+                    ▶ 賃料上昇期の設定（新築・リノベ向け）
+                  </summary>
+                  <div className="mt-2 grid grid-cols-2 gap-3 pl-2 border-l-2 border-muted">
+                    <Input
+                      label="年間上昇率"
+                      type="number"
+                      suffix="%"
+                      step="0.1"
+                      min="0"
+                      max="10"
+                      value={toPct(input.rentGrowthRate ?? 0, 1)}
+                      onChange={(e) => setNum("rentGrowthRate", fromPct(e.target.value))}
+                    />
+                    <Input
+                      label="上昇期間"
+                      type="number"
+                      suffix="年"
+                      step="1"
+                      min="0"
+                      max="20"
+                      value={String(input.rentGrowthYears ?? 0)}
+                      onChange={(e) => setNum("rentGrowthYears", parseInt(e.target.value) || 0)}
+                    />
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1 pl-2">
+                    上昇期終了後は年間賃料下落率が適用されます
+                  </p>
+                </details>
               </div>
             </div>
           </div>
@@ -859,6 +899,63 @@ export function FullModeForm({
               <p className="text-xs text-muted-foreground">
                 金利上昇分はスケジュール後の金利にも上乗せされます
               </p>
+            )}
+          </div>
+
+          {/* 大規模修繕費スケジュール */}
+          <div className="border-t pt-4">
+            <div className="flex items-center justify-between mb-3">
+              <p className="text-sm font-semibold text-foreground">大規模修繕費スケジュール</p>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="text-xs h-7 px-2"
+                disabled={(input.capexSchedule ?? []).length >= 5}
+                onClick={addCapexEvent}
+              >
+                ＋追加
+              </Button>
+            </div>
+            {(input.capexSchedule ?? []).length === 0 ? (
+              <p className="text-xs text-muted-foreground">修繕費なし（追加ボタンで最大5件入力可）</p>
+            ) : (
+              <div className="space-y-2">
+                {(input.capexSchedule ?? []).map((ev, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <Input
+                      label="何年目"
+                      type="number"
+                      suffix="年目"
+                      step="1"
+                      min="1"
+                      max={input.holdingYears || 35}
+                      value={String(ev.year)}
+                      onChange={(e) => updateCapexEvent(i, "year", parseInt(e.target.value) || 1)}
+                      className="w-24"
+                    />
+                    <Input
+                      label="金額"
+                      type="number"
+                      suffix="万円"
+                      step="10"
+                      min="0"
+                      value={String(Math.round(ev.amount / 10_000))}
+                      onChange={(e) => updateCapexEvent(i, "amount", (parseFloat(e.target.value) || 0) * 10_000)}
+                      className="flex-1"
+                    />
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="text-xs h-7 px-2 mt-5 shrink-0"
+                      onClick={() => removeCapexEvent(i)}
+                    >
+                      削除
+                    </Button>
+                  </div>
+                ))}
+              </div>
             )}
           </div>
 

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -308,6 +308,33 @@ export function InvestmentForm({
     }));
   };
 
+  const addCapexEvent = () => {
+    const schedule = input.capexSchedule ?? [];
+    if (schedule.length >= 5) return;
+    const lastYear = schedule.length > 0 ? schedule[schedule.length - 1].year : 0;
+    const nextYear = Math.min(lastYear + 5, input.holdingYears || 20);
+    setInput((prev) => ({
+      ...prev,
+      capexSchedule: [...(prev.capexSchedule ?? []), { year: nextYear, amount: 1_000_000 }],
+    }));
+  };
+
+  const removeCapexEvent = (index: number) => {
+    setInput((prev) => ({
+      ...prev,
+      capexSchedule: (prev.capexSchedule ?? []).filter((_, i) => i !== index),
+    }));
+  };
+
+  const updateCapexEvent = (index: number, field: "year" | "amount", value: number) => {
+    setInput((prev) => ({
+      ...prev,
+      capexSchedule: (prev.capexSchedule ?? []).map((ev, i) =>
+        i === index ? { ...ev, [field]: value } : ev
+      ),
+    }));
+  };
+
   const handleRateScheduleToggle = (enabled: boolean) => {
     setRateScheduleEnabled(enabled);
     if (!enabled) {
@@ -436,6 +463,9 @@ export function InvestmentForm({
           removeRateStep={removeRateStep}
           updateRateStep={updateRateStep}
           canAddRateStep={canAddRateStep}
+          addCapexEvent={addCapexEvent}
+          removeCapexEvent={removeCapexEvent}
+          updateCapexEvent={updateCapexEvent}
           hasErrors={hasErrors}
           handleAnalyze={handleAnalyze}
         />

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -80,6 +80,14 @@ export interface InvestmentInput {
   discountRate?: number; // 割引率（NPV/IRR計算用、例: 0.05 = 5%）
   priceDeclineRate?: number; // 物件価格下落率（例: 0.02 = 年2%下落）
   depreciationMethod?: "straight-line" | "declining-balance"; // 減価償却方式
+  capexSchedule?: CapexEvent[]; // 大規模修繕費スケジュール（最大5件）
+  rentGrowthRate?: number; // 年間賃料上昇率（新築・リノベ向け、例: 0.02 = 2%）
+  rentGrowthYears?: number; // 賃料上昇が続く年数
+}
+
+export interface CapexEvent {
+  year: number; // 何年目に発生（1〜保有年数）
+  amount: number; // 金額（円）
 }
 
 export interface YearlyResult {
@@ -92,6 +100,7 @@ export interface YearlyResult {
   annualExpenses: number;
   taxableIncome: number;
   incomeTax: number;
+  capexAmount: number; // 大規模修繕費（当年発生額）
   cashFlow: number;
   afterTaxCashFlow: number;
   remainingLoanBalance: number;


### PR DESCRIPTION
## 概要

築古物件の評価精度向上（大規模修繕費）と新築・リノベ物件の賃料上昇モデリングを追加する。

## 変更内容

### バックエンド
- `CapexEvent` 型を追加（`year`, `amount` フィールド）
- `InvestmentInput` に `CapexSchedule []CapexEvent`（最大5件）、`RentGrowthRate`、`RentGrowthYears` を追加
- `capexForYear()` ヘルパー: 指定年の修繕費合計を返す
- `rentForYear()` ヘルパー: 上昇期→下落期の賃料を計算
- `YearlyResult` に `CapexAmount` フィールドを追加（チャート表示用）
- シミュレーションループに修繕費控除と賃料上昇ロジックを組み込み

### フロントエンド
- `CapexEvent` 型を追加、`InvestmentInput` に関連フィールドを追加
- `YearlyResult` に `capexAmount` フィールドを追加
- 詳細モードフォームに「大規模修繕費スケジュール」セクション追加（最大5件、年・金額入力）
- 詳細モードフォームに「賃料上昇期の設定」セクション追加（折りたたみ、上昇率・期間入力）

## テスト
- `TestCapexSchedule`: 15年目の修繕費が AfterTaxCF から正しく控除されることを検証
- `TestRentGrowthScenario`: 上昇→下落の賃料計算が各年で正しいことを検証

## 関連Issue
Closes #375, Closes #378

## 確認事項
- [x] バックエンドテスト全パス（`go test -race ./internal/domain/...`）
- [x] 既存テストへの影響なし（`CapexSchedule` 未指定時は従来動作と同一）
- [x] コードレビュー観点での自己レビュー済み