### PR TITLE
test(frontend): Toast / Modal UI primitive のユニットテスト追加

### DIFF
--- a/frontend/src/components/__tests__/modal.test.tsx
+++ b/frontend/src/components/__tests__/modal.test.tsx
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Modal } from "@/components/ui/modal";
+
+describe("Modal", () => {
+  afterEach(() => {
+    // Clean up body styles and dataset between tests
+    document.body.style.overflow = "";
+    delete document.body.dataset.modalCount;
+  });
+
+  it("open=true → renders role=dialog and children visible", () => {
+    render(
+      <Modal open={true} onClose={vi.fn()} title="テストモーダル">
+        <p>モーダルのコンテンツ</p>
+      </Modal>
+    );
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText("モーダルのコンテンツ")).toBeInTheDocument();
+    expect(screen.getByText("テストモーダル")).toBeInTheDocument();
+  });
+
+  it("open=false → renders nothing (null)", () => {
+    const { container } = render(
+      <Modal open={false} onClose={vi.fn()}>
+        <p>非表示コンテンツ</p>
+      </Modal>
+    );
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("ESC key → onClose called", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open={true} onClose={onClose}>
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("backdrop click → onClose called", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open={true} onClose={onClose}>
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    const backdrop = document.querySelector('[aria-hidden="true"]') as HTMLElement;
+    expect(backdrop).not.toBeNull();
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("open=true → document.body.style.overflow === 'hidden'", () => {
+    render(
+      <Modal open={true} onClose={vi.fn()}>
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("after close → overflow reset", () => {
+    const { rerender } = render(
+      <Modal open={true} onClose={vi.fn()}>
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    expect(document.body.style.overflow).toBe("hidden");
+
+    rerender(
+      <Modal open={false} onClose={vi.fn()}>
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("Tab key focus trap: last focusable element + Tab → focus moves to first", async () => {
+    render(
+      <Modal open={true} onClose={vi.fn()} title="フォーカストラップ">
+        <button>ボタン1</button>
+        <button>ボタン2</button>
+        <button>ボタン3</button>
+      </Modal>
+    );
+
+    const dialog = screen.getByRole("dialog");
+    const focusableElements = dialog.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const focusables = Array.from(focusableElements);
+    expect(focusables.length).toBeGreaterThan(0);
+
+    const lastFocusable = focusables[focusables.length - 1];
+    const firstFocusable = focusables[0];
+
+    // Focus the last element
+    act(() => {
+      lastFocusable.focus();
+    });
+    expect(document.activeElement).toBe(lastFocusable);
+
+    // Tab from last → should wrap to first
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: false });
+    expect(document.activeElement).toBe(firstFocusable);
+  });
+
+  it("Shift+Tab key focus trap: first focusable element + Shift+Tab → focus moves to last", async () => {
+    render(
+      <Modal open={true} onClose={vi.fn()} title="フォーカストラップ">
+        <button>ボタン1</button>
+        <button>ボタン2</button>
+        <button>ボタン3</button>
+      </Modal>
+    );
+
+    const dialog = screen.getByRole("dialog");
+    const focusableElements = dialog.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const focusables = Array.from(focusableElements);
+
+    const firstFocusable = focusables[0];
+    const lastFocusable = focusables[focusables.length - 1];
+
+    // Focus the first element
+    act(() => {
+      firstFocusable.focus();
+    });
+    expect(document.activeElement).toBe(firstFocusable);
+
+    // Shift+Tab from first → should wrap to last
+    fireEvent.keyDown(document, { key: "Tab", shiftKey: true });
+    expect(document.activeElement).toBe(lastFocusable);
+  });
+
+  it("ESC key does not fire onClose when modal is not open", () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open={false} onClose={onClose}>
+        <p>コンテンツ</p>
+      </Modal>
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/__tests__/modal.test.tsx
+++ b/frontend/src/components/__tests__/modal.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { Modal } from "@/components/ui/modal";
 
 describe("Modal", () => {

--- a/frontend/src/components/__tests__/toast.test.tsx
+++ b/frontend/src/components/__tests__/toast.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import React from "react";
 import { ToastProvider, useToast } from "@/components/ui/toast";
@@ -20,6 +20,10 @@ function ToastTrigger({
 
 describe("Toast", () => {
   describe("ToastProvider / useToast", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('toast({ message, variant: "success" }) → role="alert" element with message appears', () => {
       render(
         <ToastProvider>

--- a/frontend/src/components/__tests__/toast.test.tsx
+++ b/frontend/src/components/__tests__/toast.test.tsx
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import React from "react";
+import { ToastProvider, useToast } from "@/components/ui/toast";
+
+// Helper component that calls toast() on mount
+function ToastTrigger({
+  message,
+  variant,
+}: {
+  message: string;
+  variant: "success" | "warning" | "danger";
+}) {
+  const { toast } = useToast();
+  React.useEffect(() => {
+    toast({ message, variant });
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  return null;
+}
+
+describe("Toast", () => {
+  describe("ToastProvider / useToast", () => {
+    it('toast({ message, variant: "success" }) → role="alert" element with message appears', () => {
+      render(
+        <ToastProvider>
+          <ToastTrigger message="保存しました" variant="success" />
+        </ToastProvider>
+      );
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+      expect(screen.getByText("保存しました")).toBeInTheDocument();
+    });
+
+    it("auto-dismisses after 4000ms", () => {
+      vi.useFakeTimers();
+      render(
+        <ToastProvider>
+          <ToastTrigger message="テスト" variant="success" />
+        </ToastProvider>
+      );
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      act(() => {
+        vi.advanceTimersByTime(4000);
+      });
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      vi.useRealTimers();
+    });
+
+    it("X button click → immediate dismiss", () => {
+      render(
+        <ToastProvider>
+          <ToastTrigger message="閉じるテスト" variant="warning" />
+        </ToastProvider>
+      );
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      const closeButton = screen.getByRole("button", { name: "閉じる" });
+      fireEvent.click(closeButton);
+
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("multiple toasts are all rendered", () => {
+      function MultiTrigger() {
+        const { toast } = useToast();
+        React.useEffect(() => {
+          toast({ message: "first", variant: "success" });
+          toast({ message: "second", variant: "danger" });
+        }, []); // eslint-disable-line react-hooks/exhaustive-deps
+        return null;
+      }
+      render(
+        <ToastProvider>
+          <MultiTrigger />
+        </ToastProvider>
+      );
+      const alerts = screen.getAllByRole("alert");
+      expect(alerts).toHaveLength(2);
+      expect(screen.getByText("first")).toBeInTheDocument();
+      expect(screen.getByText("second")).toBeInTheDocument();
+    });
+  });
+
+  describe("useToast outside ToastProvider", () => {
+    it("throws Error when used outside ToastProvider", () => {
+      function BadComponent() {
+        useToast();
+        return null;
+      }
+      // Suppress console.error for expected error boundary output
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      expect(() => render(<BadComponent />)).toThrow("useToast must be used within ToastProvider");
+      consoleSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## 概要
Toast と Modal コンポーネントのユニットテストを追加する。表示・自動消去・手動閉じ・フォーカストラップ・ESCキー・バックドロップクリック・body スクロールロックの各挙動を網羅的に検証する。

## 変更内容
- `frontend/src/components/__tests__/toast.test.tsx` — ToastProvider / useToast のテスト追加
  - メッセージが role="alert" で表示されること
  - 4000ms 後に自動消去されること（vi.useFakeTimers）
  - X ボタンクリックで即時消去されること
  - ToastProvider 外で useToast() を呼ぶと Error がスローされること
  - 複数トーストが同時に表示されること
- `frontend/src/components/__tests__/modal.test.tsx` — Modal コンポーネントのテスト追加
  - open=true で role="dialog" とコンテンツが表示されること
  - open=false で何もレンダリングされないこと (null)
  - ESC キーで onClose が呼ばれること
  - バックドロップクリックで onClose が呼ばれること
  - open=true 時に document.body.style.overflow === "hidden" になること
  - close 後に overflow がリセットされること
  - Tab キーのフォーカストラップ（最後→最初）が動作すること
  - Shift+Tab キーのフォーカストラップ（最初→最後）が動作すること
  - open=false のとき ESC キーで onClose が呼ばれないこと

## 関連Issue
Closes #426

## テスト
- [x] 既存テストが通ること
- [x] 新規テストを追加した場合、全ケースがPASSすること（199 tests passed）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み