### PR TITLE
fix: モバイルでURL共有ボタンが非表示になっている問題を修正

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -143,7 +143,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
             {result && lastInput && (
               <button
                 onClick={handleShare}
-                className="hidden items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium shadow-sm hover:bg-muted transition-colors lg:flex"
+                className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium shadow-sm hover:bg-muted transition-colors"
                 title="この条件をクリップボードにコピー"
               >
                 {copied ? (
@@ -151,7 +151,9 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
                 ) : (
                   <Share2 className="h-3.5 w-3.5" />
                 )}
-                {copied ? "コピーしました" : "この条件を共有"}
+                <span className="hidden sm:inline">
+                  {copied ? "コピーしました" : "この条件を共有"}
+                </span>
               </button>
             )}
             {result && lastInput && (

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -143,7 +143,8 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
             {result && lastInput && (
               <button
                 onClick={handleShare}
-                className="flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium shadow-sm hover:bg-muted transition-colors"
+                className="flex min-h-[44px] min-w-[44px] items-center gap-1.5 rounded-md border px-3 py-1.5 text-xs font-medium shadow-sm hover:bg-muted transition-colors"
+                aria-label="この条件をクリップボードにコピー"
                 title="この条件をクリップボードにコピー"
               >
                 {copied ? (

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -176,7 +176,7 @@ describe("Dashboard", () => {
     );
   });
 
-  it("シミュレーション結果表示後に「この条件を共有」ボタンが表示される", async () => {
+  it("シミュレーション結果表示後にURL共有ボタンが表示される", async () => {
     const mockResult = makeResult({ grossYield: 0.09, isAboveYieldTarget: true });
     vi.mocked(api.analyze).mockResolvedValue(mockResult);
 
@@ -186,11 +186,13 @@ describe("Dashboard", () => {
     await userEvent.click(screen.getByRole("button", { name: /シミュレーション実行/ }));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /この条件を共有/ })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /この条件をクリップボードにコピー/ })
+      ).toBeInTheDocument();
     });
   });
 
-  it("「この条件を共有」ボタンを押すとクリップボードにURLがコピーされる", async () => {
+  it("URL共有ボタンを押すとクリップボードにURLがコピーされる", async () => {
     const mockResult = makeResult({ grossYield: 0.09, isAboveYieldTarget: true });
     vi.mocked(api.analyze).mockResolvedValue(mockResult);
 
@@ -206,10 +208,12 @@ describe("Dashboard", () => {
     await userEvent.click(screen.getByRole("button", { name: /シミュレーション実行/ }));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /この条件を共有/ })).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /この条件をクリップボードにコピー/ })
+      ).toBeInTheDocument();
     });
 
-    await userEvent.click(screen.getByRole("button", { name: /この条件を共有/ }));
+    await userEvent.click(screen.getByRole("button", { name: /この条件をクリップボードにコピー/ }));
 
     expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText).toHaveBeenCalledWith(expect.any(String));


### PR DESCRIPTION
## 概要
モバイル幅（< 768px）でURL共有ボタンが `hidden ... lg:flex` クラスにより非表示になっていた問題を修正しました。共有ボタンをモバイルでも表示し、タップでURLをクリップボードにコピーできるようにしました。

## 変更内容
- `Dashboard.tsx` の共有ボタンのクラスを `hidden ... lg:flex` → `flex` に変更し、全画面幅で表示されるようにした
- ボタンラベル（「この条件を共有」/ 「コピーしました」）は小さい画面では省スペースのため `hidden sm:inline` で非表示にし、アイコンのみ表示する
- PDFダウンロードボタンは引き続き `hidden ... lg:flex` のままとし、モバイルでは非表示のまま

## 関連Issue
Closes #447

## テスト
- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [ ] コードレビュー観点での自己レビュー済み