### PR TITLE
fix(domain): モンテカルロ IRR の初期投資額を自己資金ベースに統一

### DIFF
--- a/backend/internal/domain/montecarlo.go
+++ b/backend/internal/domain/montecarlo.go
@@ -138,10 +138,15 @@ func calcIRR(result InvestmentResult, input InvestmentInput) float64 {
 		holdN = len(result.YearlyResults)
 	}
 
-	// CF系列: year0 = -TotalInvestment, year1..holdN = AfterTaxCashFlow
+	// CF系列: year0 = -equity (自己資本のみ), year1..holdN = AfterTaxCashFlow (返済後CF)
+	// ローン返済後のキャッシュフローに対応するため、初期投資額は equity ベースで計算する
 	// 最終年に売却手取りを加算
 	cfs := make([]float64, holdN+1)
-	cfs[0] = -result.TotalInvestment
+	equity := result.TotalInvestment - input.LoanAmount
+	if equity <= 0 {
+		return math.NaN()
+	}
+	cfs[0] = -equity
 	for i := 1; i <= holdN; i++ {
 		yr := result.YearlyResults[i-1]
 		cfs[i] = yr.AfterTaxCashFlow


### PR DESCRIPTION
## 概要
モンテカルロシミュレーションの `calcIRR` 関数において、IRR 計算の初期投資額（year0 CF）が `TotalInvestment`（総投資額）になっていたが、year1 以降のキャッシュフローはローン返済後（equity CF）であるため不整合が生じていた。初期投資額を equity ベース（`TotalInvestment - LoanAmount`）に修正し、整合性を確保する。

## 変更内容
- `backend/internal/domain/montecarlo.go`: `calcIRR` 関数内の初期 CF を `-TotalInvestment` から `-equity`（`= TotalInvestment - LoanAmount`）に変更
- equity が 0 以下の場合は `math.NaN()` を返すガード節を追加

## 関連Issue
Closes #506

## テスト
- [x] 既存テストが通ること（`go test -race ./internal/domain/... -timeout 120s` → ok）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み