### PR TITLE
feat(domain/frontend): 複数融資条件の横並び比較シミュレーション

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -69,7 +69,8 @@ type depreciationParams struct {
 type simulationResult struct {
 	yearlyResults           []YearlyResult
 	accumulatedDepreciation float64
-	deadCrossYear           int // -1 = デッドクロスなし
+	deadCrossYear           int     // -1 = デッドクロスなし
+	totalInterest           float64 // 保有期間の総支払利息
 }
 
 // irrNPVResult は IRR / NPV 計算結果をまとめた内部 struct。
@@ -80,7 +81,8 @@ type irrNPVResult struct {
 
 func initYieldParams(input InvestmentInput) yieldParams {
 	effectiveVacancy := math.Min(input.VacancyRate+input.VacancyRateDelta, 0.99)
-	miscExpenses := (input.LandPrice + input.BuildingCost) * input.MiscExpenseRate
+	loanFee := input.LoanAmount * input.LoanFeeRate
+	miscExpenses := (input.LandPrice+input.BuildingCost)*input.MiscExpenseRate + loanFee
 	totalInvestment := input.LandPrice + input.BuildingCost + miscExpenses
 	annualRent := input.MonthlyRent * 12 * (1 - effectiveVacancy)
 	grossYield := 0.0
@@ -172,6 +174,7 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 	cumulativeCF := 0.0
 	deadCrossYear := -1
 	var accumulatedDepreciation float64
+	var totalInterest float64
 
 	// loanParams / depreciationParams の可変フィールドをループローカルにコピー
 	currentRate := lp.currentRate
@@ -213,6 +216,11 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 			if remainingBalance < 0 {
 				remainingBalance = 0
 			}
+		}
+
+		// 保有期間内の利息のみ集計（HoldingYears 以内の年）
+		if year <= input.HoldingYears {
+			totalInterest += annualInterest
 		}
 
 		yearAnnualRent := rentForYear(yp.annualRent, input.RentDeclineRate, input.RentGrowthRate, input.RentGrowthYears, y)
@@ -284,6 +292,7 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 		yearlyResults:           yearlyResults,
 		accumulatedDepreciation: accumulatedDepreciation,
 		deadCrossYear:           deadCrossYear,
+		totalInterest:           totalInterest,
 	}
 }
 
@@ -434,6 +443,7 @@ func Analyze(ctx context.Context, input InvestmentInput) InvestmentResult {
 		LTVSensitivity:        ltvSensitivity,
 		IRR:                   irrNPV.irr,
 		NPV:                   irrNPV.npv,
+		TotalInterest:         sim.totalInterest,
 	}
 }
 

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2721,3 +2721,69 @@ func TestRentGrowthYearsZero(t *testing.T) {
 		}
 	}
 }
+
+// TestLoanFeeRate は LoanFeeRate=0.02 のとき TotalInvestment が LoanAmount×0.02 だけ増えることを検証する。
+func TestLoanFeeRate(t *testing.T) {
+	base := InvestmentInput{
+		LandPrice:       5_000_000,
+		BuildingCost:    10_000_000,
+		MiscExpenseRate: 0.07,
+		MonthlyRent:     120_000,
+		VacancyRate:     0.05,
+		LoanAmount:      13_000_000,
+		AnnualLoanRate:  0.015,
+		LoanYears:       35,
+		BuildingType:    BuildingTypeWood,
+		ExpenseRate:     0.20,
+		IncomeTaxRate:   0.33,
+		HoldingYears:    10,
+		ExitYieldTarget: 0.06,
+	}
+
+	withoutFee := Analyze(context.Background(), base)
+
+	withFee := base
+	withFee.LoanFeeRate = 0.02
+	resultWithFee := Analyze(context.Background(), withFee)
+
+	expectedIncrease := base.LoanAmount * 0.02 // 13,000,000 × 0.02 = 260,000
+	actualIncrease := resultWithFee.TotalInvestment - withoutFee.TotalInvestment
+
+	if !approxEqual(actualIncrease, expectedIncrease, epsilon) {
+		t.Errorf("TotalInvestment increase = %.0f, want %.0f (LoanAmount × LoanFeeRate)",
+			actualIncrease, expectedIncrease)
+	}
+}
+
+// TestTotalInterest は TotalInterest が保有期間の Σ AnnualInterest と一致することを検証する。
+func TestTotalInterest(t *testing.T) {
+	input := InvestmentInput{
+		LandPrice:       5_000_000,
+		BuildingCost:    10_000_000,
+		MiscExpenseRate: 0.07,
+		MonthlyRent:     120_000,
+		VacancyRate:     0.05,
+		LoanAmount:      13_000_000,
+		AnnualLoanRate:  0.015,
+		LoanYears:       35,
+		BuildingType:    BuildingTypeWood,
+		ExpenseRate:     0.20,
+		IncomeTaxRate:   0.33,
+		HoldingYears:    10,
+		ExitYieldTarget: 0.06,
+	}
+
+	result := Analyze(context.Background(), input)
+
+	// 保有期間内（HoldingYears以内）の AnnualInterest を合計して比較
+	var sumInterest float64
+	for _, yr := range result.YearlyResults {
+		if yr.Year <= input.HoldingYears {
+			sumInterest += yr.AnnualInterest
+		}
+	}
+
+	if !approxEqual(result.TotalInterest, sumInterest, epsilon) {
+		t.Errorf("TotalInterest = %.2f, want Σ AnnualInterest = %.2f", result.TotalInterest, sumInterest)
+	}
+}

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -121,6 +121,9 @@ type InvestmentInput struct {
 	// どちらかが 0 の場合は従来の RentDeclineRate のみが適用される。
 	RentGrowthRate  float64 `json:"rentGrowthRate,omitempty"`  // 年間賃料上昇率 (例: 0.02 = 2%)
 	RentGrowthYears int     `json:"rentGrowthYears,omitempty"` // 上昇が続く年数
+
+	// 融資諸費用率（保証料・登記費用等の合算）。LoanAmount × LoanFeeRate を取得費に加算。
+	LoanFeeRate float64 `json:"loanFeeRate,omitempty"`
 }
 
 // CapexEvent は大規模修繕費の発生スケジュール1件
@@ -317,6 +320,7 @@ type InvestmentResult struct {
 
 	DSCR           float64             `json:"dscr"`           // 1年目の借入金償還余裕率（NOI/年間返済額）
 	LTVSensitivity []LTVSensitivityRow `json:"ltvSensitivity"` // LTV感度分析（50%〜90%）
+	TotalInterest  float64             `json:"totalInterest"`  // 保有期間の総支払利息
 }
 
 // AcquisitionCostBreakdown は物件取得時の諸経費内訳

--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -598,6 +598,15 @@ export function FullModeForm({
                 onChange={(e) => setNum("miscExpenseRate", fromPct(e.target.value))}
                 error={fieldError("miscExpenseRate")}
               />
+              <Input
+                label="融資諸費用率"
+                type="number"
+                inputMode="decimal"
+                suffix="%"
+                step="0.1"
+                value={toPct(input.loanFeeRate ?? 0, 1)}
+                onChange={(e) => setNum("loanFeeRate", fromPct(e.target.value))}
+              />
             </div>
             <p className="text-xs text-muted-foreground mt-2">
               ※運営経費率はローン利息を含みません（管理費・修繕費・固定資産税・保険等）

--- a/frontend/src/components/LoanComparePanel.tsx
+++ b/frontend/src/components/LoanComparePanel.tsx
@@ -1,0 +1,325 @@
+"use client";
+import React, { useState } from "react";
+import {
+  LineChart,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  YAxis,
+  Tooltip,
+} from "recharts";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { analyze } from "@/lib/api";
+import type { InvestmentInput, InvestmentResult } from "@/types/investment";
+import { toMan, toPct, fromPct } from "@/lib/utils";
+import { Plus, Trash2, BarChart3 } from "lucide-react";
+
+interface LoanScenario {
+  name: string;
+  annualLoanRate: number; // 年利（小数）
+  loanYears: number;
+  ltv: number; // LTV（小数）
+  loanFeeRate: number; // 諸費用率（小数）
+}
+
+const DEFAULT_SCENARIO = (index: number): LoanScenario => ({
+  name: `シナリオ ${index + 1}`,
+  annualLoanRate: 0.015,
+  loanYears: 35,
+  ltv: 0.7,
+  loanFeeRate: 0.02,
+});
+
+interface Props {
+  baseInput: InvestmentInput;
+}
+
+export function LoanComparePanel({ baseInput }: Props) {
+  const [scenarios, setScenarios] = useState<LoanScenario[]>([
+    DEFAULT_SCENARIO(0),
+    DEFAULT_SCENARIO(1),
+  ]);
+  const [results, setResults] = useState<(InvestmentResult | null)[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const addScenario = () => {
+    if (scenarios.length >= 4) return;
+    setScenarios((prev) => [...prev, DEFAULT_SCENARIO(prev.length)]);
+  };
+
+  const removeScenario = (i: number) => {
+    if (scenarios.length <= 1) return;
+    setScenarios((prev) => prev.filter((_, idx) => idx !== i));
+    setResults((prev) => prev.filter((_, idx) => idx !== i));
+  };
+
+  const updateScenario = (i: number, patch: Partial<LoanScenario>) => {
+    setScenarios((prev) =>
+      prev.map((s, idx) => (idx === i ? { ...s, ...patch } : s))
+    );
+  };
+
+  const handleCompare = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const propertyValue = baseInput.landPrice + baseInput.buildingCost;
+      const inputs: InvestmentInput[] = scenarios.map((sc) => ({
+        ...baseInput,
+        loanAmount: propertyValue * sc.ltv,
+        annualLoanRate: sc.annualLoanRate,
+        loanYears: sc.loanYears,
+        loanFeeRate: sc.loanFeeRate,
+      }));
+      const fetched = await Promise.all(inputs.map((inp) => analyze(inp)));
+      setResults(fetched);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "比較に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  // DSCR推移データ（年次結果から HoldingYears 分）
+  const dscrSeriesForResult = (res: InvestmentResult): { year: number; dscr: number }[] => {
+    const holdingYears = baseInput.holdingYears ?? 10;
+    return res.yearlyResults
+      .filter((yr) => yr.year <= holdingYears)
+      .map((yr) => {
+        const noi = yr.annualRent - yr.annualExpenses;
+        const dscr = yr.annualLoanPayment > 0 ? noi / yr.annualLoanPayment : 0;
+        return { year: yr.year, dscr: parseFloat(dscr.toFixed(3)) };
+      });
+  };
+
+  const propertyValue = baseInput.landPrice + baseInput.buildingCost;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <BarChart3 className="h-5 w-5 text-primary" />
+          複数融資条件の横並び比較
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* シナリオ入力フォーム */}
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {scenarios.map((sc, i) => (
+            <div key={i} className="rounded-lg border bg-muted/20 p-3 space-y-2">
+              <div className="flex items-center justify-between">
+                <Input
+                  label="シナリオ名"
+                  type="text"
+                  value={sc.name}
+                  onChange={(e) => updateScenario(i, { name: e.target.value })}
+                />
+                <button
+                  onClick={() => removeScenario(i)}
+                  disabled={scenarios.length <= 1}
+                  className="ml-2 mt-5 text-muted-foreground hover:text-destructive disabled:opacity-30 disabled:cursor-not-allowed"
+                  aria-label="削除"
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              </div>
+              <Input
+                label="金利"
+                type="number"
+                inputMode="decimal"
+                suffix="%"
+                step="0.1"
+                value={toPct(sc.annualLoanRate, 1)}
+                onChange={(e) =>
+                  updateScenario(i, { annualLoanRate: fromPct(e.target.value) })
+                }
+              />
+              <Input
+                label="融資期間"
+                type="number"
+                inputMode="numeric"
+                suffix="年"
+                step="1"
+                value={sc.loanYears}
+                onChange={(e) =>
+                  updateScenario(i, { loanYears: parseInt(e.target.value, 10) || 35 })
+                }
+              />
+              <Input
+                label="LTV"
+                type="number"
+                inputMode="decimal"
+                suffix="%"
+                step="5"
+                value={toPct(sc.ltv, 0)}
+                onChange={(e) =>
+                  updateScenario(i, { ltv: fromPct(e.target.value) })
+                }
+              />
+              <Input
+                label="諸費用率"
+                type="number"
+                inputMode="decimal"
+                suffix="%"
+                step="0.5"
+                value={toPct(sc.loanFeeRate, 1)}
+                onChange={(e) =>
+                  updateScenario(i, { loanFeeRate: fromPct(e.target.value) })
+                }
+              />
+            </div>
+          ))}
+        </div>
+
+        {/* シナリオ追加 / 比較実行 */}
+        <div className="flex flex-wrap gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={addScenario}
+            disabled={scenarios.length >= 4}
+          >
+            <Plus className="mr-1 h-4 w-4" />
+            シナリオ追加
+          </Button>
+          <Button size="sm" onClick={handleCompare} loading={loading}>
+            比較実行
+          </Button>
+        </div>
+
+        {error && (
+          <p className="text-sm text-destructive">{error}</p>
+        )}
+
+        {/* 比較結果テーブル */}
+        {results.length > 0 && (
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm border-collapse">
+              <thead>
+                <tr className="border-b bg-muted/40">
+                  <th className="px-3 py-2 text-left font-medium">指標</th>
+                  {scenarios.slice(0, results.length).map((sc, i) => (
+                    <th key={i} className="px-3 py-2 text-center font-medium">
+                      {sc.name}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {/* 月返済額 */}
+                <tr>
+                  <td className="px-3 py-2 text-muted-foreground">月返済額</td>
+                  {results.map((res, i) => {
+                    if (!res) return <td key={i} className="px-3 py-2 text-center">—</td>;
+                    const monthlyPayment =
+                      res.yearlyResults[0]?.annualLoanPayment != null
+                        ? res.yearlyResults[0].annualLoanPayment / 12
+                        : 0;
+                    return (
+                      <td key={i} className="px-3 py-2 text-center">
+                        {toMan(monthlyPayment)}万円
+                      </td>
+                    );
+                  })}
+                </tr>
+                {/* DSCR（初年度） */}
+                <tr>
+                  <td className="px-3 py-2 text-muted-foreground">
+                    DSCR（初年度）
+                    <span className="ml-1 text-xs text-muted-foreground">参考値</span>
+                  </td>
+                  {results.map((res, i) => {
+                    if (!res) return <td key={i} className="px-3 py-2 text-center">—</td>;
+                    const dscr = res.dscr;
+                    const colorClass =
+                      dscr >= 1.2
+                        ? "text-green-600 font-semibold"
+                        : "text-red-600 font-semibold";
+                    return (
+                      <td key={i} className="px-3 py-2 text-center">
+                        <span className={colorClass}>{dscr.toFixed(2)}</span>
+                        {dscr < 1.0 && (
+                          <div className="text-xs text-amber-600 mt-0.5">
+                            ⚠️ 参考: DSCR &lt; 1.0 は審査通過を保証しません
+                          </div>
+                        )}
+                      </td>
+                    );
+                  })}
+                </tr>
+                {/* DSCR推移ミニグラフ */}
+                <tr>
+                  <td className="px-3 py-2 text-muted-foreground">DSCR推移</td>
+                  {results.map((res, i) => {
+                    if (!res) return <td key={i} className="px-3 py-2 text-center">—</td>;
+                    const data = dscrSeriesForResult(res);
+                    return (
+                      <td key={i} className="px-3 py-2">
+                        <ResponsiveContainer width="100%" height={80}>
+                          <LineChart data={data} margin={{ top: 4, right: 4, bottom: 4, left: 0 }}>
+                            <YAxis domain={["auto", "auto"]} hide />
+                            <Tooltip
+                              formatter={(v: number) => [v.toFixed(2), "DSCR"]}
+                              labelFormatter={(l) => `${l}年目`}
+                            />
+                            <ReferenceLine y={1.2} stroke="#ef4444" strokeDasharray="3 3" />
+                            <Line
+                              type="monotone"
+                              dataKey="dscr"
+                              dot={false}
+                              stroke="#3b82f6"
+                              strokeWidth={1.5}
+                            />
+                          </LineChart>
+                        </ResponsiveContainer>
+                      </td>
+                    );
+                  })}
+                </tr>
+                {/* デッドクロス年 */}
+                <tr>
+                  <td className="px-3 py-2 text-muted-foreground">デッドクロス年</td>
+                  {results.map((res, i) => {
+                    if (!res) return <td key={i} className="px-3 py-2 text-center">—</td>;
+                    return (
+                      <td key={i} className="px-3 py-2 text-center">
+                        {res.deadCrossYear > 0 ? `${res.deadCrossYear}年目` : "なし"}
+                      </td>
+                    );
+                  })}
+                </tr>
+                {/* 自己資金必要額 */}
+                <tr>
+                  <td className="px-3 py-2 text-muted-foreground">自己資金必要額</td>
+                  {scenarios.slice(0, results.length).map((sc, i) => {
+                    const equity = propertyValue * (1 - sc.ltv);
+                    return (
+                      <td key={i} className="px-3 py-2 text-center">
+                        {toMan(equity)}万円
+                      </td>
+                    );
+                  })}
+                </tr>
+                {/* 総支払利息 */}
+                <tr>
+                  <td className="px-3 py-2 text-muted-foreground">総支払利息</td>
+                  {results.map((res, i) => {
+                    if (!res) return <td key={i} className="px-3 py-2 text-center">—</td>;
+                    return (
+                      <td key={i} className="px-3 py-2 text-center">
+                        {toMan(res.totalInterest)}万円
+                      </td>
+                    );
+                  })}
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -6,6 +6,7 @@ import DeadCrossChart from "@/components/DeadCrossChart";
 import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
 import CostBreakdown from "@/components/CostBreakdown";
 import { LoanOptimizationPanel } from "@/components/LoanOptimizationPanel";
+import { LoanComparePanel } from "@/components/LoanComparePanel";
 import RenovationPanel from "@/components/RenovationPanel";
 import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
@@ -186,6 +187,7 @@ export function ResultsSection({
                 onLoanMethodChange={onLoanMethodChange}
                 loanAmount={lastInput.loanAmount}
               />
+              <LoanComparePanel baseInput={lastInput} />
               {simulationMode === "full" && (
                 <>
                   {result.acquisitionCosts && (

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -83,6 +83,7 @@ export interface InvestmentInput {
   capexSchedule?: CapexEvent[]; // 大規模修繕費スケジュール（最大5件）
   rentGrowthRate?: number; // 年間賃料上昇率（新築・リノベ向け、例: 0.02 = 2%）
   rentGrowthYears?: number; // 賃料上昇が続く年数
+  loanFeeRate?: number; // 融資諸費用率（保証料・登記費用等の合算）
 }
 
 export interface CapexEvent {
@@ -164,6 +165,7 @@ export interface InvestmentResult {
   ltvSensitivity: LTVSensitivityRow[]; // LTV 感度分析（50%〜90%）
   irr: number | null; // 内部収益率（収束しない場合は null）
   npv: number; // 正味現在価値
+  totalInterest: number; // 保有期間の総支払利息
 }
 
 export interface LandTransaction {


### PR DESCRIPTION
## 概要

複数の融資条件（金利・融資期間・LTV・諸費用率）を最大4スロットで横並び比較できる `LoanComparePanel` を実装しました。また、融資諸費用率（`LoanFeeRate`）を取得費に加算し、保有期間の総支払利息（`TotalInterest`）を算出する機能をバックエンドに追加しました。

## 変更内容

- `domain/types.go`: `InvestmentInput` に `LoanFeeRate`、`InvestmentResult` に `TotalInterest` フィールドを追加
- `domain/investment.go`: `initYieldParams` で `LoanAmount × LoanFeeRate` を諸経費に加算、年次ループで保有期間の利息を累積して `TotalInterest` をセット
- `domain/investment_test.go`: `TestLoanFeeRate`（取得費への加算を検証）・`TestTotalInterest`（Σ AnnualInterest との一致を検証）を追加
- `types/investment.ts`: `InvestmentInput` に `loanFeeRate?`、`InvestmentResult` に `totalInterest` を追加
- `LoanComparePanel.tsx`（新規）: 最大4スロットの入力フォーム、`Promise.all` 並列呼び出し、横並び比較表（月返済額・DSCR・DSCR推移ミニグラフ・デッドクロス年・自己資金・総支払利息）を実装
- `FullModeForm.tsx`: 「融資諸費用率」入力フィールドを諸経費率の下に追加
- `ResultsSection.tsx`: `LoanComparePanel` を `LoanOptimizationPanel` の直下に追加

## 関連Issue

closes #374, closes #298

## テスト

- [x] 既存テストが通ること（`go test -race ./internal/domain/... -timeout 60s` PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること（`TestLoanFeeRate`・`TestTotalInterest` PASS）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み