### PR TITLE
fix(domain): LTV 感度分析の総投資額に融資諸費用を加算

### DIFF
--- a/backend/internal/domain/sensitivity.go
+++ b/backend/internal/domain/sensitivity.go
@@ -10,9 +10,9 @@ func CalcLTVSensitivity(input InvestmentInput, ltvRange []float64) []LTVSensitiv
 		ltvRange = []float64{0.5, 0.6, 0.7, 0.8, 0.9}
 	}
 
-	miscExpenses := (input.LandPrice + input.BuildingCost) * input.MiscExpenseRate
-	totalInvestment := input.LandPrice + input.BuildingCost + miscExpenses
-	if totalInvestment <= 0 {
+	baseMiscExpenses := (input.LandPrice + input.BuildingCost) * input.MiscExpenseRate
+	baseCost := input.LandPrice + input.BuildingCost + baseMiscExpenses
+	if baseCost <= 0 {
 		return nil
 	}
 
@@ -25,8 +25,10 @@ func CalcLTVSensitivity(input InvestmentInput, ltvRange []float64) []LTVSensitiv
 
 	rows := make([]LTVSensitivityRow, 0, len(ltvRange))
 	for _, ltv := range ltvRange {
-		loanAmount := totalInvestment * ltv
-		equity := totalInvestment * (1 - ltv)
+		loanAmount := baseCost * ltv
+		loanFee := loanAmount * input.LoanFeeRate
+		totalInvestment := baseCost + loanFee
+		equity := totalInvestment - loanAmount
 
 		var annualDebtService float64
 		if input.LoanMethod == LoanMethodEqualPrincipal && input.LoanYears > 0 {


### PR DESCRIPTION
## 概要

`CalcLTVSensitivity` 関数において、`totalInvestment` の計算に `loanFee`（融資諸費用）が含まれていなかった不具合を修正する。

LTV ごとに `loanAmount` が変わるため、ループ外に `baseCost`（loanFee 除外の取得コスト）を定義し、ループ内で各 `loanAmount` に対応した `loanFee` を加算して `totalInvestment` を算出するよう変更した。また LTV の基準は循環参照を避けるため `baseCost` を使用する。

## 変更内容

- `baseMiscExpenses` / `baseCost` をループ外で定義（loanFee を含まない取得コスト）
- ループ内で `loanAmount = baseCost * ltv` → `loanFee = loanAmount * LoanFeeRate` → `totalInvestment = baseCost + loanFee` の順に算出
- `equity = totalInvestment - loanAmount`（自己資本 = 取得コスト合計 − 借入額）に修正

## 関連Issue

Closes #508

## テスト

- [x] 既存テストが通ること（`go test -race ./internal/domain/... -timeout 120s` → ok）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み