### PR TITLE
fix(rent-stats): MLIT HTTP 400 を防ぐため ToQuarter を動的算出に変更

### DIFF
--- a/backend/internal/api/rent_handler.go
+++ b/backend/internal/api/rent_handler.go
@@ -34,13 +34,13 @@ func (h *Handler) GetRentStats(c *gin.Context) {
 	// 直近2年分のデータを取得する
 	now := time.Now()
 	toYear := now.Year()
-	fromYear := toYear - 2
 	currentQuarter := (int(now.Month())-1)/3 + 1
 	toQuarter := currentQuarter - 1
 	if toQuarter == 0 {
 		toQuarter = 4
 		toYear--
 	}
+	fromYear := toYear - 2
 
 	q := mlit.LandPriceQuery{
 		Area:      area,

--- a/backend/internal/api/rent_handler.go
+++ b/backend/internal/api/rent_handler.go
@@ -35,6 +35,12 @@ func (h *Handler) GetRentStats(c *gin.Context) {
 	now := time.Now()
 	toYear := now.Year()
 	fromYear := toYear - 2
+	currentQuarter := (int(now.Month())-1)/3 + 1
+	toQuarter := currentQuarter - 1
+	if toQuarter == 0 {
+		toQuarter = 4
+		toYear--
+	}
 
 	q := mlit.LandPriceQuery{
 		Area:      area,
@@ -42,7 +48,7 @@ func (h *Handler) GetRentStats(c *gin.Context) {
 		Year:      fromYear,
 		Quarter:   1,
 		ToYear:    toYear,
-		ToQuarter: 4,
+		ToQuarter: toQuarter,
 	}
 
 	result, err := h.mlitClient.FetchRentStats(c.Request.Context(), q, areaSqm)


### PR DESCRIPTION
## 概要

`/api/rent-stats` エンドポイントで MLIT API の `ToQuarter` を `4`（Q4）にハードコードしていたため、Q4以外の時期（現在: 2026年Q2）に呼び出すと未来の四半期データをリクエストし HTTP 400 が返っていた。現在の月から現在の四半期を動的に算出し、MLIT データ公表ラグ（1クォーター）を考慮して `toQuarter - 1` を上限とするよう修正した。

## 変更内容

`backend/internal/api/rent_handler.go`

- `now.Month()` から現在の四半期を算出
- `toQuarter = currentQuarter - 1`（Q1のとき前年Q4に巻き戻し）
- `LandPriceQuery.ToQuarter` に動的計算値を設定

## テスト

- `go test -race ./... -timeout 120s` — 全パスを確認済み

Closes #532