### PR TITLE
feat: カスタムストレステスト入力スライダーの追加 (#442)

### DIFF
--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -25,6 +25,14 @@ import { TermTooltip } from "@/components/ui/TermTooltip";
 import { MobileSummaryCard } from "@/components/MobileSummaryCard";
 import { analyze } from "@/lib/api";
 
+const CUSTOM_SCENARIO_LABEL = "カスタム" as const;
+
+export function getDscrColorClass(dscr: number): string {
+  if (dscr >= 1.2) return "text-green-600";
+  if (dscr >= 1.0) return "text-yellow-600";
+  return "text-red-600";
+}
+
 /**
  * Mobile 1×2 KPI strip showing metrics not already in MobileSummaryCard.
  * MobileSummaryCard covers yield/DSCR/dead-cross; this adds investment totals.
@@ -88,6 +96,12 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
   const [customLoading, setCustomLoading] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
   const fetchCustomScenario = useCallback(
     (loanDeltaPct: number, vacancyDeltaPct: number) => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -105,10 +119,10 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
             loanRateDelta: loanDelta,
             vacancyRateDelta: vacancyDelta,
           });
-          const custom = res.stressScenarios.find((s) => s.label === "カスタム") ?? null;
+          const custom = res.stressScenarios.find((s) => s.label === CUSTOM_SCENARIO_LABEL) ?? null;
           setCustomScenario(custom);
-        } catch {
-          // フェッチ失敗時はカスタム行を非表示のまま
+        } catch (err) {
+          console.error("[CustomStressTest] fetch failed:", err);
           setCustomScenario(null);
         } finally {
           setCustomLoading(false);
@@ -274,9 +288,7 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                   {isExpanded && (
                     <div className="grid grid-cols-2 gap-x-4 gap-y-1 border-t px-3 pb-3 pt-2 text-sm">
                       <span className="text-muted-foreground">DSCR</span>
-                      <span
-                        className={`text-right font-medium ${s.dscr >= 1.2 ? "text-green-600" : s.dscr >= 1.0 ? "text-yellow-600" : "text-red-600"}`}
-                      >
+                      <span className={`text-right font-medium ${getDscrColorClass(s.dscr)}`}>
                         {s.dscr.toFixed(2)}
                       </span>
                       <span className="text-muted-foreground">CF黒転年</span>
@@ -342,7 +354,7 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                   <div className="grid grid-cols-2 gap-x-4 gap-y-1 border-t px-3 pb-3 pt-2 text-sm">
                     <span className="text-muted-foreground">DSCR</span>
                     <span
-                      className={`text-right font-medium ${customScenario.dscr >= 1.2 ? "text-green-600" : customScenario.dscr >= 1.0 ? "text-yellow-600" : "text-red-600"}`}
+                      className={`text-right font-medium ${getDscrColorClass(customScenario.dscr)}`}
                     >
                       {customScenario.dscr.toFixed(2)}
                     </span>
@@ -409,9 +421,7 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                           ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%`
                           : "±0"}
                       </td>
-                      <td
-                        className={`py-2 text-right font-medium ${s.dscr >= 1.2 ? "text-green-600" : s.dscr >= 1.0 ? "text-yellow-600" : "text-red-600"}`}
-                      >
+                      <td className={`py-2 text-right font-medium ${getDscrColorClass(s.dscr)}`}>
                         {s.dscr.toFixed(2)}
                       </td>
                       <td className="py-2 text-right text-muted-foreground">
@@ -444,7 +454,7 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                       {customVacancyRateDelta > 0 ? `+${customVacancyRateDelta.toFixed(0)}%` : "±0"}
                     </td>
                     <td
-                      className={`py-2 text-right font-medium ${customScenario.dscr >= 1.2 ? "text-green-600" : customScenario.dscr >= 1.0 ? "text-yellow-600" : "text-red-600"}`}
+                      className={`py-2 text-right font-medium ${getDscrColorClass(customScenario.dscr)}`}
                     >
                       {customScenario.dscr.toFixed(2)}
                     </td>

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -33,6 +33,12 @@ export function getDscrColorClass(dscr: number): string {
   return "text-red-600";
 }
 
+export function getDscrBadge(dscr: number): React.ReactElement {
+  if (dscr >= 1.2) return <Badge variant="success">安全</Badge>;
+  if (dscr >= 1.0) return <Badge variant="warning">注意</Badge>;
+  return <Badge variant="danger">危険</Badge>;
+}
+
 /**
  * Mobile 1×2 KPI strip showing metrics not already in MobileSummaryCard.
  * MobileSummaryCard covers yield/DSCR/dead-cross; this adds investment totals.
@@ -336,13 +342,7 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                     カスタム <span className="text-xs text-blue-500">★</span>
                   </span>
                   <div className="flex items-center gap-2">
-                    {customScenario.dscr >= 1.2 ? (
-                      <Badge variant="success">安全</Badge>
-                    ) : customScenario.dscr >= 1.0 ? (
-                      <Badge variant="warning">注意</Badge>
-                    ) : (
-                      <Badge variant="danger">危険</Badge>
-                    )}
+                    {getDscrBadge(customScenario.dscr)}
                     {expandedScenario === stressScenarios.length ? (
                       <ChevronUp className="h-4 w-4 text-muted-foreground" />
                     ) : (
@@ -463,15 +463,7 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                         ? "なし"
                         : `${customScenario.breakEvenYear}年目`}
                     </td>
-                    <td className="py-2 text-right">
-                      {customScenario.dscr >= 1.2 ? (
-                        <Badge variant="success">安全</Badge>
-                      ) : customScenario.dscr >= 1.0 ? (
-                        <Badge variant="warning">注意</Badge>
-                      ) : (
-                        <Badge variant="danger">危険</Badge>
-                      )}
-                    </td>
+                    <td className="py-2 text-right">{getDscrBadge(customScenario.dscr)}</td>
                   </tr>
                 )}
               </tbody>

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -1,7 +1,8 @@
 "use client";
-import React, { useState } from "react";
+import React, { useState, useEffect, useRef, useCallback } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Slider } from "@/components/ui/slider";
 import type {
   InvestmentInput,
   InvestmentResult,
@@ -18,9 +19,11 @@ import {
   Users,
   ChevronDown,
   ChevronUp,
+  Loader2,
 } from "lucide-react";
 import { TermTooltip } from "@/components/ui/TermTooltip";
 import { MobileSummaryCard } from "@/components/MobileSummaryCard";
+import { analyze } from "@/lib/api";
 
 /**
  * Mobile 1×2 KPI strip showing metrics not already in MobileSummaryCard.
@@ -77,6 +80,47 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
 
   const stressScenarios: StressScenarioResult[] = result.stressScenarios ?? [];
   const [expandedScenario, setExpandedScenario] = useState<number | null>(null);
+
+  // カスタムストレステスト入力
+  const [customLoanRateDelta, setCustomLoanRateDelta] = useState(0); // 0〜3 (%)
+  const [customVacancyRateDelta, setCustomVacancyRateDelta] = useState(0); // 0〜30 (%)
+  const [customScenario, setCustomScenario] = useState<StressScenarioResult | null>(null);
+  const [customLoading, setCustomLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const fetchCustomScenario = useCallback(
+    (loanDeltaPct: number, vacancyDeltaPct: number) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      const loanDelta = loanDeltaPct / 100;
+      const vacancyDelta = vacancyDeltaPct / 100;
+      if (loanDelta === 0 && vacancyDelta === 0) {
+        setCustomScenario(null);
+        return;
+      }
+      setCustomLoading(true);
+      debounceRef.current = setTimeout(async () => {
+        try {
+          const res = await analyze({
+            ...input,
+            loanRateDelta: loanDelta,
+            vacancyRateDelta: vacancyDelta,
+          });
+          const custom = res.stressScenarios.find((s) => s.label === "カスタム") ?? null;
+          setCustomScenario(custom);
+        } catch {
+          // フェッチ失敗時はカスタム行を非表示のまま
+          setCustomScenario(null);
+        } finally {
+          setCustomLoading(false);
+        }
+      }, 400);
+    },
+    [input]
+  );
+
+  useEffect(() => {
+    fetchCustomScenario(customLoanRateDelta, customVacancyRateDelta);
+  }, [customLoanRateDelta, customVacancyRateDelta, fetchCustomScenario]);
 
   const gaugePosition = Math.min(yieldPct / maxYieldPct, 1) * 100;
   const targetPosition = 50; // 目標は常にゲージ中央
@@ -162,6 +206,35 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
           <CardTitle className="text-base">ストレステストシナリオ（銀行融資審査用）</CardTitle>
         </CardHeader>
         <CardContent>
+          {/* カスタムストレステスト入力スライダー */}
+          <div className="mb-4 rounded-lg border border-border bg-muted/30 p-4 space-y-4">
+            <p className="text-sm font-medium">カスタムシナリオ設定</p>
+            <Slider
+              label="金利オフセット"
+              value={customLoanRateDelta}
+              min={0}
+              max={3}
+              step={0.1}
+              onChange={(v) => setCustomLoanRateDelta(v)}
+              formatValue={(v) => (v === 0 ? "±0" : `+${v.toFixed(1)}%`)}
+            />
+            <Slider
+              label="空室率オフセット"
+              value={customVacancyRateDelta}
+              min={0}
+              max={30}
+              step={1}
+              onChange={(v) => setCustomVacancyRateDelta(v)}
+              formatValue={(v) => (v === 0 ? "±0" : `+${v.toFixed(0)}%`)}
+            />
+            {(customLoanRateDelta > 0 || customVacancyRateDelta > 0) && customLoading && (
+              <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                計算中…
+              </p>
+            )}
+          </div>
+
           {/* Mobile: accordion (lg:hidden) */}
           <div className="space-y-1 lg:hidden">
             {stressScenarios.map((s, idx) => {
@@ -227,6 +300,70 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                 </div>
               );
             })}
+            {/* カスタムシナリオ行（モバイル） */}
+            {customLoading && (customLoanRateDelta > 0 || customVacancyRateDelta > 0) && (
+              <div className="rounded-lg border border-blue-200 bg-blue-50">
+                <div className="flex items-center gap-2 px-3 py-3 text-sm text-muted-foreground">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  カスタム（計算中）
+                </div>
+              </div>
+            )}
+            {!customLoading && customScenario && (
+              <div className="rounded-lg border border-blue-200 bg-blue-50">
+                <button
+                  type="button"
+                  className="flex w-full items-center justify-between px-3 py-3 text-left min-h-[44px]"
+                  onClick={() =>
+                    setExpandedScenario(
+                      expandedScenario === stressScenarios.length ? null : stressScenarios.length
+                    )
+                  }
+                >
+                  <span className="text-sm font-medium text-blue-700">
+                    カスタム <span className="text-xs text-blue-500">★</span>
+                  </span>
+                  <div className="flex items-center gap-2">
+                    {customScenario.dscr >= 1.2 ? (
+                      <Badge variant="success">安全</Badge>
+                    ) : customScenario.dscr >= 1.0 ? (
+                      <Badge variant="warning">注意</Badge>
+                    ) : (
+                      <Badge variant="danger">危険</Badge>
+                    )}
+                    {expandedScenario === stressScenarios.length ? (
+                      <ChevronUp className="h-4 w-4 text-muted-foreground" />
+                    ) : (
+                      <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                    )}
+                  </div>
+                </button>
+                {expandedScenario === stressScenarios.length && (
+                  <div className="grid grid-cols-2 gap-x-4 gap-y-1 border-t px-3 pb-3 pt-2 text-sm">
+                    <span className="text-muted-foreground">DSCR</span>
+                    <span
+                      className={`text-right font-medium ${customScenario.dscr >= 1.2 ? "text-green-600" : customScenario.dscr >= 1.0 ? "text-yellow-600" : "text-red-600"}`}
+                    >
+                      {customScenario.dscr.toFixed(2)}
+                    </span>
+                    <span className="text-muted-foreground">CF黒転年</span>
+                    <span className="text-right">
+                      {customScenario.breakEvenYear === -1
+                        ? "なし"
+                        : `${customScenario.breakEvenYear}年目`}
+                    </span>
+                    <span className="text-muted-foreground">金利△</span>
+                    <span className="text-right">
+                      {customLoanRateDelta > 0 ? `+${customLoanRateDelta.toFixed(1)}%` : "±0"}
+                    </span>
+                    <span className="text-muted-foreground">空室△</span>
+                    <span className="text-right">
+                      {customVacancyRateDelta > 0 ? `+${customVacancyRateDelta.toFixed(0)}%` : "±0"}
+                    </span>
+                  </div>
+                )}
+              </div>
+            )}
           </div>
 
           {/* Desktop: horizontal table (hidden on mobile) */}
@@ -284,6 +421,49 @@ export function YieldAnalysis({ result, input, populationForecast }: Props) {
                     </tr>
                   );
                 })}
+                {/* カスタムシナリオ行（デスクトップ） */}
+                {customLoading && (customLoanRateDelta > 0 || customVacancyRateDelta > 0) && (
+                  <tr className="border-b bg-blue-50">
+                    <td className="py-2 font-medium text-blue-700" colSpan={6}>
+                      <span className="flex items-center gap-1">
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                        カスタム（計算中）
+                      </span>
+                    </td>
+                  </tr>
+                )}
+                {!customLoading && customScenario && (
+                  <tr className="border-b bg-blue-50">
+                    <td className="py-2 font-medium text-blue-700">
+                      カスタム <span className="ml-0.5 text-xs text-blue-500">★</span>
+                    </td>
+                    <td className="py-2 text-right">
+                      {customLoanRateDelta > 0 ? `+${customLoanRateDelta.toFixed(1)}%` : "±0"}
+                    </td>
+                    <td className="py-2 text-right">
+                      {customVacancyRateDelta > 0 ? `+${customVacancyRateDelta.toFixed(0)}%` : "±0"}
+                    </td>
+                    <td
+                      className={`py-2 text-right font-medium ${customScenario.dscr >= 1.2 ? "text-green-600" : customScenario.dscr >= 1.0 ? "text-yellow-600" : "text-red-600"}`}
+                    >
+                      {customScenario.dscr.toFixed(2)}
+                    </td>
+                    <td className="py-2 text-right text-muted-foreground">
+                      {customScenario.breakEvenYear === -1
+                        ? "なし"
+                        : `${customScenario.breakEvenYear}年目`}
+                    </td>
+                    <td className="py-2 text-right">
+                      {customScenario.dscr >= 1.2 ? (
+                        <Badge variant="success">安全</Badge>
+                      ) : customScenario.dscr >= 1.0 ? (
+                        <Badge variant="warning">注意</Badge>
+                      ) : (
+                        <Badge variant="danger">危険</Badge>
+                      )}
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
           </div>

--- a/frontend/src/components/__tests__/YieldAnalysisCustomScenario.test.tsx
+++ b/frontend/src/components/__tests__/YieldAnalysisCustomScenario.test.tsx
@@ -1,0 +1,180 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import { YieldAnalysis, getDscrColorClass } from "@/components/YieldAnalysis";
+import { makeInput, makeResult } from "./helpers";
+import type { StressScenarioResult } from "@/types/investment";
+
+vi.mock("@/lib/api", () => ({
+  analyze: vi.fn(),
+}));
+
+import * as api from "@/lib/api";
+
+function makeStressScenario(overrides: Partial<StressScenarioResult> = {}): StressScenarioResult {
+  return {
+    label: "カスタム",
+    dscr: 1.1,
+    breakEvenYear: 5,
+    interestRateDelta: 0.01,
+    vacancyRateDelta: 0.1,
+    totalCashFlow: 500_000,
+    isSafe: true,
+    ...overrides,
+  };
+}
+
+describe("getDscrColorClass", () => {
+  it("dscr=1.3 のとき text-green-600 を返す", () => {
+    expect(getDscrColorClass(1.3)).toBe("text-green-600");
+  });
+
+  it("dscr=1.2 のとき text-green-600 を返す（境界値）", () => {
+    expect(getDscrColorClass(1.2)).toBe("text-green-600");
+  });
+
+  it("dscr=1.1 のとき text-yellow-600 を返す", () => {
+    expect(getDscrColorClass(1.1)).toBe("text-yellow-600");
+  });
+
+  it("dscr=1.0 のとき text-yellow-600 を返す（境界値）", () => {
+    expect(getDscrColorClass(1.0)).toBe("text-yellow-600");
+  });
+
+  it("dscr=0.9 のとき text-red-600 を返す", () => {
+    expect(getDscrColorClass(0.9)).toBe("text-red-600");
+  });
+});
+
+describe("YieldAnalysis — カスタムストレステスト", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("スライダーが両方 0 のときカスタム行は表示されない", () => {
+    render(<YieldAnalysis result={makeResult()} input={makeInput()} />);
+    // Both sliders start at 0, so no custom scenario row should appear.
+    // The "カスタム（計算中）" loading row and custom result row should both be absent.
+    expect(screen.queryByText(/計算中/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/カスタム（計算中）/)).not.toBeInTheDocument();
+    expect(vi.mocked(api.analyze)).not.toHaveBeenCalled();
+  });
+
+  it("金利スライダーを変更すると debounce 後に analyze が正しい loanRateDelta で呼ばれる", async () => {
+    vi.mocked(api.analyze).mockResolvedValue(
+      makeResult({
+        stressScenarios: [makeStressScenario({ label: "カスタム", dscr: 1.15 })],
+      })
+    );
+
+    render(<YieldAnalysis result={makeResult()} input={makeInput()} />);
+
+    // The loan rate slider (金利オフセット) — value range 0-3
+    const sliders = screen.getAllByRole("slider");
+    const loanSlider = sliders[0];
+
+    act(() => {
+      fireEvent.change(loanSlider, { target: { value: "1" } });
+    });
+
+    // analyze should NOT have been called yet (debounce pending)
+    expect(vi.mocked(api.analyze)).not.toHaveBeenCalled();
+
+    // Advance timers past the 400ms debounce, flush async microtasks
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(vi.mocked(api.analyze)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(api.analyze)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loanRateDelta: 0.01,
+        vacancyRateDelta: 0,
+      })
+    );
+  });
+
+  it("空室率スライダーを変更すると debounce 後に analyze が正しい vacancyRateDelta で呼ばれる", async () => {
+    vi.mocked(api.analyze).mockResolvedValue(
+      makeResult({
+        stressScenarios: [makeStressScenario({ label: "カスタム", dscr: 0.95 })],
+      })
+    );
+
+    render(<YieldAnalysis result={makeResult()} input={makeInput()} />);
+
+    const sliders = screen.getAllByRole("slider");
+    const vacancySlider = sliders[1];
+
+    act(() => {
+      fireEvent.change(vacancySlider, { target: { value: "10" } });
+    });
+
+    expect(vi.mocked(api.analyze)).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(vi.mocked(api.analyze)).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(api.analyze)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        loanRateDelta: 0,
+        vacancyRateDelta: 0.1,
+      })
+    );
+  });
+
+  it("analyze が「カスタム」シナリオを返すとカスタム行がテーブルに表示される", async () => {
+    vi.mocked(api.analyze).mockResolvedValue(
+      makeResult({
+        stressScenarios: [makeStressScenario({ label: "カスタム", dscr: 1.25 })],
+      })
+    );
+
+    render(<YieldAnalysis result={makeResult()} input={makeInput()} />);
+
+    const sliders = screen.getAllByRole("slider");
+    act(() => {
+      fireEvent.change(sliders[0], { target: { value: "1" } });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    // Custom scenario row appears — the DSCR value should be visible
+    expect(screen.getAllByText("1.25").length).toBeGreaterThan(0);
+  });
+
+  it("フェッチ中はローディングスピナーが表示される", async () => {
+    let resolveAnalyze!: (v: ReturnType<typeof makeResult>) => void;
+    const pending = new Promise<ReturnType<typeof makeResult>>((r) => {
+      resolveAnalyze = r;
+    });
+    vi.mocked(api.analyze).mockReturnValue(pending);
+
+    render(<YieldAnalysis result={makeResult()} input={makeInput()} />);
+
+    const sliders = screen.getAllByRole("slider");
+    act(() => {
+      fireEvent.change(sliders[0], { target: { value: "2" } });
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    // Loading spinner text should appear (e.g. "カスタム（計算中）")
+    expect(screen.getAllByText(/計算中/).length).toBeGreaterThan(0);
+
+    // Resolve to clean up
+    await act(async () => {
+      resolveAnalyze(makeResult());
+    });
+  });
+});

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -44,6 +44,8 @@ export function Slider({
           step={step}
           value={value}
           onChange={(e) => onChange(Number(e.target.value))}
+          aria-label={label}
+          aria-valuetext={formatValue ? formatValue(value) : String(value)}
           className="absolute inset-0 h-2 w-full cursor-pointer opacity-0"
         />
         <div


### PR DESCRIPTION
## 概要
ストレステスト表の上部に、金利オフセットと空室率オフセットを自由に設定できるスライダーを追加しました。いずれかのスライダーを動かすと、バックエンドにリクエストを送り、結果の「カスタム」シナリオ行をテーブルに追記します。既存の固定シナリオ（金利+1%等）はそのまま維持されます。

## 変更内容
- `YieldAnalysis.tsx` にカスタムシナリオ入力UI（スライダー×2）を追加
  - 金利オフセット: 0〜+3%（0.1%刻み）
  - 空室率オフセット: 0〜+30%（1%刻み）
- スライダー変更時に400msデバウンスでバックエンドの `/api/investment/analyze` を呼び出し、`loanRateDelta`・`vacancyRateDelta` を渡す
- バックエンドが返す「カスタム」シナリオ行をモバイルアコーディオン・デスクトップテーブルの両方に青色ハイライトで追記
- 計算中はローディングスピナーを表示

## 関連Issue
Closes #442

## テスト
- [x] 既存テストが通ること（vitest 185件 全PASS）
- [x] TypeScript型チェック通過（`npm run type-check` エラーなし）
- [x] Prettier フォーマット通過（`npx prettier --write` 適用済み）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み