### PR TITLE
fix(domain): 定率法乗数を 1.5 から 2.0 に修正・建物への定率法適用を禁止

### DIFF
--- a/backend/internal/domain/cashflow.go
+++ b/backend/internal/domain/cashflow.go
@@ -91,7 +91,7 @@ func initDepreciationParams(input InvestmentInput) depreciationParams {
 	var bookValue, decliningRate float64
 	if input.DepreciationMethod == DepreciationMethodDecliningBalance {
 		bookValue = input.BuildingCost
-		decliningRate = 1.5 / float64(usefulLife)
+		decliningRate = 2.0 / float64(usefulLife)
 	}
 	return depreciationParams{
 		usefulLife:         usefulLife,

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -183,6 +183,12 @@ func (i *InvestmentInput) Validate() error {
 			)
 		}
 	}
+	// 建物は平成10年（1998年）4月以降、定率法不可（国税庁 No.2100）
+	if i.DepreciationMethod == DepreciationMethodDecliningBalance && i.BuildingCost > 0 {
+		return fmt.Errorf(
+			"建物の償却方法は定額法のみです（1998年4月以降取得の建物は定率法を選択できません）",
+		)
+	}
 	return nil
 }
 

--- a/frontend/src/components/sections/LoanSection.tsx
+++ b/frontend/src/components/sections/LoanSection.tsx
@@ -147,15 +147,20 @@ export function LoanSection({
               onChange={(e) => setNum("priceDeclineRate", fromPct(e.target.value))}
               error={fieldError("priceDeclineRate")}
             />
-            <Select
-              label="減価償却方式"
-              value={input.depreciationMethod ?? "straight-line"}
-              onChange={(e) => setStr("depreciationMethod", e.target.value)}
-              options={[
-                { value: "straight-line", label: "定額法" },
-                { value: "declining-balance", label: "定率法" },
-              ]}
-            />
+            <div className="flex flex-col gap-1">
+              <Select
+                label="減価償却方式"
+                value={input.depreciationMethod ?? "straight-line"}
+                onChange={(e) => setStr("depreciationMethod", e.target.value)}
+                options={[
+                  { value: "straight-line", label: "定額法" },
+                  { value: "declining-balance", label: "定率法" },
+                ]}
+              />
+              <p className="text-xs text-muted-foreground">
+                ※ 定率法は建物には適用不可（1998年4月以降取得）
+              </p>
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/sections/LoanSection.tsx
+++ b/frontend/src/components/sections/LoanSection.tsx
@@ -160,6 +160,12 @@ export function LoanSection({
               <p className="text-xs text-muted-foreground">
                 ※ 定率法は建物には適用不可（1998年4月以降取得）
               </p>
+              {(input.depreciationMethod ?? "straight-line") === "declining-balance" && (
+                <p className="text-yellow-700 bg-yellow-50 border border-yellow-200 rounded p-2 text-xs">
+                  ⚠️
+                  定率法は建物には適用できません。バックエンドでエラーになります。定額法を選択してください。
+                </p>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 概要

定率法（declining-balance）の減価償却率乗数が誤って 1.5 になっていたため、正しい値 2.0 に修正した。
また、1998年4月以降取得の建物は定率法を選択できない（国税庁 No.2100）にもかかわらず、バックエンドでバリデーションが行われておらず、フロントエンドにも説明がなかったため、両方を補完した。

## 変更内容

- `backend/internal/domain/cashflow.go`: `initDepreciationParams` 内の定率法乗数を 1.5 → 2.0 に修正
- `backend/internal/domain/types.go`: `Validate()` に建物（BuildingCost > 0）に対する定率法選択を拒否するバリデーションを追加
- `frontend/src/components/sections/LoanSection.tsx`: 減価償却方式セレクトの下に「定率法は建物には適用不可（1998年4月以降取得）」の注記を追加

## 関連Issue

Closes #504

## テスト

- [x] 既存テストが通ること（`go test -race ./internal/domain/... -timeout 120s` → ok）
- [x] 新規テストを追加した場合、全ケースがPASSすること（既存テストで確認済み）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み