### PR TITLE
fix(backend): Go 1.25.9 → 1.25.10 へ更新し CRITICAL CVE を解消

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.25.9-alpine AS builder
+FROM golang:1.25.10-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/yield-guard/backend
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.56.0
@@ -36,6 +36,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect


### PR DESCRIPTION
## 概要

2026-05-10 以降、Backend Deploy to Cloud Run が Trivy CRITICAL 脆弱性スキャンで連続失敗している問題を修正する。

## 背景

- **前回の同様修正**: PR #436（2026-05-06）で Go 1.25.5 → 1.25.9 に更新して CVE を解消
- **今回の再発原因**: Trivy の脆弱性 DB が 2026-05-10 頃に更新され、Go 1.25.9 に影響する以下の CRITICAL CVE が新規登録された

| CVE | 影響パッケージ |
|-----|------------|
| CVE-2026-32283 | crypto/tls |
| CVE-2026-32281 | crypto/x509 |
| CVE-2026-32280 | crypto/tls, crypto/x509 |
| CVE-2026-25679 | net/url |
| CVE-2025-68121 | crypto/tls |
| CVE-2025-61728 | archive/zip |
| CVE-2025-61726 | net/url |

- `ignore-unfixed: true` 設定のため「修正版あり」の CVE のみ検出対象
- `golang:1.25.10-alpine` が現在利用可能であり、これらの CVE をすべて解消する

## 変更内容

- `backend/Dockerfile`: `golang:1.25.9-alpine` → `golang:1.25.10-alpine`
- `backend/go.mod`: `go 1.25.9` → `go 1.25.10`（+ `go mod tidy` による間接依存の追加 `felixge/httpsnoop`）

## 確認事項

- [ ] Backend CI（golangci-lint / go test / go build）グリーン
- [ ] Deploy ワークフローの Trivy スキャンがグリーン
- [ ] Cloud Run へのデプロイ成功