### PR TITLE
fix(iam): deployer SA に billing.admin を付与 (Billing Budget 管理)

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -153,6 +153,14 @@ resource "google_project_iam_member" "deployer_cloudfunctions_admin" {
   member  = "serviceAccount:${google_service_account.deployer.email}"
 }
 
+resource "google_billing_account_iam_member" "deployer_billing_admin" {
+  # Required to create and update Billing Budgets via terraform apply.
+  # billing.admin is needed; billing.costsManager does not include budgets.update in practice.
+  billing_account_id = var.billing_account_id
+  role               = "roles/billing.admin"
+  member             = "serviceAccount:${google_service_account.deployer.email}"
+}
+
 # --- Runtime SA permissions (Cloud Run only) ---
 
 resource "google_secret_manager_secret_iam_member" "mlit_accessor" {


### PR DESCRIPTION
## 概要

`terraform apply` で Billing Budget の更新が以下のエラーで失敗していた問題を修正。

```
Error updating Budget: googleapi: Error 403: The caller does not have permission
```

## 原因

`roles/billing.costsManager` は `billing.budgets.update` を含むはずだが、実際には Billing Budget の更新に `billing.admin` が必要だった。

## 変更内容

- `terraform/iam.tf`: deployer SA に `google_billing_account_iam_member` で `roles/billing.admin` を付与

## ブートストラップ手順

このリソースを Terraform で管理するには deployer SA 自身が Billing Account IAM を操作できる必要があるため、初回は手動で付与済み

## 関連

#518 〜 #521 の apply 失敗対応