### PR TITLE
feat(frontend): Fullモード入力のドラフト自動保存（localStorage）

### DIFF
--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -13,6 +13,7 @@ import { type GeocodeState } from "@/components/sections/LocationSection";
 
 const QUICK_HISTORY_KEY = "yield-guard:quick-history";
 const QUICK_HISTORY_MAX = 5;
+const FULL_DRAFT_KEY = "yield-guard:full-draft";
 
 function loadQuickHistory(): QuickHistoryEntry[] {
   if (typeof window === "undefined") return [];
@@ -130,6 +131,7 @@ export function InvestmentForm({
   const [showCustomLoan, setShowCustomLoan] = useState(false);
   const [quickHistory, setQuickHistory] = useState<QuickHistoryEntry[]>([]);
   const [rateScheduleEnabled, setRateScheduleEnabled] = useState(false);
+  const [pendingDraft, setPendingDraft] = useState<Partial<InvestmentInput> | null>(null);
 
   const isQuick = simulationMode === "quick";
 
@@ -225,6 +227,56 @@ export function InvestmentForm({
 
   useEffect(() => {
     setQuickHistory(loadQuickHistory());
+  }, []);
+
+  // Load Full-mode draft on mount (run once)
+  useEffect(() => {
+    if (isQuick) return;
+    try {
+      const raw = typeof window !== "undefined" ? localStorage.getItem(FULL_DRAFT_KEY) : null;
+      if (!raw) return;
+      const draft = JSON.parse(raw) as Partial<InvestmentInput>;
+      setPendingDraft(draft);
+    } catch {
+      // ignore
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Debounced auto-save for Full mode
+  const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (isQuick) return;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    saveTimerRef.current = setTimeout(() => {
+      try {
+        localStorage.setItem(FULL_DRAFT_KEY, JSON.stringify(input));
+      } catch {
+        // ignore
+      }
+    }, 500);
+    return () => {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
+    };
+  }, [input, isQuick]);
+
+  const handleRestoreDraft = useCallback(() => {
+    if (!pendingDraft) return;
+    setInput((prev) => ({ ...prev, ...pendingDraft }));
+    setPendingDraft(null);
+    try {
+      localStorage.removeItem(FULL_DRAFT_KEY);
+    } catch {
+      // ignore
+    }
+  }, [pendingDraft]);
+
+  const handleDiscardDraft = useCallback(() => {
+    setPendingDraft(null);
+    try {
+      localStorage.removeItem(FULL_DRAFT_KEY);
+    } catch {
+      // ignore
+    }
   }, []);
 
   const handleAreaChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -362,6 +414,11 @@ export function InvestmentForm({
       setQuickHistory(saveQuickHistory(entry));
       onAnalyze(payload, quickTotalPriceMan);
     } else {
+      try {
+        localStorage.removeItem(FULL_DRAFT_KEY);
+      } catch {
+        // ignore
+      }
       onAnalyze(sortedInput(input));
     }
   };
@@ -442,6 +499,28 @@ export function InvestmentForm({
   return (
     <div className="space-y-4">
       {showModeToggle && <SimulationModeToggle mode={simulationMode} onChange={onModeChange} />}
+
+      {!isQuick && pendingDraft && (
+        <div className="flex items-center justify-between rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-2 text-sm">
+          <span>前回の入力を復元しますか？</span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={handleRestoreDraft}
+              className="rounded bg-yellow-400 px-3 py-1 text-xs font-medium text-white hover:bg-yellow-500"
+            >
+              復元する
+            </button>
+            <button
+              type="button"
+              onClick={handleDiscardDraft}
+              className="rounded bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-300"
+            >
+              破棄する
+            </button>
+          </div>
+        </div>
+      )}
 
       {isQuick ? (
         <QuickModeForm

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -235,6 +235,8 @@ export function InvestmentForm({
       const raw = typeof window !== "undefined" ? localStorage.getItem(FULL_DRAFT_KEY) : null;
       if (!raw) return;
       const draft = JSON.parse(raw) as Partial<InvestmentInput>;
+      if (!Array.isArray(draft.rateAdjustmentSchedule)) delete draft.rateAdjustmentSchedule;
+      if (!Array.isArray(draft.capexSchedule)) delete draft.capexSchedule;
       setPendingDraft(draft);
     } catch {
       // ignore

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -231,7 +231,6 @@ export function InvestmentForm({
 
   // Load Full-mode draft on mount (run once)
   useEffect(() => {
-    if (isQuick) return;
     try {
       const raw = typeof window !== "undefined" ? localStorage.getItem(FULL_DRAFT_KEY) : null;
       if (!raw) return;
@@ -240,7 +239,7 @@ export function InvestmentForm({
     } catch {
       // ignore
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, []);
 
   // Debounced auto-save for Full mode
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -261,6 +260,7 @@ export function InvestmentForm({
 
   const handleRestoreDraft = useCallback(() => {
     if (!pendingDraft) return;
+    if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
     setInput((prev) => ({ ...prev, ...pendingDraft }));
     setPendingDraft(null);
     try {
@@ -414,6 +414,7 @@ export function InvestmentForm({
       setQuickHistory(saveQuickHistory(entry));
       onAnalyze(payload, quickTotalPriceMan);
     } else {
+      if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       try {
         localStorage.removeItem(FULL_DRAFT_KEY);
       } catch {


### PR DESCRIPTION
## 概要

Fullモードでの入力内容を `localStorage` に自動保存し、次回訪問時に復元できるようにする。

## 変更内容

- `FULL_DRAFT_KEY = "yield-guard:full-draft"` を追加
- `input` または `isQuick` が変化するたびに 500ms デバウンスで `localStorage` へ保存
- マウント時に保存済みドラフトがあれば `pendingDraft` に読み込み、Fullモード時のみ復元バナーを表示
- バナーには「復元する」「破棄する」ボタンを配置
  - 「復元する」→ `input` にドラフトをマージし、バナーを閉じる
  - 「破棄する」→ ドラフトを削除し、バナーを閉じる
- `handleAnalyze` のFullモード分岐で分析実行時にドラフトをクリア
- Quickモードには一切影響しない（`yield-guard:quick-history` キーも変更なし）

## 関連Issue

Closes #446

## テスト

- [x] 既存テスト 185件がすべて PASS
- [x] TypeScript コンパイルエラーなし（`tsc --noEmit`）
- [x] Prettier フォーマットチェック通過
- [x] ESLint エラーなし（toast.tsx の既存 warning のみ）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み