### PR TITLE
fix(docker): .dockerignore の除外対象を拡充してビルドコンテキストを最適化

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,3 +1,9 @@
 *_test.go
 *.md
 .git
+.env*
+.github/
+docs/
+terraform/
+Makefile
+coverage/

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -2,3 +2,9 @@ node_modules
 .next
 *.md
 .git
+.env*
+coverage/
+**/*.test.ts
+**/*.spec.ts
+__tests__/
+.github/


### PR DESCRIPTION
## 概要

`backend/.dockerignore` と `frontend/.dockerignore` の除外対象が最小限であり、不要ファイルのビルドコンテキスト混入と `.env` 等の機密ファイルリスクを低減するため除外対象を拡充した。

## 変更内容

### `backend/.dockerignore`
追加:
- `.env*` — 機密情報を含む可能性のある環境変数ファイル
- `.github/` — CI 設定ファイル
- `docs/` — バックエンドコンテキスト外のドキュメント
- `terraform/` — インフラ設定
- `Makefile` — ローカル開発用タスクランナー
- `coverage/` — テストカバレッジレポート

### `frontend/.dockerignore`
追加:
- `.env*` — 機密情報を含む可能性のある環境変数ファイル
- `coverage/` — テストカバレッジレポート
- `**/*.test.ts` / `**/*.spec.ts` — テストファイル
- `__tests__/` — テストディレクトリ
- `.github/` — CI 設定ファイル

## 関連Issue

Closes #408

## テスト

- [x] 既存テストが通ること（`.dockerignore` の変更はビルド動作に影響しない）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み