### PR TITLE
ci(deploy): upgrade setup-buildx-action v3→v4.0.0 (Node.js 24 対応)

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -44,7 +44,7 @@ jobs:
         run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
       - name: Build and push Docker image
         run: |


### PR DESCRIPTION
## 概要

`deploy-backend.yml` の `docker/setup-buildx-action@v3.12.0` が Node.js 20 非推奨の warning を出しているため v4.0.0 にアップグレードする。

```
Node.js 20 actions are deprecated.
docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f (v3.12.0)
→ 2026年6月2日から Node.js 24 がデフォルト化
→ 2026年9月16日に Node.js 20 がランナーから削除
```

## 変更内容

| 項目 | 変更前 | 変更後 |
|---|---|---|
| action バージョン | `v3.12.0` (`8d2750c`) | `v4.0.0` (`4d04d5d`) |
| Node.js | 20（非推奨） | 24（対応済み） |

## 動作確認

- [ ] `deploy-backend.yml` の "Set up Docker Buildx" ステップで Node.js 20 deprecation warning が消えることを確認
- [ ] Build and push Docker image ステップが成功することを確認

Closes #427