### PR TITLE
fix(infra): terraform apply 失敗の修正

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -37,13 +37,13 @@ func main() {
 		port = "8080"
 	}
 
-	mlitAPIKey := readSecret("/secrets/mlit-api-key", "MLIT_API_KEY")
+	mlitAPIKey := readSecret("/secrets/mlit-api-key/value", "MLIT_API_KEY")
 	if mlitAPIKey == "" {
 		slog.Error("MLIT_API_KEY is not set")
 		os.Exit(1)
 	}
 
-	appInternalAPIKey := readSecret("/secrets/app-internal-api-key", "APP_INTERNAL_API_KEY")
+	appInternalAPIKey := readSecret("/secrets/app-internal-api-key/value", "APP_INTERNAL_API_KEY")
 	if os.Getenv("GIN_MODE") == "release" && appInternalAPIKey == "" {
 		slog.Error("APP_INTERNAL_API_KEY must be set in production (GIN_MODE=release)")
 		os.Exit(1)
@@ -56,7 +56,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	googleMapsAPIKey := readSecret("/secrets/google-maps-api-key", "GOOGLE_MAPS_API_KEY")
+	googleMapsAPIKey := readSecret("/secrets/google-maps-api-key/value", "GOOGLE_MAPS_API_KEY")
 
 	mlitClient := mlit.NewClient(mlitAPIKey)
 	geocodeClient := api.NewGoogleGeocodeClient(googleMapsAPIKey)

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -47,17 +47,17 @@ resource "google_cloud_run_v2_service" "backend" {
 
       volume_mounts {
         name       = "mlit-api-key"
-        mount_path = "/secrets"
+        mount_path = "/secrets/mlit-api-key"
       }
 
       volume_mounts {
         name       = "app-internal-api-key"
-        mount_path = "/secrets"
+        mount_path = "/secrets/app-internal-api-key"
       }
 
       volume_mounts {
         name       = "google-maps-api-key"
-        mount_path = "/secrets"
+        mount_path = "/secrets/google-maps-api-key"
       }
 
       dynamic "env" {
@@ -97,7 +97,7 @@ resource "google_cloud_run_v2_service" "backend" {
       secret {
         secret = google_secret_manager_secret.mlit_api_key.secret_id
         items {
-          path    = "mlit-api-key"
+          path    = "value"
           version = "latest"
         }
       }
@@ -108,7 +108,7 @@ resource "google_cloud_run_v2_service" "backend" {
       secret {
         secret = google_secret_manager_secret.app_internal_api_key.secret_id
         items {
-          path    = "app-internal-api-key"
+          path    = "value"
           version = "latest"
         }
       }
@@ -119,7 +119,7 @@ resource "google_cloud_run_v2_service" "backend" {
       secret {
         secret = google_secret_manager_secret.google_maps_api_key.secret_id
         items {
-          path    = "google-maps-api-key"
+          path    = "value"
           version = "latest"
         }
       }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -94,6 +94,13 @@ resource "google_service_account_iam_member" "deployer_act_as_backend" {
   member             = "serviceAccount:${google_service_account.deployer.email}"
 }
 
+resource "google_service_account_iam_member" "deployer_act_as_billing_stop" {
+  # deployer SA impersonates billing_stop SA when deploying Cloud Function.
+  service_account_id = google_service_account.billing_stop.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.deployer.email}"
+}
+
 resource "google_storage_bucket_iam_member" "deployer_tfstate_admin" {
   # storage.admin includes getIamPolicy/setIamPolicy needed for terraform apply.
   bucket = "yield-guard-tfstate"
@@ -113,6 +120,27 @@ resource "google_project_iam_member" "deployer_secret_manager_admin" {
   # Required to create and manage Secret Manager secrets via terraform apply.
   project = var.project_id
   role    = "roles/secretmanager.admin"
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_project_iam_member" "deployer_storage_admin" {
+  # Required to create GCS buckets (e.g. Cloud Function source bucket) via terraform apply.
+  project = var.project_id
+  role    = "roles/storage.admin"
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_project_iam_member" "deployer_pubsub_admin" {
+  # Required to create Pub/Sub topics and subscriptions via terraform apply.
+  project = var.project_id
+  role    = "roles/pubsub.admin"
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_project_iam_member" "deployer_cloudfunctions_admin" {
+  # Required to deploy Cloud Functions Gen2 via terraform apply.
+  project = var.project_id
+  role    = "roles/cloudfunctions.admin"
   member  = "serviceAccount:${google_service_account.deployer.email}"
 }
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -130,10 +130,11 @@ resource "google_project_iam_member" "deployer_storage_admin" {
   member  = "serviceAccount:${google_service_account.deployer.email}"
 }
 
-resource "google_project_iam_member" "deployer_pubsub_admin" {
+resource "google_project_iam_member" "deployer_pubsub_editor" {
   # Required to create Pub/Sub topics and subscriptions via terraform apply.
+  # pubsub.editor covers create/delete/update without IAM management (unlike pubsub.admin).
   project = var.project_id
-  role    = "roles/pubsub.admin"
+  role    = "roles/pubsub.editor"
   member  = "serviceAccount:${google_service_account.deployer.email}"
 }
 


### PR DESCRIPTION
## 概要

`terraform apply` で発生した3つのエラーを修正する。

## エラーと対処

### 1. Cloud Run — Duplicate mount paths forbidden
**エラー**: `template.containers[0].volume_mounts: Duplicate mount paths [/secrets] forbidden`

Cloud Run v2 はコンテナ内で同一の `mount_path` を複数ボリュームに指定することを禁止している。

**修正** (`terraform/cloud_run.tf`):
- 各ボリュームの `mount_path` を `/secrets/<secret-name>` に変更（一意化）
- `items.path` を `"value"` に統一 → ファイルパス: `/secrets/<name>/value`

**修正** (`backend/cmd/server/main.go`):
- `readSecret` の第1引数を `/secrets/<name>/value` に更新

### 2. GCS バケット作成 403
**エラー**: `storage.buckets.create access denied`

deployer SA はバケットレベルの `storage.admin`（tfstate バケットのみ）しか持っておらず、新規バケット作成に必要なプロジェクトレベル権限がなかった。

**修正** (`terraform/iam.tf`): `roles/storage.admin` をプロジェクトレベルで付与

### 3. Pub/Sub トピック作成 403
**エラー**: `pubsub.topics.create: IAM_PERMISSION_DENIED`

deployer SA に Pub/Sub 操作権限がなかった。

**修正** (`terraform/iam.tf`): `roles/pubsub.admin` + `roles/cloudfunctions.admin` を付与

### 4. Cloud Function デプロイ用 act-as バインディング追加（予防的）
deployer SA が billing_stop SA として Cloud Function をデプロイするための `roles/iam.serviceAccountUser` バインディングを追加。

## 関連

#469 #470 #471 #472 の apply 失敗対応

## テスト

- [ ] `go build ./...` → OK
- [ ] `terraform plan` で意図した差分のみ
- [ ] `terraform apply` が通ること