### PR TITLE
refactor(frontend): FullModeForm.tsx を4セクションに分割（1004行→247行）

### DIFF
--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -6,10 +6,14 @@ import { Calculator, Info } from "lucide-react";
 import type { InvestmentInput, RateAdjustment, RentDeclineHint } from "@/types/investment";
 import type { Municipality } from "@/lib/api";
 import type { ZoningType } from "@/lib/zoning";
-import { LocationSection } from "@/components/sections/LocationSection";
+import { LocationSection, type GeocodeState } from "@/components/sections/LocationSection";
 import { PropertyInfoSection } from "@/components/sections/PropertyInfoSection";
 import { LoanSection } from "@/components/sections/LoanSection";
-import { ScenarioSection } from "@/components/sections/ScenarioSection";
+import {
+  ScenarioSection,
+  type RateScheduleHandlers,
+  type CapexHandlers,
+} from "@/components/sections/ScenarioSection";
 
 interface FullModeFormProps {
   area: string;
@@ -22,17 +26,8 @@ interface FullModeFormProps {
   muniLoading: boolean;
   muniError: string | null;
   isOnline: boolean | null;
-  propertyLat: string;
-  setPropertyLat: (v: string) => void;
-  propertyLng: string;
-  setPropertyLng: (v: string) => void;
-  addressInput: string;
-  setAddressInput: (v: string) => void;
-  geocodeStatus: "idle" | "loading" | "success" | "error";
-  setGeocodeStatus: (v: "idle" | "loading" | "success" | "error") => void;
-  geocodeError: string;
-  geocodeLocationType: string;
-  setGeocodeLocationType: (v: string) => void;
+  geocode: GeocodeState;
+  onGeocodeChange: (patch: Partial<GeocodeState>) => void;
   showManualCoords: boolean;
   handleGeocode: () => Promise<void>;
   loading: boolean;
@@ -41,16 +36,6 @@ interface FullModeFormProps {
   setNum: (key: keyof InvestmentInput, value: number) => void;
   setStr: (key: keyof InvestmentInput, value: string) => void;
   fieldError: (key: string) => string | undefined;
-  showBuildingHelper: boolean;
-  setShowBuildingHelper: React.Dispatch<React.SetStateAction<boolean>>;
-  taxAmount: string;
-  setTaxAmount: (v: string) => void;
-  landAssess: string;
-  setLandAssess: (v: string) => void;
-  buildingAssess: string;
-  setBuildingAssess: (v: string) => void;
-  totalPrice: string;
-  setTotalPrice: (v: string) => void;
   rentHint: RentDeclineHint | null;
   rentHintLoading: boolean;
   rentHintError: string | null;
@@ -59,15 +44,8 @@ interface FullModeFormProps {
   handleCashPurchaseToggle: (checked: boolean) => void;
   zoningType: ZoningType;
   setZoningType: (v: ZoningType) => void;
-  rateScheduleEnabled: boolean;
-  handleRateScheduleToggle: (enabled: boolean) => void;
-  addRateStep: () => void;
-  removeRateStep: (i: number) => void;
-  updateRateStep: (i: number, field: keyof RateAdjustment, value: number) => void;
-  canAddRateStep: boolean;
-  addCapexEvent: () => void;
-  removeCapexEvent: (i: number) => void;
-  updateCapexEvent: (i: number, field: "year" | "amount", value: number) => void;
+  rateSchedule: RateScheduleHandlers;
+  capex: CapexHandlers;
   hasErrors: boolean;
   handleAnalyze: () => void;
 }
@@ -83,17 +61,8 @@ export function FullModeForm({
   muniLoading,
   muniError,
   isOnline,
-  propertyLat,
-  setPropertyLat,
-  propertyLng,
-  setPropertyLng,
-  addressInput,
-  setAddressInput,
-  geocodeStatus,
-  setGeocodeStatus,
-  geocodeError,
-  geocodeLocationType,
-  setGeocodeLocationType,
+  geocode,
+  onGeocodeChange,
   showManualCoords,
   handleGeocode,
   loading,
@@ -102,16 +71,6 @@ export function FullModeForm({
   setNum,
   setStr,
   fieldError,
-  showBuildingHelper,
-  setShowBuildingHelper,
-  taxAmount,
-  setTaxAmount,
-  landAssess,
-  setLandAssess,
-  buildingAssess,
-  setBuildingAssess,
-  totalPrice,
-  setTotalPrice,
   rentHint,
   rentHintLoading,
   rentHintError,
@@ -120,15 +79,8 @@ export function FullModeForm({
   handleCashPurchaseToggle,
   zoningType,
   setZoningType,
-  rateScheduleEnabled,
-  handleRateScheduleToggle,
-  addRateStep,
-  removeRateStep,
-  updateRateStep,
-  canAddRateStep,
-  addCapexEvent,
-  removeCapexEvent,
-  updateCapexEvent,
+  rateSchedule,
+  capex,
   hasErrors,
   handleAnalyze,
 }: FullModeFormProps) {
@@ -145,17 +97,8 @@ export function FullModeForm({
         muniLoading={muniLoading}
         muniError={muniError}
         isOnline={isOnline}
-        propertyLat={propertyLat}
-        setPropertyLat={setPropertyLat}
-        propertyLng={propertyLng}
-        setPropertyLng={setPropertyLng}
-        addressInput={addressInput}
-        setAddressInput={setAddressInput}
-        geocodeStatus={geocodeStatus}
-        setGeocodeStatus={setGeocodeStatus}
-        geocodeError={geocodeError}
-        geocodeLocationType={geocodeLocationType}
-        setGeocodeLocationType={setGeocodeLocationType}
+        geocode={geocode}
+        onGeocodeChange={onGeocodeChange}
         showManualCoords={showManualCoords}
         handleGeocode={handleGeocode}
         loading={loading}
@@ -175,16 +118,6 @@ export function FullModeForm({
             setNum={setNum}
             setStr={setStr}
             fieldError={fieldError}
-            showBuildingHelper={showBuildingHelper}
-            setShowBuildingHelper={setShowBuildingHelper}
-            taxAmount={taxAmount}
-            setTaxAmount={setTaxAmount}
-            landAssess={landAssess}
-            setLandAssess={setLandAssess}
-            buildingAssess={buildingAssess}
-            setBuildingAssess={setBuildingAssess}
-            totalPrice={totalPrice}
-            setTotalPrice={setTotalPrice}
             rentHint={rentHint}
             rentHintLoading={rentHintLoading}
             rentHintError={rentHintError}
@@ -205,15 +138,8 @@ export function FullModeForm({
           <ScenarioSection
             input={input}
             setNum={setNum}
-            rateScheduleEnabled={rateScheduleEnabled}
-            handleRateScheduleToggle={handleRateScheduleToggle}
-            addRateStep={addRateStep}
-            removeRateStep={removeRateStep}
-            updateRateStep={updateRateStep}
-            canAddRateStep={canAddRateStep}
-            addCapexEvent={addCapexEvent}
-            removeCapexEvent={removeCapexEvent}
-            updateCapexEvent={updateCapexEvent}
+            rateSchedule={rateSchedule}
+            capex={capex}
           />
 
           <Button

--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -1,36 +1,15 @@
 "use client";
 import React from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Select } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
-import { Slider } from "@/components/ui/slider";
-import type { InvestmentInput, BuildingType, RateAdjustment, CapexEvent } from "@/types/investment";
-import { toMan, fromMan, toPct, fromPct, formatPct } from "@/lib/utils";
+import { Calculator, Info } from "lucide-react";
+import type { InvestmentInput, RateAdjustment, RentDeclineHint } from "@/types/investment";
 import type { Municipality } from "@/lib/api";
-import type { RentDeclineHint } from "@/types/investment";
-import {
-  PREFECTURES,
-  BUILDING_TYPES,
-  RENT_DECLINE_DEFAULTS,
-  getPeriodLabel,
-} from "@/lib/investmentFormConstants";
-import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
-import { Search, Calculator, Info, AlertTriangle, ShieldCheck, Plus, Trash2 } from "lucide-react";
-
-const LOCATION_TYPE_LABEL: Record<string, string> = {
-  ROOFTOP: "番地レベルで取得",
-  RANGE_INTERPOLATED: "住所レベルで取得",
-  GEOMETRIC_CENTER: "地点レベルで取得",
-  APPROXIMATE: "近似位置で取得（精度低）",
-};
-
-function calcFromTax(taxMan: number): number {
-  return taxMan / 0.1;
-}
-function calcFromAssessment(totalMan: number, landA: number, buildingA: number): number {
-  return landA + buildingA > 0 ? totalMan * (buildingA / (landA + buildingA)) : 0;
-}
+import type { ZoningType } from "@/lib/zoning";
+import { LocationSection } from "@/components/sections/LocationSection";
+import { PropertyInfoSection } from "@/components/sections/PropertyInfoSection";
+import { LoanSection } from "@/components/sections/LoanSection";
+import { ScenarioSection } from "@/components/sections/ScenarioSection";
 
 interface FullModeFormProps {
   area: string;
@@ -155,163 +134,34 @@ export function FullModeForm({
 }: FullModeFormProps) {
   return (
     <>
-      {/* 相場データ取得（常時表示） */}
-      <Card>
-        <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Search className="h-5 w-5 text-primary" />
-            土地相場データ取得
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            <Select
-              label="都道府県"
-              value={area}
-              onChange={handleAreaChange}
-              options={PREFECTURES}
-            />
-            <div className="flex flex-col gap-1">
-              <label className="text-sm font-medium text-foreground">市区町村</label>
-              <input
-                type="text"
-                placeholder="例: 前橋市"
-                value={muniFilter}
-                onChange={(e) => setMuniFilter(e.target.value)}
-                className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                aria-label="市区町村を検索"
-              />
-              <select
-                value={city}
-                onChange={handleCityChange}
-                className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-              >
-                <option value="">（全市区町村）</option>
-                {muniLoading ? (
-                  <option disabled>読み込み中...</option>
-                ) : filteredMunicipalities.length === 0 && muniFilter.trim() ? (
-                  <option disabled>該当なし</option>
-                ) : (
-                  filteredMunicipalities.map((m) => (
-                    <option key={m.id} value={m.id}>
-                      {m.name}
-                    </option>
-                  ))
-                )}
-              </select>
-              {muniError && <p className="text-xs text-destructive">{muniError}</p>}
-              {muniFilter.trim() && filteredMunicipalities.length > 0 && (
-                <p className="text-xs text-muted-foreground">
-                  {filteredMunicipalities.length}件該当
-                </p>
-              )}
-            </div>
-          </div>
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-col gap-1">
-              <label className="text-sm font-medium text-foreground">物件住所（任意）</label>
-              <p className="text-xs text-muted-foreground">
-                丁目・番地まで入力してください（建物名・部屋番号は不要）
-              </p>
-              <div className="flex gap-2">
-                <input
-                  type="text"
-                  placeholder="例: 東京都渋谷区道玄坂1-2"
-                  value={addressInput}
-                  onChange={(e) => {
-                    setAddressInput(e.target.value);
-                    setGeocodeStatus("idle");
-                    setGeocodeLocationType("");
-                    setPropertyLat("");
-                    setPropertyLng("");
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") handleGeocode();
-                  }}
-                  className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                  aria-label="物件住所"
-                />
-                <Button
-                  variant="outline"
-                  loading={geocodeStatus === "loading"}
-                  disabled={!addressInput.trim() || geocodeStatus === "loading"}
-                  onClick={handleGeocode}
-                  className="shrink-0"
-                >
-                  座標を取得
-                </Button>
-              </div>
-              {geocodeStatus === "success" && (
-                <p className="text-xs text-green-600">
-                  ✓ {LOCATION_TYPE_LABEL[geocodeLocationType] ?? "座標を取得しました"}
-                </p>
-              )}
-              {geocodeStatus === "error" && (
-                <p className="text-xs text-destructive">{geocodeError}</p>
-              )}
-            </div>
-            {showManualCoords && (
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-                <div className="flex flex-col gap-1">
-                  <label className="text-sm font-medium text-foreground">緯度（手動入力）</label>
-                  <input
-                    type="number"
-                    inputMode="decimal"
-                    placeholder="例: 35.6762"
-                    step="0.0001"
-                    value={propertyLat}
-                    onChange={(e) => setPropertyLat(e.target.value)}
-                    className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                    aria-label="物件の緯度"
-                  />
-                </div>
-                <div className="flex flex-col gap-1">
-                  <label className="text-sm font-medium text-foreground">経度（手動入力）</label>
-                  <input
-                    type="number"
-                    inputMode="decimal"
-                    placeholder="例: 139.6503"
-                    step="0.0001"
-                    value={propertyLng}
-                    onChange={(e) => setPropertyLng(e.target.value)}
-                    className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
-                    aria-label="物件の経度"
-                  />
-                </div>
-              </div>
-            )}
-          </div>
-          <p className="text-xs text-muted-foreground">
-            {getPeriodLabel()}
-            分の宅地取引実績（国交省公式API）を取得します。緯度・経度を入力すると周辺駅の需要スコアも取得します
-          </p>
-          {isOnline === false && (
-            <p className="text-xs text-amber-700">オフライン中は相場取得を利用できません</p>
-          )}
-          <Button
-            variant="outline"
-            className="w-full"
-            loading={loading}
-            disabled={isOnline === false}
-            onClick={() => {
-              const lat = parseFloat(propertyLat);
-              const lng = parseFloat(propertyLng);
-              const hasCoords = !isNaN(lat) && !isNaN(lng);
-              onFetchLandPrices(
-                area,
-                city,
-                hasCoords ? lat : undefined,
-                hasCoords ? lng : undefined
-              );
-            }}
-          >
-            <Search className="h-4 w-4" />
-            相場データを取得
-          </Button>
-        </CardContent>
-      </Card>
+      <LocationSection
+        area={area}
+        handleAreaChange={handleAreaChange}
+        city={city}
+        handleCityChange={handleCityChange}
+        muniFilter={muniFilter}
+        setMuniFilter={setMuniFilter}
+        filteredMunicipalities={filteredMunicipalities}
+        muniLoading={muniLoading}
+        muniError={muniError}
+        isOnline={isOnline}
+        propertyLat={propertyLat}
+        setPropertyLat={setPropertyLat}
+        propertyLng={propertyLng}
+        setPropertyLng={setPropertyLng}
+        addressInput={addressInput}
+        setAddressInput={setAddressInput}
+        geocodeStatus={geocodeStatus}
+        setGeocodeStatus={setGeocodeStatus}
+        geocodeError={geocodeError}
+        geocodeLocationType={geocodeLocationType}
+        setGeocodeLocationType={setGeocodeLocationType}
+        showManualCoords={showManualCoords}
+        handleGeocode={handleGeocode}
+        loading={loading}
+        onFetchLandPrices={onFetchLandPrices}
+      />
 
-      {/* 物件・投資条件（フラット） */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
@@ -320,658 +170,51 @@ export function FullModeForm({
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
-          {/* 物件情報 */}
-          <div>
-            <p className="text-sm font-semibold text-foreground mb-3">物件情報</p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <Input
-                label="土地取得価格"
-                type="number"
-                inputMode="numeric"
-                suffix="万円"
-                value={toMan(input.landPrice)}
-                onChange={(e) => setNum("landPrice", fromMan(e.target.value))}
-                error={fieldError("landPrice")}
-              />
-              <Input
-                label="土地面積"
-                type="number"
-                inputMode="decimal"
-                suffix="m²"
-                value={String(input.landArea)}
-                onChange={(e) => setNum("landArea", parseFloat(e.target.value) || 0)}
-              />
-              <div className="sm:col-span-2">
-                <Input
-                  label="建物価格"
-                  type="number"
-                  inputMode="numeric"
-                  suffix="万円"
-                  value={toMan(input.buildingCost)}
-                  onChange={(e) => setNum("buildingCost", fromMan(e.target.value))}
-                  error={fieldError("buildingCost")}
-                />
-                <p className="text-xs text-muted-foreground mt-1">
-                  新築は建設費、中古は売買契約書記載の建物価格（消費税の課税対象部分）を入力
-                </p>
+          <PropertyInfoSection
+            input={input}
+            setNum={setNum}
+            setStr={setStr}
+            fieldError={fieldError}
+            showBuildingHelper={showBuildingHelper}
+            setShowBuildingHelper={setShowBuildingHelper}
+            taxAmount={taxAmount}
+            setTaxAmount={setTaxAmount}
+            landAssess={landAssess}
+            setLandAssess={setLandAssess}
+            buildingAssess={buildingAssess}
+            setBuildingAssess={setBuildingAssess}
+            totalPrice={totalPrice}
+            setTotalPrice={setTotalPrice}
+            rentHint={rentHint}
+            rentHintLoading={rentHintLoading}
+            rentHintError={rentHintError}
+            handleFetchRentHint={handleFetchRentHint}
+            zoningType={zoningType}
+            setZoningType={setZoningType}
+          />
 
-                <button
-                  type="button"
-                  className="mt-2 text-xs text-primary underline-offset-2 hover:underline"
-                  onClick={() => setShowBuildingHelper((p) => !p)}
-                >
-                  {showBuildingHelper
-                    ? "▲ 按分ヘルパーを閉じる"
-                    : "▼ 建物価格がわからない場合（按分ヘルパー）"}
-                </button>
+          <LoanSection
+            input={input}
+            setNum={setNum}
+            setStr={setStr}
+            fieldError={fieldError}
+            isCashPurchase={isCashPurchase}
+            handleCashPurchaseToggle={handleCashPurchaseToggle}
+          />
 
-                {showBuildingHelper && (
-                  <div className="mt-2 rounded-md bg-muted/50 p-3 space-y-3 text-sm">
-                    <div>
-                      <p className="font-medium text-xs mb-1">① 消費税額から計算（最も確実）</p>
-                      <div className="flex gap-2 items-end">
-                        <div className="flex-1">
-                          <Input
-                            label="消費税額"
-                            type="number"
-                            inputMode="numeric"
-                            suffix="万円"
-                            value={taxAmount}
-                            onChange={(e) => setTaxAmount(e.target.value)}
-                          />
-                        </div>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          size="sm"
-                          className="mb-0 shrink-0"
-                          onClick={() => {
-                            const tax = parseFloat(taxAmount) || 0;
-                            const result = calcFromTax(tax);
-                            if (result > 0) setNum("buildingCost", result * 10_000);
-                          }}
-                        >
-                          適用
-                        </Button>
-                      </div>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        建物価格 = 消費税額 ÷ 0.1
-                      </p>
-                    </div>
-                    <div>
-                      <p className="font-medium text-xs mb-1">② 固定資産税評価額の比率で按分</p>
-                      <div className="grid grid-cols-3 gap-2">
-                        <Input
-                          label="土地評価額"
-                          type="number"
-                          inputMode="numeric"
-                          suffix="万円"
-                          value={landAssess}
-                          onChange={(e) => setLandAssess(e.target.value)}
-                        />
-                        <Input
-                          label="建物評価額"
-                          type="number"
-                          inputMode="numeric"
-                          suffix="万円"
-                          value={buildingAssess}
-                          onChange={(e) => setBuildingAssess(e.target.value)}
-                        />
-                        <Input
-                          label="購入総額"
-                          type="number"
-                          inputMode="numeric"
-                          suffix="万円"
-                          value={totalPrice}
-                          onChange={(e) => setTotalPrice(e.target.value)}
-                        />
-                      </div>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        size="sm"
-                        className="mt-2"
-                        onClick={() => {
-                          const total = parseFloat(totalPrice) || 0;
-                          const land = parseFloat(landAssess) || 0;
-                          const building = parseFloat(buildingAssess) || 0;
-                          const result = calcFromAssessment(total, land, building);
-                          if (result > 0) setNum("buildingCost", result * 10_000);
-                        }}
-                      >
-                        按分して適用
-                      </Button>
-                      <p className="text-xs text-muted-foreground mt-1">
-                        建物価格 = 総額 × 建物評価 ÷（土地+建物評価）
-                      </p>
-                    </div>
-                  </div>
-                )}
-              </div>
-              <Input
-                label="築年数"
-                type="number"
-                inputMode="numeric"
-                suffix="年（0=新築）"
-                value={String(input.buildingAge)}
-                onChange={(e) => setNum("buildingAge", parseInt(e.target.value) || 0)}
-              />
-              <Input
-                label="最寄り駅徒歩"
-                type="number"
-                inputMode="numeric"
-                suffix="分（0=未入力）"
-                value={String(input.stationMinutes)}
-                onChange={(e) => setNum("stationMinutes", parseInt(e.target.value) || 0)}
-              />
-              <Select
-                label="建物構造"
-                value={input.buildingType}
-                onChange={(e) => {
-                  const bt = e.target.value as BuildingType;
-                  setStr("buildingType", bt);
-                  setNum("rentDeclineRate", RENT_DECLINE_DEFAULTS[bt]);
-                }}
-                options={BUILDING_TYPES}
-              />
-              <div>
-                <Input
-                  label="年間賃料下落率"
-                  type="number"
-                  suffix="%"
-                  step="0.1"
-                  value={toPct(input.rentDeclineRate, 1)}
-                  onChange={(e) => setNum("rentDeclineRate", fromPct(e.target.value))}
-                />
-                <p className="text-xs text-muted-foreground mt-1">
-                  建物構造から自動設定（例: 木造1%/年）
-                </p>
-                <div className="mt-2">
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    disabled={!area || rentHintLoading}
-                    onClick={handleFetchRentHint}
-                    className="text-xs h-7 px-2"
-                  >
-                    {rentHintLoading ? "取得中…" : "地域の参考値を取得"}
-                  </Button>
-                  {rentHintError && (
-                    <p className="text-xs text-destructive mt-1">{rentHintError}</p>
-                  )}
-                  {rentHint && !rentHintError && (
-                    <p className="text-xs text-muted-foreground mt-1">
-                      {rentHint.fallbackUsed
-                        ? "データ不足のため地域参考値なし。構造別平均値を推奨します"
-                        : `地価公示より参考値: ${toPct(rentHint.hintRate, 1)}%/年（${rentHint.dataPointCount}件）`}
-                    </p>
-                  )}
-                </div>
-              </div>
-
-              {/* 賃料上昇シナリオ（新築・リノベ向け） */}
-              <div className="col-span-full">
-                <details className="group">
-                  <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground select-none">
-                    ▶ 賃料上昇期の設定（新築・リノベ向け）
-                  </summary>
-                  <div className="mt-2 grid grid-cols-2 gap-3 pl-2 border-l-2 border-muted">
-                    <Input
-                      label="年間上昇率"
-                      type="number"
-                      suffix="%"
-                      step="0.1"
-                      min="0"
-                      max="10"
-                      value={toPct(input.rentGrowthRate ?? 0, 1)}
-                      onChange={(e) => setNum("rentGrowthRate", fromPct(e.target.value))}
-                    />
-                    <Input
-                      label="上昇期間"
-                      type="number"
-                      suffix="年"
-                      step="1"
-                      min="0"
-                      max="20"
-                      value={String(input.rentGrowthYears ?? 0)}
-                      onChange={(e) => setNum("rentGrowthYears", parseInt(e.target.value) || 0)}
-                    />
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-1 pl-2">
-                    上昇期終了後は年間賃料下落率が適用されます
-                  </p>
-                </details>
-              </div>
-            </div>
-          </div>
-
-          {/* 収益条件 */}
-          <div className="border-t pt-4">
-            <p className="text-sm font-semibold text-foreground mb-3">収益条件</p>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <Input
-                label="想定月額賃料"
-                type="number"
-                inputMode="numeric"
-                suffix="円"
-                value={String(input.monthlyRent)}
-                onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
-                error={fieldError("monthlyRent")}
-              />
-              <Input
-                label="現況空室率"
-                type="number"
-                inputMode="numeric"
-                suffix="%"
-                step="1"
-                value={toPct(input.actualVacancyRate, 0)}
-                onChange={(e) => setNum("actualVacancyRate", fromPct(e.target.value))}
-              />
-              <Input
-                label="想定空室率（長期）"
-                type="number"
-                inputMode="numeric"
-                suffix="%"
-                step="1"
-                value={toPct(input.vacancyRate, 0)}
-                onChange={(e) => setNum("vacancyRate", fromPct(e.target.value))}
-                error={fieldError("vacancyRate")}
-              />
-              <Input
-                label="運営経費率※"
-                type="number"
-                inputMode="numeric"
-                suffix="%"
-                step="1"
-                value={toPct(input.expenseRate, 0)}
-                onChange={(e) => setNum("expenseRate", fromPct(e.target.value))}
-                error={fieldError("expenseRate")}
-              />
-              <Input
-                label="諸経費率"
-                type="number"
-                inputMode="decimal"
-                suffix="%"
-                step="0.5"
-                value={toPct(input.miscExpenseRate, 1)}
-                onChange={(e) => setNum("miscExpenseRate", fromPct(e.target.value))}
-                error={fieldError("miscExpenseRate")}
-              />
-              <Input
-                label="融資諸費用率"
-                type="number"
-                inputMode="decimal"
-                suffix="%"
-                step="0.1"
-                value={toPct(input.loanFeeRate ?? 0, 1)}
-                onChange={(e) => setNum("loanFeeRate", fromPct(e.target.value))}
-              />
-            </div>
-            <p className="text-xs text-muted-foreground mt-2">
-              ※運営経費率はローン利息を含みません（管理費・修繕費・固定資産税・保険等）
-            </p>
-            <div className="mt-3 space-y-2">
-              <Select
-                label="用途地域（任意）"
-                value={zoningType}
-                onChange={(e) => setZoningType(e.target.value as ZoningType)}
-                options={[
-                  { value: "", label: "（未選択）" },
-                  ...ZONING_TYPES.map((z) => ({ value: z, label: z })),
-                ]}
-              />
-              {zoningType &&
-                (() => {
-                  const meta = ZONING_META[zoningType];
-                  if (!meta) return null;
-                  if (meta.riskLevel === 0)
-                    return (
-                      <div className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-2 text-green-800 text-xs">
-                        <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5" />
-                        <span>良好な住環境です</span>
-                      </div>
-                    );
-                  const styles: Record<number, string> = {
-                    1: "border-blue-200 bg-blue-50 text-blue-800",
-                    2: "border-yellow-300 bg-yellow-50 text-yellow-800",
-                    3: "border-red-300 bg-red-50 text-red-800",
-                  };
-                  const labels: Record<number, string> = {
-                    1: "低リスク",
-                    2: "中リスク",
-                    3: "高リスク",
-                  };
-                  return (
-                    <div
-                      className={`flex items-start gap-2 rounded-md border p-2 text-xs ${styles[meta.riskLevel]}`}
-                    >
-                      <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
-                      <div>
-                        <span className="font-semibold">{labels[meta.riskLevel]}: </span>
-                        <span>{meta.riskMessage}</span>
-                      </div>
-                    </div>
-                  );
-                })()}
-            </div>
-          </div>
-
-          {/* ローン条件 */}
-          <div className="border-t pt-4">
-            <div className="flex items-center justify-between mb-3">
-              <p className="text-sm font-semibold text-foreground">ローン条件</p>
-              <label className="flex items-center gap-2 cursor-pointer select-none">
-                <input
-                  type="checkbox"
-                  checked={isCashPurchase}
-                  onChange={(e) => handleCashPurchaseToggle(e.target.checked)}
-                  className="h-4 w-4 rounded border-input accent-primary"
-                  aria-label="現金購入（ローンなし）"
-                />
-                <span className="text-sm font-medium">現金購入（ローンなし）</span>
-              </label>
-            </div>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-              <Input
-                label="ローン金額"
-                type="number"
-                inputMode="numeric"
-                suffix="万円"
-                value={toMan(input.loanAmount)}
-                onChange={(e) => {
-                  if (!isCashPurchase) setNum("loanAmount", fromMan(e.target.value));
-                }}
-                error={fieldError("loanAmount")}
-                disabled={isCashPurchase}
-              />
-              <Input
-                label="年利"
-                type="number"
-                inputMode="decimal"
-                suffix="%"
-                step="0.01"
-                value={toPct(input.annualLoanRate)}
-                onChange={(e) => {
-                  if (!isCashPurchase) setNum("annualLoanRate", fromPct(e.target.value));
-                }}
-                error={fieldError("annualLoanRate")}
-                disabled={isCashPurchase}
-              />
-              <Input
-                label="返済期間"
-                type="number"
-                inputMode="numeric"
-                suffix="年"
-                value={String(input.loanYears)}
-                onChange={(e) => {
-                  if (!isCashPurchase) setNum("loanYears", parseInt(e.target.value) || 0);
-                }}
-                error={fieldError("loanYears")}
-                disabled={isCashPurchase}
-              />
-            </div>
-          </div>
-
-          {/* 出口戦略 */}
-          <div className="border-t pt-4">
-            <p className="text-sm font-semibold text-foreground mb-3">出口戦略</p>
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-              <Input
-                label="売却予定年数"
-                type="number"
-                inputMode="numeric"
-                suffix="年後"
-                value={String(input.holdingYears)}
-                onChange={(e) => setNum("holdingYears", parseInt(e.target.value) || 10)}
-                error={fieldError("holdingYears")}
-              />
-              <Input
-                label="売却時目標利回り（実質）"
-                type="number"
-                inputMode="decimal"
-                suffix="%"
-                step="0.5"
-                value={toPct(input.exitYieldTarget, 1)}
-                onChange={(e) => setNum("exitYieldTarget", fromPct(e.target.value))}
-                error={fieldError("exitYieldTarget")}
-              />
-              <Input
-                label="目標表面利回り"
-                type="number"
-                inputMode="decimal"
-                suffix="%"
-                step="0.5"
-                value={toPct(input.yieldTarget, 1)}
-                onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
-                error={fieldError("yieldTarget")}
-              />
-              <Input
-                label="所得税率（実効）"
-                type="number"
-                inputMode="numeric"
-                suffix="%"
-                step="1"
-                value={toPct(input.incomeTaxRate, 0)}
-                onChange={(e) => setNum("incomeTaxRate", fromPct(e.target.value))}
-                error={fieldError("incomeTaxRate")}
-              />
-            </div>
-
-            {/* NPV / IRR 設定 */}
-            <div className="mt-4">
-              <p className="text-xs font-semibold text-muted-foreground mb-2">NPV / IRR 設定</p>
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                <Input
-                  label="割引率"
-                  type="number"
-                  inputMode="decimal"
-                  suffix="%"
-                  step="0.1"
-                  value={toPct(input.discountRate ?? 0.05, 1)}
-                  onChange={(e) => setNum("discountRate", fromPct(e.target.value))}
-                  error={fieldError("discountRate")}
-                />
-                <Input
-                  label="物件価格下落率"
-                  type="number"
-                  inputMode="decimal"
-                  suffix="%"
-                  step="0.1"
-                  value={toPct(input.priceDeclineRate ?? 0, 1)}
-                  onChange={(e) => setNum("priceDeclineRate", fromPct(e.target.value))}
-                  error={fieldError("priceDeclineRate")}
-                />
-                <Select
-                  label="減価償却方式"
-                  value={input.depreciationMethod ?? "straight-line"}
-                  onChange={(e) => setStr("depreciationMethod", e.target.value)}
-                  options={[
-                    { value: "straight-line", label: "定額法" },
-                    { value: "declining-balance", label: "定率法" },
-                  ]}
-                />
-              </div>
-            </div>
-          </div>
-
-          {/* 変動金利スケジュール */}
-          <div className="border-t pt-4 space-y-3">
-            <div className="flex items-center justify-between">
-              <p className="text-sm font-semibold text-foreground">変動金利シミュレーション</p>
-              <label className="flex items-center gap-2 cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={rateScheduleEnabled}
-                  onChange={(e) => handleRateScheduleToggle(e.target.checked)}
-                  className="h-4 w-4 rounded border-gray-300"
-                />
-                <span className="text-xs text-muted-foreground">有効にする</span>
-              </label>
-            </div>
-            {rateScheduleEnabled && (
-              <div className="space-y-2">
-                <p className="text-xs text-muted-foreground">
-                  指定年以降の適用金利（絶対値）を設定します。最大3ステップ。
-                </p>
-                {input.rateAdjustmentSchedule.map((step, i) => {
-                  const maxYear = input.loanYears || 35;
-                  const prevYear = i > 0 ? input.rateAdjustmentSchedule[i - 1].afterYear : 1;
-                  const yearError =
-                    step.afterYear < 2
-                      ? "2年目以降を指定してください"
-                      : step.afterYear > maxYear
-                        ? `${maxYear}年以内を指定してください`
-                        : step.afterYear <= prevYear
-                          ? `前のステップより後の年を指定してください`
-                          : undefined;
-                  const rateError =
-                    step.rate <= 0 || step.rate > 0.3
-                      ? "0%超〜30%の範囲で入力してください"
-                      : undefined;
-                  return (
-                    <div key={i} className="flex items-center gap-2">
-                      <Input
-                        label={i === 0 ? "開始年" : ""}
-                        type="number"
-                        inputMode="numeric"
-                        suffix="年目〜"
-                        min="2"
-                        max={String(maxYear)}
-                        step="1"
-                        value={String(step.afterYear)}
-                        onChange={(e) =>
-                          updateRateStep(i, "afterYear", parseInt(e.target.value) || 2)
-                        }
-                        error={yearError}
-                      />
-                      <Input
-                        label={i === 0 ? "適用金利" : ""}
-                        type="number"
-                        inputMode="decimal"
-                        suffix="%"
-                        min="0.1"
-                        max="30"
-                        step="0.1"
-                        value={(step.rate * 100).toFixed(2)}
-                        onChange={(e) =>
-                          updateRateStep(i, "rate", (parseFloat(e.target.value) || 0) / 100)
-                        }
-                        error={rateError}
-                      />
-                      <button
-                        type="button"
-                        onClick={() => removeRateStep(i)}
-                        className={`text-muted-foreground hover:text-destructive flex-shrink-0 ${i === 0 ? "mt-5" : ""}`}
-                        aria-label="削除"
-                      >
-                        <Trash2 className="h-4 w-4" />
-                      </button>
-                    </div>
-                  );
-                })}
-                {canAddRateStep && (
-                  <button
-                    type="button"
-                    onClick={addRateStep}
-                    className="flex items-center gap-1 text-xs text-primary hover:underline"
-                  >
-                    <Plus className="h-3 w-3" />
-                    金利ステップを追加
-                  </button>
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* ストレステスト */}
-          <div className="border-t pt-4 space-y-4">
-            <p className="text-sm font-semibold text-foreground">ストレステスト</p>
-            <Slider
-              label="空室率の上昇"
-              value={input.vacancyRateDelta}
-              min={0}
-              max={0.3}
-              step={0.01}
-              onChange={(v) => setNum("vacancyRateDelta", v)}
-              formatValue={(v) => `+${formatPct(v)}`}
-            />
-            <Slider
-              label="金利の上昇"
-              value={input.loanRateDelta}
-              min={0}
-              max={0.03}
-              step={0.001}
-              onChange={(v) => setNum("loanRateDelta", v)}
-              formatValue={(v) => `+${formatPct(v)}`}
-            />
-            {rateScheduleEnabled && input.loanRateDelta > 0 && (
-              <p className="text-xs text-muted-foreground">
-                金利上昇分はスケジュール後の金利にも上乗せされます
-              </p>
-            )}
-          </div>
-
-          {/* 大規模修繕費スケジュール */}
-          <div className="border-t pt-4">
-            <div className="flex items-center justify-between mb-3">
-              <p className="text-sm font-semibold text-foreground">大規模修繕費スケジュール</p>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="text-xs h-7 px-2"
-                disabled={(input.capexSchedule ?? []).length >= 5}
-                onClick={addCapexEvent}
-              >
-                ＋追加
-              </Button>
-            </div>
-            {(input.capexSchedule ?? []).length === 0 ? (
-              <p className="text-xs text-muted-foreground">
-                修繕費なし（追加ボタンで最大5件入力可）
-              </p>
-            ) : (
-              <div className="space-y-2">
-                {(input.capexSchedule ?? []).map((ev, i) => (
-                  <div key={i} className="flex items-center gap-2">
-                    <Input
-                      label="何年目"
-                      type="number"
-                      suffix="年目"
-                      step="1"
-                      min="1"
-                      max={input.holdingYears || 35}
-                      value={String(ev.year)}
-                      onChange={(e) => updateCapexEvent(i, "year", parseInt(e.target.value) || 1)}
-                      className="w-24"
-                    />
-                    <Input
-                      label="金額"
-                      type="number"
-                      suffix="万円"
-                      step="10"
-                      min="0"
-                      value={String(Math.round(ev.amount / 10_000))}
-                      onChange={(e) =>
-                        updateCapexEvent(i, "amount", (parseFloat(e.target.value) || 0) * 10_000)
-                      }
-                      className="flex-1"
-                    />
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="text-xs h-7 px-2 mt-5 shrink-0"
-                      onClick={() => removeCapexEvent(i)}
-                    >
-                      削除
-                    </Button>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+          <ScenarioSection
+            input={input}
+            setNum={setNum}
+            rateScheduleEnabled={rateScheduleEnabled}
+            handleRateScheduleToggle={handleRateScheduleToggle}
+            addRateStep={addRateStep}
+            removeRateStep={removeRateStep}
+            updateRateStep={updateRateStep}
+            canAddRateStep={canAddRateStep}
+            addCapexEvent={addCapexEvent}
+            removeCapexEvent={removeCapexEvent}
+            updateCapexEvent={updateCapexEvent}
+          />
 
           <Button
             className="w-full"

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -271,68 +271,69 @@ export function InvestmentForm({
     }
   };
 
-  const addRateStep = () => {
-    const schedule = input.rateAdjustmentSchedule;
-    const maxYear = input.loanYears || 35;
-    const lastYear = schedule.length > 0 ? schedule[schedule.length - 1].afterYear : 1;
-    if (lastYear >= maxYear) return;
-    const nextYear = Math.min(lastYear + 5, maxYear);
-    const newStep: RateAdjustment = { afterYear: nextYear, rate: input.annualLoanRate + 0.005 };
-    setInput((prev) => ({
-      ...prev,
-      rateAdjustmentSchedule: [...prev.rateAdjustmentSchedule, newStep],
-    }));
-  };
+  const addRateStep = useCallback(() => {
+    setInput((prev) => {
+      const schedule = prev.rateAdjustmentSchedule;
+      const maxYear = prev.loanYears || 35;
+      const lastYear = schedule.length > 0 ? schedule[schedule.length - 1].afterYear : 1;
+      if (lastYear >= maxYear) return prev;
+      const nextYear = Math.min(lastYear + 5, maxYear);
+      const newStep: RateAdjustment = { afterYear: nextYear, rate: prev.annualLoanRate + 0.005 };
+      return { ...prev, rateAdjustmentSchedule: [...prev.rateAdjustmentSchedule, newStep] };
+    });
+  }, []);
 
-  const removeRateStep = (index: number) => {
+  const removeRateStep = useCallback((index: number) => {
     setInput((prev) => ({
       ...prev,
       rateAdjustmentSchedule: prev.rateAdjustmentSchedule.filter((_, i) => i !== index),
     }));
-  };
+  }, []);
 
-  const updateRateStep = (index: number, field: keyof RateAdjustment, value: number) => {
-    setInput((prev) => ({
-      ...prev,
-      rateAdjustmentSchedule: prev.rateAdjustmentSchedule.map((s, i) =>
-        i === index ? { ...s, [field]: value } : s
-      ),
-    }));
-  };
+  const updateRateStep = useCallback(
+    (index: number, field: keyof RateAdjustment, value: number) => {
+      setInput((prev) => ({
+        ...prev,
+        rateAdjustmentSchedule: prev.rateAdjustmentSchedule.map((s, i) =>
+          i === index ? { ...s, [field]: value } : s
+        ),
+      }));
+    },
+    []
+  );
 
-  const addCapexEvent = () => {
-    const schedule = input.capexSchedule ?? [];
-    if (schedule.length >= 5) return;
-    const lastYear = schedule.length > 0 ? schedule[schedule.length - 1].year : 0;
-    const nextYear = Math.min(lastYear + 5, input.holdingYears || 20);
-    setInput((prev) => ({
-      ...prev,
-      capexSchedule: [...(prev.capexSchedule ?? []), { year: nextYear, amount: 1_000_000 }],
-    }));
-  };
+  const addCapexEvent = useCallback(() => {
+    setInput((prev) => {
+      const schedule = prev.capexSchedule ?? [];
+      if (schedule.length >= 5) return prev;
+      const lastYear = schedule.length > 0 ? schedule[schedule.length - 1].year : 0;
+      const nextYear = Math.min(lastYear + 5, prev.holdingYears || 20);
+      return { ...prev, capexSchedule: [...schedule, { year: nextYear, amount: 1_000_000 }] };
+    });
+  }, []);
 
-  const removeCapexEvent = (index: number) => {
+  const removeCapexEvent = useCallback((index: number) => {
     setInput((prev) => ({
       ...prev,
       capexSchedule: (prev.capexSchedule ?? []).filter((_, i) => i !== index),
     }));
-  };
+  }, []);
 
-  const updateCapexEvent = (index: number, field: "year" | "amount", value: number) => {
+  const updateCapexEvent = useCallback((index: number, field: "year" | "amount", value: number) => {
     setInput((prev) => ({
       ...prev,
       capexSchedule: (prev.capexSchedule ?? []).map((ev, i) =>
         i === index ? { ...ev, [field]: value } : ev
       ),
     }));
-  };
+  }, []);
 
-  const handleRateScheduleToggle = (enabled: boolean) => {
+  const handleRateScheduleToggle = useCallback((enabled: boolean) => {
     setRateScheduleEnabled(enabled);
     if (!enabled) {
       setInput((prev) => ({ ...prev, rateAdjustmentSchedule: [] }));
     }
-  };
+  }, []);
 
   const sortedInput = (src: InvestmentInput): InvestmentInput => ({
     ...src,

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -9,6 +9,7 @@ import { useMunicipalitiesLoader } from "@/hooks/useMunicipalitiesLoader";
 import { useRentDeclineHint } from "@/hooks/useRentDeclineHint";
 import { QuickModeForm, type QuickHistoryEntry } from "@/components/QuickModeForm";
 import { FullModeForm } from "@/components/FullModeForm";
+import { type GeocodeState } from "@/components/sections/LocationSection";
 
 const QUICK_HISTORY_KEY = "yield-guard:quick-history";
 const QUICK_HISTORY_MAX = 5;
@@ -129,11 +130,6 @@ export function InvestmentForm({
   const [showCustomLoan, setShowCustomLoan] = useState(false);
   const [quickHistory, setQuickHistory] = useState<QuickHistoryEntry[]>([]);
   const [rateScheduleEnabled, setRateScheduleEnabled] = useState(false);
-  const [showBuildingHelper, setShowBuildingHelper] = useState(false);
-  const [taxAmount, setTaxAmount] = useState("");
-  const [landAssess, setLandAssess] = useState("");
-  const [buildingAssess, setBuildingAssess] = useState("");
-  const [totalPrice, setTotalPrice] = useState("");
 
   const isQuick = simulationMode === "quick";
 
@@ -376,6 +372,39 @@ export function InvestmentForm({
     setNum("monthlyRent", parseFloat(last.monthlyRentYen) || 0);
   };
 
+  // geocode オブジェクト（FullModeForm 向け）
+  const geocode: GeocodeState = {
+    address: addressInput,
+    status: geocodeStatus,
+    error: geocodeError,
+    locationType: geocodeLocationType,
+    lat: propertyLat,
+    lng: propertyLng,
+  };
+  const onGeocodeChange = useCallback((patch: Partial<GeocodeState>) => {
+    if ("address" in patch) setAddressInput(patch.address!);
+    if ("status" in patch) setGeocodeStatus(patch.status!);
+    if ("error" in patch) setGeocodeError(patch.error!);
+    if ("locationType" in patch) setGeocodeLocationType(patch.locationType!);
+    if ("lat" in patch) setPropertyLat(patch.lat!);
+    if ("lng" in patch) setPropertyLng(patch.lng!);
+  }, []);
+
+  // rateSchedule / capex ハンドラオブジェクト（FullModeForm 向け）
+  const rateSchedule = {
+    enabled: rateScheduleEnabled,
+    onToggle: handleRateScheduleToggle,
+    onAdd: addRateStep,
+    onRemove: removeRateStep,
+    onUpdate: updateRateStep,
+    canAdd: canAddRateStep,
+  };
+  const capex = {
+    onAdd: addCapexEvent,
+    onRemove: removeCapexEvent,
+    onUpdate: updateCapexEvent,
+  };
+
   const sharedMuniProps = {
     area,
     handleAreaChange,
@@ -419,32 +448,26 @@ export function InvestmentForm({
         />
       ) : (
         <FullModeForm
-          {...sharedMuniProps}
-          setPropertyLat={setPropertyLat}
-          setPropertyLng={setPropertyLng}
-          addressInput={addressInput}
-          setAddressInput={setAddressInput}
-          geocodeStatus={geocodeStatus}
-          setGeocodeStatus={setGeocodeStatus}
-          geocodeError={geocodeError}
-          geocodeLocationType={geocodeLocationType}
-          setGeocodeLocationType={setGeocodeLocationType}
+          area={area}
+          handleAreaChange={handleAreaChange}
+          city={city}
+          handleCityChange={handleCityChange}
+          muniFilter={muniFilter}
+          setMuniFilter={setMuniFilter}
+          filteredMunicipalities={filteredMunicipalities}
+          muniLoading={muniLoading}
+          muniError={muniError}
+          isOnline={isOnline}
+          geocode={geocode}
+          onGeocodeChange={onGeocodeChange}
           showManualCoords={showManualCoords}
           handleGeocode={handleGeocode}
+          loading={loading}
+          onFetchLandPrices={onFetchLandPrices}
           input={input}
           setNum={setNum}
           setStr={setStr}
           fieldError={fieldError}
-          showBuildingHelper={showBuildingHelper}
-          setShowBuildingHelper={setShowBuildingHelper}
-          taxAmount={taxAmount}
-          setTaxAmount={setTaxAmount}
-          landAssess={landAssess}
-          setLandAssess={setLandAssess}
-          buildingAssess={buildingAssess}
-          setBuildingAssess={setBuildingAssess}
-          totalPrice={totalPrice}
-          setTotalPrice={setTotalPrice}
           rentHint={rentHint}
           rentHintLoading={rentHintLoading}
           rentHintError={rentHintError}
@@ -453,15 +476,8 @@ export function InvestmentForm({
           handleCashPurchaseToggle={handleCashPurchaseToggle}
           zoningType={zoningType}
           setZoningType={setZoningType}
-          rateScheduleEnabled={rateScheduleEnabled}
-          handleRateScheduleToggle={handleRateScheduleToggle}
-          addRateStep={addRateStep}
-          removeRateStep={removeRateStep}
-          updateRateStep={updateRateStep}
-          canAddRateStep={canAddRateStep}
-          addCapexEvent={addCapexEvent}
-          removeCapexEvent={removeCapexEvent}
-          updateCapexEvent={updateCapexEvent}
+          rateSchedule={rateSchedule}
+          capex={capex}
           hasErrors={hasErrors}
           handleAnalyze={handleAnalyze}
         />

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -373,37 +373,53 @@ export function InvestmentForm({
   };
 
   // geocode オブジェクト（FullModeForm 向け）
-  const geocode: GeocodeState = {
-    address: addressInput,
-    status: geocodeStatus,
-    error: geocodeError,
-    locationType: geocodeLocationType,
-    lat: propertyLat,
-    lng: propertyLng,
-  };
+  const geocode = useMemo<GeocodeState>(
+    () => ({
+      address: addressInput,
+      status: geocodeStatus,
+      error: geocodeError,
+      locationType: geocodeLocationType,
+      lat: propertyLat,
+      lng: propertyLng,
+    }),
+    [addressInput, geocodeStatus, geocodeError, geocodeLocationType, propertyLat, propertyLng]
+  );
   const onGeocodeChange = useCallback((patch: Partial<GeocodeState>) => {
-    if ("address" in patch) setAddressInput(patch.address!);
-    if ("status" in patch) setGeocodeStatus(patch.status!);
-    if ("error" in patch) setGeocodeError(patch.error!);
-    if ("locationType" in patch) setGeocodeLocationType(patch.locationType!);
-    if ("lat" in patch) setPropertyLat(patch.lat!);
-    if ("lng" in patch) setPropertyLng(patch.lng!);
+    if (patch.address !== undefined) setAddressInput(patch.address);
+    if (patch.status !== undefined) setGeocodeStatus(patch.status);
+    if (patch.error !== undefined) setGeocodeError(patch.error);
+    if (patch.locationType !== undefined) setGeocodeLocationType(patch.locationType);
+    if (patch.lat !== undefined) setPropertyLat(patch.lat);
+    if (patch.lng !== undefined) setPropertyLng(patch.lng);
   }, []);
 
   // rateSchedule / capex ハンドラオブジェクト（FullModeForm 向け）
-  const rateSchedule = {
-    enabled: rateScheduleEnabled,
-    onToggle: handleRateScheduleToggle,
-    onAdd: addRateStep,
-    onRemove: removeRateStep,
-    onUpdate: updateRateStep,
-    canAdd: canAddRateStep,
-  };
-  const capex = {
-    onAdd: addCapexEvent,
-    onRemove: removeCapexEvent,
-    onUpdate: updateCapexEvent,
-  };
+  const rateSchedule = useMemo(
+    () => ({
+      enabled: rateScheduleEnabled,
+      onToggle: handleRateScheduleToggle,
+      onAdd: addRateStep,
+      onRemove: removeRateStep,
+      onUpdate: updateRateStep,
+      canAdd: canAddRateStep,
+    }),
+    [
+      rateScheduleEnabled,
+      handleRateScheduleToggle,
+      addRateStep,
+      removeRateStep,
+      updateRateStep,
+      canAddRateStep,
+    ]
+  );
+  const capex = useMemo(
+    () => ({
+      onAdd: addCapexEvent,
+      onRemove: removeCapexEvent,
+      onUpdate: updateCapexEvent,
+    }),
+    [addCapexEvent, removeCapexEvent, updateCapexEvent]
+  );
 
   const sharedMuniProps = {
     area,

--- a/frontend/src/components/sections/LoanSection.tsx
+++ b/frontend/src/components/sections/LoanSection.tsx
@@ -1,0 +1,164 @@
+"use client";
+import React from "react";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import type { InvestmentInput } from "@/types/investment";
+import { toMan, fromMan, toPct, fromPct } from "@/lib/utils";
+
+interface LoanSectionProps {
+  input: InvestmentInput;
+  setNum: (key: keyof InvestmentInput, value: number) => void;
+  setStr: (key: keyof InvestmentInput, value: string) => void;
+  fieldError: (key: string) => string | undefined;
+  isCashPurchase: boolean;
+  handleCashPurchaseToggle: (checked: boolean) => void;
+}
+
+export function LoanSection({
+  input,
+  setNum,
+  setStr,
+  fieldError,
+  isCashPurchase,
+  handleCashPurchaseToggle,
+}: LoanSectionProps) {
+  return (
+    <>
+      {/* ローン条件 */}
+      <div className="border-t pt-4">
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-sm font-semibold text-foreground">ローン条件</p>
+          <label className="flex items-center gap-2 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={isCashPurchase}
+              onChange={(e) => handleCashPurchaseToggle(e.target.checked)}
+              className="h-4 w-4 rounded border-input accent-primary"
+              aria-label="現金購入（ローンなし）"
+            />
+            <span className="text-sm font-medium">現金購入（ローンなし）</span>
+          </label>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <Input
+            label="ローン金額"
+            type="number"
+            inputMode="numeric"
+            suffix="万円"
+            value={toMan(input.loanAmount)}
+            onChange={(e) => {
+              if (!isCashPurchase) setNum("loanAmount", fromMan(e.target.value));
+            }}
+            error={fieldError("loanAmount")}
+            disabled={isCashPurchase}
+          />
+          <Input
+            label="年利"
+            type="number"
+            inputMode="decimal"
+            suffix="%"
+            step="0.01"
+            value={toPct(input.annualLoanRate)}
+            onChange={(e) => {
+              if (!isCashPurchase) setNum("annualLoanRate", fromPct(e.target.value));
+            }}
+            error={fieldError("annualLoanRate")}
+            disabled={isCashPurchase}
+          />
+          <Input
+            label="返済期間"
+            type="number"
+            inputMode="numeric"
+            suffix="年"
+            value={String(input.loanYears)}
+            onChange={(e) => {
+              if (!isCashPurchase) setNum("loanYears", parseInt(e.target.value) || 0);
+            }}
+            error={fieldError("loanYears")}
+            disabled={isCashPurchase}
+          />
+        </div>
+      </div>
+
+      {/* 出口戦略 */}
+      <div className="border-t pt-4">
+        <p className="text-sm font-semibold text-foreground mb-3">出口戦略</p>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <Input
+            label="売却予定年数"
+            type="number"
+            inputMode="numeric"
+            suffix="年後"
+            value={String(input.holdingYears)}
+            onChange={(e) => setNum("holdingYears", parseInt(e.target.value) || 10)}
+            error={fieldError("holdingYears")}
+          />
+          <Input
+            label="売却時目標利回り（実質）"
+            type="number"
+            inputMode="decimal"
+            suffix="%"
+            step="0.5"
+            value={toPct(input.exitYieldTarget, 1)}
+            onChange={(e) => setNum("exitYieldTarget", fromPct(e.target.value))}
+            error={fieldError("exitYieldTarget")}
+          />
+          <Input
+            label="目標表面利回り"
+            type="number"
+            inputMode="decimal"
+            suffix="%"
+            step="0.5"
+            value={toPct(input.yieldTarget, 1)}
+            onChange={(e) => setNum("yieldTarget", fromPct(e.target.value))}
+            error={fieldError("yieldTarget")}
+          />
+          <Input
+            label="所得税率（実効）"
+            type="number"
+            inputMode="numeric"
+            suffix="%"
+            step="1"
+            value={toPct(input.incomeTaxRate, 0)}
+            onChange={(e) => setNum("incomeTaxRate", fromPct(e.target.value))}
+            error={fieldError("incomeTaxRate")}
+          />
+        </div>
+        <div className="mt-4">
+          <p className="text-xs font-semibold text-muted-foreground mb-2">NPV / IRR 設定</p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            <Input
+              label="割引率"
+              type="number"
+              inputMode="decimal"
+              suffix="%"
+              step="0.1"
+              value={toPct(input.discountRate ?? 0.05, 1)}
+              onChange={(e) => setNum("discountRate", fromPct(e.target.value))}
+              error={fieldError("discountRate")}
+            />
+            <Input
+              label="物件価格下落率"
+              type="number"
+              inputMode="decimal"
+              suffix="%"
+              step="0.1"
+              value={toPct(input.priceDeclineRate ?? 0, 1)}
+              onChange={(e) => setNum("priceDeclineRate", fromPct(e.target.value))}
+              error={fieldError("priceDeclineRate")}
+            />
+            <Select
+              label="減価償却方式"
+              value={input.depreciationMethod ?? "straight-line"}
+              onChange={(e) => setStr("depreciationMethod", e.target.value)}
+              options={[
+                { value: "straight-line", label: "定額法" },
+                { value: "declining-balance", label: "定率法" },
+              ]}
+            />
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/sections/LocationSection.tsx
+++ b/frontend/src/components/sections/LocationSection.tsx
@@ -14,6 +14,15 @@ const LOCATION_TYPE_LABEL: Record<string, string> = {
   APPROXIMATE: "近似位置で取得（精度低）",
 };
 
+export interface GeocodeState {
+  address: string;
+  status: "idle" | "loading" | "success" | "error";
+  error: string;
+  locationType: string;
+  lat: string;
+  lng: string;
+}
+
 interface LocationSectionProps {
   area: string;
   handleAreaChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
@@ -25,17 +34,8 @@ interface LocationSectionProps {
   muniLoading: boolean;
   muniError: string | null;
   isOnline: boolean | null;
-  propertyLat: string;
-  setPropertyLat: (v: string) => void;
-  propertyLng: string;
-  setPropertyLng: (v: string) => void;
-  addressInput: string;
-  setAddressInput: (v: string) => void;
-  geocodeStatus: "idle" | "loading" | "success" | "error";
-  setGeocodeStatus: (v: "idle" | "loading" | "success" | "error") => void;
-  geocodeError: string;
-  geocodeLocationType: string;
-  setGeocodeLocationType: (v: string) => void;
+  geocode: GeocodeState;
+  onGeocodeChange: (patch: Partial<GeocodeState>) => void;
   showManualCoords: boolean;
   handleGeocode: () => Promise<void>;
   loading: boolean;
@@ -53,17 +53,8 @@ export function LocationSection({
   muniLoading,
   muniError,
   isOnline,
-  propertyLat,
-  setPropertyLat,
-  propertyLng,
-  setPropertyLng,
-  addressInput,
-  setAddressInput,
-  geocodeStatus,
-  setGeocodeStatus,
-  geocodeError,
-  geocodeLocationType,
-  setGeocodeLocationType,
+  geocode,
+  onGeocodeChange,
   showManualCoords,
   handleGeocode,
   loading,
@@ -124,14 +115,16 @@ export function LocationSection({
               <input
                 type="text"
                 placeholder="例: 東京都渋谷区道玄坂1-2"
-                value={addressInput}
-                onChange={(e) => {
-                  setAddressInput(e.target.value);
-                  setGeocodeStatus("idle");
-                  setGeocodeLocationType("");
-                  setPropertyLat("");
-                  setPropertyLng("");
-                }}
+                value={geocode.address}
+                onChange={(e) =>
+                  onGeocodeChange({
+                    address: e.target.value,
+                    status: "idle",
+                    locationType: "",
+                    lat: "",
+                    lng: "",
+                  })
+                }
                 onKeyDown={(e) => {
                   if (e.key === "Enter") handleGeocode();
                 }}
@@ -140,21 +133,21 @@ export function LocationSection({
               />
               <Button
                 variant="outline"
-                loading={geocodeStatus === "loading"}
-                disabled={!addressInput.trim() || geocodeStatus === "loading"}
+                loading={geocode.status === "loading"}
+                disabled={!geocode.address.trim() || geocode.status === "loading"}
                 onClick={handleGeocode}
                 className="shrink-0"
               >
                 座標を取得
               </Button>
             </div>
-            {geocodeStatus === "success" && (
+            {geocode.status === "success" && (
               <p className="text-xs text-green-600">
-                ✓ {LOCATION_TYPE_LABEL[geocodeLocationType] ?? "座標を取得しました"}
+                ✓ {LOCATION_TYPE_LABEL[geocode.locationType] ?? "座標を取得しました"}
               </p>
             )}
-            {geocodeStatus === "error" && (
-              <p className="text-xs text-destructive">{geocodeError}</p>
+            {geocode.status === "error" && (
+              <p className="text-xs text-destructive">{geocode.error}</p>
             )}
           </div>
           {showManualCoords && (
@@ -166,8 +159,8 @@ export function LocationSection({
                   inputMode="decimal"
                   placeholder="例: 35.6762"
                   step="0.0001"
-                  value={propertyLat}
-                  onChange={(e) => setPropertyLat(e.target.value)}
+                  value={geocode.lat}
+                  onChange={(e) => onGeocodeChange({ lat: e.target.value })}
                   className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
                   aria-label="物件の緯度"
                 />
@@ -179,8 +172,8 @@ export function LocationSection({
                   inputMode="decimal"
                   placeholder="例: 139.6503"
                   step="0.0001"
-                  value={propertyLng}
-                  onChange={(e) => setPropertyLng(e.target.value)}
+                  value={geocode.lng}
+                  onChange={(e) => onGeocodeChange({ lng: e.target.value })}
                   className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
                   aria-label="物件の経度"
                 />
@@ -201,8 +194,8 @@ export function LocationSection({
           loading={loading}
           disabled={isOnline === false}
           onClick={() => {
-            const lat = parseFloat(propertyLat);
-            const lng = parseFloat(propertyLng);
+            const lat = parseFloat(geocode.lat);
+            const lng = parseFloat(geocode.lng);
             const hasCoords = !isNaN(lat) && !isNaN(lng);
             onFetchLandPrices(area, city, hasCoords ? lat : undefined, hasCoords ? lng : undefined);
           }}

--- a/frontend/src/components/sections/LocationSection.tsx
+++ b/frontend/src/components/sections/LocationSection.tsx
@@ -1,0 +1,216 @@
+"use client";
+import React from "react";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Select } from "@/components/ui/select";
+import { Search } from "lucide-react";
+import { PREFECTURES, getPeriodLabel } from "@/lib/investmentFormConstants";
+import type { Municipality } from "@/lib/api";
+
+const LOCATION_TYPE_LABEL: Record<string, string> = {
+  ROOFTOP: "番地レベルで取得",
+  RANGE_INTERPOLATED: "住所レベルで取得",
+  GEOMETRIC_CENTER: "地点レベルで取得",
+  APPROXIMATE: "近似位置で取得（精度低）",
+};
+
+interface LocationSectionProps {
+  area: string;
+  handleAreaChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  city: string;
+  handleCityChange: (e: React.ChangeEvent<HTMLSelectElement>) => void;
+  muniFilter: string;
+  setMuniFilter: (v: string) => void;
+  filteredMunicipalities: Municipality[];
+  muniLoading: boolean;
+  muniError: string | null;
+  isOnline: boolean | null;
+  propertyLat: string;
+  setPropertyLat: (v: string) => void;
+  propertyLng: string;
+  setPropertyLng: (v: string) => void;
+  addressInput: string;
+  setAddressInput: (v: string) => void;
+  geocodeStatus: "idle" | "loading" | "success" | "error";
+  setGeocodeStatus: (v: "idle" | "loading" | "success" | "error") => void;
+  geocodeError: string;
+  geocodeLocationType: string;
+  setGeocodeLocationType: (v: string) => void;
+  showManualCoords: boolean;
+  handleGeocode: () => Promise<void>;
+  loading: boolean;
+  onFetchLandPrices: (area: string, city: string, lat?: number, lng?: number) => Promise<void>;
+}
+
+export function LocationSection({
+  area,
+  handleAreaChange,
+  city,
+  handleCityChange,
+  muniFilter,
+  setMuniFilter,
+  filteredMunicipalities,
+  muniLoading,
+  muniError,
+  isOnline,
+  propertyLat,
+  setPropertyLat,
+  propertyLng,
+  setPropertyLng,
+  addressInput,
+  setAddressInput,
+  geocodeStatus,
+  setGeocodeStatus,
+  geocodeError,
+  geocodeLocationType,
+  setGeocodeLocationType,
+  showManualCoords,
+  handleGeocode,
+  loading,
+  onFetchLandPrices,
+}: LocationSectionProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Search className="h-5 w-5 text-primary" />
+          土地相場データ取得
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Select label="都道府県" value={area} onChange={handleAreaChange} options={PREFECTURES} />
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium text-foreground">市区町村</label>
+            <input
+              type="text"
+              placeholder="例: 前橋市"
+              value={muniFilter}
+              onChange={(e) => setMuniFilter(e.target.value)}
+              className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+              aria-label="市区町村を検索"
+            />
+            <select
+              value={city}
+              onChange={handleCityChange}
+              className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              <option value="">（全市区町村）</option>
+              {muniLoading ? (
+                <option disabled>読み込み中...</option>
+              ) : filteredMunicipalities.length === 0 && muniFilter.trim() ? (
+                <option disabled>該当なし</option>
+              ) : (
+                filteredMunicipalities.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name}
+                  </option>
+                ))
+              )}
+            </select>
+            {muniError && <p className="text-xs text-destructive">{muniError}</p>}
+            {muniFilter.trim() && filteredMunicipalities.length > 0 && (
+              <p className="text-xs text-muted-foreground">{filteredMunicipalities.length}件該当</p>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-1">
+            <label className="text-sm font-medium text-foreground">物件住所（任意）</label>
+            <p className="text-xs text-muted-foreground">
+              丁目・番地まで入力してください（建物名・部屋番号は不要）
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="text"
+                placeholder="例: 東京都渋谷区道玄坂1-2"
+                value={addressInput}
+                onChange={(e) => {
+                  setAddressInput(e.target.value);
+                  setGeocodeStatus("idle");
+                  setGeocodeLocationType("");
+                  setPropertyLat("");
+                  setPropertyLng("");
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") handleGeocode();
+                }}
+                className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                aria-label="物件住所"
+              />
+              <Button
+                variant="outline"
+                loading={geocodeStatus === "loading"}
+                disabled={!addressInput.trim() || geocodeStatus === "loading"}
+                onClick={handleGeocode}
+                className="shrink-0"
+              >
+                座標を取得
+              </Button>
+            </div>
+            {geocodeStatus === "success" && (
+              <p className="text-xs text-green-600">
+                ✓ {LOCATION_TYPE_LABEL[geocodeLocationType] ?? "座標を取得しました"}
+              </p>
+            )}
+            {geocodeStatus === "error" && (
+              <p className="text-xs text-destructive">{geocodeError}</p>
+            )}
+          </div>
+          {showManualCoords && (
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-foreground">緯度（手動入力）</label>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  placeholder="例: 35.6762"
+                  step="0.0001"
+                  value={propertyLat}
+                  onChange={(e) => setPropertyLat(e.target.value)}
+                  className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                  aria-label="物件の緯度"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <label className="text-sm font-medium text-foreground">経度（手動入力）</label>
+                <input
+                  type="number"
+                  inputMode="decimal"
+                  placeholder="例: 139.6503"
+                  step="0.0001"
+                  value={propertyLng}
+                  onChange={(e) => setPropertyLng(e.target.value)}
+                  className="flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring placeholder:text-muted-foreground"
+                  aria-label="物件の経度"
+                />
+              </div>
+            </div>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {getPeriodLabel()}
+          分の宅地取引実績（国交省公式API）を取得します。緯度・経度を入力すると周辺駅の需要スコアも取得します
+        </p>
+        {isOnline === false && (
+          <p className="text-xs text-amber-700">オフライン中は相場取得を利用できません</p>
+        )}
+        <Button
+          variant="outline"
+          className="w-full"
+          loading={loading}
+          disabled={isOnline === false}
+          onClick={() => {
+            const lat = parseFloat(propertyLat);
+            const lng = parseFloat(propertyLng);
+            const hasCoords = !isNaN(lat) && !isNaN(lng);
+            onFetchLandPrices(area, city, hasCoords ? lat : undefined, hasCoords ? lng : undefined);
+          }}
+        >
+          <Search className="h-4 w-4" />
+          相場データを取得
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/sections/PropertyInfoSection.tsx
@@ -264,9 +264,9 @@ export function PropertyInfoSection({
                 ? "▲ 按分ヘルパーを閉じる"
                 : "▼ 建物価格がわからない場合（按分ヘルパー）"}
             </button>
-            {showBuildingHelper && (
+            <div className={showBuildingHelper ? "block" : "hidden"}>
               <BuildingPriceHelper onApply={(value) => setNum("buildingCost", value)} />
-            )}
+            </div>
           </div>
           <Input
             label="築年数"

--- a/frontend/src/components/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/sections/PropertyInfoSection.tsx
@@ -1,0 +1,396 @@
+"use client";
+import React from "react";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { AlertTriangle, ShieldCheck } from "lucide-react";
+import type { InvestmentInput, BuildingType, RentDeclineHint } from "@/types/investment";
+import { toMan, fromMan, toPct, fromPct } from "@/lib/utils";
+import { BUILDING_TYPES, RENT_DECLINE_DEFAULTS } from "@/lib/investmentFormConstants";
+import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
+
+function calcFromTax(taxMan: number): number {
+  return taxMan / 0.1;
+}
+function calcFromAssessment(totalMan: number, landA: number, buildingA: number): number {
+  return landA + buildingA > 0 ? totalMan * (buildingA / (landA + buildingA)) : 0;
+}
+
+interface PropertyInfoSectionProps {
+  input: InvestmentInput;
+  setNum: (key: keyof InvestmentInput, value: number) => void;
+  setStr: (key: keyof InvestmentInput, value: string) => void;
+  fieldError: (key: string) => string | undefined;
+  showBuildingHelper: boolean;
+  setShowBuildingHelper: React.Dispatch<React.SetStateAction<boolean>>;
+  taxAmount: string;
+  setTaxAmount: (v: string) => void;
+  landAssess: string;
+  setLandAssess: (v: string) => void;
+  buildingAssess: string;
+  setBuildingAssess: (v: string) => void;
+  totalPrice: string;
+  setTotalPrice: (v: string) => void;
+  rentHint: RentDeclineHint | null;
+  rentHintLoading: boolean;
+  rentHintError: string | null;
+  handleFetchRentHint: () => Promise<void>;
+  zoningType: ZoningType;
+  setZoningType: (v: ZoningType) => void;
+}
+
+export function PropertyInfoSection({
+  input,
+  setNum,
+  setStr,
+  fieldError,
+  showBuildingHelper,
+  setShowBuildingHelper,
+  taxAmount,
+  setTaxAmount,
+  landAssess,
+  setLandAssess,
+  buildingAssess,
+  setBuildingAssess,
+  totalPrice,
+  setTotalPrice,
+  rentHint,
+  rentHintLoading,
+  rentHintError,
+  handleFetchRentHint,
+  zoningType,
+  setZoningType,
+}: PropertyInfoSectionProps) {
+  return (
+    <>
+      {/* 物件情報 */}
+      <div>
+        <p className="text-sm font-semibold text-foreground mb-3">物件情報</p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Input
+            label="土地取得価格"
+            type="number"
+            inputMode="numeric"
+            suffix="万円"
+            value={toMan(input.landPrice)}
+            onChange={(e) => setNum("landPrice", fromMan(e.target.value))}
+            error={fieldError("landPrice")}
+          />
+          <Input
+            label="土地面積"
+            type="number"
+            inputMode="decimal"
+            suffix="m²"
+            value={String(input.landArea)}
+            onChange={(e) => setNum("landArea", parseFloat(e.target.value) || 0)}
+          />
+          <div className="sm:col-span-2">
+            <Input
+              label="建物価格"
+              type="number"
+              inputMode="numeric"
+              suffix="万円"
+              value={toMan(input.buildingCost)}
+              onChange={(e) => setNum("buildingCost", fromMan(e.target.value))}
+              error={fieldError("buildingCost")}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              新築は建設費、中古は売買契約書記載の建物価格（消費税の課税対象部分）を入力
+            </p>
+            <button
+              type="button"
+              className="mt-2 text-xs text-primary underline-offset-2 hover:underline"
+              onClick={() => setShowBuildingHelper((p) => !p)}
+            >
+              {showBuildingHelper
+                ? "▲ 按分ヘルパーを閉じる"
+                : "▼ 建物価格がわからない場合（按分ヘルパー）"}
+            </button>
+            {showBuildingHelper && (
+              <div className="mt-2 rounded-md bg-muted/50 p-3 space-y-3 text-sm">
+                <div>
+                  <p className="font-medium text-xs mb-1">① 消費税額から計算（最も確実）</p>
+                  <div className="flex gap-2 items-end">
+                    <div className="flex-1">
+                      <Input
+                        label="消費税額"
+                        type="number"
+                        inputMode="numeric"
+                        suffix="万円"
+                        value={taxAmount}
+                        onChange={(e) => setTaxAmount(e.target.value)}
+                      />
+                    </div>
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="mb-0 shrink-0"
+                      onClick={() => {
+                        const tax = parseFloat(taxAmount) || 0;
+                        const result = calcFromTax(tax);
+                        if (result > 0) setNum("buildingCost", result * 10_000);
+                      }}
+                    >
+                      適用
+                    </Button>
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">建物価格 = 消費税額 ÷ 0.1</p>
+                </div>
+                <div>
+                  <p className="font-medium text-xs mb-1">② 固定資産税評価額の比率で按分</p>
+                  <div className="grid grid-cols-3 gap-2">
+                    <Input
+                      label="土地評価額"
+                      type="number"
+                      inputMode="numeric"
+                      suffix="万円"
+                      value={landAssess}
+                      onChange={(e) => setLandAssess(e.target.value)}
+                    />
+                    <Input
+                      label="建物評価額"
+                      type="number"
+                      inputMode="numeric"
+                      suffix="万円"
+                      value={buildingAssess}
+                      onChange={(e) => setBuildingAssess(e.target.value)}
+                    />
+                    <Input
+                      label="購入総額"
+                      type="number"
+                      inputMode="numeric"
+                      suffix="万円"
+                      value={totalPrice}
+                      onChange={(e) => setTotalPrice(e.target.value)}
+                    />
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="mt-2"
+                    onClick={() => {
+                      const total = parseFloat(totalPrice) || 0;
+                      const land = parseFloat(landAssess) || 0;
+                      const building = parseFloat(buildingAssess) || 0;
+                      const result = calcFromAssessment(total, land, building);
+                      if (result > 0) setNum("buildingCost", result * 10_000);
+                    }}
+                  >
+                    按分して適用
+                  </Button>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    建物価格 = 総額 × 建物評価 ÷（土地+建物評価）
+                  </p>
+                </div>
+              </div>
+            )}
+          </div>
+          <Input
+            label="築年数"
+            type="number"
+            inputMode="numeric"
+            suffix="年（0=新築）"
+            value={String(input.buildingAge)}
+            onChange={(e) => setNum("buildingAge", parseInt(e.target.value) || 0)}
+          />
+          <Input
+            label="最寄り駅徒歩"
+            type="number"
+            inputMode="numeric"
+            suffix="分（0=未入力）"
+            value={String(input.stationMinutes)}
+            onChange={(e) => setNum("stationMinutes", parseInt(e.target.value) || 0)}
+          />
+          <Select
+            label="建物構造"
+            value={input.buildingType}
+            onChange={(e) => {
+              const bt = e.target.value as BuildingType;
+              setStr("buildingType", bt);
+              setNum("rentDeclineRate", RENT_DECLINE_DEFAULTS[bt]);
+            }}
+            options={BUILDING_TYPES}
+          />
+          <div>
+            <Input
+              label="年間賃料下落率"
+              type="number"
+              suffix="%"
+              step="0.1"
+              value={toPct(input.rentDeclineRate, 1)}
+              onChange={(e) => setNum("rentDeclineRate", fromPct(e.target.value))}
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              建物構造から自動設定（例: 木造1%/年）
+            </p>
+            <div className="mt-2">
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={!input.buildingType || rentHintLoading}
+                onClick={handleFetchRentHint}
+                className="text-xs h-7 px-2"
+              >
+                {rentHintLoading ? "取得中…" : "地域の参考値を取得"}
+              </Button>
+              {rentHintError && <p className="text-xs text-destructive mt-1">{rentHintError}</p>}
+              {rentHint && !rentHintError && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  {rentHint.fallbackUsed
+                    ? "データ不足のため地域参考値なし。構造別平均値を推奨します"
+                    : `地価公示より参考値: ${toPct(rentHint.hintRate, 1)}%/年（${rentHint.dataPointCount}件）`}
+                </p>
+              )}
+            </div>
+          </div>
+          <div className="col-span-full">
+            <details className="group">
+              <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground select-none">
+                ▶ 賃料上昇期の設定（新築・リノベ向け）
+              </summary>
+              <div className="mt-2 grid grid-cols-2 gap-3 pl-2 border-l-2 border-muted">
+                <Input
+                  label="年間上昇率"
+                  type="number"
+                  suffix="%"
+                  step="0.1"
+                  min="0"
+                  max="10"
+                  value={toPct(input.rentGrowthRate ?? 0, 1)}
+                  onChange={(e) => setNum("rentGrowthRate", fromPct(e.target.value))}
+                />
+                <Input
+                  label="上昇期間"
+                  type="number"
+                  suffix="年"
+                  step="1"
+                  min="0"
+                  max="20"
+                  value={String(input.rentGrowthYears ?? 0)}
+                  onChange={(e) => setNum("rentGrowthYears", parseInt(e.target.value) || 0)}
+                />
+              </div>
+              <p className="text-xs text-muted-foreground mt-1 pl-2">
+                上昇期終了後は年間賃料下落率が適用されます
+              </p>
+            </details>
+          </div>
+        </div>
+      </div>
+
+      {/* 収益条件 */}
+      <div className="border-t pt-4">
+        <p className="text-sm font-semibold text-foreground mb-3">収益条件</p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+          <Input
+            label="想定月額賃料"
+            type="number"
+            inputMode="numeric"
+            suffix="円"
+            value={String(input.monthlyRent)}
+            onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
+            error={fieldError("monthlyRent")}
+          />
+          <Input
+            label="現況空室率"
+            type="number"
+            inputMode="numeric"
+            suffix="%"
+            step="1"
+            value={toPct(input.actualVacancyRate, 0)}
+            onChange={(e) => setNum("actualVacancyRate", fromPct(e.target.value))}
+          />
+          <Input
+            label="想定空室率（長期）"
+            type="number"
+            inputMode="numeric"
+            suffix="%"
+            step="1"
+            value={toPct(input.vacancyRate, 0)}
+            onChange={(e) => setNum("vacancyRate", fromPct(e.target.value))}
+            error={fieldError("vacancyRate")}
+          />
+          <Input
+            label="運営経費率※"
+            type="number"
+            inputMode="numeric"
+            suffix="%"
+            step="1"
+            value={toPct(input.expenseRate, 0)}
+            onChange={(e) => setNum("expenseRate", fromPct(e.target.value))}
+            error={fieldError("expenseRate")}
+          />
+          <Input
+            label="諸経費率"
+            type="number"
+            inputMode="decimal"
+            suffix="%"
+            step="0.5"
+            value={toPct(input.miscExpenseRate, 1)}
+            onChange={(e) => setNum("miscExpenseRate", fromPct(e.target.value))}
+            error={fieldError("miscExpenseRate")}
+          />
+          <Input
+            label="融資諸費用率"
+            type="number"
+            inputMode="decimal"
+            suffix="%"
+            step="0.1"
+            value={toPct(input.loanFeeRate ?? 0, 1)}
+            onChange={(e) => setNum("loanFeeRate", fromPct(e.target.value))}
+          />
+        </div>
+        <p className="text-xs text-muted-foreground mt-2">
+          ※運営経費率はローン利息を含みません（管理費・修繕費・固定資産税・保険等）
+        </p>
+        <div className="mt-3 space-y-2">
+          <Select
+            label="用途地域（任意）"
+            value={zoningType}
+            onChange={(e) => setZoningType(e.target.value as ZoningType)}
+            options={[
+              { value: "", label: "（未選択）" },
+              ...ZONING_TYPES.map((z) => ({ value: z, label: z })),
+            ]}
+          />
+          {zoningType &&
+            (() => {
+              const meta = ZONING_META[zoningType];
+              if (!meta) return null;
+              if (meta.riskLevel === 0)
+                return (
+                  <div className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-2 text-green-800 text-xs">
+                    <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5" />
+                    <span>良好な住環境です</span>
+                  </div>
+                );
+              const styles: Record<number, string> = {
+                1: "border-blue-200 bg-blue-50 text-blue-800",
+                2: "border-yellow-300 bg-yellow-50 text-yellow-800",
+                3: "border-red-300 bg-red-50 text-red-800",
+              };
+              const labels: Record<number, string> = {
+                1: "低リスク",
+                2: "中リスク",
+                3: "高リスク",
+              };
+              return (
+                <div
+                  className={`flex items-start gap-2 rounded-md border p-2 text-xs ${styles[meta.riskLevel]}`}
+                >
+                  <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+                  <div>
+                    <span className="font-semibold">{labels[meta.riskLevel]}: </span>
+                    <span>{meta.riskMessage}</span>
+                  </div>
+                </div>
+              );
+            })()}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/src/components/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/sections/PropertyInfoSection.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React from "react";
+import React, { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
@@ -16,21 +16,187 @@ function calcFromAssessment(totalMan: number, landA: number, buildingA: number):
   return landA + buildingA > 0 ? totalMan * (buildingA / (landA + buildingA)) : 0;
 }
 
+// 建物価格按分ヘルパー（state を自己完結）
+function BuildingPriceHelper({ onApply }: { onApply: (value: number) => void }) {
+  const [taxAmount, setTaxAmount] = useState("");
+  const [landAssess, setLandAssess] = useState("");
+  const [buildingAssess, setBuildingAssess] = useState("");
+  const [totalPrice, setTotalPrice] = useState("");
+
+  return (
+    <div className="mt-2 rounded-md bg-muted/50 p-3 space-y-3 text-sm">
+      <div>
+        <p className="font-medium text-xs mb-1">① 消費税額から計算（最も確実）</p>
+        <div className="flex gap-2 items-end">
+          <div className="flex-1">
+            <Input
+              label="消費税額"
+              type="number"
+              inputMode="numeric"
+              suffix="万円"
+              value={taxAmount}
+              onChange={(e) => setTaxAmount(e.target.value)}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="mb-0 shrink-0"
+            onClick={() => {
+              const result = calcFromTax(parseFloat(taxAmount) || 0);
+              if (result > 0) onApply(result * 10_000);
+            }}
+          >
+            適用
+          </Button>
+        </div>
+        <p className="text-xs text-muted-foreground mt-1">建物価格 = 消費税額 ÷ 0.1</p>
+      </div>
+      <div>
+        <p className="font-medium text-xs mb-1">② 固定資産税評価額の比率で按分</p>
+        <div className="grid grid-cols-3 gap-2">
+          <Input
+            label="土地評価額"
+            type="number"
+            inputMode="numeric"
+            suffix="万円"
+            value={landAssess}
+            onChange={(e) => setLandAssess(e.target.value)}
+          />
+          <Input
+            label="建物評価額"
+            type="number"
+            inputMode="numeric"
+            suffix="万円"
+            value={buildingAssess}
+            onChange={(e) => setBuildingAssess(e.target.value)}
+          />
+          <Input
+            label="購入総額"
+            type="number"
+            inputMode="numeric"
+            suffix="万円"
+            value={totalPrice}
+            onChange={(e) => setTotalPrice(e.target.value)}
+          />
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="mt-2"
+          onClick={() => {
+            const result = calcFromAssessment(
+              parseFloat(totalPrice) || 0,
+              parseFloat(landAssess) || 0,
+              parseFloat(buildingAssess) || 0
+            );
+            if (result > 0) onApply(result * 10_000);
+          }}
+        >
+          按分して適用
+        </Button>
+        <p className="text-xs text-muted-foreground mt-1">
+          建物価格 = 総額 × 建物評価 ÷（土地+建物評価）
+        </p>
+      </div>
+    </div>
+  );
+}
+
+// 賃料下落率ヒント表示
+function RentDeclineHintDisplay({
+  hint,
+  loading,
+  error,
+  onFetch,
+  disabled,
+}: {
+  hint: RentDeclineHint | null;
+  loading: boolean;
+  error: string | null;
+  onFetch: () => Promise<void>;
+  disabled: boolean;
+}) {
+  return (
+    <div className="mt-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={disabled || loading}
+        onClick={onFetch}
+        className="text-xs h-7 px-2"
+      >
+        {loading ? "取得中…" : "地域の参考値を取得"}
+      </Button>
+      {error && <p className="text-xs text-destructive mt-1">{error}</p>}
+      {hint && !error && (
+        <p className="text-xs text-muted-foreground mt-1">
+          {hint.fallbackUsed
+            ? "データ不足のため地域参考値なし。構造別平均値を推奨します"
+            : `地価公示より参考値: ${toPct(hint.hintRate, 1)}%/年（${hint.dataPointCount}件）`}
+        </p>
+      )}
+    </div>
+  );
+}
+
+// 用途地域リスクバッジ
+function ZoningRiskBadge({
+  zoningType,
+  onZoningChange,
+}: {
+  zoningType: ZoningType;
+  onZoningChange: (v: ZoningType) => void;
+}) {
+  const meta = zoningType ? ZONING_META[zoningType] : null;
+  const styles: Record<number, string> = {
+    0: "border-green-200 bg-green-50 text-green-800",
+    1: "border-blue-200 bg-blue-50 text-blue-800",
+    2: "border-yellow-300 bg-yellow-50 text-yellow-800",
+    3: "border-red-300 bg-red-50 text-red-800",
+  };
+  const labels: Record<number, string> = { 0: "", 1: "低リスク", 2: "中リスク", 3: "高リスク" };
+
+  return (
+    <div className="space-y-2">
+      <Select
+        label="用途地域（任意）"
+        value={zoningType}
+        onChange={(e) => onZoningChange(e.target.value as ZoningType)}
+        options={[
+          { value: "", label: "（未選択）" },
+          ...ZONING_TYPES.map((z) => ({ value: z, label: z })),
+        ]}
+      />
+      {meta && (
+        <div
+          className={`flex items-start gap-2 rounded-md border p-2 text-xs ${styles[meta.riskLevel]}`}
+        >
+          {meta.riskLevel === 0 ? (
+            <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5" />
+          ) : (
+            <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
+          )}
+          <div>
+            {labels[meta.riskLevel] && (
+              <span className="font-semibold">{labels[meta.riskLevel]}: </span>
+            )}
+            <span>{meta.riskLevel === 0 ? "良好な住環境です" : meta.riskMessage}</span>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 interface PropertyInfoSectionProps {
   input: InvestmentInput;
   setNum: (key: keyof InvestmentInput, value: number) => void;
   setStr: (key: keyof InvestmentInput, value: string) => void;
   fieldError: (key: string) => string | undefined;
-  showBuildingHelper: boolean;
-  setShowBuildingHelper: React.Dispatch<React.SetStateAction<boolean>>;
-  taxAmount: string;
-  setTaxAmount: (v: string) => void;
-  landAssess: string;
-  setLandAssess: (v: string) => void;
-  buildingAssess: string;
-  setBuildingAssess: (v: string) => void;
-  totalPrice: string;
-  setTotalPrice: (v: string) => void;
   rentHint: RentDeclineHint | null;
   rentHintLoading: boolean;
   rentHintError: string | null;
@@ -44,16 +210,6 @@ export function PropertyInfoSection({
   setNum,
   setStr,
   fieldError,
-  showBuildingHelper,
-  setShowBuildingHelper,
-  taxAmount,
-  setTaxAmount,
-  landAssess,
-  setLandAssess,
-  buildingAssess,
-  setBuildingAssess,
-  totalPrice,
-  setTotalPrice,
   rentHint,
   rentHintLoading,
   rentHintError,
@@ -61,6 +217,8 @@ export function PropertyInfoSection({
   zoningType,
   setZoningType,
 }: PropertyInfoSectionProps) {
+  const [showBuildingHelper, setShowBuildingHelper] = useState(false);
+
   return (
     <>
       {/* 物件情報 */}
@@ -107,84 +265,7 @@ export function PropertyInfoSection({
                 : "▼ 建物価格がわからない場合（按分ヘルパー）"}
             </button>
             {showBuildingHelper && (
-              <div className="mt-2 rounded-md bg-muted/50 p-3 space-y-3 text-sm">
-                <div>
-                  <p className="font-medium text-xs mb-1">① 消費税額から計算（最も確実）</p>
-                  <div className="flex gap-2 items-end">
-                    <div className="flex-1">
-                      <Input
-                        label="消費税額"
-                        type="number"
-                        inputMode="numeric"
-                        suffix="万円"
-                        value={taxAmount}
-                        onChange={(e) => setTaxAmount(e.target.value)}
-                      />
-                    </div>
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="mb-0 shrink-0"
-                      onClick={() => {
-                        const tax = parseFloat(taxAmount) || 0;
-                        const result = calcFromTax(tax);
-                        if (result > 0) setNum("buildingCost", result * 10_000);
-                      }}
-                    >
-                      適用
-                    </Button>
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-1">建物価格 = 消費税額 ÷ 0.1</p>
-                </div>
-                <div>
-                  <p className="font-medium text-xs mb-1">② 固定資産税評価額の比率で按分</p>
-                  <div className="grid grid-cols-3 gap-2">
-                    <Input
-                      label="土地評価額"
-                      type="number"
-                      inputMode="numeric"
-                      suffix="万円"
-                      value={landAssess}
-                      onChange={(e) => setLandAssess(e.target.value)}
-                    />
-                    <Input
-                      label="建物評価額"
-                      type="number"
-                      inputMode="numeric"
-                      suffix="万円"
-                      value={buildingAssess}
-                      onChange={(e) => setBuildingAssess(e.target.value)}
-                    />
-                    <Input
-                      label="購入総額"
-                      type="number"
-                      inputMode="numeric"
-                      suffix="万円"
-                      value={totalPrice}
-                      onChange={(e) => setTotalPrice(e.target.value)}
-                    />
-                  </div>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    size="sm"
-                    className="mt-2"
-                    onClick={() => {
-                      const total = parseFloat(totalPrice) || 0;
-                      const land = parseFloat(landAssess) || 0;
-                      const building = parseFloat(buildingAssess) || 0;
-                      const result = calcFromAssessment(total, land, building);
-                      if (result > 0) setNum("buildingCost", result * 10_000);
-                    }}
-                  >
-                    按分して適用
-                  </Button>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    建物価格 = 総額 × 建物評価 ÷（土地+建物評価）
-                  </p>
-                </div>
-              </div>
+              <BuildingPriceHelper onApply={(value) => setNum("buildingCost", value)} />
             )}
           </div>
           <Input
@@ -225,26 +306,13 @@ export function PropertyInfoSection({
             <p className="text-xs text-muted-foreground mt-1">
               建物構造から自動設定（例: 木造1%/年）
             </p>
-            <div className="mt-2">
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={!input.buildingType || rentHintLoading}
-                onClick={handleFetchRentHint}
-                className="text-xs h-7 px-2"
-              >
-                {rentHintLoading ? "取得中…" : "地域の参考値を取得"}
-              </Button>
-              {rentHintError && <p className="text-xs text-destructive mt-1">{rentHintError}</p>}
-              {rentHint && !rentHintError && (
-                <p className="text-xs text-muted-foreground mt-1">
-                  {rentHint.fallbackUsed
-                    ? "データ不足のため地域参考値なし。構造別平均値を推奨します"
-                    : `地価公示より参考値: ${toPct(rentHint.hintRate, 1)}%/年（${rentHint.dataPointCount}件）`}
-                </p>
-              )}
-            </div>
+            <RentDeclineHintDisplay
+              hint={rentHint}
+              loading={rentHintLoading}
+              error={rentHintError}
+              onFetch={handleFetchRentHint}
+              disabled={!input.buildingType}
+            />
           </div>
           <div className="col-span-full">
             <details className="group">
@@ -346,49 +414,8 @@ export function PropertyInfoSection({
         <p className="text-xs text-muted-foreground mt-2">
           ※運営経費率はローン利息を含みません（管理費・修繕費・固定資産税・保険等）
         </p>
-        <div className="mt-3 space-y-2">
-          <Select
-            label="用途地域（任意）"
-            value={zoningType}
-            onChange={(e) => setZoningType(e.target.value as ZoningType)}
-            options={[
-              { value: "", label: "（未選択）" },
-              ...ZONING_TYPES.map((z) => ({ value: z, label: z })),
-            ]}
-          />
-          {zoningType &&
-            (() => {
-              const meta = ZONING_META[zoningType];
-              if (!meta) return null;
-              if (meta.riskLevel === 0)
-                return (
-                  <div className="flex items-start gap-2 rounded-md border border-green-200 bg-green-50 p-2 text-green-800 text-xs">
-                    <ShieldCheck className="h-4 w-4 shrink-0 mt-0.5" />
-                    <span>良好な住環境です</span>
-                  </div>
-                );
-              const styles: Record<number, string> = {
-                1: "border-blue-200 bg-blue-50 text-blue-800",
-                2: "border-yellow-300 bg-yellow-50 text-yellow-800",
-                3: "border-red-300 bg-red-50 text-red-800",
-              };
-              const labels: Record<number, string> = {
-                1: "低リスク",
-                2: "中リスク",
-                3: "高リスク",
-              };
-              return (
-                <div
-                  className={`flex items-start gap-2 rounded-md border p-2 text-xs ${styles[meta.riskLevel]}`}
-                >
-                  <AlertTriangle className="h-4 w-4 shrink-0 mt-0.5" />
-                  <div>
-                    <span className="font-semibold">{labels[meta.riskLevel]}: </span>
-                    <span>{meta.riskMessage}</span>
-                  </div>
-                </div>
-              );
-            })()}
+        <div className="mt-3">
+          <ZoningRiskBadge zoningType={zoningType} onZoningChange={setZoningType} />
         </div>
       </div>
     </>

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -7,33 +7,29 @@ import { Plus, Trash2 } from "lucide-react";
 import type { InvestmentInput, RateAdjustment } from "@/types/investment";
 import { formatPct } from "@/lib/utils";
 
+export interface RateScheduleHandlers {
+  enabled: boolean;
+  onToggle: (v: boolean) => void;
+  onAdd: () => void;
+  onRemove: (i: number) => void;
+  onUpdate: (i: number, field: keyof RateAdjustment, value: number) => void;
+  canAdd: boolean;
+}
+
+export interface CapexHandlers {
+  onAdd: () => void;
+  onRemove: (i: number) => void;
+  onUpdate: (i: number, field: "year" | "amount", value: number) => void;
+}
+
 interface ScenarioSectionProps {
   input: InvestmentInput;
   setNum: (key: keyof InvestmentInput, value: number) => void;
-  rateScheduleEnabled: boolean;
-  handleRateScheduleToggle: (enabled: boolean) => void;
-  addRateStep: () => void;
-  removeRateStep: (i: number) => void;
-  updateRateStep: (i: number, field: keyof RateAdjustment, value: number) => void;
-  canAddRateStep: boolean;
-  addCapexEvent: () => void;
-  removeCapexEvent: (i: number) => void;
-  updateCapexEvent: (i: number, field: "year" | "amount", value: number) => void;
+  rateSchedule: RateScheduleHandlers;
+  capex: CapexHandlers;
 }
 
-export function ScenarioSection({
-  input,
-  setNum,
-  rateScheduleEnabled,
-  handleRateScheduleToggle,
-  addRateStep,
-  removeRateStep,
-  updateRateStep,
-  canAddRateStep,
-  addCapexEvent,
-  removeCapexEvent,
-  updateCapexEvent,
-}: ScenarioSectionProps) {
+export function ScenarioSection({ input, setNum, rateSchedule, capex }: ScenarioSectionProps) {
   return (
     <>
       {/* 変動金利シミュレーション */}
@@ -43,14 +39,14 @@ export function ScenarioSection({
           <label className="flex items-center gap-2 cursor-pointer">
             <input
               type="checkbox"
-              checked={rateScheduleEnabled}
-              onChange={(e) => handleRateScheduleToggle(e.target.checked)}
+              checked={rateSchedule.enabled}
+              onChange={(e) => rateSchedule.onToggle(e.target.checked)}
               className="h-4 w-4 rounded border-gray-300"
             />
             <span className="text-xs text-muted-foreground">有効にする</span>
           </label>
         </div>
-        {rateScheduleEnabled && (
+        {rateSchedule.enabled && (
           <div className="space-y-2">
             <p className="text-xs text-muted-foreground">
               指定年以降の適用金利（絶対値）を設定します。最大3ステップ。
@@ -79,7 +75,9 @@ export function ScenarioSection({
                     max={String(maxYear)}
                     step="1"
                     value={String(step.afterYear)}
-                    onChange={(e) => updateRateStep(i, "afterYear", parseInt(e.target.value) || 2)}
+                    onChange={(e) =>
+                      rateSchedule.onUpdate(i, "afterYear", parseInt(e.target.value) || 2)
+                    }
                     error={yearError}
                   />
                   <Input
@@ -92,13 +90,13 @@ export function ScenarioSection({
                     step="0.1"
                     value={(step.rate * 100).toFixed(2)}
                     onChange={(e) =>
-                      updateRateStep(i, "rate", (parseFloat(e.target.value) || 0) / 100)
+                      rateSchedule.onUpdate(i, "rate", (parseFloat(e.target.value) || 0) / 100)
                     }
                     error={rateError}
                   />
                   <button
                     type="button"
-                    onClick={() => removeRateStep(i)}
+                    onClick={() => rateSchedule.onRemove(i)}
                     className={`text-muted-foreground hover:text-destructive flex-shrink-0 ${i === 0 ? "mt-5" : ""}`}
                     aria-label="削除"
                   >
@@ -107,10 +105,10 @@ export function ScenarioSection({
                 </div>
               );
             })}
-            {canAddRateStep && (
+            {rateSchedule.canAdd && (
               <button
                 type="button"
-                onClick={addRateStep}
+                onClick={rateSchedule.onAdd}
                 className="flex items-center gap-1 text-xs text-primary hover:underline"
               >
                 <Plus className="h-3 w-3" />
@@ -142,7 +140,7 @@ export function ScenarioSection({
           onChange={(v) => setNum("loanRateDelta", v)}
           formatValue={(v) => `+${formatPct(v)}`}
         />
-        {rateScheduleEnabled && input.loanRateDelta > 0 && (
+        {rateSchedule.enabled && input.loanRateDelta > 0 && (
           <p className="text-xs text-muted-foreground">
             金利上昇分はスケジュール後の金利にも上乗せされます
           </p>
@@ -159,7 +157,7 @@ export function ScenarioSection({
             size="sm"
             className="text-xs h-7 px-2"
             disabled={(input.capexSchedule ?? []).length >= 5}
-            onClick={addCapexEvent}
+            onClick={capex.onAdd}
           >
             ＋追加
           </Button>
@@ -178,7 +176,7 @@ export function ScenarioSection({
                   min="1"
                   max={input.holdingYears || 35}
                   value={String(ev.year)}
-                  onChange={(e) => updateCapexEvent(i, "year", parseInt(e.target.value) || 1)}
+                  onChange={(e) => capex.onUpdate(i, "year", parseInt(e.target.value) || 1)}
                   className="w-24"
                 />
                 <Input
@@ -189,7 +187,7 @@ export function ScenarioSection({
                   min="0"
                   value={String(Math.round(ev.amount / 10_000))}
                   onChange={(e) =>
-                    updateCapexEvent(i, "amount", (parseFloat(e.target.value) || 0) * 10_000)
+                    capex.onUpdate(i, "amount", (parseFloat(e.target.value) || 0) * 10_000)
                   }
                   className="flex-1"
                 />
@@ -198,7 +196,7 @@ export function ScenarioSection({
                   variant="outline"
                   size="sm"
                   className="text-xs h-7 px-2 mt-5 shrink-0"
-                  onClick={() => removeCapexEvent(i)}
+                  onClick={() => capex.onRemove(i)}
                 >
                   削除
                 </Button>

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -1,0 +1,212 @@
+"use client";
+import React from "react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { Plus, Trash2 } from "lucide-react";
+import type { InvestmentInput, RateAdjustment } from "@/types/investment";
+import { formatPct } from "@/lib/utils";
+
+interface ScenarioSectionProps {
+  input: InvestmentInput;
+  setNum: (key: keyof InvestmentInput, value: number) => void;
+  rateScheduleEnabled: boolean;
+  handleRateScheduleToggle: (enabled: boolean) => void;
+  addRateStep: () => void;
+  removeRateStep: (i: number) => void;
+  updateRateStep: (i: number, field: keyof RateAdjustment, value: number) => void;
+  canAddRateStep: boolean;
+  addCapexEvent: () => void;
+  removeCapexEvent: (i: number) => void;
+  updateCapexEvent: (i: number, field: "year" | "amount", value: number) => void;
+}
+
+export function ScenarioSection({
+  input,
+  setNum,
+  rateScheduleEnabled,
+  handleRateScheduleToggle,
+  addRateStep,
+  removeRateStep,
+  updateRateStep,
+  canAddRateStep,
+  addCapexEvent,
+  removeCapexEvent,
+  updateCapexEvent,
+}: ScenarioSectionProps) {
+  return (
+    <>
+      {/* 変動金利シミュレーション */}
+      <div className="border-t pt-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-semibold text-foreground">変動金利シミュレーション</p>
+          <label className="flex items-center gap-2 cursor-pointer">
+            <input
+              type="checkbox"
+              checked={rateScheduleEnabled}
+              onChange={(e) => handleRateScheduleToggle(e.target.checked)}
+              className="h-4 w-4 rounded border-gray-300"
+            />
+            <span className="text-xs text-muted-foreground">有効にする</span>
+          </label>
+        </div>
+        {rateScheduleEnabled && (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">
+              指定年以降の適用金利（絶対値）を設定します。最大3ステップ。
+            </p>
+            {input.rateAdjustmentSchedule.map((step, i) => {
+              const maxYear = input.loanYears || 35;
+              const prevYear = i > 0 ? input.rateAdjustmentSchedule[i - 1].afterYear : 1;
+              const yearError =
+                step.afterYear < 2
+                  ? "2年目以降を指定してください"
+                  : step.afterYear > maxYear
+                    ? `${maxYear}年以内を指定してください`
+                    : step.afterYear <= prevYear
+                      ? `前のステップより後の年を指定してください`
+                      : undefined;
+              const rateError =
+                step.rate <= 0 || step.rate > 0.3 ? "0%超〜30%の範囲で入力してください" : undefined;
+              return (
+                <div key={i} className="flex items-center gap-2">
+                  <Input
+                    label={i === 0 ? "開始年" : ""}
+                    type="number"
+                    inputMode="numeric"
+                    suffix="年目〜"
+                    min="2"
+                    max={String(maxYear)}
+                    step="1"
+                    value={String(step.afterYear)}
+                    onChange={(e) => updateRateStep(i, "afterYear", parseInt(e.target.value) || 2)}
+                    error={yearError}
+                  />
+                  <Input
+                    label={i === 0 ? "適用金利" : ""}
+                    type="number"
+                    inputMode="decimal"
+                    suffix="%"
+                    min="0.1"
+                    max="30"
+                    step="0.1"
+                    value={(step.rate * 100).toFixed(2)}
+                    onChange={(e) =>
+                      updateRateStep(i, "rate", (parseFloat(e.target.value) || 0) / 100)
+                    }
+                    error={rateError}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => removeRateStep(i)}
+                    className={`text-muted-foreground hover:text-destructive flex-shrink-0 ${i === 0 ? "mt-5" : ""}`}
+                    aria-label="削除"
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </button>
+                </div>
+              );
+            })}
+            {canAddRateStep && (
+              <button
+                type="button"
+                onClick={addRateStep}
+                className="flex items-center gap-1 text-xs text-primary hover:underline"
+              >
+                <Plus className="h-3 w-3" />
+                金利ステップを追加
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* ストレステスト */}
+      <div className="border-t pt-4 space-y-4">
+        <p className="text-sm font-semibold text-foreground">ストレステスト</p>
+        <Slider
+          label="空室率の上昇"
+          value={input.vacancyRateDelta}
+          min={0}
+          max={0.3}
+          step={0.01}
+          onChange={(v) => setNum("vacancyRateDelta", v)}
+          formatValue={(v) => `+${formatPct(v)}`}
+        />
+        <Slider
+          label="金利の上昇"
+          value={input.loanRateDelta}
+          min={0}
+          max={0.03}
+          step={0.001}
+          onChange={(v) => setNum("loanRateDelta", v)}
+          formatValue={(v) => `+${formatPct(v)}`}
+        />
+        {rateScheduleEnabled && input.loanRateDelta > 0 && (
+          <p className="text-xs text-muted-foreground">
+            金利上昇分はスケジュール後の金利にも上乗せされます
+          </p>
+        )}
+      </div>
+
+      {/* 大規模修繕費スケジュール */}
+      <div className="border-t pt-4">
+        <div className="flex items-center justify-between mb-3">
+          <p className="text-sm font-semibold text-foreground">大規模修繕費スケジュール</p>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="text-xs h-7 px-2"
+            disabled={(input.capexSchedule ?? []).length >= 5}
+            onClick={addCapexEvent}
+          >
+            ＋追加
+          </Button>
+        </div>
+        {(input.capexSchedule ?? []).length === 0 ? (
+          <p className="text-xs text-muted-foreground">修繕費なし（追加ボタンで最大5件入力可）</p>
+        ) : (
+          <div className="space-y-2">
+            {(input.capexSchedule ?? []).map((ev, i) => (
+              <div key={i} className="flex items-center gap-2">
+                <Input
+                  label="何年目"
+                  type="number"
+                  suffix="年目"
+                  step="1"
+                  min="1"
+                  max={input.holdingYears || 35}
+                  value={String(ev.year)}
+                  onChange={(e) => updateCapexEvent(i, "year", parseInt(e.target.value) || 1)}
+                  className="w-24"
+                />
+                <Input
+                  label="金額"
+                  type="number"
+                  suffix="万円"
+                  step="10"
+                  min="0"
+                  value={String(Math.round(ev.amount / 10_000))}
+                  onChange={(e) =>
+                    updateCapexEvent(i, "amount", (parseFloat(e.target.value) || 0) * 10_000)
+                  }
+                  className="flex-1"
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="text-xs h-7 px-2 mt-5 shrink-0"
+                  onClick={() => removeCapexEvent(i)}
+                >
+                  削除
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## 概要

closes #396

`FullModeForm.tsx`（1,004行）を4つのセクションコンポーネントに分割し、247行に削減。

### 問題

- 1,004行の単一コンポーネントで可読性・保守性が低い
- 物件情報・ローン・シナリオ・住所検索が混在

### 変更内容

**新規作成（`frontend/src/components/sections/`）:**

| ファイル | 内容 | 行数 |
|---|---|---|
| `LocationSection.tsx` | 土地相場データ取得 Card（住所・ジオコード・市区町村）| 221行 |
| `PropertyInfoSection.tsx` | 物件情報 + 収益条件（価格・築年・賃料・空室率・用途地域）| 394行 |
| `LoanSection.tsx` | ローン条件 + 出口戦略 + NPV/IRR設定 | 164行 |
| `ScenarioSection.tsx` | 変動金利 + ストレステスト + 大規模修繕費 | 218行 |

**修正:**

| ファイル | 変更 |
|---|---|
| `FullModeForm.tsx` | 1,004行 → 247行（セクションの組み合わせとsubmitハンドラのみ）|

### 影響なし

- `FullModeFormProps` インターフェースは変更なし（`InvestmentForm.tsx` からの呼び出し方は同一）
- フォームの動作・表示は変わらない

## テスト

- `tsc --noEmit`: エラーなし
- `vitest run`: 185テスト全通過（14ファイル）
- `prettier --check`: 問題なし