### PR TITLE
fix(infra): cloudbilling.googleapis.com を有効化 (Billing Account IAM 管理)

### DIFF
--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -34,3 +34,9 @@ resource "google_project_service" "billingbudgets" {
   service            = "billingbudgets.googleapis.com"
   disable_on_destroy = false
 }
+
+resource "google_project_service" "cloudbilling" {
+  # Required for google_billing_account_iam_member to retrieve and set billing account IAM policies.
+  service            = "cloudbilling.googleapis.com"
+  disable_on_destroy = false
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -159,6 +159,8 @@ resource "google_billing_account_iam_member" "deployer_billing_admin" {
   billing_account_id = var.billing_account_id
   role               = "roles/billing.admin"
   member             = "serviceAccount:${google_service_account.deployer.email}"
+
+  depends_on = [google_project_service.cloudbilling]
 }
 
 # --- Runtime SA permissions (Cloud Run only) ---


### PR DESCRIPTION
## 概要

`google_billing_account_iam_member` の適用時に以下のエラーが発生した問題を修正。

```
Error retrieving IAM policy for billing account: Cloud Billing API has not been
used in project *** before or it is disabled.
```

## 変更内容

- `terraform/apis.tf`: `cloudbilling.googleapis.com` を専用リソースとして追加
- `terraform/iam.tf`: `deployer_billing_admin` に `depends_on = [cloudbilling]` を追加

## 補足

Billing Budget 403 は `billing.admin` の IAM 伝播タイミング問題が原因の可能性もあり、本 PR の apply 後に解消される見込み。

## 関連

#522 の apply 失敗の後続対応