### PR TITLE
fix(ci): Docker build cache を Artifact Registry から GitHub Actions cache に変更

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
       id-token: write
       security-events: write
+      actions: write
 
     env:
       IMAGE: asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/yield-guard/backend
@@ -54,9 +55,11 @@ jobs:
           # mode=max: builder ステージ（Go コンパイル結果）を含む全レイヤーを保存。
           # min だと最終 alpine ステージのみでコンパイルが毎回走る。
           # --load: Trivy スキャンのためローカル Docker daemon にイメージを展開する。
+          # type=gha: GitHub Actions キャッシュを使用することで Artifact Registry への
+          # egress 転送（GCP→Azure）が発生しなくなりコストを削減できる。
           docker buildx build \
-            --cache-from "type=registry,ref=${{ env.IMAGE }}:buildcache" \
-            --cache-to   "type=registry,ref=${{ env.IMAGE }}:buildcache,mode=max" \
+            --cache-from "type=gha,scope=${{ github.workflow }}" \
+            --cache-to   "type=gha,scope=${{ github.workflow }},mode=max" \
             --tag "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}" \
             --load \
             ./backend


### PR DESCRIPTION
## 概要

- Artifact Registry の Internet Egress 課金（AsiaPacific to AsiaPacific）を解消する
- Docker ビルドキャッシュの保存先を `type=registry`（Artifact Registry）から `type=gha`（GitHub Actions cache）に変更

## 背景・原因

デプロイのたびに GitHub Actions ランナー（Azure）が Artifact Registry（GCP）から `buildcache` イメージを pull しており、GCP → Azure のインターネット egress として課金されていた。

```
【変更前】GitHub Actions ランナー ←── pull ── Artifact Registry (GCP) ← 課金発生
【変更後】GitHub Actions ランナー ←── pull ── GitHub キャッシュサーバー  ← 無料
```

closes #502

## 変更内容

- `--cache-from`/`--cache-to` を `type=registry` → `type=gha` に変更
- `scope=${{ github.workflow }}` を追加しジョブ間のキャッシュ汚染を防止
- `permissions: actions: write` を追加（GHA キャッシュ API 書き込みに必要）

## 影響範囲

- `.github/workflows/deploy-backend.yml` のみ
- バックエンドコード・本番環境への影響なし
- ビルド時間は変わらない（`mode=max` 維持でビルダーステージもキャッシュ）

## 残作業

マージ後、Artifact Registry に残っている `buildcache` タグを手動削除する：

```bash
gcloud artifacts docker images delete \
  asia-northeast1-docker.pkg.dev/<PROJECT_ID>/yield-guard/backend:buildcache
```

## チェックリスト

- [x] `actions: write` permission 追加済み
- [x] `scope` パラメータでキャッシュ分離済み
- [ ] マージ後に AR の buildcache タグを削除