### PR TITLE
feat(frontend): 重大ハザード（ERROR/WARNING）の専用アラートバナーを追加

### DIFF
--- a/frontend/src/components/HazardAlertBanner.tsx
+++ b/frontend/src/components/HazardAlertBanner.tsx
@@ -10,12 +10,12 @@ const HAZARD_LABEL_MAP: Record<string, string> = {
   liquefaction: "液状化",
 };
 
-function getHazardTypeLabel(code: string): string {
+function getHazardTypeLabel(code: string): string | null {
   const lower = code.toLowerCase();
   for (const [key, label] of Object.entries(HAZARD_LABEL_MAP)) {
     if (lower.includes(key)) return label;
   }
-  return "";
+  return null;
 }
 
 interface HazardAlertBannerProps {
@@ -24,11 +24,11 @@ interface HazardAlertBannerProps {
 }
 
 export function HazardAlertBanner({ hazardRisks, externalUrbanRisks }: HazardAlertBannerProps) {
+  const base = hazardRisks ?? [];
+  const seen = new Set(base.map((h) => h.code));
   const allRisks: UrbanRisk[] = [
-    ...(hazardRisks ?? []),
-    ...(externalUrbanRisks ?? []).filter(
-      (r) => !(hazardRisks ?? []).some((h) => h.code === r.code)
-    ),
+    ...base,
+    ...(externalUrbanRisks ?? []).filter((r) => !seen.has(r.code)),
   ];
 
   const errorRisks = allRisks.filter((r) => r.level === "ERROR");
@@ -43,13 +43,12 @@ export function HazardAlertBanner({ hazardRisks, externalUrbanRisks }: HazardAle
         return (
           <div
             key={risk.code}
-            role="listitem"
             className="flex items-start gap-3 rounded-md border-2 border-red-500 bg-red-50 p-4 text-red-900"
           >
             <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-red-600" />
             <div>
               <p className="text-sm font-bold">
-                ⚠ 重大ハザード{hazardType ? `（${hazardType}）` : ""}: {risk.title}
+                ⚠ 重大ハザード{hazardType && `（${hazardType}）`}: {risk.title}
               </p>
               <p className="mt-0.5 text-sm">{risk.description}</p>
               <p className="mt-1 text-xs text-red-700">
@@ -64,13 +63,12 @@ export function HazardAlertBanner({ hazardRisks, externalUrbanRisks }: HazardAle
         return (
           <div
             key={risk.code}
-            role="listitem"
             className="flex items-start gap-3 rounded-md border-2 border-yellow-400 bg-yellow-50 p-4 text-yellow-900"
           >
             <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-yellow-600" />
             <div>
               <p className="text-sm font-bold">
-                ⚠ ハザード注意{hazardType ? `（${hazardType}）` : ""}: {risk.title}
+                ⚠ ハザード注意{hazardType && `（${hazardType}）`}: {risk.title}
               </p>
               <p className="mt-0.5 text-sm">{risk.description}</p>
             </div>

--- a/frontend/src/components/HazardAlertBanner.tsx
+++ b/frontend/src/components/HazardAlertBanner.tsx
@@ -1,0 +1,82 @@
+"use client";
+import React from "react";
+import { ShieldAlert, AlertTriangle } from "lucide-react";
+import type { UrbanRisk } from "@/types/investment";
+
+const HAZARD_LABEL_MAP: Record<string, string> = {
+  flood: "洪水",
+  tsunami: "津波",
+  landslide: "土砂",
+  liquefaction: "液状化",
+};
+
+function getHazardTypeLabel(code: string): string {
+  const lower = code.toLowerCase();
+  for (const [key, label] of Object.entries(HAZARD_LABEL_MAP)) {
+    if (lower.includes(key)) return label;
+  }
+  return "";
+}
+
+interface HazardAlertBannerProps {
+  hazardRisks: UrbanRisk[] | null | undefined;
+  externalUrbanRisks?: UrbanRisk[] | null;
+}
+
+export function HazardAlertBanner({ hazardRisks, externalUrbanRisks }: HazardAlertBannerProps) {
+  const allRisks: UrbanRisk[] = [
+    ...(hazardRisks ?? []),
+    ...(externalUrbanRisks ?? []).filter(
+      (r) => !(hazardRisks ?? []).some((h) => h.code === r.code)
+    ),
+  ];
+
+  const errorRisks = allRisks.filter((r) => r.level === "ERROR");
+  const warningRisks = allRisks.filter((r) => r.level === "WARNING");
+
+  if (errorRisks.length === 0 && warningRisks.length === 0) return null;
+
+  return (
+    <div role="alert" aria-label="ハザード警告" className="space-y-2">
+      {errorRisks.map((risk) => {
+        const hazardType = getHazardTypeLabel(risk.code);
+        return (
+          <div
+            key={risk.code}
+            role="listitem"
+            className="flex items-start gap-3 rounded-md border-2 border-red-500 bg-red-50 p-4 text-red-900"
+          >
+            <ShieldAlert className="mt-0.5 h-5 w-5 shrink-0 text-red-600" />
+            <div>
+              <p className="text-sm font-bold">
+                ⚠ 重大ハザード{hazardType ? `（${hazardType}）` : ""}: {risk.title}
+              </p>
+              <p className="mt-0.5 text-sm">{risk.description}</p>
+              <p className="mt-1 text-xs text-red-700">
+                投資スコアに関わらず、このリスクは必ず確認してください。
+              </p>
+            </div>
+          </div>
+        );
+      })}
+      {warningRisks.map((risk) => {
+        const hazardType = getHazardTypeLabel(risk.code);
+        return (
+          <div
+            key={risk.code}
+            role="listitem"
+            className="flex items-start gap-3 rounded-md border-2 border-yellow-400 bg-yellow-50 p-4 text-yellow-900"
+          >
+            <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-yellow-600" />
+            <div>
+              <p className="text-sm font-bold">
+                ⚠ ハザード注意{hazardType ? `（${hazardType}）` : ""}: {risk.title}
+              </p>
+              <p className="mt-0.5 text-sm">{risk.description}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -10,6 +10,7 @@ import { LoanComparePanel } from "@/components/LoanComparePanel";
 import RenovationPanel from "@/components/RenovationPanel";
 import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
+import { HazardAlertBanner } from "@/components/HazardAlertBanner";
 import { MonteCarloChart } from "@/components/MonteCarloChart";
 import NegotiationPanel from "@/components/NegotiationPanel";
 import WatchlistPanel from "@/components/WatchlistPanel";
@@ -169,6 +170,8 @@ export function ResultsSection({
 
       {activeTab === "simulation" && (
         <>
+          <HazardAlertBanner hazardRisks={hazardRisks} externalUrbanRisks={externalUrbanRisks} />
+
           {investmentScore && <InvestmentScoreCard score={investmentScore} />}
 
           {propertyLat !== undefined && (

--- a/frontend/src/components/__tests__/HazardAlertBanner.test.tsx
+++ b/frontend/src/components/__tests__/HazardAlertBanner.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { HazardAlertBanner } from "@/components/HazardAlertBanner";
+import type { UrbanRisk } from "@/types/investment";
+
+const errorRisk: UrbanRisk = {
+  code: "flood_major",
+  level: "ERROR",
+  title: "大規模洪水浸水区域",
+  description: "浸水深3m以上の区域です",
+};
+
+const warningRisk: UrbanRisk = {
+  code: "tsunami_low",
+  level: "WARNING",
+  title: "津波浸水想定区域",
+  description: "津波により浸水するおそれがある区域です",
+};
+
+const infoRisk: UrbanRisk = {
+  code: "info_zone",
+  level: "INFO",
+  title: "情報のみ",
+  description: "参考情報です",
+};
+
+describe("HazardAlertBanner", () => {
+  it("ERROR レベルのリスクがあるとき赤いアラートバナーとリスクタイトルを表示する", () => {
+    render(<HazardAlertBanner hazardRisks={[errorRisk]} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/大規模洪水浸水区域/)).toBeInTheDocument();
+    const alertDiv = screen
+      .getAllByText(/重大ハザード/)
+      .find((el) => el.closest(".border-red-500"));
+    expect(alertDiv).toBeTruthy();
+  });
+
+  it("WARNING レベルのリスクがあるとき黄色いアラートバナーを表示する", () => {
+    render(<HazardAlertBanner hazardRisks={[warningRisk]} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.getByText(/津波浸水想定区域/)).toBeInTheDocument();
+    const alertDiv = screen
+      .getAllByText(/ハザード注意/)
+      .find((el) => el.closest(".border-yellow-400"));
+    expect(alertDiv).toBeTruthy();
+  });
+
+  it("INFO レベルのリスクのみのとき何もレンダリングしない", () => {
+    const { container } = render(<HazardAlertBanner hazardRisks={[infoRisk]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("hazardRisks と externalUrbanRisks に同じ code があるとき1件のみ表示する（dedup）", () => {
+    const duplicate: UrbanRisk = { ...errorRisk };
+    render(<HazardAlertBanner hazardRisks={[errorRisk]} externalUrbanRisks={[duplicate]} />);
+    const titles = screen.getAllByText(/大規模洪水浸水区域/);
+    expect(titles).toHaveLength(1);
+  });
+
+  it("flood_major コードのとき「洪水」ラベルを表示する", () => {
+    render(<HazardAlertBanner hazardRisks={[errorRisk]} />);
+    expect(screen.getByText(/（洪水）/)).toBeInTheDocument();
+  });
+
+  it("tsunami_xxx コードのとき「津波」ラベルを表示する", () => {
+    render(<HazardAlertBanner hazardRisks={[warningRisk]} />);
+    expect(screen.getByText(/（津波）/)).toBeInTheDocument();
+  });
+
+  it("マッチしないコードのとき hazard type ラベルを表示しない", () => {
+    const unknownRisk: UrbanRisk = {
+      code: "unknown_risk",
+      level: "ERROR",
+      title: "未知のリスク",
+      description: "説明なし",
+    };
+    render(<HazardAlertBanner hazardRisks={[unknownRisk]} />);
+    expect(screen.queryByText(/（.*）/)).not.toBeInTheDocument();
+    expect(screen.getByText(/未知のリスク/)).toBeInTheDocument();
+  });
+
+  it("両配列が null / undefined のとき何もレンダリングしない", () => {
+    const { container } = render(
+      <HazardAlertBanner hazardRisks={null} externalUrbanRisks={null} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("外側ラッパーに role=alert が付与され、内側の div に role=listitem がない", () => {
+    render(<HazardAlertBanner hazardRisks={[errorRisk, warningRisk]} />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+    expect(screen.queryAllByRole("listitem")).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## 概要
`UrbanRisk.level` が `ERROR` または `WARNING` のリスクを、投資スコアとは独立した専用バナーとして常時表示する `HazardAlertBanner` コンポーネントを追加した。

## 変更内容
- `frontend/src/components/HazardAlertBanner.tsx` を新規作成
  - `ERROR` レベル → 赤いアラートバナー（重大ハザード）
  - `WARNING` レベル → 黄色いアラートバナー（ハザード注意）
  - ハザード種別（洪水・津波・土砂・液状化）を `code` から自動判定してラベル表示
  - 投資スコアに関わらず必ず確認すべき旨のメッセージを表示
- `frontend/src/components/ResultsSection.tsx` を修正
  - `HazardAlertBanner` を `InvestmentScoreCard` より上に配置し、高スコアでも ERROR バナーが隠れないようにした

## 関連Issue
Closes #444

## テスト
- [x] 既存テストが通ること（185 tests passed）
- [x] TypeScript 型チェック通過（`tsc --noEmit`）
- [x] Prettier フォーマット適用済み

## 確認事項
- [x] コードレビュー観点での自己レビュー済み