### PR TITLE
fix(ci): Prettierフォーマットエラーとstaticcheck QF1005を修正

### DIFF
--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2662,7 +2662,7 @@ func TestRentGrowthScenario(t *testing.T) {
 	}
 
 	// 3年目(y=2): 上昇期 → baseRent * 1.02^2
-	want2 := baseAnnualRent * math.Pow(1+growthRate, 2)
+	want2 := baseAnnualRent * (1 + growthRate) * (1 + growthRate)
 	got2 := rentForYear(baseAnnualRent, declineRate, growthRate, growthYears, 2)
 	if !approxEqual(got2, want2, 1.0) {
 		t.Errorf("y=2: rent=%.0f, want %.0f", got2, want2)
@@ -2670,7 +2670,7 @@ func TestRentGrowthScenario(t *testing.T) {
 
 	// 4年目(y=3): 上昇期終了後1年目 → peak * (1-0.01)^1
 	peak := baseAnnualRent * math.Pow(1+growthRate, float64(growthYears))
-	want3 := peak * math.Pow(1-declineRate, 1)
+	want3 := peak * (1 - declineRate)
 	got3 := rentForYear(baseAnnualRent, declineRate, growthRate, growthYears, 3)
 	if !approxEqual(got3, want3, 1.0) {
 		t.Errorf("y=3: rent=%.0f, want %.0f", got3, want3)

--- a/frontend/src/components/DeadCrossChart.tsx
+++ b/frontend/src/components/DeadCrossChart.tsx
@@ -83,7 +83,11 @@ function DeadCrossChart({ result }: Props) {
           <ComposedChart data={data} margin={{ top: 8, right: 16, left: 0, bottom: 0 }}>
             <CartesianGrid strokeDasharray="3 3" stroke="#e5e7eb" />
             <XAxis dataKey="year" tick={{ fontSize: 11 }} interval={4} />
-            <YAxis tickFormatter={(v) => `${v}万`} tick={{ fontSize: 11 }} width={isMobile ? 32 : 50} />
+            <YAxis
+              tickFormatter={(v) => `${v}万`}
+              tick={{ fontSize: 11 }}
+              width={isMobile ? 32 : 50}
+            />
             <Tooltip
               formatter={(value: number, name: string) => [`${value}万円`, name]}
               labelStyle={{ fontWeight: "bold" }}

--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -928,7 +928,9 @@ export function FullModeForm({
               </Button>
             </div>
             {(input.capexSchedule ?? []).length === 0 ? (
-              <p className="text-xs text-muted-foreground">修繕費なし（追加ボタンで最大5件入力可）</p>
+              <p className="text-xs text-muted-foreground">
+                修繕費なし（追加ボタンで最大5件入力可）
+              </p>
             ) : (
               <div className="space-y-2">
                 {(input.capexSchedule ?? []).map((ev, i) => (
@@ -951,7 +953,9 @@ export function FullModeForm({
                       step="10"
                       min="0"
                       value={String(Math.round(ev.amount / 10_000))}
-                      onChange={(e) => updateCapexEvent(i, "amount", (parseFloat(e.target.value) || 0) * 10_000)}
+                      onChange={(e) =>
+                        updateCapexEvent(i, "amount", (parseFloat(e.target.value) || 0) * 10_000)
+                      }
                       className="flex-1"
                     />
                     <Button

--- a/frontend/src/components/LoanComparePanel.tsx
+++ b/frontend/src/components/LoanComparePanel.tsx
@@ -1,13 +1,6 @@
 "use client";
 import React, { useState } from "react";
-import {
-  LineChart,
-  Line,
-  ReferenceLine,
-  ResponsiveContainer,
-  YAxis,
-  Tooltip,
-} from "recharts";
+import { LineChart, Line, ReferenceLine, ResponsiveContainer, YAxis, Tooltip } from "recharts";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -57,9 +50,7 @@ export function LoanComparePanel({ baseInput }: Props) {
   };
 
   const updateScenario = (i: number, patch: Partial<LoanScenario>) => {
-    setScenarios((prev) =>
-      prev.map((s, idx) => (idx === i ? { ...s, ...patch } : s))
-    );
+    setScenarios((prev) => prev.map((s, idx) => (idx === i ? { ...s, ...patch } : s)));
   };
 
   const handleCompare = async () => {
@@ -133,9 +124,7 @@ export function LoanComparePanel({ baseInput }: Props) {
                 suffix="%"
                 step="0.1"
                 value={toPct(sc.annualLoanRate, 1)}
-                onChange={(e) =>
-                  updateScenario(i, { annualLoanRate: fromPct(e.target.value) })
-                }
+                onChange={(e) => updateScenario(i, { annualLoanRate: fromPct(e.target.value) })}
               />
               <Input
                 label="融資期間"
@@ -155,9 +144,7 @@ export function LoanComparePanel({ baseInput }: Props) {
                 suffix="%"
                 step="5"
                 value={toPct(sc.ltv, 0)}
-                onChange={(e) =>
-                  updateScenario(i, { ltv: fromPct(e.target.value) })
-                }
+                onChange={(e) => updateScenario(i, { ltv: fromPct(e.target.value) })}
               />
               <Input
                 label="諸費用率"
@@ -166,9 +153,7 @@ export function LoanComparePanel({ baseInput }: Props) {
                 suffix="%"
                 step="0.5"
                 value={toPct(sc.loanFeeRate, 1)}
-                onChange={(e) =>
-                  updateScenario(i, { loanFeeRate: fromPct(e.target.value) })
-                }
+                onChange={(e) => updateScenario(i, { loanFeeRate: fromPct(e.target.value) })}
               />
             </div>
           ))}
@@ -190,9 +175,7 @@ export function LoanComparePanel({ baseInput }: Props) {
           </Button>
         </div>
 
-        {error && (
-          <p className="text-sm text-destructive">{error}</p>
-        )}
+        {error && <p className="text-sm text-destructive">{error}</p>}
 
         {/* 比較結果テーブル */}
         {results.length > 0 && (
@@ -213,7 +196,12 @@ export function LoanComparePanel({ baseInput }: Props) {
                 <tr>
                   <td className="px-3 py-2 text-muted-foreground">月返済額</td>
                   {results.map((res, i) => {
-                    if (!res) return <td key={i} className="px-3 py-2 text-center">—</td>;
+                    if (!res)
+                      return (
+                        <td key={i} className="px-3 py-2 text-center">
+                          —
+                        </td>
+                      );
                     const monthlyPayment =
                       res.yearlyResults[0]?.annualLoanPayment != null
                         ? res.yearlyResults[0].annualLoanPayment / 12
@@ -232,12 +220,15 @@ export function LoanComparePanel({ baseInput }: Props) {
                     <span className="ml-1 text-xs text-muted-foreground">参考値</span>
                   </td>
                   {results.map((res, i) => {
-                    if (!res) return <td key={i} className="px-3 py-2 text-center">—</td>;
+                    if (!res)
+                      return (
+                        <td key={i} className="px-3 py-2 text-center">
+                          —
+                        </td>
+                      );
                     const dscr = res.dscr;
                     const colorClass =
-                      dscr >= 1.2
-                        ? "text-green-600 font-semibold"
-                        : "text-red-600 font-semibold";
+                      dscr >= 1.2 ? "text-green-600 font-semibold" : "text-red-600 font-semibold";
                     return (
                       <td key={i} className="px-3 py-2 text-center">
                         <span className={colorClass}>{dscr.toFixed(2)}</span>
@@ -254,7 +245,12 @@ export function LoanComparePanel({ baseInput }: Props) {
                 <tr>
                   <td className="px-3 py-2 text-muted-foreground">DSCR推移</td>
                   {results.map((res, i) => {
-                    if (!res) return <td key={i} className="px-3 py-2 text-center">—</td>;
+                    if (!res)
+                      return (
+                        <td key={i} className="px-3 py-2 text-center">
+                          —
+                        </td>
+                      );
                     const data = dscrSeriesForResult(res);
                     return (
                       <td key={i} className="px-3 py-2">
@@ -283,7 +279,12 @@ export function LoanComparePanel({ baseInput }: Props) {
                 <tr>
                   <td className="px-3 py-2 text-muted-foreground">デッドクロス年</td>
                   {results.map((res, i) => {
-                    if (!res) return <td key={i} className="px-3 py-2 text-center">—</td>;
+                    if (!res)
+                      return (
+                        <td key={i} className="px-3 py-2 text-center">
+                          —
+                        </td>
+                      );
                     return (
                       <td key={i} className="px-3 py-2 text-center">
                         {res.deadCrossYear > 0 ? `${res.deadCrossYear}年目` : "なし"}
@@ -307,7 +308,12 @@ export function LoanComparePanel({ baseInput }: Props) {
                 <tr>
                   <td className="px-3 py-2 text-muted-foreground">総支払利息</td>
                   {results.map((res, i) => {
-                    if (!res) return <td key={i} className="px-3 py-2 text-center">—</td>;
+                    if (!res)
+                      return (
+                        <td key={i} className="px-3 py-2 text-center">
+                          —
+                        </td>
+                      );
                     return (
                       <td key={i} className="px-3 py-2 text-center">
                         {toMan(res.totalInterest)}万円

--- a/frontend/src/components/MobileSummaryCard.tsx
+++ b/frontend/src/components/MobileSummaryCard.tsx
@@ -29,8 +29,7 @@ export function MobileSummaryCard({ result, input, yieldPct, netYieldPct }: Prop
 
   const dscrColor =
     dscr >= 1.2 ? "text-green-700" : dscr >= 1.0 ? "text-yellow-700" : "text-red-700";
-  const dscrBg =
-    dscr >= 1.2 ? "bg-green-50" : dscr >= 1.0 ? "bg-yellow-50" : "bg-red-50";
+  const dscrBg = dscr >= 1.2 ? "bg-green-50" : dscr >= 1.0 ? "bg-yellow-50" : "bg-red-50";
 
   async function handlePdf() {
     setPdfLoading(true);
@@ -68,9 +67,13 @@ export function MobileSummaryCard({ result, input, yieldPct, netYieldPct }: Prop
           <p className="text-xs text-muted-foreground">DSCR</p>
           <p className={`font-bold ${dscrColor}`}>{dscr.toFixed(2)}</p>
         </div>
-        <div className={`col-span-1 rounded-lg px-2 py-1.5 ${hasDeadCross ? (deadCrossEarly ? "bg-red-50" : "bg-yellow-50") : "bg-green-50"}`}>
+        <div
+          className={`col-span-1 rounded-lg px-2 py-1.5 ${hasDeadCross ? (deadCrossEarly ? "bg-red-50" : "bg-yellow-50") : "bg-green-50"}`}
+        >
           <p className="text-xs text-muted-foreground">デッドクロス</p>
-          <p className={`font-bold ${hasDeadCross ? (deadCrossEarly ? "text-red-700" : "text-yellow-700") : "text-green-700"}`}>
+          <p
+            className={`font-bold ${hasDeadCross ? (deadCrossEarly ? "text-red-700" : "text-yellow-700") : "text-green-700"}`}
+          >
             {hasDeadCross ? `${deadCrossYear}年目〜` : "なし"}
           </p>
         </div>

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -179,7 +179,10 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
                         DSCR: {item.metrics.dscr.toFixed(2)}
                       </span>
                       <span className="text-xs text-purple-600">
-                        IRR: {item.metrics.irr !== null ? `${(item.metrics.irr * 100).toFixed(1)}%` : "-"}
+                        IRR:{" "}
+                        {item.metrics.irr !== null
+                          ? `${(item.metrics.irr * 100).toFixed(1)}%`
+                          : "-"}
                       </span>
                     </div>
                   )}

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -10,7 +10,15 @@ import type {
   YieldScenarios,
 } from "@/types/investment";
 import { formatMan, formatPct, formatYen } from "@/lib/utils";
-import { TrendingUp, TrendingDown, AlertTriangle, CheckCircle, Users, ChevronDown, ChevronUp } from "lucide-react";
+import {
+  TrendingUp,
+  TrendingDown,
+  AlertTriangle,
+  CheckCircle,
+  Users,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
 import { TermTooltip } from "@/components/ui/TermTooltip";
 import { MobileSummaryCard } from "@/components/MobileSummaryCard";
 
@@ -193,7 +201,9 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                   {isExpanded && (
                     <div className="grid grid-cols-2 gap-x-4 gap-y-1 border-t px-3 pb-3 pt-2 text-sm">
                       <span className="text-muted-foreground">DSCR</span>
-                      <span className={`text-right font-medium ${s.dscr >= 1.2 ? "text-green-600" : s.dscr >= 1.0 ? "text-yellow-600" : "text-red-600"}`}>
+                      <span
+                        className={`text-right font-medium ${s.dscr >= 1.2 ? "text-green-600" : s.dscr >= 1.0 ? "text-yellow-600" : "text-red-600"}`}
+                      >
                         {s.dscr.toFixed(2)}
                       </span>
                       <span className="text-muted-foreground">CF黒転年</span>
@@ -202,11 +212,15 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                       </span>
                       <span className="text-muted-foreground">金利△</span>
                       <span className="text-right">
-                        {s.interestRateDelta !== 0 ? `+${(s.interestRateDelta * 100).toFixed(1)}%` : "±0"}
+                        {s.interestRateDelta !== 0
+                          ? `+${(s.interestRateDelta * 100).toFixed(1)}%`
+                          : "±0"}
                       </span>
                       <span className="text-muted-foreground">空室△</span>
                       <span className="text-right">
-                        {s.vacancyRateDelta !== 0 ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%` : "±0"}
+                        {s.vacancyRateDelta !== 0
+                          ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%`
+                          : "±0"}
                       </span>
                     </div>
                   )}

--- a/frontend/src/components/__tests__/helpers.ts
+++ b/frontend/src/components/__tests__/helpers.ts
@@ -87,6 +87,7 @@ export function makeYearlyResult(
     isDeadCrossYear: false,
     isInDeadCrossZone: false,
     effectiveRate: 0.015,
+    capexAmount: 0,
     ...overrides,
   };
 }
@@ -128,6 +129,7 @@ export function makeResult(overrides: Partial<InvestmentResult> = {}): Investmen
     ltvSensitivity: [],
     irr: 0.07,
     npv: 1_200_000,
+    totalInterest: 3_500_000,
     ...overrides,
   };
 }

--- a/frontend/src/lib/__tests__/investment.test.ts
+++ b/frontend/src/lib/__tests__/investment.test.ts
@@ -480,3 +480,104 @@ describe("calcStressScenario - rent decline and after-tax CF", () => {
     expect(s1.breakEvenYear).toBe(-1);
   });
 });
+
+// ─── analyze: capex schedule ──────────────────────────────────────────────────
+
+describe("analyze - capex schedule", () => {
+  it("capexSchedule なしの場合、全年の capexAmount が 0", () => {
+    const r = analyze(BASE_INPUT);
+    r.yearlyResults.forEach((yr) => {
+      expect(yr.capexAmount).toBe(0);
+    });
+  });
+
+  it("指定年の capexAmount が入力値と一致する", () => {
+    const r = analyze({ ...BASE_INPUT, capexSchedule: [{ year: 3, amount: 1_000_000 }] });
+    expect(r.yearlyResults[2].capexAmount).toBe(1_000_000);
+  });
+
+  it("capex 発生年の cashFlow が非発生年より capexAmount 分だけ少ない", () => {
+    const base = analyze(BASE_INPUT);
+    const withCapex = analyze({
+      ...BASE_INPUT,
+      capexSchedule: [{ year: 3, amount: 1_000_000 }],
+    });
+    const diff = base.yearlyResults[2].cashFlow - withCapex.yearlyResults[2].cashFlow;
+    expect(approxEqual(diff, 1_000_000)).toBe(true);
+  });
+
+  it("capex 非発生年の cashFlow は影響を受けない", () => {
+    const base = analyze(BASE_INPUT);
+    const withCapex = analyze({
+      ...BASE_INPUT,
+      capexSchedule: [{ year: 3, amount: 1_000_000 }],
+    });
+    expect(approxEqual(base.yearlyResults[0].cashFlow, withCapex.yearlyResults[0].cashFlow)).toBe(
+      true
+    );
+    expect(approxEqual(base.yearlyResults[4].cashFlow, withCapex.yearlyResults[4].cashFlow)).toBe(
+      true
+    );
+  });
+
+  it("同年に複数の capex イベントがある場合は合算される", () => {
+    const r = analyze({
+      ...BASE_INPUT,
+      capexSchedule: [
+        { year: 5, amount: 500_000 },
+        { year: 5, amount: 300_000 },
+      ],
+    });
+    expect(r.yearlyResults[4].capexAmount).toBe(800_000);
+  });
+
+  it("ローン期間（35年）を超えた capex イベントは yearlyResults に現れない", () => {
+    const r = analyze({
+      ...BASE_INPUT,
+      capexSchedule: [{ year: 40, amount: 2_000_000 }],
+    });
+    r.yearlyResults.forEach((yr) => {
+      expect(yr.capexAmount).toBe(0);
+    });
+  });
+
+  it("capex は cashFlow を減らすが taxableIncome には影響しない", () => {
+    const base = analyze(BASE_INPUT);
+    const withCapex = analyze({
+      ...BASE_INPUT,
+      capexSchedule: [{ year: 2, amount: 500_000 }],
+    });
+    expect(
+      approxEqual(base.yearlyResults[1].taxableIncome, withCapex.yearlyResults[1].taxableIncome)
+    ).toBe(true);
+    expect(
+      base.yearlyResults[1].cashFlow - withCapex.yearlyResults[1].cashFlow
+    ).toBeCloseTo(500_000, -2);
+  });
+
+  it("capex はストレスシナリオの totalCashFlow にも反映される", () => {
+    const base = analyze(BASE_INPUT);
+    const withCapex = analyze({
+      ...BASE_INPUT,
+      capexSchedule: [{ year: 1, amount: 1_000_000 }],
+    });
+    const baseBaseline = base.stressScenarios.find((s) => s.label === "ベースライン")!;
+    const capexBaseline = withCapex.stressScenarios.find((s) => s.label === "ベースライン")!;
+    expect(baseBaseline.totalCashFlow - capexBaseline.totalCashFlow).toBeCloseTo(1_000_000, -2);
+  });
+});
+
+// ─── analyze: totalInterest ───────────────────────────────────────────────────
+
+describe("analyze - totalInterest", () => {
+  it("totalInterest が yearlyResults の annualInterest 合計と一致する", () => {
+    const r = analyze(BASE_INPUT);
+    const sum = r.yearlyResults.reduce((acc, yr) => acc + yr.annualInterest, 0);
+    expect(approxEqual(r.totalInterest, sum)).toBe(true);
+  });
+
+  it("無借金物件は totalInterest が 0", () => {
+    const r = analyze({ ...BASE_INPUT, loanAmount: 0 });
+    expect(r.totalInterest).toBe(0);
+  });
+});

--- a/frontend/src/lib/investment.ts
+++ b/frontend/src/lib/investment.ts
@@ -717,7 +717,11 @@ export function analyze(inputRaw: InvestmentInput): InvestmentResult {
     const taxableIncome = yearAnnualRent - annualInterest - yearDepreciation - yearExpenses;
     const incomeTax = taxableIncome > 0 ? taxableIncome * input.incomeTaxRate : 0;
 
-    const cashFlow = yearAnnualRent - annualLoanPayment - yearExpenses;
+    const capexAmount = (input.capexSchedule ?? [])
+      .filter((ev) => ev.year === year)
+      .reduce((sum, ev) => sum + ev.amount, 0);
+
+    const cashFlow = yearAnnualRent - annualLoanPayment - yearExpenses - capexAmount;
     const afterTaxCF = cashFlow - incomeTax;
     cumulativeCF += afterTaxCF;
 
@@ -729,10 +733,6 @@ export function analyze(inputRaw: InvestmentInput): InvestmentResult {
       deadCrossYear = year;
       isDeadCrossYear = true;
     }
-
-    const capexAmount = (input.capexSchedule ?? [])
-      .filter((ev) => ev.year === year)
-      .reduce((sum, ev) => sum + ev.amount, 0);
 
     yearlyResults.push({
       year,

--- a/frontend/src/lib/investment.ts
+++ b/frontend/src/lib/investment.ts
@@ -730,6 +730,10 @@ export function analyze(inputRaw: InvestmentInput): InvestmentResult {
       isDeadCrossYear = true;
     }
 
+    const capexAmount = (input.capexSchedule ?? [])
+      .filter((ev) => ev.year === year)
+      .reduce((sum, ev) => sum + ev.amount, 0);
+
     yearlyResults.push({
       year,
       annualRent: yearAnnualRent,
@@ -747,6 +751,7 @@ export function analyze(inputRaw: InvestmentInput): InvestmentResult {
       isDeadCrossYear,
       isInDeadCrossZone: inDeadCrossZone,
       effectiveRate: currentRate,
+      capexAmount,
     });
   }
 
@@ -846,5 +851,6 @@ export function analyze(inputRaw: InvestmentInput): InvestmentResult {
     ltvSensitivity,
     irr,
     npv,
+    totalInterest: yearlyResults.reduce((sum, yr) => sum + yr.annualInterest, 0),
   };
 }

--- a/frontend/src/lib/investment.ts
+++ b/frontend/src/lib/investment.ts
@@ -451,7 +451,11 @@ function calcStressScenario(
       if (yearDSCR < minDSCR) minDSCR = yearDSCR;
     }
 
-    const cf = yearNOI - yearLoan;
+    const yearCapex = (inInput.capexSchedule ?? [])
+      .filter((ev) => ev.year === y)
+      .reduce((sum, ev) => sum + ev.amount, 0);
+
+    const cf = yearNOI - yearLoan - yearCapex;
     // 減価償却は省略した保守的近似（簡略ストレス計算のため過大に税を見積もる）
     const taxableIncome = yearNOI - yearInterest;
     const incomeTax = taxableIncome > 0 ? taxableIncome * inInput.incomeTaxRate : 0;


### PR DESCRIPTION
## 概要

`main` ブランチで発生していた複数のCI失敗と、レビューで発覚した実装不備を合わせて修正する。

## 変更内容

- **Frontend CI（Prettier フォーマットエラー）**
  - 下記6コンポーネントに `prettier --write` を適用
    - `DeadCrossChart.tsx` / `FullModeForm.tsx` / `LoanComparePanel.tsx`
    - `MobileSummaryCard.tsx` / `WatchlistPanel.tsx` / `YieldAnalysis.tsx`

- **Backend CI（staticcheck QF1005）**
  - `investment_test.go`: `math.Pow(x, 2)` → `x * x`、`math.Pow(x, 1)` → `x` に展開

- **Frontend typecheck**
  - `YearlyResult` に `capexAmount: number` を追加（型定義への未追従）
  - `InvestmentResult` に `totalInterest: number` を追加（型定義への未追従）
  - テストヘルパー（`helpers.ts`）の両フィールドを補完

- **capex のキャッシュフロー反映（実装不備の修正）**
  - `capexSchedule` に入力された修繕費が `cashFlow` / `afterTaxCashFlow` / `cumulativeCashFlow` に反映されていなかったため修正
  - 税務上の扱い（資本計上・減価償却）に倣い `taxableIncome` は変更しない

## 関連Issue

なし（CI 修正 + 実装不備修正）

## テスト

- [x] `go build ./...` でコンパイル確認済み
- [x] `npx tsc --noEmit` でtypecheck通過確認済み
- [x] CI（Backend CI / Frontend CI）グリーン確認済み

## 確認事項

- [x] コードレビュー観点での自己レビュー済み