### PR TITLE
fix(telemetry): OTelトレースエクスポートの400エラー修正（gcp.project_id欠落）

### DIFF
--- a/backend/internal/telemetry/setup.go
+++ b/backend/internal/telemetry/setup.go
@@ -9,6 +9,7 @@ import (
 
 	monitoring "github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/exporters/stdout/stdoutmetric"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
@@ -76,17 +77,23 @@ func initInstruments(mp metric.MeterProvider) {
 // Otherwise stdout exporters are used (local dev).
 // Returns a shutdown function that must be deferred by the caller.
 func Setup(ctx context.Context, serviceName, serviceVersion string) (func(context.Context) error, error) {
+	gcpProject := os.Getenv("GOOGLE_CLOUD_PROJECT")
+
+	resAttrs := []attribute.KeyValue{
+		semconv.ServiceName(serviceName),
+		semconv.ServiceVersion(serviceVersion),
+	}
+	// telemetry.googleapis.com/v1/traces requires "gcp.project_id" in the OTel resource.
+	if gcpProject != "" {
+		resAttrs = append(resAttrs, attribute.String("gcp.project_id", gcpProject))
+	}
+
 	res, err := resource.New(ctx,
-		resource.WithAttributes(
-			semconv.ServiceName(serviceName),
-			semconv.ServiceVersion(serviceVersion),
-		),
+		resource.WithAttributes(resAttrs...),
 	)
 	if err != nil {
 		return nil, err
 	}
-
-	gcpProject := os.Getenv("GOOGLE_CLOUD_PROJECT")
 
 	// --- Trace exporter ---
 	var traceExporter sdktrace.SpanExporter


### PR DESCRIPTION
## 概要

Cloud Runデプロイ後、OTelトレースが30秒ごとに400エラーで失敗し続けていた問題を修正する。

## 原因

`telemetry.googleapis.com/v1/traces` はOTelリソース属性に `gcp.project_id` を要求するが、`setup.go` の `resource.New()` が `service.name` / `service.version` しか設定していなかった。

```
400 Bad Request: Resource is missing required attribute "gcp.project_id"
```

30日間で321件以上のエラーログが蓄積されており、OTelバッチャーのリトライがバックグラウンドで常時HTTP通信を行っていた。

## 変更内容

- `backend/internal/telemetry/setup.go`
  - `gcpProject` の取得を `resource.New()` より前に移動
  - `GOOGLE_CLOUD_PROJECT` が設定されている場合（本番環境）に `gcp.project_id` 属性をリソースに追加
  - `attribute` パッケージをインポートに追加

## 確認事項

- [x] `go build ./...` 通過
- [x] `go test ./internal/telemetry/...` 通過（既存テスト全PASS）
- [ ] Cloud Runデプロイ後、Cloud Trace コンソールでトレースが表示されることを確認

## 関連

Cloud Runの謎の料金発生調査で発見。エラーにより本来蓄積されるはずのトレースデータが全件欠落していた。