### PR TITLE
feat(frontend/backend): 入力賃料の妥当性検証 — エリア相場との乖離表示 (#391)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ Copy `.env.example` → `.env` (project root).
 | `GET` | `/api/hazard` | Hazard info: flood/storm/tsunami/landslide (tile coords) |
 | `GET` | `/api/investment-score` | Investment suitability score (tile coords) |
 | `GET` | `/api/investment-score-heatmap` | Batch investment scores for viewport bbox (minLat, maxLat, minLng, maxLng, z=11-15) |
+| `GET` | `/api/rent-stats` | Area rent market stats: median/average/count from MLIT rental data (area, municipality, area_sqm) |
 
 ## Directory structure
 
@@ -83,6 +84,7 @@ yield-guard/
 │       │   └── types.go            # API response types
 │       └── api/
 │           ├── handler.go          # HTTP handlers
+│           ├── rent_handler.go     # GET /api/rent-stats handler
 │           └── router.go           # Gin router + CORS + auth middleware
 ├── frontend/src/
 │   ├── app/                        # Next.js App Router pages

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -34,6 +34,7 @@ type MLITClient interface {
 	FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.StormHazardItem, error)
 	FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.TsunamiHazardItem, error)
 	FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domain.LandslideHazardItem, error)
+	FetchRentStats(ctx context.Context, q mlit.LandPriceQuery, areaSqm float64) (domain.RentStatsResult, error)
 }
 
 type Handler struct {

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -168,6 +168,7 @@ type mockMLITClient struct {
 	stormHazardFunc      func(ctx context.Context, z, x, y int) ([]domain.StormHazardItem, error)
 	tsunamiHazardFunc    func(ctx context.Context, z, x, y int) ([]domain.TsunamiHazardItem, error)
 	landslideHazardFunc  func(ctx context.Context, z, x, y int) ([]domain.LandslideHazardItem, error)
+	rentStatsFunc        func(ctx context.Context, q mlit.LandPriceQuery, areaSqm float64) (domain.RentStatsResult, error)
 }
 
 func (m *mockMLITClient) FetchLandPrices(ctx context.Context, q mlit.LandPriceQuery) ([]domain.LandTransaction, error) {
@@ -268,6 +269,12 @@ func (m *mockMLITClient) FetchLandslideHazard(ctx context.Context, z, x, y int) 
 		return m.landslideHazardFunc(ctx, z, x, y)
 	}
 	return []domain.LandslideHazardItem{}, nil
+}
+func (m *mockMLITClient) FetchRentStats(ctx context.Context, q mlit.LandPriceQuery, areaSqm float64) (domain.RentStatsResult, error) {
+	if m.rentStatsFunc != nil {
+		return m.rentStatsFunc(ctx, q, areaSqm)
+	}
+	return domain.RentStatsResult{}, nil
 }
 
 // newTestRouter はモッククライアントを使ったテスト用ルーターを返す

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -1598,3 +1598,86 @@ func TestUpstreamErrorNotExposed(t *testing.T) {
 		})
 	}
 }
+
+// ---- GetRentStats ----
+
+func TestGetRentStats_MissingArea(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{}, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/rent-stats", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetRentStats_Success(t *testing.T) {
+	client := &mockMLITClient{
+		rentStatsFunc: func(_ context.Context, _ mlit.LandPriceQuery, _ float64) (domain.RentStatsResult, error) {
+			return domain.RentStatsResult{Median: 80000, Average: 82000, Count: 15}, nil
+		},
+	}
+	r := newTestRouter(client, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/rent-stats?area=13", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var result domain.RentStatsResult
+	if err := json.NewDecoder(w.Body).Decode(&result); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if result.Median != 80000 {
+		t.Errorf("expected median=80000, got %v", result.Median)
+	}
+	if result.Average != 82000 {
+		t.Errorf("expected average=82000, got %v", result.Average)
+	}
+	if result.Count != 15 {
+		t.Errorf("expected count=15, got %d", result.Count)
+	}
+}
+
+func TestGetRentStats_NoData(t *testing.T) {
+	client := &mockMLITClient{
+		rentStatsFunc: func(_ context.Context, _ mlit.LandPriceQuery, _ float64) (domain.RentStatsResult, error) {
+			return domain.RentStatsResult{}, nil
+		},
+	}
+	r := newTestRouter(client, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/rent-stats?area=13", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if strings.TrimSpace(body) != "null" {
+		t.Errorf("expected null response for count=0, got %s", body)
+	}
+}
+
+func TestGetRentStats_FetchError(t *testing.T) {
+	client := &mockMLITClient{
+		rentStatsFunc: func(_ context.Context, _ mlit.LandPriceQuery, _ float64) (domain.RentStatsResult, error) {
+			return domain.RentStatsResult{}, errors.New("upstream error")
+		},
+	}
+	r := newTestRouter(client, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/rent-stats?area=13", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	// エラーはサイレントに null を返す
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (silent error), got %d: %s", w.Code, w.Body.String())
+	}
+	body := w.Body.String()
+	if strings.TrimSpace(body) != "null" {
+		t.Errorf("expected null response on error, got %s", body)
+	}
+}

--- a/backend/internal/api/rent_handler.go
+++ b/backend/internal/api/rent_handler.go
@@ -1,0 +1,62 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/yield-guard/backend/internal/mlit"
+)
+
+// GetRentStats は XIT001（賃貸）からエリア賃料相場を返す
+// GET /api/rent-stats?area=13[&municipality=13101][&area_sqm=60]
+func (h *Handler) GetRentStats(c *gin.Context) {
+	area := c.Query("area")
+	if area == "" {
+		badRequest(c, "area は必須パラメータです")
+		return
+	}
+
+	municipality := c.Query("municipality")
+
+	areaSqm := 0.0
+	if s := c.Query("area_sqm"); s != "" {
+		v, err := strconv.ParseFloat(s, 64)
+		if err != nil || v <= 0 {
+			badRequest(c, "area_sqm は正の数値で指定してください")
+			return
+		}
+		areaSqm = v
+	}
+
+	// 直近2年分のデータを取得する
+	now := time.Now()
+	toYear := now.Year()
+	fromYear := toYear - 2
+
+	q := mlit.LandPriceQuery{
+		Area:      area,
+		City:      municipality,
+		Year:      fromYear,
+		Quarter:   1,
+		ToYear:    toYear,
+		ToQuarter: 4,
+	}
+
+	result, err := h.mlitClient.FetchRentStats(c.Request.Context(), q, areaSqm)
+	if err != nil {
+		slog.WarnContext(c.Request.Context(), "FetchRentStats failed", "err", err, "area", area)
+		// データなしはサイレントに空レスポンスを返す（フロントはhide）
+		c.JSON(http.StatusOK, nil)
+		return
+	}
+
+	if result.Count == 0 {
+		c.JSON(http.StatusOK, nil)
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -136,7 +136,7 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/investment-score-heatmap", analyzeRL.middleware(), h.GetInvestmentScoreHeatmap)
 		api.GET("/area-discovery", analyzeRL.middleware(), h.HandleAreaDiscovery)
 		api.GET("/geocode", h.GetGeocode)
-		api.GET("/rent-stats", h.GetRentStats)
+		api.GET("/rent-stats", analyzeRL.middleware(), h.GetRentStats)
 	}
 
 	return r

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -136,6 +136,7 @@ func NewRouter(h *Handler) *gin.Engine {
 		api.GET("/investment-score-heatmap", analyzeRL.middleware(), h.GetInvestmentScoreHeatmap)
 		api.GET("/area-discovery", analyzeRL.middleware(), h.HandleAreaDiscovery)
 		api.GET("/geocode", h.GetGeocode)
+		api.GET("/rent-stats", h.GetRentStats)
 	}
 
 	return r

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -551,6 +551,13 @@ type RenovationResult struct {
 	ClassifiedItems     []ClassifiedRenovationItem `json:"classifiedItems"`
 }
 
+// RentStatsResult は賃貸取引価格の統計情報
+type RentStatsResult struct {
+	Median  float64 `json:"median"`  // 月額賃料 中央値（円）
+	Average float64 `json:"average"` // 月額賃料 平均値（円）
+	Count   int     `json:"count"`   // サンプル数
+}
+
 // HeatmapTile はヒートマップの1タイル分の投資スコア情報
 type HeatmapTile struct {
 	X          int     `json:"x"`

--- a/backend/internal/mlit/cache.go
+++ b/backend/internal/mlit/cache.go
@@ -75,6 +75,7 @@ type cache struct {
 	stormHazard          *genericCache[domain.StormHazardItem]
 	tsunamiHazard        *genericCache[domain.TsunamiHazardItem]
 	landslideHazard      *genericCache[domain.LandslideHazardItem]
+	rentStats            *genericCache[domain.RentStatsResult]
 }
 
 func newCache() *cache {
@@ -94,6 +95,7 @@ func newCache() *cache {
 		stormHazard:          newGenericCache[domain.StormHazardItem](),
 		tsunamiHazard:        newGenericCache[domain.TsunamiHazardItem](),
 		landslideHazard:      newGenericCache[domain.LandslideHazardItem](),
+		rentStats:            newGenericCache[domain.RentStatsResult](),
 	}
 }
 

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1016,6 +1017,177 @@ func (c *Client) FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domai
 	}
 	c.cache.landslideHazard.set(key, result)
 	return result, nil
+}
+
+// FetchRentStats は XIT001（priceClassification=03）から賃貸取引データを取得し、
+// 月額賃料の中央値・平均値・件数を返す。area_sqm が 0 より大きい場合は
+// 面積が area_sqm ± 50% の範囲のレコードのみを対象にフィルタリングする。
+// キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
+func (c *Client) FetchRentStats(ctx context.Context, q LandPriceQuery, areaSqm float64) (domain.RentStatsResult, error) {
+	ctx, span := otel.Tracer(mlitTracerName).Start(ctx, "mlit.FetchRentStats")
+	defer span.End()
+
+	span.SetAttributes(
+		semconv.ServerAddress("www.reinfolib.mlit.go.jp"),
+		semconv.ServerPort(443),
+		semconv.URLScheme("https"),
+		attribute.String("mlit.endpoint", "XIT001_rent"),
+		attribute.String("mlit.query.area", q.Area),
+		attribute.String("mlit.query.city", q.City),
+	)
+
+	cacheKeySuffix := fmt.Sprintf("rent:%s:%s:%d:%d:%d:%d:%.1f",
+		q.Area, q.City, q.Year, q.Quarter, q.ToYear, q.ToQuarter, areaSqm)
+	if cached, ok := c.cache.rentStats.get(cacheKeySuffix); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT001_rent")))
+		if len(cached) == 0 {
+			return domain.RentStatsResult{}, nil
+		}
+		return cached[0], nil
+	}
+	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT001_rent")))
+	span.SetAttributes(attribute.Bool("mlit.cache.hit", false))
+
+	if q.Area == "" {
+		return domain.RentStatsResult{}, fmt.Errorf("area is required")
+	}
+	if q.Year == 0 || q.Quarter == 0 || q.ToYear == 0 || q.ToQuarter == 0 {
+		return domain.RentStatsResult{}, fmt.Errorf("year, quarter, to_year, to_quarter are required")
+	}
+
+	params := url.Values{}
+	params.Set("area", q.Area)
+	params.Set("year", strconv.Itoa(q.Year))
+	params.Set("quarter", strconv.Itoa(q.Quarter))
+	params.Set("toYear", strconv.Itoa(q.ToYear))
+	params.Set("toQuarter", strconv.Itoa(q.ToQuarter))
+	params.Set("priceClassification", "03") // 賃貸
+	if q.City != "" {
+		params.Set("city", q.City)
+	}
+	apiURL := c.baseURL + endpointLandPrices + "?" + params.Encode()
+
+	var lastErr error
+	for attempt := 0; attempt < maxRetries; attempt++ {
+		if attempt > 0 {
+			delay := retryBaseDelay * time.Duration(1<<uint(attempt-1))
+			select {
+			case <-ctx.Done():
+				return domain.RentStatsResult{}, fmt.Errorf("context cancelled during retry: %w", ctx.Err())
+			case <-time.After(delay):
+			}
+		}
+
+		start := time.Now()
+		result, err := c.doRentRequest(ctx, apiURL, areaSqm)
+		latencySec := time.Since(start).Seconds()
+		telemetry.MLITAPILatencyHistogram.Record(ctx, latencySec,
+			metric.WithAttributes(attribute.String("mlit.endpoint", "XIT001_rent")))
+
+		if err == nil {
+			span.SetAttributes(attribute.Int("mlit.retry.count", attempt))
+			if result.Count == 0 {
+				c.cache.rentStats.set(cacheKeySuffix, []domain.RentStatsResult{})
+			} else {
+				c.cache.rentStats.set(cacheKeySuffix, []domain.RentStatsResult{result})
+			}
+			return result, nil
+		}
+		lastErr = err
+		if isClientError(err) {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			return domain.RentStatsResult{}, err
+		}
+	}
+	span.RecordError(lastErr)
+	span.SetStatus(codes.Error, lastErr.Error())
+	return domain.RentStatsResult{}, fmt.Errorf("rent stats API request failed after %d attempts: %w", maxRetries, lastErr)
+}
+
+// doRentRequest は賃貸取引データを取得してパースし、月額賃料統計を計算する。
+func (c *Client) doRentRequest(ctx context.Context, apiURL string, areaSqm float64) (domain.RentStatsResult, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return domain.RentStatsResult{}, fmt.Errorf("request build error: %w", err)
+	}
+	if c.apiKey != "" {
+		req.Header.Set("Ocp-Apim-Subscription-Key", c.apiKey)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return domain.RentStatsResult{}, fmt.Errorf("rent API request failed: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
+		return domain.RentStatsResult{}, &clientError{code: resp.StatusCode}
+	}
+	if resp.StatusCode != http.StatusOK {
+		return domain.RentStatsResult{}, fmt.Errorf("rent API returned status %d", resp.StatusCode)
+	}
+
+	var apiResp APIResponse
+	if err := json.NewDecoder(resp.Body).Decode(&apiResp); err != nil {
+		return domain.RentStatsResult{}, fmt.Errorf("rent JSON decode error: %w", err)
+	}
+	if apiResp.Status != "OK" {
+		return domain.RentStatsResult{}, fmt.Errorf("rent API status: %s", apiResp.Status)
+	}
+
+	return parseRentStats(apiResp.Data, areaSqm), nil
+}
+
+// parseRentStats は賃貸取引データから月額賃料の統計を算出する。
+// areaSqm が 0 より大きい場合、面積が areaSqm の 50%〜150% の範囲のレコードのみ対象とする。
+func parseRentStats(raw []Transaction, areaSqm float64) domain.RentStatsResult {
+	var rents []float64
+	for _, t := range raw {
+		// 賃貸は TradePrice が月額賃料（円）
+		price := parseFloat(t.TradePrice)
+		if price <= 0 {
+			continue
+		}
+		// 面積フィルタ（任意）
+		if areaSqm > 0 {
+			area := parseFloat(t.Area)
+			if area <= 0 {
+				continue
+			}
+			if area < areaSqm*0.5 || area > areaSqm*1.5 {
+				continue
+			}
+		}
+		rents = append(rents, price)
+	}
+
+	if len(rents) == 0 {
+		return domain.RentStatsResult{}
+	}
+
+	sort.Float64s(rents)
+
+	sum := 0.0
+	for _, r := range rents {
+		sum += r
+	}
+	avg := sum / float64(len(rents))
+
+	n := len(rents)
+	var median float64
+	if n%2 == 0 {
+		median = (rents[n/2-1] + rents[n/2]) / 2
+	} else {
+		median = rents[n/2]
+	}
+
+	return domain.RentStatsResult{
+		Median:  median,
+		Average: avg,
+		Count:   n,
+	}
 }
 
 // isLandType は取引種別が宅地(土地)かどうかを判定する

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -1152,6 +1152,7 @@ func parseRentStats(raw []Transaction, areaSqm float64) domain.RentStatsResult {
 		}
 		// 面積フィルタ（任意）
 		if areaSqm > 0 {
+			// Area フィールドは XIT001（賃貸）では専有面積（m²）を示す
 			area := parseFloat(t.Area)
 			if area <= 0 {
 				continue

--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -124,6 +124,8 @@ export function FullModeForm({
             handleFetchRentHint={handleFetchRentHint}
             zoningType={zoningType}
             setZoningType={setZoningType}
+            area={area}
+            city={city}
           />
 
           <LoanSection

--- a/frontend/src/components/QuickModeForm.tsx
+++ b/frontend/src/components/QuickModeForm.tsx
@@ -9,6 +9,7 @@ import { toMan, fromMan, toPct, fromPct } from "@/lib/utils";
 import type { Municipality } from "@/lib/api";
 import { PREFECTURES, getPeriodLabel } from "@/lib/investmentFormConstants";
 import { Search, Calculator, Info, ChevronDown, ChevronUp } from "lucide-react";
+import { RentValidationHint } from "@/components/RentValidationHint";
 
 export interface QuickHistoryEntry {
   totalPriceMan: string;
@@ -203,15 +204,18 @@ export function QuickModeForm({
                 内部で土地70%・建物30%に按分して計算します
               </p>
             </div>
-            <Input
-              label="想定月額賃料"
-              type="number"
-              inputMode="numeric"
-              suffix="円"
-              value={String(input.monthlyRent)}
-              onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
-              error={fieldError("monthlyRent")}
-            />
+            <div>
+              <Input
+                label="想定月額賃料"
+                type="number"
+                inputMode="numeric"
+                suffix="円"
+                value={String(input.monthlyRent)}
+                onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
+                error={fieldError("monthlyRent")}
+              />
+              <RentValidationHint monthlyRent={input.monthlyRent} area={area} city={city} />
+            </div>
             <div className="space-y-2">
               <label className="flex items-center gap-2 cursor-pointer select-none min-h-[44px]">
                 <input

--- a/frontend/src/components/RentValidationHint.tsx
+++ b/frontend/src/components/RentValidationHint.tsx
@@ -10,32 +10,34 @@ interface RentValidationHintProps {
 
 function badge(
   level: RentDeviationLevel,
-  deviationPct: number
+  deviationPct: number,
+  city: string
 ): { className: string; message: string } | null {
   if (level === null) return null;
   const sign = deviationPct >= 0 ? "+" : "";
   const pctStr = `${sign}${deviationPct.toFixed(1)}%`;
+  const scopeNote = city ? "" : "（都道府県全体）";
 
   switch (level) {
     case "normal":
       return {
         className: "text-muted-foreground",
-        message: `相場比 ${pctStr}（適正範囲）`,
+        message: `相場比 ${pctStr}${scopeNote}（適正範囲）`,
       };
     case "high-warn":
       return {
         className: "text-yellow-700",
-        message: `相場比 ${pctStr} — 相場より高め。空室リスクを考慮してください`,
+        message: `相場比 ${pctStr}${scopeNote} — 相場より高め。空室リスクを考慮してください`,
       };
     case "high-danger":
       return {
         className: "text-destructive",
-        message: `相場比 ${pctStr} — 相場から大きく乖離しています`,
+        message: `相場比 ${pctStr}${scopeNote} — 相場から大きく乖離しています`,
       };
     case "low-note":
       return {
         className: "text-blue-700",
-        message: `相場比 ${pctStr} — 相場より低め。利回り改善の余地があります`,
+        message: `相場比 ${pctStr}${scopeNote} — 相場より低め。利回り改善の余地があります`,
       };
     default:
       return null;
@@ -55,7 +57,7 @@ export function RentValidationHint({ monthlyRent, area, city }: RentValidationHi
 
   if (deviationPct === null || level === null) return null;
 
-  const info = badge(level, deviationPct);
+  const info = badge(level, deviationPct, city);
   if (!info) return null;
 
   return (

--- a/frontend/src/components/RentValidationHint.tsx
+++ b/frontend/src/components/RentValidationHint.tsx
@@ -43,7 +43,11 @@ function badge(
 }
 
 export function RentValidationHint({ monthlyRent, area, city }: RentValidationHintProps) {
-  const { deviationPct, level, loading } = useRentValidation(monthlyRent, area, city);
+  const { stats, deviationPct, level, loading, lowSample } = useRentValidation(
+    monthlyRent,
+    area,
+    city
+  );
 
   if (loading) {
     return <p className="text-xs text-muted-foreground mt-1">賃料相場を確認中…</p>;
@@ -54,5 +58,14 @@ export function RentValidationHint({ monthlyRent, area, city }: RentValidationHi
   const info = badge(level, deviationPct);
   if (!info) return null;
 
-  return <p className={`text-xs mt-1 ${info.className}`}>{info.message}</p>;
+  return (
+    <div className="mt-1">
+      <p className={`text-xs ${info.className}`}>{info.message}</p>
+      {lowSample && stats && (
+        <p className="text-xs text-muted-foreground mt-0.5">
+          ※ サンプル数が少ないため参考値です（{stats.count}件）
+        </p>
+      )}
+    </div>
+  );
 }

--- a/frontend/src/components/RentValidationHint.tsx
+++ b/frontend/src/components/RentValidationHint.tsx
@@ -12,7 +12,7 @@ function badge(
   level: RentDeviationLevel,
   deviationPct: number
 ): { className: string; message: string } | null {
-  if (level === null || deviationPct === null) return null;
+  if (level === null) return null;
   const sign = deviationPct >= 0 ? "+" : "";
   const pctStr = `${sign}${deviationPct.toFixed(1)}%`;
 

--- a/frontend/src/components/RentValidationHint.tsx
+++ b/frontend/src/components/RentValidationHint.tsx
@@ -1,0 +1,58 @@
+"use client";
+import React from "react";
+import { useRentValidation, type RentDeviationLevel } from "@/hooks/useRentValidation";
+
+interface RentValidationHintProps {
+  monthlyRent: number;
+  area: string;
+  city: string;
+}
+
+function badge(
+  level: RentDeviationLevel,
+  deviationPct: number
+): { className: string; message: string } | null {
+  if (level === null || deviationPct === null) return null;
+  const sign = deviationPct >= 0 ? "+" : "";
+  const pctStr = `${sign}${deviationPct.toFixed(1)}%`;
+
+  switch (level) {
+    case "normal":
+      return {
+        className: "text-muted-foreground",
+        message: `相場比 ${pctStr}（適正範囲）`,
+      };
+    case "high-warn":
+      return {
+        className: "text-yellow-700",
+        message: `相場比 ${pctStr} — 相場より高め。空室リスクを考慮してください`,
+      };
+    case "high-danger":
+      return {
+        className: "text-destructive",
+        message: `相場比 ${pctStr} — 相場から大きく乖離しています`,
+      };
+    case "low-note":
+      return {
+        className: "text-blue-700",
+        message: `相場比 ${pctStr} — 相場より低め。利回り改善の余地があります`,
+      };
+    default:
+      return null;
+  }
+}
+
+export function RentValidationHint({ monthlyRent, area, city }: RentValidationHintProps) {
+  const { deviationPct, level, loading } = useRentValidation(monthlyRent, area, city);
+
+  if (loading) {
+    return <p className="text-xs text-muted-foreground mt-1">賃料相場を確認中…</p>;
+  }
+
+  if (deviationPct === null || level === null) return null;
+
+  const info = badge(level, deviationPct);
+  if (!info) return null;
+
+  return <p className={`text-xs mt-1 ${info.className}`}>{info.message}</p>;
+}

--- a/frontend/src/components/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/sections/PropertyInfoSection.tsx
@@ -8,6 +8,7 @@ import type { InvestmentInput, BuildingType, RentDeclineHint } from "@/types/inv
 import { toMan, fromMan, toPct, fromPct } from "@/lib/utils";
 import { BUILDING_TYPES, RENT_DECLINE_DEFAULTS } from "@/lib/investmentFormConstants";
 import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
+import { RentValidationHint } from "@/components/RentValidationHint";
 
 function calcFromTax(taxMan: number): number {
   return taxMan / 0.1;
@@ -203,6 +204,8 @@ interface PropertyInfoSectionProps {
   handleFetchRentHint: () => Promise<void>;
   zoningType: ZoningType;
   setZoningType: (v: ZoningType) => void;
+  area: string;
+  city: string;
 }
 
 export function PropertyInfoSection({
@@ -216,6 +219,8 @@ export function PropertyInfoSection({
   handleFetchRentHint,
   zoningType,
   setZoningType,
+  area,
+  city,
 }: PropertyInfoSectionProps) {
   const [showBuildingHelper, setShowBuildingHelper] = useState(false);
 
@@ -353,15 +358,18 @@ export function PropertyInfoSection({
       <div className="border-t pt-4">
         <p className="text-sm font-semibold text-foreground mb-3">収益条件</p>
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <Input
-            label="想定月額賃料"
-            type="number"
-            inputMode="numeric"
-            suffix="円"
-            value={String(input.monthlyRent)}
-            onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
-            error={fieldError("monthlyRent")}
-          />
+          <div>
+            <Input
+              label="想定月額賃料"
+              type="number"
+              inputMode="numeric"
+              suffix="円"
+              value={String(input.monthlyRent)}
+              onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
+              error={fieldError("monthlyRent")}
+            />
+            <RentValidationHint monthlyRent={input.monthlyRent} area={area} city={city} />
+          </div>
           <Input
             label="現況空室率"
             type="number"

--- a/frontend/src/hooks/useRentValidation.ts
+++ b/frontend/src/hooks/useRentValidation.ts
@@ -1,0 +1,85 @@
+"use client";
+import { useState, useEffect, useRef } from "react";
+import { fetchRentStats, type RentStatsResult } from "@/lib/api";
+
+export type RentDeviationLevel = "normal" | "high-warn" | "high-danger" | "low-note" | null;
+
+export interface RentValidationState {
+  stats: RentStatsResult | null;
+  deviationPct: number | null;
+  level: RentDeviationLevel;
+  loading: boolean;
+}
+
+const DEBOUNCE_MS = 600;
+
+/**
+ * monthlyRent と area/municipality が揃ったとき、エリア賃料相場を取得して
+ * 入力賃料の乖離度を返す。
+ * - ±10% 以内     → "normal"
+ * - +10%〜+30%   → "high-warn"
+ * - +30% 超       → "high-danger"
+ * - -20% 以下     → "low-note"
+ */
+export function useRentValidation(
+  monthlyRent: number,
+  area: string,
+  city: string
+): RentValidationState {
+  const [stats, setStats] = useState<RentStatsResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    // area が未設定、または賃料が 0 以下の場合はリセット
+    if (!area || monthlyRent <= 0) {
+      setStats(null);
+      setLoading(false);
+      return;
+    }
+
+    setLoading(true);
+
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+    }
+
+    timerRef.current = setTimeout(async () => {
+      try {
+        const result = await fetchRentStats({
+          area,
+          municipality: city || undefined,
+        });
+        setStats(result);
+      } catch {
+        // データなし・ネットワークエラーはサイレント
+        setStats(null);
+      } finally {
+        setLoading(false);
+      }
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, [monthlyRent, area, city]);
+
+  if (!stats || !stats.median || monthlyRent <= 0) {
+    return { stats, deviationPct: null, level: null, loading };
+  }
+
+  const deviationPct = ((monthlyRent - stats.median) / stats.median) * 100;
+
+  let level: RentDeviationLevel = "normal";
+  if (deviationPct >= 30) {
+    level = "high-danger";
+  } else if (deviationPct >= 10) {
+    level = "high-warn";
+  } else if (deviationPct <= -20) {
+    level = "low-note";
+  }
+
+  return { stats, deviationPct, level, loading };
+}

--- a/frontend/src/hooks/useRentValidation.ts
+++ b/frontend/src/hooks/useRentValidation.ts
@@ -38,13 +38,12 @@ export function useRentValidation(
       return;
     }
 
-    setLoading(true);
-
     if (timerRef.current) {
       clearTimeout(timerRef.current);
     }
 
     timerRef.current = setTimeout(async () => {
+      setLoading(true);
       try {
         const result = await fetchRentStats({
           area,

--- a/frontend/src/hooks/useRentValidation.ts
+++ b/frontend/src/hooks/useRentValidation.ts
@@ -9,6 +9,7 @@ export interface RentValidationState {
   deviationPct: number | null;
   level: RentDeviationLevel;
   loading: boolean;
+  lowSample: boolean;
 }
 
 const DEBOUNCE_MS = 600;
@@ -66,10 +67,11 @@ export function useRentValidation(
   }, [monthlyRent, area, city]);
 
   if (!stats || !stats.median || monthlyRent <= 0) {
-    return { stats, deviationPct: null, level: null, loading };
+    return { stats, deviationPct: null, level: null, loading, lowSample: false };
   }
 
   const deviationPct = ((monthlyRent - stats.median) / stats.median) * 100;
+  const lowSample = stats.count < 10;
 
   let level: RentDeviationLevel = "normal";
   if (deviationPct >= 30) {
@@ -80,5 +82,5 @@ export function useRentValidation(
     level = "low-note";
   }
 
-  return { stats, deviationPct, level, loading };
+  return { stats, deviationPct, level, loading, lowSample };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -286,3 +286,25 @@ export async function fetchGeocode(address: string): Promise<GeocodeResult> {
   const res = await fetch(`${BASE}/geocode?${q}`);
   return handleResponse<GeocodeResult>(res);
 }
+
+export interface RentStatsResult {
+  median: number;
+  average: number;
+  count: number;
+}
+
+/** エリア賃料相場（中央値・平均値・件数）を取得（XIT001 賃貸） */
+export async function fetchRentStats(params: {
+  area: string;
+  municipality?: string;
+  areaSqm?: number;
+}): Promise<RentStatsResult | null> {
+  const q = new URLSearchParams({ area: params.area });
+  if (params.municipality) q.set("municipality", params.municipality);
+  if (params.areaSqm && params.areaSqm > 0) q.set("area_sqm", String(params.areaSqm));
+  const res = await fetch(`${BASE}/rent-stats?${q}`);
+  if (!res.ok) return null;
+  const data = await res.json();
+  if (!data || data.count === 0) return null;
+  return data as RentStatsResult;
+}


### PR DESCRIPTION
## 概要

月額賃料（`monthlyRent`）入力時に、エリア（都道府県・市区町村）の賃料相場と比較し、乖離度をインラインバッジで表示する機能を実装しました。フォームでエリアが設定されている状態で賃料を変更すると、600ms のデバウンス後に `/api/rent-stats` を呼び出し、結果を入力欄直下に表示します。

## 変更内容

### バックエンド

- `domain.RentStatsResult` 型を追加（`median`, `average`, `count`）
- `mlit.Client.FetchRentStats()` を追加: XIT001 の `priceClassification=03`（賃貸）で直近2年分のデータを取得し、月額賃料の中央値・平均値・件数を算出。面積フィルタ（`area_sqm` ± 50%）対応。24h TTL キャッシュ付き
- `GET /api/rent-stats` エンドポイントを追加: パラメータは `area`（必須）、`municipality`（任意）、`area_sqm`（任意）
- データなし・API エラー時は 200 + null ボディでサイレント返却（フロントは非表示）
- `MLITClient` インターフェースに `FetchRentStats` を追加、テスト用モックも対応

### フロントエンド

- `fetchRentStats()` を `lib/api.ts` に追加
- `useRentValidation` フック: `monthlyRent` / `area` / `city` を監視し、600ms デバウンス後に相場取得・乖離率計算
- `RentValidationHint` コンポーネント: 乖離度に応じた色付きバッジを表示
  - ±10% 以内: グレー「適正範囲」
  - +10〜+30%: 黄色「相場より高め。空室リスクを考慮してください」
  - +30% 超: 赤「相場から大きく乖離しています」
  - −20% 以下: 青「相場より低め。利回り改善の余地があります」
- `PropertyInfoSection`・`QuickModeForm` の月額賃料入力欄直下に組み込み

## 関連Issue

Closes #391

## テスト

- [x] `go test -race ./... -timeout 120s` 全テストパス
- [x] `next build` でビルドエラー・TypeScript エラーなし
- [x] `prettier --write` 実行済み

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] データなし時はサイレント（エラー表示なし）
- [x] 600ms デバウンス・24h キャッシュで API 呼び出しを最小化