### PR TITLE
fix(input): 数値入力フィールドの右寄せ・フォーカス時全選択を追加

### DIFF
--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -8,8 +8,16 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, label, suffix, error, id, ...props }, ref) => {
+  ({ className, label, suffix, error, id, onFocus, ...props }, ref) => {
     const inputId = id ?? label;
+    const isNumeric =
+      props.type === "number" || props.inputMode === "numeric" || props.inputMode === "decimal";
+
+    const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
+      if (isNumeric) e.target.select();
+      onFocus?.(e);
+    };
+
     return (
       <div className="flex flex-col gap-1">
         {label && (
@@ -21,8 +29,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <input
             id={inputId}
             ref={ref}
+            onFocus={handleFocus}
             className={cn(
               "flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+              isNumeric && "text-right",
               suffix && "pr-12",
               error && "border-destructive",
               className


### PR DESCRIPTION
## 概要

- 数値フィールドが左寄せで表示されていた問題を修正
- 初期値 `0` の状態でフォーカスしてタイプすると `0XX` のような0プリフィックス状態になっていた問題を修正

## 変更内容

`frontend/src/components/ui/input.tsx` のみ変更。

`type="number"` / `inputMode="numeric"` / `inputMode="decimal"` を検出し：
- `text-right` クラスを自動適用 → 右寄せ表示
- `onFocus` で `e.target.select()` を呼び出し → フォーカス時に全選択、タイプで即上書き可能

## 影響範囲

- `Input` UIコンポーネントを使う全数値フィールド（クイックモード・フルモード共通）
- 既存の `onFocus` prop がある場合はそのまま動作（`onFocus?.(e)` で委譲）

## テスト

- [ ] クイックモード: 物件価格・賃料フィールドが右寄せになっている
- [ ] クイックモード: `0` の状態でフォーカス→タイプで全選択されて上書きできる
- [ ] フルモード: 同様に確認
- [ ] `npm test` 全242件通過

Closes #438