### PR TITLE
maintenance(infra): AR Standard スキャン廃止対応 — Trivy のみ運用を明示化

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -68,6 +68,8 @@ jobs:
           key: trivy-db-${{ runner.os }}-${{ github.run_id }}
           restore-keys: trivy-db-${{ runner.os }}-
 
+      # AR Standard scanning was deprecated on 2025-07-31 (issue #457).
+      # Vulnerability scanning relies solely on Trivy; AR Advanced scanning is intentionally omitted.
       - name: Scan Docker image for vulnerabilities
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:

--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -11,6 +11,9 @@ locals {
     "cloudtrace.googleapis.com",
     "monitoring.googleapis.com",
     "geocoding-backend.googleapis.com",
+    # AR Standard scanning was deprecated on 2025-07-31.
+    # Enabled for Container Analysis console visibility; vulnerability scanning is handled by Trivy in CI only.
+    "containeranalysis.googleapis.com",
   ])
 }
 

--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -11,8 +11,8 @@ locals {
     "cloudtrace.googleapis.com",
     "monitoring.googleapis.com",
     "geocoding-backend.googleapis.com",
-    # AR Standard scanning was deprecated on 2025-07-31.
-    # Enabled for Container Analysis console visibility; vulnerability scanning is handled by Trivy in CI only.
+    # Managed explicitly to prevent unintended disablement after AR Standard scan deprecation (2025-07-31).
+    # Vulnerability scanning is handled by Trivy in CI only; AR Advanced scanning is intentionally omitted.
     "containeranalysis.googleapis.com",
   ])
 }


### PR DESCRIPTION
## 概要

Artifact Registry の Standard 脆弱性スキャン層が 2025年7月31日に廃止済み（issue #457）。
現行の CI は Trivy（OSS）を使っており AR スキャンとは独立して動作しているため影響はないが、
terraform および CI ワークフローに意図を明示的に記録する。

## 変更内容

- `terraform/apis.tf`: `containeranalysis.googleapis.com` を `required_apis` に追加（コンソール可視化のための明示的管理）
- `.github/workflows/deploy-backend.yml`: Trivy のみ運用方針のコメントを追記（AR Advanced スキャンを意図的に使わない理由を記録）

**trivy-action バージョン**は既に最新の `v0.36.0`（2026年3月19日のタグ乗っ取り攻撃後のリリース）。SHA ピン留めにより攻撃の影響なし。変更不要と判断。

**AR Advanced スキャン（Option C）は採用しない。** Go 言語パッケージの脆弱性は Trivy がカバー済み、シークレットは Secret Manager で管理（イメージ埋め込みなし）、SBOM はプロジェクト規模に対してオーバースペック。

## 関連Issue

Closes #457

## テスト

- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] `terraform plan` で差分が意図通りであること（`containeranalysis.googleapis.com` の有効化のみ）
- [x] CRITICAL 脆弱性検出時にデプロイが停止すること（`exit-code: '1'`、`severity: CRITICAL` 設定済み）