### PR TITLE
security: CVE-2026-31431 Docker セキュリティ強化（Copy Fail 対応）

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -13,8 +13,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     CGO_ENABLED=0 GOOS=linux go build -trimpath -o server ./cmd/server
 
-# alpine:latest ではなくバージョンを固定して再現性を確保
-FROM alpine:3.21
+# CVE-2026-31431 パッチ適用済み alpine:3.22 以降を使用すること
+FROM alpine:3.22
 RUN apk --no-cache add ca-certificates tzdata
 # root実行を避けるために専用ユーザーを作成
 RUN adduser -D -u 1000 appuser

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       PORT: "8080"
       ALLOW_ORIGINS: "${ALLOW_ORIGINS:-http://localhost:3000}"
       MLIT_API_KEY: "${MLIT_API_KEY}"
+    # CVE-2026-31431: setuid 経由の権限昇格を防ぐ多層防御
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     healthcheck:
       test: ["CMD", "wget", "-qO-", "http://localhost:8080/health"]
       interval: 10s
@@ -26,6 +31,11 @@ services:
       - "3000:3000"
     environment:
       BACKEND_URL: "http://backend:8080"
+    # CVE-2026-31431: setuid 経由の権限昇格を防ぐ多層防御
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
     depends_on:
       backend:
         condition: service_healthy

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,18 +1,19 @@
 # syntax=docker/dockerfile:1
-FROM node:20-alpine AS deps
+# CVE-2026-31431 パッチ適用済み alpine3.22 以降を使用すること
+FROM node:20-alpine3.22 AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 # npmキャッシュをホストに永続化
 RUN --mount=type=cache,target=/root/.npm \
     npm ci
 
-FROM node:20-alpine AS builder
+FROM node:20-alpine3.22 AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
-FROM node:20-alpine AS runner
+FROM node:20-alpine3.22 AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 # root実行を避けるために専用ユーザーを作成


### PR DESCRIPTION
## 概要

CVE-2026-31431 "Copy Fail"（Linux カーネル権限昇格脆弱性）に対する Docker 環境のセキュリティ強化対応。  
詳細調査は #430 を参照。

## 変更内容

- `docker-compose.yml`: backend / frontend 両サービスに `no-new-privileges:true` と `cap_drop: ALL` を追加
- `backend/Dockerfile`: ランタイムイメージを `alpine:3.21` → `alpine:3.22` へ更新
- `frontend/Dockerfile`: 全ステージを `node:20-alpine` → `node:20-alpine3.22` へ更新

## 対応する脅威モデル

| 対策 | 効果 |
|------|------|
| `no-new-privileges:true` | コンテナ内で setuid バイナリを実行しても特権昇格をブロック |
| `cap_drop: ALL` | Linux ケイパビリティを全剥奪し、ホストカーネル exploit の影響範囲を縮小 |
| alpine:3.22 へ更新 | CVE パッチ済み Alpine ユーザーランドを使用 |

## 注意事項

CVE-2026-31431 の根本原因はホスト Linux カーネルにある。本 PR はコンテナ側の多層防御であり、**ホスト OS のカーネルパッチ適用（各ディストリのアップデート）が最優先の対処**となる。  
Cloud Run 側のパッチ状況は GCP Security Bulletins で別途確認すること。

## テスト

- [ ] `make docker-up` でコンテナが正常起動することを確認
- [ ] `docker inspect yield-guard-backend-1 | grep -A5 SecurityOpt` で `no-new-privileges` が設定されていることを確認
- [ ] `/health` エンドポイントが 200 を返すことを確認

Closes #430