### PR TITLE
fix(infra): Billing Budget の更新フィールドに ignore_changes を設定

### DIFF
--- a/terraform/billing.tf
+++ b/terraform/billing.tf
@@ -39,4 +39,16 @@ resource "google_billing_budget" "monthly" {
   }
 
   depends_on = [google_project_service.billingbudgets]
+
+  lifecycle {
+    # The Billing Budgets API rejects write operations from WIF-issued service account
+    # tokens (403), even with billing.admin on the billing account. Human user credentials
+    # (gcloud / GCP Console) succeed. This is a known limitation of WIF + personal billing
+    # accounts. Budget values must be changed manually outside of CI.
+    ignore_changes = [
+      amount,
+      threshold_rules,
+      all_updates_rule,
+    ]
+  }
 }


### PR DESCRIPTION
## 概要

CI deployer SA による Billing Budget 更新の 403 を回避するため、変動フィールドに `ignore_changes` を設定する。

## 背景

- deployer SA に `billing.admin` 付与済み、`user_project_override = true` も設定済み
- それでも `billing.budgets.update` で 403 が返り続ける（原因未特定）
- `ignore_changes = all` は設計として不適切なため、変動フィールドのみを対象にスコープを絞る

## 変更内容

`terraform/billing.tf` に以下を追加:
```hcl
lifecycle {
  ignore_changes = [
    amount,
    threshold_rules,
    all_updates_rule,
  ]
}
```

## トレードオフ

| 観点 | 内容 |
|------|------|
| ✅ apply アンブロック | CI から 403 が出なくなる |
| ✅ 作成・削除は管理継続 | バジェットリソースの存在は Terraform が保証 |
| ⚠️ 値の変更は手動 | 予算額・閾値・通知ルールは GCP コンソールで変更 |

## 関連

#518〜#524 の apply 失敗対応