### PR TITLE
docs(claude): CLAUDE.md に Claude Code 向け操作ルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,7 +137,6 @@ These rules define the safety boundary for autonomous Claude Code operations.
 - **Never force-push** (`git push --force`) — prevents overwriting remote history
 - **Never skip hooks** (`git commit --no-verify`) — pre-commit hooks must always run
 - **`git reset --hard` only on explicit instruction** — prevents loss of uncommitted work
-- All commits must be made on a `feature/*` branch
 
 ### Secrets and environment variables
 
@@ -147,9 +146,10 @@ These rules define the safety boundary for autonomous Claude Code operations.
 
 ### Infrastructure
 
-- **`terraform destroy` and `terraform apply` only on explicit instruction** — prevents accidental deletion of Cloud Run services or IAM resources
+- **`terraform destroy` only on explicit instruction** — prevents accidental deletion of Cloud Run services or IAM resources
+- **`terraform apply` requires confirmation** — always review the plan output before applying
 - **Never modify GCS bucket contents or Secret Manager secrets directly** — these are managed by Terraform
-- **`make docker-down` followed by data-destructive commands requires confirmation**
+- **Destructive local operations** (`docker volume rm`, `rm -rf`, etc.) require confirmation before execution
 
 ### PR and external actions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,32 @@ yield-guard/
 ## MCP servers
 
 `docs` server is configured in `.mcp.json` — use `mcp__docs__*` tools to read `docs/` design documents (overview, API reference, domain specs, etc.).
+
+## Claude Code operating rules
+
+These rules define the safety boundary for autonomous Claude Code operations.
+
+### Git operations
+
+- **Never push directly to `main`** — always work on a `feature/*` branch and open a PR
+- **Never force-push** (`git push --force`) — prevents overwriting remote history
+- **Never skip hooks** (`git commit --no-verify`) — pre-commit hooks must always run
+- **`git reset --hard` only on explicit instruction** — prevents loss of uncommitted work
+- All commits must be made on a `feature/*` branch
+
+### Secrets and environment variables
+
+- **Never read, display, or log the contents of `.env`** — `MLIT_API_KEY`, `APP_INTERNAL_API_KEY`, and other secrets must not appear in output
+- **Never stage or commit `.env`** — it is gitignored; do not force-add it
+- **Never include secret values in API responses, test output, or error messages**
+
+### Infrastructure
+
+- **`terraform destroy` and `terraform apply` only on explicit instruction** — prevents accidental deletion of Cloud Run services or IAM resources
+- **Never modify GCS bucket contents or Secret Manager secrets directly** — these are managed by Terraform
+- **`make docker-down` followed by data-destructive commands requires confirmation**
+
+### PR and external actions
+
+- **Never merge a PR without explicit instruction** — even if CI passes
+- **Never post comments to Issues or PRs without explicit instruction** — unintended external communication must be avoided


### PR DESCRIPTION
## 概要

Claude Code が自律的に操作する際の安全境界を `CLAUDE.md` に明文化する。

## 変更内容

`## Claude Code operating rules` セクションを新設し、以下4カテゴリのルールを追加。

- **Git 操作**: `main` 直接 push 禁止・`--force` / `--no-verify` 禁止・`reset --hard` は明示指示のみ
- **シークレット**: `.env` の読み取り・出力・コミット禁止、環境変数の実値を出力に含めない
- **インフラ**: `terraform destroy` は明示指示のみ、`terraform apply` は plan 確認後、GCS / Secret Manager の直接変更禁止
- **PR・外部操作**: マージ・Issue/PR コメント投稿は明示指示のみ

## レビュー対応

- 冗長行（`All commits must be made on a feature/* branch`）を削除
- `terraform destroy` と `terraform apply` のルールを分離（destroy=禁止、apply=確認後）
- `make docker-down` の曖昧な表現を `docker volume rm` / `rm -rf` 等の具体例に修正

## 関連 Issue

Closes #498