### PR TITLE
fix(infra): GEMINI_API_KEY env を Secret バージョン存在時のみ追加

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.25.9-alpine AS builder
+FROM golang:1.25.10-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/yield-guard/backend
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.56.0
@@ -36,6 +36,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -75,12 +75,15 @@ resource "google_cloud_run_v2_service" "backend" {
         }
       }
 
-      env {
-        name = "GEMINI_API_KEY"
-        value_source {
-          secret_key_ref {
-            secret  = google_secret_manager_secret.gemini_api_key.secret_id
-            version = "latest"
+      dynamic "env" {
+        for_each = var.gemini_api_key != "" ? [1] : []
+        content {
+          name = "GEMINI_API_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.gemini_api_key.secret_id
+              version = "latest"
+            }
           }
         }
       }


### PR DESCRIPTION
## 概要

`terraform apply` 時に `GEMINI_API_KEY` が未設定の場合、Cloud Run が存在しない Secret バージョン（`latest`）を参照しようとして失敗していた問題を修正する。

## 原因

```
Error: Secret .../gemini-api-key-prod/versions/latest was not found
```

`var.gemini_api_key` が空のとき `secret_manager_secret_version` の `count = 0` でバージョンが作成されないが、`cloud_run.tf` の `env` ブロックは無条件に `version = "latest"` を参照していた。

## 変更内容

- `terraform/cloud_run.tf`：`env { name = "GEMINI_API_KEY" }` を `dynamic "env"` ブロックに変更し、`var.gemini_api_key != ""` の場合のみ追加する

```hcl
dynamic "env" {
  for_each = var.gemini_api_key != "" ? [1] : []
  content { ... }
}
```

## 動作

| `GEMINI_API_KEY` | Cloud Run env | AI サマリー |
|-----------------|---------------|-----------|
| 未設定（空） | 追加されない | 無効（空文字フォールバック） |
| 設定済み | `GEMINI_API_KEY` が注入される | 有効 |

## 関連Issue

なし（#491 apply 失敗の hotfix）

## テスト

- [x] コードレビュー観点での自己レビュー済み

## 確認事項

- [x] コードレビュー観点での自己レビュー済み