### PR TITLE
fix(infra): billing provider に user_project_override を設定して Billing Budget 403 を解消

### DIFF
--- a/terraform/billing.tf
+++ b/terraform/billing.tf
@@ -1,12 +1,14 @@
 # ─────────────────────────────────────────────────────
 # 予算アラート (#256)
-# 前提: Deployer SA に請求アカウントレベルの roles/billing.costsManager が必要。
-# Terraform 管理外のため初回のみ手動付与:
+# 前提: Deployer SA に請求アカウントレベルの roles/billing.admin が必要。
+# google_billing_account_iam_member.deployer_billing_admin で Terraform 管理済み。
+# 初回ブートストラップのみ手動付与が必要:
 #   gcloud billing accounts add-iam-policy-binding <BILLING_ACCOUNT_ID> \
 #     --member="serviceAccount:<deployer-sa-email>" \
-#     --role="roles/billing.costsManager"
+#     --role="roles/billing.admin"
 # ─────────────────────────────────────────────────────
 resource "google_billing_budget" "monthly" {
+  provider        = google.billing
   billing_account = var.billing_account_id
   display_name    = "Yield Guard 月次予算アラート"
 

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -154,6 +154,7 @@ resource "google_project_iam_member" "deployer_cloudfunctions_admin" {
 }
 
 resource "google_billing_account_iam_member" "deployer_billing_admin" {
+  provider = google.billing
   # Required to create and update Billing Budgets via terraform apply.
   # billing.admin is needed; billing.costsManager does not include budgets.update in practice.
   billing_account_id = var.billing_account_id

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -22,6 +22,16 @@ provider "google" {
   region  = var.region
 }
 
+# Billing Account-scoped resources (e.g. google_billing_budget) require a quota
+# project to be specified explicitly; without it the API returns 403.
+provider "google" {
+  alias                 = "billing"
+  project               = var.project_id
+  region                = var.region
+  user_project_override = true
+  billing_project       = var.project_id
+}
+
 data "google_project" "project" {}
 
 locals {


### PR DESCRIPTION
## 概要

`terraform apply` で Billing Budget / Billing Account IAM の更新が 403 で失敗し続ける根本原因を修正。

## 原因

Billing Account スコープの API（`billingbudgets.googleapis.com` / `cloudbilling.googleapis.com`）は、呼び出し時にクォータプロジェクトを明示しないと 403 を返す既知の制約がある。

## 変更内容

- `terraform/main.tf`: `google.billing` エイリアスプロバイダーを追加
  - `user_project_override = true`
  - `billing_project = var.project_id`
- `terraform/billing.tf`: `google_billing_budget.monthly` に `provider = google.billing` を指定
- `terraform/iam.tf`: `google_billing_account_iam_member.deployer_billing_admin` に `provider = google.billing` を指定

## 関連

#518〜#523 の apply 失敗対応の完了