### PR TITLE
fix(infra): eventarc.googleapis.com を有効化 (Cloud Functions Gen2 トリガー)

### DIFF
--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -17,6 +17,8 @@ locals {
     "pubsub.googleapis.com",
     "cloudfunctions.googleapis.com",
     "cloudbuild.googleapis.com",
+    # Required for Cloud Functions Gen2 Pub/Sub event triggers (Eventarc backend).
+    "eventarc.googleapis.com",
   ])
 }
 


### PR DESCRIPTION
## 概要

Cloud Functions Gen2 の Pub/Sub イベントトリガーは Eventarc をバックエンドとして使用するが、`eventarc.googleapis.com` が `required_apis` に未登録だったため apply 時に 403 が発生していた。

## エラー

```
Error creating function: Eventarc API has not been used in project *** before or it is disabled.
```

## 変更内容

- `terraform/apis.tf`: `eventarc.googleapis.com` を `required_apis` に追加

## 関連

#518 #519 #520 の apply 失敗対応