### PR TITLE
feat(ci/docker): Docker CI インフラ改善

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -54,3 +54,7 @@ jobs:
 
       - name: go build
         run: go build ./cmd/server
+
+      - name: docker build (smoke test)
+        working-directory: .
+        run: docker build ./backend

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -43,14 +43,18 @@ jobs:
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5730f0cb9d99d49f19a89cf9c85e9c26c62b81c  # v3.10.0
+
       - name: Build and push Docker image
         run: |
-          docker build \
+          docker buildx build \
+            --cache-from type=registry,ref=${{ env.IMAGE }}:cache \
+            --cache-to   type=registry,ref=${{ env.IMAGE }}:cache,mode=max \
             --tag "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}" \
             --tag "${{ env.IMAGE }}:latest" \
+            --push \
             ./backend
-          docker push "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}"
-          docker push "${{ env.IMAGE }}:latest"
 
       - name: Deploy to Cloud Run
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d  # v3.0.1

--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -44,7 +44,7 @@ jobs:
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5730f0cb9d99d49f19a89cf9c85e9c26c62b81c  # v3.10.0
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
 
       - name: Build and push Docker image
         run: |

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,3 +1,9 @@
 *_test.go
 *.md
 .git
+.env*
+.github/
+docs/
+terraform/
+Makefile
+coverage/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.25-alpine AS builder
+FROM golang:1.25.5-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -2,3 +2,9 @@ node_modules
 .next
 *.md
 .git
+.env*
+coverage/
+**/*.test.ts
+**/*.spec.ts
+__tests__/
+.github/


### PR DESCRIPTION
## 概要

高優先度のインフラ関連 issue 3本と低優先度1本をまとめて対応します。

- #402 golang イメージ patch バージョン統一（バグ修正）
- #404 backend-ci.yml に Docker ビルドスモークテスト追加
- #403 deploy-backend.yml に Buildx + レジストリキャッシュ追加
- #408 `.dockerignore` 除外対象の拡充

## 変更内容

### fix(docker): golang イメージを 1.25.5-alpine に統一 (#402)

`go.mod` が `go 1.25.5` を指定しているにもかかわらず `backend/Dockerfile` は `golang:1.25-alpine`（patch なし）を使用していた。patch バージョンの不一致はビルド再現性を損なうため、`golang:1.25.5-alpine` に統一した。

### feat(ci): Docker ビルドスモークテストを追加 (#404)

`backend-ci.yml` の `go build` ステップ直後に `docker build ./backend` を追加。Dockerfile 固有の問題（ベースイメージ typo・COPY パス誤り等）をデプロイ前に CI で検知できるようにした。

### feat(ci): deploy-backend.yml に Buildx + レジストリキャッシュを追加 (#403)

`docker/setup-buildx-action` を追加し、`docker build` を `docker buildx build` に変更。Artifact Registry をキャッシュストアとして使用することで、依存ライブラリや中間レイヤーの再利用が可能になりビルド時間を短縮する。`docker push` ステップは `--push` フラグに統合して削除した。

### fix(docker): .dockerignore 除外対象を拡充 (#408)

backend・frontend 双方の `.dockerignore` に `.env*`・`coverage/`・`.github/` 等を追加。機密ファイルの混入リスクを低減し、ビルドコンテキストサイズを最小化した。

## テスト計画

- [ ] backend-ci.yml の `docker build (smoke test)` ステップが CI で成功する
- [ ] `backend/Dockerfile` が `golang:1.25.5-alpine` を使用していることをビルドログで確認
- [ ] deploy-backend.yml のデプロイ後に Artifact Registry に `:cache` タグが作成される

Closes #402, #403, #404, #408