### PR TITLE
feat: Secret Manager ボリュームマウントによるシークレット安全配信 (#464)

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 	"time"
 
@@ -15,6 +16,14 @@ import (
 	"github.com/yield-guard/backend/internal/telemetry"
 )
 
+// readSecret reads a secret from a volume-mounted file, falling back to an env var for local dev.
+func readSecret(filePath, envKey string) string {
+	if data, err := os.ReadFile(filePath); err == nil {
+		return strings.TrimSpace(string(data))
+	}
+	return os.Getenv(envKey)
+}
+
 func main() {
 	logger.Init(os.Stderr)
 
@@ -23,12 +32,14 @@ func main() {
 		port = "8080"
 	}
 
-	if os.Getenv("MLIT_API_KEY") == "" {
+	mlitAPIKey := readSecret("/secrets/mlit-api-key", "MLIT_API_KEY")
+	if mlitAPIKey == "" {
 		slog.Error("MLIT_API_KEY is not set")
 		os.Exit(1)
 	}
 
-	if os.Getenv("GIN_MODE") == "release" && os.Getenv("APP_INTERNAL_API_KEY") == "" {
+	appInternalAPIKey := readSecret("/secrets/app-internal-api-key", "APP_INTERNAL_API_KEY")
+	if os.Getenv("GIN_MODE") == "release" && appInternalAPIKey == "" {
 		slog.Error("APP_INTERNAL_API_KEY must be set in production (GIN_MODE=release)")
 		os.Exit(1)
 	}
@@ -40,10 +51,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	mlitClient := mlit.NewClient()
-	geocodeClient := api.NewGoogleGeocodeClient(os.Getenv("GOOGLE_MAPS_API_KEY"))
+	mlitClient := mlit.NewClient(mlitAPIKey)
+	geocodeClient := api.NewGoogleGeocodeClient(readSecret("/secrets/google-maps-api-key", "GOOGLE_MAPS_API_KEY"))
 	handler := api.NewHandler(mlitClient, geocodeClient)
-	router := api.NewRouter(handler)
+	router := api.NewRouter(handler, appInternalAPIKey)
 
 	srv := &http.Server{
 		Addr:    ":" + port,

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -17,9 +17,14 @@ import (
 )
 
 // readSecret reads a secret from a volume-mounted file, falling back to an env var for local dev.
+// Non-existence is silent; other errors (e.g. permission denied) are logged as warnings to aid debugging.
 func readSecret(filePath, envKey string) string {
-	if data, err := os.ReadFile(filePath); err == nil {
+	data, err := os.ReadFile(filePath)
+	if err == nil {
 		return strings.TrimSpace(string(data))
+	}
+	if !os.IsNotExist(err) {
+		slog.Warn("failed to read secret file, falling back to env", "path", filePath, "error", err)
 	}
 	return os.Getenv(envKey)
 }
@@ -51,8 +56,10 @@ func main() {
 		os.Exit(1)
 	}
 
+	googleMapsAPIKey := readSecret("/secrets/google-maps-api-key", "GOOGLE_MAPS_API_KEY")
+
 	mlitClient := mlit.NewClient(mlitAPIKey)
-	geocodeClient := api.NewGoogleGeocodeClient(readSecret("/secrets/google-maps-api-key", "GOOGLE_MAPS_API_KEY"))
+	geocodeClient := api.NewGoogleGeocodeClient(googleMapsAPIKey)
 	handler := api.NewHandler(mlitClient, geocodeClient)
 	router := api.NewRouter(handler, appInternalAPIKey)
 

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"strings"
 	"testing"
 
@@ -280,7 +281,7 @@ func (m *mockMLITClient) FetchRentStats(ctx context.Context, q mlit.LandPriceQue
 // newTestRouter はモッククライアントを使ったテスト用ルーターを返す
 func newTestRouter(client MLITClient, geocodeClient GeocodeClient) *gin.Engine {
 	h := NewHandler(client, geocodeClient)
-	return NewRouter(h)
+	return NewRouter(h, os.Getenv("APP_INTERNAL_API_KEY"))
 }
 
 var validBase = domain.InvestmentInput{

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -17,8 +17,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-func internalKeyMiddleware() gin.HandlerFunc {
-	key := os.Getenv("APP_INTERNAL_API_KEY")
+func internalKeyMiddleware(key string) gin.HandlerFunc {
 	keyBytes := []byte(key)
 	return func(c *gin.Context) {
 		if key != "" && subtle.ConstantTimeCompare([]byte(c.GetHeader("X-Internal-Key")), keyBytes) != 1 {
@@ -82,7 +81,7 @@ func recoveryMiddleware() gin.HandlerFunc {
 }
 
 // NewRouter は Gin ルーターを初期化して返す
-func NewRouter(h *Handler) *gin.Engine {
+func NewRouter(h *Handler, appInternalAPIKey string) *gin.Engine {
 	r := gin.New()
 
 	r.Use(otelgin.Middleware("yield-guard-backend"))
@@ -115,7 +114,7 @@ func NewRouter(h *Handler) *gin.Engine {
 	r.GET("/health", h.HealthCheck)
 
 	api := r.Group("/api")
-	api.Use(internalKeyMiddleware())
+	api.Use(internalKeyMiddleware(appInternalAPIKey))
 	api.Use(generalRL.middleware())
 	{
 		api.GET("/land-prices/stats", h.GetLandPrices)

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -7,7 +7,6 @@ import (
 	"math"
 	"net/http"
 	"net/url"
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -62,12 +61,11 @@ type Client struct {
 }
 
 // NewClient は新しい Client を返す。
-// 環境変数 MLIT_API_KEY からAPIキーを読み込む。
-func NewClient() *Client {
+func NewClient(apiKey string) *Client {
 	return &Client{
 		httpClient: &http.Client{Timeout: requestTimeout},
 		baseURL:    mlitBaseURL,
-		apiKey:     os.Getenv("MLIT_API_KEY"),
+		apiKey:     apiKey,
 		cache:      newCache(),
 	}
 }

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -45,34 +45,19 @@ resource "google_cloud_run_v2_service" "backend" {
         value = "release"
       }
 
-      env {
-        name = "MLIT_API_KEY"
-        value_source {
-          secret_key_ref {
-            secret  = google_secret_manager_secret.mlit_api_key.secret_id
-            version = "latest"
-          }
-        }
+      volume_mounts {
+        name       = "mlit-api-key"
+        mount_path = "/secrets"
       }
 
-      env {
-        name = "APP_INTERNAL_API_KEY"
-        value_source {
-          secret_key_ref {
-            secret  = google_secret_manager_secret.app_internal_api_key.secret_id
-            version = "latest"
-          }
-        }
+      volume_mounts {
+        name       = "app-internal-api-key"
+        mount_path = "/secrets"
       }
 
-      env {
-        name = "GOOGLE_MAPS_API_KEY"
-        value_source {
-          secret_key_ref {
-            secret  = google_secret_manager_secret.google_maps_api_key.secret_id
-            version = "latest"
-          }
-        }
+      volume_mounts {
+        name       = "google-maps-api-key"
+        mount_path = "/secrets"
       }
 
       dynamic "env" {
@@ -104,6 +89,39 @@ resource "google_cloud_run_v2_service" "backend" {
         initial_delay_seconds = 5
         period_seconds        = 5
         failure_threshold     = 10
+      }
+    }
+
+    volumes {
+      name = "mlit-api-key"
+      secret {
+        secret = google_secret_manager_secret.mlit_api_key.secret_id
+        items {
+          path    = "mlit-api-key"
+          version = "latest"
+        }
+      }
+    }
+
+    volumes {
+      name = "app-internal-api-key"
+      secret {
+        secret = google_secret_manager_secret.app_internal_api_key.secret_id
+        items {
+          path    = "app-internal-api-key"
+          version = "latest"
+        }
+      }
+    }
+
+    volumes {
+      name = "google-maps-api-key"
+      secret {
+        secret = google_secret_manager_secret.google_maps_api_key.secret_id
+        items {
+          path    = "google-maps-api-key"
+          version = "latest"
+        }
       }
     }
   }


### PR DESCRIPTION
## 概要

Cloud Run のシークレット注入を環境変数方式からボリュームマウント方式へ移行します。

## 背景・目的

環境変数は `printenv` や `/proc/self/environ` から読み取れるため、SSRF 等の脆弱性を突かれた際に露出リスクがありました。Secret Manager ボリュームマウント (2025年 GA) に移行することで、ファイルベースの安全な配信を実現します。

Close #464

## 変更内容

### インフラ (`terraform/cloud_run.tf`)
- `MLIT_API_KEY` / `APP_INTERNAL_API_KEY` / `GOOGLE_MAPS_API_KEY` の `env.value_source.secret_key_ref` ブロックを削除
- 3つの `volume_mounts` + `volumes` ブロックに置き換え（マウント先: `/secrets/{secret-name}`）

### バックエンド
- `backend/internal/mlit/client.go`: `NewClient()` が `os.Getenv` を直接呼ぶ実装を廃止し、`NewClient(apiKey string)` で受け取るよう変更
- `backend/internal/api/router.go`: `internalKeyMiddleware()` → `internalKeyMiddleware(key string)` + `NewRouter(h, appInternalAPIKey string)` に変更
- `backend/cmd/server/main.go`: `readSecret(filePath, envKey string)` ヘルパーを追加し、ファイル読み込み → env フォールバックの順でシークレットを取得

## ローカル開発への影響

ファイルが存在しない場合は従来通り環境変数にフォールバックするため、`.env` ベースのローカル開発は変更不要です。

## テスト

- `go test -race ./... -timeout 120s` → 全パス
- ローカル起動: `.env` の環境変数フォールバックで動作確認済み
- `terraform plan` で 3 env ブロック削除 + 3 `volume_mounts` + 3 `volumes` の差分のみが出ることを確認予定（IAM 変更なし）

## IAM

`roles/secretmanager.secretAccessor` は既に backend SA に付与済みのため変更不要。