### PR TITLE
fix(input): type=text に切り替えて数値フィールドのフォーカス全選択を修正

### DIFF
--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -163,7 +163,7 @@ describe("Dashboard", () => {
       "true"
     );
     // 物件価格フィールドが復元されていること
-    expect(screen.getByLabelText(/物件価格（土地＋建物の総額）/)).toHaveValue(2000);
+    expect(screen.getByLabelText(/物件価格（土地＋建物の総額）/)).toHaveValue("2000");
   });
 
   it("initialParamsでフルモードが復元される", () => {

--- a/frontend/src/components/__tests__/InvestmentForm.test.tsx
+++ b/frontend/src/components/__tests__/InvestmentForm.test.tsx
@@ -325,8 +325,8 @@ describe("InvestmentForm", () => {
       });
       renderForm("quick");
       await userEvent.click(screen.getByText(/前回の入力から開始/));
-      expect(screen.getByLabelText(/物件価格（土地＋建物の総額）/)).toHaveValue(3000);
-      expect(screen.getByLabelText(/想定月額賃料/)).toHaveValue(150000);
+      expect(screen.getByLabelText(/物件価格（土地＋建物の総額）/)).toHaveValue("3000");
+      expect(screen.getByLabelText(/想定月額賃料/)).toHaveValue("150000");
       vi.unstubAllGlobals();
     });
   });

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -8,10 +8,12 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, label, suffix, error, id, onFocus, ...props }, ref) => {
+  ({ className, label, suffix, error, id, onFocus, type, ...props }, ref) => {
     const inputId = id ?? label;
+    // select() is not supported on type="number" per spec; use type="text" so select() works
     const isNumeric =
-      props.type === "number" || props.inputMode === "numeric" || props.inputMode === "decimal";
+      type === "number" || props.inputMode === "numeric" || props.inputMode === "decimal";
+    const resolvedType = isNumeric ? "text" : type;
 
     const handleFocus = (e: React.FocusEvent<HTMLInputElement>) => {
       if (isNumeric) e.target.select();
@@ -29,6 +31,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           <input
             id={inputId}
             ref={ref}
+            type={resolvedType}
             onFocus={handleFocus}
             className={cn(
               "flex h-11 sm:h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",


### PR DESCRIPTION
## 概要

PR #439 の修正（フォーカス時全選択）が実際には動作していなかった問題を修正。

## 原因

`select()` は **`type="number"` 入力では仕様上動作しない**（MDN: `select()` is not applicable to `number` input type）。  
そのため前回の `e.target.select()` 呼び出しは no-op だった。

## 変更内容

`frontend/src/components/ui/input.tsx`

- `type="number"` を検出したとき、DOM には `type="text"` を使うよう変更
- `inputMode="numeric"/"decimal"` はそのまま渡すためモバイルの数字キーボードは維持
- スピナー（↑↓ボタン）も消え、副次的にUXが改善

```tsx
// type="number" は select() が動作しないため type="text" に変換
const resolvedType = isNumeric ? "text" : type;
```

`frontend/src/components/__tests__/Dashboard.test.tsx`  
`frontend/src/components/__tests__/InvestmentForm.test.tsx`

- `type="text"` になると `toHaveValue()` が文字列を返すため、テストの期待値を数値→文字列に修正

## テスト

- [x] `npm test` 全185件通過
- [ ] フォーカス時に既存値が全選択され、タイプで即上書きできることを目視確認
- [ ] モバイルで数字キーボードが表示されることを確認

Closes #438