### PR TITLE
fix(iam): Cloud Functions Gen2 ビルド用 Compute SA act-as 権限を追加

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -101,6 +101,14 @@ resource "google_service_account_iam_member" "deployer_act_as_billing_stop" {
   member             = "serviceAccount:${google_service_account.deployer.email}"
 }
 
+resource "google_service_account_iam_member" "deployer_act_as_default_compute" {
+  # Cloud Functions Gen2 build (Cloud Build) runs as the default Compute SA.
+  # deployer SA must be able to act as it to submit the build job.
+  service_account_id = "projects/${var.project_id}/serviceAccounts/${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.deployer.email}"
+}
+
 resource "google_storage_bucket_iam_member" "deployer_tfstate_admin" {
   # storage.admin includes getIamPolicy/setIamPolicy needed for terraform apply.
   bucket = "yield-guard-tfstate"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,6 +22,8 @@ provider "google" {
   region  = var.region
 }
 
+data "google_project" "project" {}
+
 locals {
   service_name     = "yield-guard-${var.env}-backend"
   sa_name          = "sa-yield-guard-${var.env}"


### PR DESCRIPTION
## 概要

`terraform apply` で Cloud Functions Gen2 のデプロイが以下のエラーで失敗した問題を修正。

```
Caller is missing permission 'iam.serviceaccounts.actAs' on
198563667438-compute@developer.gserviceaccount.com
```

## 原因

Cloud Functions Gen2 はビルド時に Cloud Build を使用し、Cloud Build は**デフォルト Compute Engine SA**（`{project_number}-compute@developer.gserviceaccount.com`）として実行される。deployer SA がこの SA に act-as できず、ビルドジョブの投入に失敗していた。

## 変更内容

- `terraform/main.tf`: `data.google_project.project` データソースを追加（プロジェクト番号取得用）
- `terraform/iam.tf`: deployer SA → デフォルト Compute SA への `roles/iam.serviceAccountUser` バインディングを追加

## 別途対応が必要な事項

`google_billing_budget` の 403 は Billing Account レベルの権限不足であり、GCP Billing コンソールで deployer SA に `roles/billing.costsManager` を手動付与する必要がある（Terraform では付与不可）。

## 関連

#518 #519 の apply 失敗の後続対応