### PR TITLE
fix(iam): storage/pubsub 作成とIAM付与の競合状態を修正

### DIFF
--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -4,6 +4,8 @@ resource "google_storage_bucket" "functions_source" {
   location                    = var.region
   uniform_bucket_level_access = true
   force_destroy               = true
+
+  depends_on = [google_project_iam_member.deployer_storage_admin]
 }
 
 data "archive_file" "billing_stop" {

--- a/terraform/pubsub.tf
+++ b/terraform/pubsub.tf
@@ -2,6 +2,9 @@ resource "google_pubsub_topic" "billing_alerts" {
   name    = "billing-alerts-${var.env}"
   project = var.project_id
 
-  depends_on = [google_project_service.apis]
+  depends_on = [
+    google_project_service.apis,
+    google_project_iam_member.deployer_pubsub_editor,
+  ]
 }
 


### PR DESCRIPTION
## 概要

`terraform apply` で storage.buckets.create と pubsub.topics.create の 403 が発生した原因は、deployer SA への IAM 付与（#518）とリソース作成が同時並走し、IAM が GCP に伝播する前にリソース作成が始まったため。

## 変更内容

- `terraform/functions.tf`: `google_storage_bucket.functions_source` に `depends_on = [deployer_storage_admin]` を追加
- `terraform/pubsub.tf`: `google_pubsub_topic.billing_alerts` に `depends_on = [deployer_pubsub_editor]` を追加

## 補足

IAM 付与自体は #518 の apply で GCP に反映済み。今回の `depends_on` は同一 apply 内でリソース作成と IAM 付与が同時に走った場合の競合を防ぐ（destroy → re-apply 時などの再現防止）。

startup probe 失敗（Cloud Run）は Deploy Backend と Terraform CI が同時実行したタイミング問題であり、現在は新イメージが正しくデプロイ済み。次回 apply では解消される見込み。

## 関連

#518 の apply 失敗の後続対応