### PR TITLE
ci(backend): upgrade golangci-lint-action v7→v9.2.0 (Node.js 24 対応)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -38,7 +38,7 @@ jobs:
           cache-dependency-path: backend/go.sum
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa  # v7.0.1
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9.2.0
         with:
           working-directory: backend
           version: v2.11.4


### PR DESCRIPTION
## 概要

Backend CI で以下の deprecation warning が発生していたため対応する。

```
Node.js 20 actions are deprecated.
golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa (v7.0.1)
→ 2026年6月2日から Node.js 24 がデフォルト化
→ 2026年9月16日に Node.js 20 がランナーから削除
```

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| action バージョン | `v7.0.1` (`9fae48a`) | `v9.2.0` (`1e7e51e`) |
| Node.js | 20（非推奨） | 24（対応済み） |
| golangci-lint バージョン | `v2.11.4`（変更なし） | `v2.11.4`（変更なし） |

## 動作確認

- [ ] Backend CI の golangci-lint ステップで Node.js 20 deprecation warning が消えることを確認

Refs #403