### PR TITLE
feat(frontend): デッドクロス発生時の対策アドバイスと早期警告バッジを追加

### DIFF
--- a/frontend/src/components/DeadCrossChart.tsx
+++ b/frontend/src/components/DeadCrossChart.tsx
@@ -20,6 +20,8 @@ import { Skull, ShieldCheck } from "lucide-react";
 import { TermTooltip } from "@/components/ui/TermTooltip";
 import { useResponsiveChart } from "@/lib/useChartHeight";
 
+const DEADCROSS_EARLY_CODE = "DEADCROSS_EARLY" as const;
+
 const ADVICE_ITEMS = [
   "減価償却が大きい築浅物件への切り替え",
   "法定耐用年数前の売却（デッドクロス前の出口）",
@@ -32,10 +34,14 @@ interface AdviceGuideProps {
 }
 
 function DeadCrossAdviceGuide({ deadCrossYear, criticalErrors }: AdviceGuideProps) {
-  const isEarlyWarning = criticalErrors.some((e) => e.code === "DEADCROSS_EARLY");
+  const isEarlyWarning = criticalErrors.some((e) => e.code === DEADCROSS_EARLY_CODE);
 
   return (
-    <div className="mt-4 rounded-md border border-orange-200 bg-orange-50 p-4">
+    <div
+      role="note"
+      aria-label="デッドクロス対策ガイド"
+      className="mt-4 rounded-md border border-orange-200 bg-orange-50 p-4"
+    >
       <div className="flex items-center gap-2 mb-2">
         <p className="text-sm font-semibold text-orange-900">対策ガイド</p>
         {isEarlyWarning && <Badge variant="danger">早期警告</Badge>}
@@ -44,8 +50,8 @@ function DeadCrossAdviceGuide({ deadCrossYear, criticalErrors }: AdviceGuideProp
         保有{deadCrossYear}年目から税負担が増加します。以下の対策を検討してください：
       </p>
       <ul className="space-y-1">
-        {ADVICE_ITEMS.map((item) => (
-          <li key={item} className="flex items-start gap-2 text-sm text-orange-700">
+        {ADVICE_ITEMS.map((item, i) => (
+          <li key={i} className="flex items-start gap-2 text-sm text-orange-700">
             <span className="mt-0.5 shrink-0">•</span>
             <span>{item}</span>
           </li>

--- a/frontend/src/components/DeadCrossChart.tsx
+++ b/frontend/src/components/DeadCrossChart.tsx
@@ -14,11 +14,46 @@ import {
 } from "recharts";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import type { InvestmentResult } from "@/types/investment";
+import type { CriticalError, InvestmentResult } from "@/types/investment";
 import { formatMan } from "@/lib/utils";
 import { Skull, ShieldCheck } from "lucide-react";
 import { TermTooltip } from "@/components/ui/TermTooltip";
 import { useResponsiveChart } from "@/lib/useChartHeight";
+
+const ADVICE_ITEMS = [
+  "減価償却が大きい築浅物件への切り替え",
+  "法定耐用年数前の売却（デッドクロス前の出口）",
+  "法人化による損益通算",
+] as const;
+
+interface AdviceGuideProps {
+  deadCrossYear: number;
+  criticalErrors: CriticalError[];
+}
+
+function DeadCrossAdviceGuide({ deadCrossYear, criticalErrors }: AdviceGuideProps) {
+  const isEarlyWarning = criticalErrors.some((e) => e.code === "DEADCROSS_EARLY");
+
+  return (
+    <div className="mt-4 rounded-md border border-orange-200 bg-orange-50 p-4">
+      <div className="flex items-center gap-2 mb-2">
+        <p className="text-sm font-semibold text-orange-900">対策ガイド</p>
+        {isEarlyWarning && <Badge variant="danger">早期警告</Badge>}
+      </div>
+      <p className="text-sm text-orange-800 mb-3">
+        保有{deadCrossYear}年目から税負担が増加します。以下の対策を検討してください：
+      </p>
+      <ul className="space-y-1">
+        {ADVICE_ITEMS.map((item) => (
+          <li key={item} className="flex items-start gap-2 text-sm text-orange-700">
+            <span className="mt-0.5 shrink-0">•</span>
+            <span>{item}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
 
 interface Props {
   result: InvestmentResult;
@@ -144,6 +179,13 @@ function DeadCrossChart({ result }: Props) {
               </strong>
             </p>
           </div>
+        )}
+
+        {hasDeadCross && (
+          <DeadCrossAdviceGuide
+            deadCrossYear={deadCrossYear}
+            criticalErrors={result.criticalErrors}
+          />
         )}
       </CardContent>
     </Card>

--- a/frontend/src/components/__tests__/DeadCrossAdviceGuide.test.tsx
+++ b/frontend/src/components/__tests__/DeadCrossAdviceGuide.test.tsx
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DeadCrossChart from "@/components/DeadCrossChart";
+import { makeResult, makeYearlyResult } from "./helpers";
+import type { CriticalError } from "@/types/investment";
+
+const deadCrossYear = 8;
+
+function makeDeadCrossResult(criticalErrors: CriticalError[] = []) {
+  const yearlyResults = Array.from({ length: 35 }, (_, i) =>
+    makeYearlyResult(i + 1, {
+      isInDeadCrossZone: i + 1 >= deadCrossYear,
+      annualPrincipal: i + 1 >= deadCrossYear ? 700_000 : 500_000,
+      annualDepreciation: i + 1 >= deadCrossYear ? 400_000 : 600_000,
+    })
+  );
+  return makeResult({ deadCrossYear, yearlyResults, criticalErrors });
+}
+
+describe("DeadCrossAdviceGuide", () => {
+  it("criticalErrors に DEADCROSS_EARLY が含まれるとき「早期警告」バッジを表示する", () => {
+    const errors: CriticalError[] = [
+      { code: "DEADCROSS_EARLY", status: "WARNING", message: "10年以内にデッドクロスが発生します" },
+    ];
+    render(<DeadCrossChart result={makeDeadCrossResult(errors)} />);
+    expect(screen.getByText("早期警告")).toBeInTheDocument();
+  });
+
+  it("criticalErrors に DEADCROSS_EARLY が含まれないとき「早期警告」バッジを表示しない", () => {
+    render(<DeadCrossChart result={makeDeadCrossResult([])} />);
+    expect(screen.queryByText("早期警告")).not.toBeInTheDocument();
+  });
+
+  it("3つのアドバイス項目がすべてレンダリングされる", () => {
+    render(<DeadCrossChart result={makeDeadCrossResult()} />);
+    expect(screen.getByText("減価償却が大きい築浅物件への切り替え")).toBeInTheDocument();
+    expect(screen.getByText("法定耐用年数前の売却（デッドクロス前の出口）")).toBeInTheDocument();
+    expect(screen.getByText("法人化による損益通算")).toBeInTheDocument();
+  });
+
+  it("deadCrossYear の数値がテキストに含まれる", () => {
+    render(<DeadCrossChart result={makeDeadCrossResult()} />);
+    expect(screen.getByText(/保有8年目から税負担が増加します/)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## 概要

デッドクロス検出時に「対策ガイド」コンポーネントを `DeadCrossChart` チャートの下部に表示する機能を追加しました。デッドクロスが10年以内に発生する場合（`DEADCROSS_EARLY`）は赤バッジ「早期警告」を強調表示します。デッドクロスなしの場合は対策ガイドを非表示にします。

## 変更内容

- `DeadCrossAdviceGuide` コンポーネントを `DeadCrossChart.tsx` 内に追加
- デッドクロス発生年を含むメッセージ「保有X年目から税負担が増加します。以下の対策を検討してください：」を表示
- 静的な対策アイテムを3点表示：
  - 減価償却が大きい築浅物件への切り替え
  - 法定耐用年数前の売却（デッドクロス前の出口）
  - 法人化による損益通算
- `criticalErrors` に `code: "DEADCROSS_EARLY"` が含まれる場合、`Badge variant="danger"` で「早期警告」を表示
- デッドクロスなし（`deadCrossYear <= 0` または `> 35`）の場合は対策ガイドを非表示

## 関連Issue

Closes #445

## テスト

- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み