### PR TITLE
feat(frontend): Toast / Modal UI primitive を追加 (#410)

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { ServiceWorkerRegistrar } from "@/components/ServiceWorkerRegistrar";
 import "./globals.css";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { ToastProvider } from "@/components/ui/toast";
 
 export const viewport: Viewport = {
   width: "device-width",
@@ -19,7 +20,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="ja">
       <body>
         <ServiceWorkerRegistrar />
-        <TooltipProvider>{children}</TooltipProvider>
+        <ToastProvider>
+          <TooltipProvider>{children}</TooltipProvider>
+        </ToastProvider>
       </body>
     </html>
   );

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -110,7 +110,7 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
     setPendingDeleteId(null);
     toast({
       message: target ? `「${target.name}」を削除しました` : "削除しました",
-      variant: "danger",
+      variant: "warning",
     });
   }
 

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -3,6 +3,8 @@
 import React, { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Modal } from "@/components/ui/modal";
+import { useToast } from "@/components/ui/toast";
 import { Trash2, ClipboardList } from "lucide-react";
 import type { WatchlistItem, WatchlistStatus, InvestmentResult } from "@/types/investment";
 
@@ -55,6 +57,8 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
   const [nameInput, setNameInput] = useState("");
   const [memoInput, setMemoInput] = useState("");
   const [nameError, setNameError] = useState("");
+  const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const { toast } = useToast();
 
   useEffect(() => {
     saveItems(items);
@@ -92,136 +96,174 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
     setItems((prev) => [newItem, ...prev]);
     setNameInput("");
     setMemoInput("");
+    toast({ message: `「${trimmed}」をウォッチリストに追加しました`, variant: "success" });
   }
 
   function handleStatusChange(id: string, status: WatchlistStatus) {
     setItems((prev) => prev.map((item) => (item.id === id ? { ...item, status } : item)));
   }
 
-  function handleDelete(id: string) {
-    setItems((prev) => prev.filter((item) => item.id !== id));
+  function handleDeleteConfirm() {
+    if (!pendingDeleteId) return;
+    const target = items.find((item) => item.id === pendingDeleteId);
+    setItems((prev) => prev.filter((item) => item.id !== pendingDeleteId));
+    setPendingDeleteId(null);
+    toast({
+      message: target ? `「${target.name}」を削除しました` : "削除しました",
+      variant: "danger",
+    });
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
     if (e.key === "Enter") handleAdd();
   }
 
-  return (
-    <Card className="rounded-xl shadow-sm">
-      <CardHeader className="pb-2">
-        <CardTitle className="flex items-center gap-2 text-base font-semibold">
-          <ClipboardList className="h-4 w-4 text-primary" />
-          物件候補ウォッチリスト
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        {/* Add form */}
-        <div className="space-y-2">
-          <div className="flex gap-2">
-            <div className="flex-1">
-              <input
-                type="text"
-                placeholder="物件名（必須）"
-                value={nameInput}
-                onChange={(e) => {
-                  setNameInput(e.target.value);
-                  if (nameError) setNameError("");
-                }}
-                onKeyDown={handleKeyDown}
-                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                aria-label="物件名"
-              />
-              {nameError && <p className="mt-0.5 text-xs text-destructive">{nameError}</p>}
-            </div>
-            <Button type="button" size="sm" onClick={handleAdd} className="shrink-0">
-              追加
-            </Button>
-          </div>
-          <input
-            type="text"
-            placeholder="メモ（任意）"
-            value={memoInput}
-            onChange={(e) => setMemoInput(e.target.value)}
-            onKeyDown={handleKeyDown}
-            className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-            aria-label="メモ"
-          />
-        </div>
+  const pendingDeleteName = items.find((item) => item.id === pendingDeleteId)?.name ?? "";
 
-        {/* List */}
-        {items.length === 0 ? (
-          <p className="py-6 text-center text-sm text-muted-foreground">
-            まだ物件が登録されていません
-          </p>
-        ) : (
-          <ul className="divide-y divide-border">
-            {items.map((item) => (
-              <li
-                key={item.id}
-                className="flex flex-col gap-2 py-3 sm:flex-row sm:items-start sm:gap-3"
-              >
-                {/* Left: name + meta */}
-                <div className="min-w-0 flex-1 space-y-0.5">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <span className="truncate text-sm font-medium">{item.name}</span>
-                    <span
-                      className={`inline-flex shrink-0 rounded px-2 py-0.5 text-xs font-medium ${STATUS_BADGE[item.status]}`}
-                    >
-                      {item.status}
-                    </span>
-                  </div>
-                  {item.metrics && (
-                    <div className="flex flex-wrap gap-2 pt-0.5">
-                      <span className="text-xs text-blue-600">
-                        表面利回り: {(item.metrics.grossYield * 100).toFixed(1)}%
-                      </span>
-                      <span className={`text-xs ${getDscrColor(item.metrics.dscr)}`}>
-                        DSCR: {item.metrics.dscr.toFixed(2)}
-                      </span>
-                      <span className="text-xs text-purple-600">
-                        IRR:{" "}
-                        {item.metrics.irr !== null
-                          ? `${(item.metrics.irr * 100).toFixed(1)}%`
-                          : "-"}
+  return (
+    <>
+      <Card className="rounded-xl shadow-sm">
+        <CardHeader className="pb-2">
+          <CardTitle className="flex items-center gap-2 text-base font-semibold">
+            <ClipboardList className="h-4 w-4 text-primary" />
+            物件候補ウォッチリスト
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Add form */}
+          <div className="space-y-2">
+            <div className="flex gap-2">
+              <div className="flex-1">
+                <input
+                  type="text"
+                  placeholder="物件名（必須）"
+                  value={nameInput}
+                  onChange={(e) => {
+                    setNameInput(e.target.value);
+                    if (nameError) setNameError("");
+                  }}
+                  onKeyDown={handleKeyDown}
+                  className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  aria-label="物件名"
+                />
+                {nameError && <p className="mt-0.5 text-xs text-destructive">{nameError}</p>}
+              </div>
+              <Button type="button" size="sm" onClick={handleAdd} className="shrink-0">
+                追加
+              </Button>
+            </div>
+            <input
+              type="text"
+              placeholder="メモ（任意）"
+              value={memoInput}
+              onChange={(e) => setMemoInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              aria-label="メモ"
+            />
+          </div>
+
+          {/* List */}
+          {items.length === 0 ? (
+            <p className="py-6 text-center text-sm text-muted-foreground">
+              まだ物件が登録されていません
+            </p>
+          ) : (
+            <ul className="divide-y divide-border">
+              {items.map((item) => (
+                <li
+                  key={item.id}
+                  className="flex flex-col gap-2 py-3 sm:flex-row sm:items-start sm:gap-3"
+                >
+                  {/* Left: name + meta */}
+                  <div className="min-w-0 flex-1 space-y-0.5">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <span className="truncate text-sm font-medium">{item.name}</span>
+                      <span
+                        className={`inline-flex shrink-0 rounded px-2 py-0.5 text-xs font-medium ${STATUS_BADGE[item.status]}`}
+                      >
+                        {item.status}
                       </span>
                     </div>
-                  )}
-                  {item.memo && (
-                    <p className="truncate text-xs text-muted-foreground">{item.memo}</p>
-                  )}
-                  <p className="text-xs text-muted-foreground">
-                    登録日: {formatDate(item.addedAt)}
-                  </p>
-                </div>
+                    {item.metrics && (
+                      <div className="flex flex-wrap gap-2 pt-0.5">
+                        <span className="text-xs text-blue-600">
+                          表面利回り: {(item.metrics.grossYield * 100).toFixed(1)}%
+                        </span>
+                        <span className={`text-xs ${getDscrColor(item.metrics.dscr)}`}>
+                          DSCR: {item.metrics.dscr.toFixed(2)}
+                        </span>
+                        <span className="text-xs text-purple-600">
+                          IRR:{" "}
+                          {item.metrics.irr !== null
+                            ? `${(item.metrics.irr * 100).toFixed(1)}%`
+                            : "-"}
+                        </span>
+                      </div>
+                    )}
+                    {item.memo && (
+                      <p className="truncate text-xs text-muted-foreground">{item.memo}</p>
+                    )}
+                    <p className="text-xs text-muted-foreground">
+                      登録日: {formatDate(item.addedAt)}
+                    </p>
+                  </div>
 
-                {/* Right: status selector + delete */}
-                <div className="flex shrink-0 items-center gap-2">
-                  <select
-                    value={item.status}
-                    onChange={(e) => handleStatusChange(item.id, e.target.value as WatchlistStatus)}
-                    className="h-8 rounded-md border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
-                    aria-label={`${item.name} のステータスを変更`}
-                  >
-                    {STATUS_OPTIONS.map((o) => (
-                      <option key={o.value} value={o.value}>
-                        {o.label}
-                      </option>
-                    ))}
-                  </select>
-                  <button
-                    type="button"
-                    onClick={() => handleDelete(item.id)}
-                    className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
-                    aria-label={`${item.name} を削除`}
-                  >
-                    <Trash2 className="h-3.5 w-3.5" />
-                  </button>
-                </div>
-              </li>
-            ))}
-          </ul>
-        )}
-      </CardContent>
-    </Card>
+                  {/* Right: status selector + delete */}
+                  <div className="flex shrink-0 items-center gap-2">
+                    <select
+                      value={item.status}
+                      onChange={(e) =>
+                        handleStatusChange(item.id, e.target.value as WatchlistStatus)
+                      }
+                      className="h-8 rounded-md border border-input bg-background px-2 text-xs focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      aria-label={`${item.name} のステータスを変更`}
+                    >
+                      {STATUS_OPTIONS.map((o) => (
+                        <option key={o.value} value={o.value}>
+                          {o.label}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      onClick={() => setPendingDeleteId(item.id)}
+                      className="flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-destructive/10 hover:text-destructive transition-colors"
+                      aria-label={`${item.name} を削除`}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Delete confirmation modal */}
+      <Modal
+        open={pendingDeleteId !== null}
+        onClose={() => setPendingDeleteId(null)}
+        title="削除の確認"
+      >
+        <p className="text-sm text-foreground">
+          「{pendingDeleteName}」をウォッチリストから削除しますか？
+        </p>
+        <div className="mt-4 flex gap-2 justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => setPendingDeleteId(null)}
+          >
+            キャンセル
+          </Button>
+          <Button type="button" variant="destructive" size="sm" onClick={handleDeleteConfirm}>
+            削除
+          </Button>
+        </div>
+      </Modal>
+    </>
   );
 }

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  children: React.ReactNode;
+}
+
+export function Modal({ open, onClose, title, children }: ModalProps) {
+  React.useEffect(() => {
+    if (!open) return;
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={title ? "modal-title" : undefined}
+    >
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/50" onClick={onClose} aria-hidden="true" />
+
+      {/* Panel */}
+      <div
+        className={cn(
+          "relative z-10 w-full bg-background shadow-xl",
+          "rounded-t-2xl sm:rounded-xl sm:max-w-md",
+          "animate-in slide-in-from-bottom-4 sm:slide-in-from-bottom-0 sm:zoom-in-95 fade-in-0"
+        )}
+      >
+        {/* Header */}
+        {title && (
+          <div className="flex items-center justify-between border-b px-4 py-3">
+            <h2 id="modal-title" className="text-sm font-semibold text-foreground">
+              {title}
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+              aria-label="閉じる"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        )}
+
+        {/* Body */}
+        <div className="px-4 py-4">{children}</div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -4,6 +4,8 @@ import * as React from "react";
 import { X } from "lucide-react";
 import { cn } from "@/lib/utils";
 
+const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
 interface ModalProps {
   open: boolean;
   onClose: () => void;
@@ -14,33 +16,65 @@ interface ModalProps {
 export function Modal({ open, onClose, title, children }: ModalProps) {
   const titleId = React.useId();
   const panelRef = React.useRef<HTMLDivElement>(null);
+  // onClose を ref 経由で参照することで、インライン arrow の再生成による
+  // useEffect の不要な再実行を防ぐ
+  const onCloseRef = React.useRef(onClose);
+  React.useEffect(() => {
+    onCloseRef.current = onClose;
+  });
 
-  // ESC キーで閉じる
+  // ESC キー + Tab フォーカストラップ
   React.useEffect(() => {
     if (!open) return;
-    function handleKey(e: KeyboardEvent) {
-      if (e.key === "Escape") onClose();
+
+    function getFocusables() {
+      return Array.from(panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []);
     }
+
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onCloseRef.current();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const focusables = getFocusables();
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
-  }, [open, onClose]);
+  }, [open]);
 
-  // body スクロールロック
+  // body スクロールロック（複数モーダル対応: 参照カウンタで管理）
   React.useEffect(() => {
     if (!open) return;
+    const count = Number(document.body.dataset.modalCount ?? 0) + 1;
+    document.body.dataset.modalCount = String(count);
     document.body.style.overflow = "hidden";
     return () => {
-      document.body.style.overflow = "";
+      const next = Number(document.body.dataset.modalCount ?? 1) - 1;
+      document.body.dataset.modalCount = String(next);
+      if (next === 0) document.body.style.overflow = "";
     };
   }, [open]);
 
   // フォーカスを最初のフォーカス可能要素へ移動
   React.useEffect(() => {
     if (!open) return;
-    const el = panelRef.current?.querySelector<HTMLElement>(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-    el?.focus();
+    panelRef.current?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
   }, [open]);
 
   if (!open) return null;
@@ -53,7 +87,11 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
       aria-labelledby={title ? titleId : undefined}
     >
       {/* Backdrop */}
-      <div className="absolute inset-0 bg-black/50" onClick={onClose} aria-hidden="true" />
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={() => onCloseRef.current()}
+        aria-hidden="true"
+      />
 
       {/* Panel */}
       <div
@@ -72,7 +110,7 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
             </h2>
             <button
               type="button"
-              onClick={onClose}
+              onClick={() => onCloseRef.current()}
               className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
               aria-label="閉じる"
             >

--- a/frontend/src/components/ui/modal.tsx
+++ b/frontend/src/components/ui/modal.tsx
@@ -12,6 +12,10 @@ interface ModalProps {
 }
 
 export function Modal({ open, onClose, title, children }: ModalProps) {
+  const titleId = React.useId();
+  const panelRef = React.useRef<HTMLDivElement>(null);
+
+  // ESC キーで閉じる
   React.useEffect(() => {
     if (!open) return;
     function handleKey(e: KeyboardEvent) {
@@ -21,6 +25,24 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
     return () => document.removeEventListener("keydown", handleKey);
   }, [open, onClose]);
 
+  // body スクロールロック
+  React.useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  // フォーカスを最初のフォーカス可能要素へ移動
+  React.useEffect(() => {
+    if (!open) return;
+    const el = panelRef.current?.querySelector<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    el?.focus();
+  }, [open]);
+
   if (!open) return null;
 
   return (
@@ -28,13 +50,14 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center"
       role="dialog"
       aria-modal="true"
-      aria-labelledby={title ? "modal-title" : undefined}
+      aria-labelledby={title ? titleId : undefined}
     >
       {/* Backdrop */}
       <div className="absolute inset-0 bg-black/50" onClick={onClose} aria-hidden="true" />
 
       {/* Panel */}
       <div
+        ref={panelRef}
         className={cn(
           "relative z-10 w-full bg-background shadow-xl",
           "rounded-t-2xl sm:rounded-xl sm:max-w-md",
@@ -44,7 +67,7 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
         {/* Header */}
         {title && (
           <div className="flex items-center justify-between border-b px-4 py-3">
-            <h2 id="modal-title" className="text-sm font-semibold text-foreground">
+            <h2 id={titleId} className="text-sm font-semibold text-foreground">
               {title}
             </h2>
             <button

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -56,8 +56,17 @@ function ToastItem({ item, onDismiss }: { item: ToastItem; onDismiss: (id: strin
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [items, setItems] = React.useState<ToastItem[]>([]);
+  const timers = React.useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  React.useEffect(() => {
+    return () => {
+      timers.current.forEach((t) => clearTimeout(t));
+    };
+  }, []);
 
   const dismiss = React.useCallback((id: string) => {
+    clearTimeout(timers.current.get(id));
+    timers.current.delete(id);
     setItems((prev) => prev.filter((t) => t.id !== id));
   }, []);
 
@@ -68,7 +77,8 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
           ? crypto.randomUUID()
           : String(Date.now());
       setItems((prev) => [...prev, { id, message, variant }]);
-      setTimeout(() => dismiss(id), 4000);
+      const timer = setTimeout(() => dismiss(id), 4000);
+      timers.current.set(id, timer);
     },
     [dismiss]
   );

--- a/frontend/src/components/ui/toast.tsx
+++ b/frontend/src/components/ui/toast.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import * as React from "react";
+import { CheckCircle, AlertTriangle, XCircle, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+type ToastVariant = "success" | "warning" | "danger";
+
+interface ToastItem {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+}
+
+interface ToastContextValue {
+  toast: (opts: { message: string; variant: ToastVariant }) => void;
+}
+
+const ToastContext = React.createContext<ToastContextValue | null>(null);
+
+const VARIANT_STYLES: Record<ToastVariant, string> = {
+  success: "bg-[hsl(var(--success))] text-white",
+  warning: "bg-[hsl(var(--warning))] text-white",
+  danger: "bg-[hsl(var(--destructive))] text-white",
+};
+
+const VARIANT_ICONS: Record<ToastVariant, React.ReactNode> = {
+  success: <CheckCircle className="h-4 w-4 shrink-0" />,
+  warning: <AlertTriangle className="h-4 w-4 shrink-0" />,
+  danger: <XCircle className="h-4 w-4 shrink-0" />,
+};
+
+function ToastItem({ item, onDismiss }: { item: ToastItem; onDismiss: (id: string) => void }) {
+  return (
+    <div
+      role="alert"
+      className={cn(
+        "flex items-center gap-2 rounded-lg px-4 py-3 shadow-lg text-sm min-w-64 max-w-sm",
+        "animate-in slide-in-from-right-4 fade-in-0",
+        VARIANT_STYLES[item.variant]
+      )}
+    >
+      {VARIANT_ICONS[item.variant]}
+      <span className="flex-1">{item.message}</span>
+      <button
+        type="button"
+        onClick={() => onDismiss(item.id)}
+        className="ml-1 rounded opacity-70 hover:opacity-100 transition-opacity"
+        aria-label="閉じる"
+      >
+        <X className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [items, setItems] = React.useState<ToastItem[]>([]);
+
+  const dismiss = React.useCallback((id: string) => {
+    setItems((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const toast = React.useCallback(
+    ({ message, variant }: { message: string; variant: ToastVariant }) => {
+      const id =
+        typeof crypto !== "undefined" && crypto.randomUUID
+          ? crypto.randomUUID()
+          : String(Date.now());
+      setItems((prev) => [...prev, { id, message, variant }]);
+      setTimeout(() => dismiss(id), 4000);
+    },
+    [dismiss]
+  );
+
+  return (
+    <ToastContext.Provider value={{ toast }}>
+      {children}
+      <Toaster items={items} onDismiss={dismiss} />
+    </ToastContext.Provider>
+  );
+}
+
+function Toaster({ items, onDismiss }: { items: ToastItem[]; onDismiss: (id: string) => void }) {
+  if (items.length === 0) return null;
+  return (
+    <div className="fixed top-4 right-4 z-50 flex flex-col gap-2">
+      {items.map((item) => (
+        <ToastItem key={item.id} item={item} onDismiss={onDismiss} />
+      ))}
+    </div>
+  );
+}
+
+export function useToast(): ToastContextValue {
+  const ctx = React.useContext(ToastContext);
+  if (!ctx) throw new Error("useToast must be used within ToastProvider");
+  return ctx;
+}


### PR DESCRIPTION
## 概要

- `frontend/src/components/ui/toast.tsx` を新規追加（成功・警告・危険の3バリアント、4秒自動 dismiss、右上スライドイン）
- `frontend/src/components/ui/modal.tsx` を新規追加（デスクトップ: 中央、モバイル: `rounded-t-2xl` ボトムシート）
- `layout.tsx` に `ToastProvider` を追加し全ページで利用可能に
- `WatchlistPanel.tsx` を新 primitive に差し替え（追加時: success toast、削除時: 確認モーダル → danger toast）

## 変更内容

### 追加ファイル
- `components/ui/toast.tsx` — `ToastProvider`・`useToast` hook・`Toaster` を1ファイルに集約。外部ライブラリ不使用、React context のみで管理
- `components/ui/modal.tsx` — `open/onClose/title/children` の最小 props。ESC キー・backdrop クリックで閉じる

### 変更ファイル
- `app/layout.tsx` — `<ToastProvider>` でラップし `Toaster` を注入
- `components/WatchlistPanel.tsx` — 即時削除を confirm modal 経由に変更、追加・削除後にトースト通知

## 動作確認

- [ ] 物件追加 → 右上に緑の success toast、4秒後に自動消去
- [ ] 削除ボタン → 確認モーダルが開く
- [ ] モバイル幅で削除 → ボトムシート表示（`rounded-t-2xl`）
- [ ] 削除確認 → アイテム削除 + 赤の danger toast
- [ ] ESC / backdrop クリック → モーダルが閉じる
- [ ] vitest 全242件通過
- [ ] prettier / tsc エラーなし

## 関連 issue

closes #410