### PR TITLE
ci: PR時にVercelプレビューデプロイを追加 (#467)

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -77,7 +77,8 @@ jobs:
     needs: ci
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
       pull-requests: write
@@ -105,7 +106,13 @@ jobs:
         if: github.event_name == 'pull_request'
         id: preview
         run: |
-          URL=$(vercel deploy --yes 2>/dev/null)
+          OUTPUT=$(vercel deploy --yes 2>&1)
+          echo "$OUTPUT"
+          URL=$(echo "$OUTPUT" | grep -E '^https://' | tail -1)
+          if [ -z "$URL" ]; then
+            echo "::error::Vercel deploy failed or URL not found"
+            exit 1
+          fi
           echo "url=$URL" >> $GITHUB_OUTPUT
         working-directory: frontend
         env:
@@ -115,16 +122,32 @@ jobs:
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        with:
+          script: |
+            const marker = '<!-- vercel-preview -->';
+            const url = process.env.PREVIEW_URL;
+            const body = `${marker}\n## Vercel プレビュー\n\n${url}\n\n> ⚠️ このプレビューは本番 API (\`NEXT_PUBLIC_API_URL\`) を使用しています。`;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PREVIEW_URL: ${{ steps.preview.outputs.url }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          gh pr comment "$PR_NUMBER" \
-            --repo "$REPO" \
-            --body "## Vercel プレビュー
-
-          $PREVIEW_URL
-
-          > ⚠️ このプレビューは本番 API (\`NEXT_PUBLIC_API_URL\`) を使用しています。"

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -75,9 +75,12 @@ jobs:
     name: Deploy to Vercel
     runs-on: ubuntu-24.04
     needs: ci
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: |
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      github.event_name == 'pull_request'
     permissions:
       contents: read
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -89,10 +92,39 @@ jobs:
       - name: Install Vercel CLI
         run: npm install -g vercel@51.8.0
 
-      - name: Deploy to Vercel
+      - name: Deploy to Vercel (production)
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: vercel deploy --prod --yes
         working-directory: frontend
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Deploy to Vercel (preview)
+        if: github.event_name == 'pull_request'
+        id: preview
+        run: |
+          URL=$(vercel deploy --yes 2>/dev/null)
+          echo "url=$URL" >> $GITHUB_OUTPUT
+        working-directory: frontend
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Comment preview URL on PR
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PREVIEW_URL: ${{ steps.preview.outputs.url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh pr comment "$PR_NUMBER" \
+            --repo "$REPO" \
+            --body "## Vercel プレビュー
+
+          $PREVIEW_URL
+
+          > ⚠️ このプレビューは本番 API (\`NEXT_PUBLIC_API_URL\`) を使用しています。"


### PR DESCRIPTION
## 概要

`frontend-ci.yml` の `deploy` ジョブを PR 時にも実行するよう拡張し、プレビュー URL を PR コメントに自動投稿する。レビュアーが main マージ前に実際の動作を確認できるようになる。

## 変更内容

- `deploy` ジョブの `if` 条件を `main push` のみ → `main push || pull_request` に拡張
- `permissions` に `pull-requests: write` を追加（PR コメント投稿に必要）
- main push 時：従来どおり `vercel deploy --prod --yes`
- PR 時：`vercel deploy --yes`（プレビューモード）→ 出力 URL を取得 → `gh pr comment` で PR に投稿

## 関連Issue

Closes #467

## テスト

- [x] 既存テストが通ること
- [x] ワークフロー YAML の構文を確認済み

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] プレビューは本番 API (`NEXT_PUBLIC_API_URL`) を叩く点を注意事項として PR コメントに明記