### PR TITLE
docs(domain/frontend): ストレスΔと変動金利スケジュール重ね合わせ挙動の明文化

### DIFF
--- a/backend/internal/domain/cashflow.go
+++ b/backend/internal/domain/cashflow.go
@@ -299,7 +299,10 @@ func calcAllStressScenarios(ctx context.Context, input InvestmentInput) []Stress
 	return scenarioResults
 }
 
-// calcStressScenario は指定の金利・空室率オフセットでシナリオ計算を行い結果を返す
+// calcStressScenario は指定の金利・空室率オフセットでシナリオ計算を行い結果を返す。
+// RateAdjustmentSchedule が設定されている場合、rateDelta はスケジュール金利にも
+// 上乗せされる（resolveRateForYear の仕様による）。
+// この挙動はフロントエンドの注釈で明示されている。
 func calcStressScenario(ctx context.Context, base InvestmentInput, label string, rateDelta, vacDelta float64) StressScenarioResult {
 	_, span := otel.Tracer(domainTracerName).Start(ctx, "domain.calcStressScenario")
 	defer span.End()

--- a/backend/internal/domain/loan.go
+++ b/backend/internal/domain/loan.go
@@ -76,9 +76,11 @@ func CalcEqualPrincipalPayment(principal, annualRate float64, months, month int)
 	return monthlyPrincipal + monthlyInterest
 }
 
-// resolveRateForYear はスケジュールと基準金利から指定年の適用金利を返す。
+// resolveRateForYear は基準金利・変動スケジュール・ストレスΔから指定年の実効金利を返す。
+// 変動金利スケジュールが設定されている場合、スケジュールで指定された絶対金利に
+// rateDelta（ストレスΔ）を上乗せした値が実効金利となる。
+// 例: schedule で 3年目から 2.0%、rateDelta=+1% → 3年目以降の実効金利は 3.0%
 // schedule が空の場合は baseRate + rateDelta を返す（固定金利）。
-// rateDelta はストレステスト用の追加オフセット。
 func resolveRateForYear(baseRate, rateDelta float64, schedule []RateAdjustment, year int) float64 {
 	rate := baseRate
 	for _, adj := range schedule {

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -50,6 +50,7 @@ export function ScenarioSection({ input, setNum, rateSchedule, capex }: Scenario
           <div className="space-y-2">
             <p className="text-xs text-muted-foreground">
               指定年以降の適用金利（絶対値）を設定します。最大3ステップ。
+              ストレステストを併用する場合、ストレスΔはここで設定した金利にも加算されます。
             </p>
             {input.rateAdjustmentSchedule.map((step, i) => {
               const maxYear = input.loanYears || 35;
@@ -140,9 +141,10 @@ export function ScenarioSection({ input, setNum, rateSchedule, capex }: Scenario
           onChange={(v) => setNum("loanRateDelta", v)}
           formatValue={(v) => `+${formatPct(v)}`}
         />
-        {rateSchedule.enabled && input.loanRateDelta > 0 && (
-          <p className="text-xs text-muted-foreground">
-            金利上昇分はスケジュール後の金利にも上乗せされます
+        {rateSchedule.enabled && input.rateAdjustmentSchedule && input.rateAdjustmentSchedule.length > 0 && (
+          <p className="text-xs text-amber-600 mt-1">
+            ※ 変動金利スケジュールが設定されています。
+            ストレスΔはスケジュールの各年金利にも上乗せされます。
           </p>
         )}
       </div>

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -141,12 +141,15 @@ export function ScenarioSection({ input, setNum, rateSchedule, capex }: Scenario
           onChange={(v) => setNum("loanRateDelta", v)}
           formatValue={(v) => `+${formatPct(v)}`}
         />
-        {rateSchedule.enabled && input.rateAdjustmentSchedule && input.rateAdjustmentSchedule.length > 0 && (
-          <p className="text-xs text-amber-600 mt-1">
-            ※ 変動金利スケジュールが設定されています。
-            ストレスΔはスケジュールの各年金利にも上乗せされます。
-          </p>
-        )}
+        {rateSchedule.enabled &&
+          input.rateAdjustmentSchedule &&
+          input.rateAdjustmentSchedule.length > 0 &&
+          input.loanRateDelta > 0 && (
+            <p className="text-xs text-amber-600 mt-1">
+              ※ 変動金利スケジュールが設定されています。
+              ストレスΔはスケジュールの各年金利にも上乗せされます。
+            </p>
+          )}
       </div>
 
       {/* 大規模修繕費スケジュール */}


### PR DESCRIPTION
## 概要

ストレステスト（`loanRateDelta`）と変動金利スケジュール（`RateAdjustmentSchedule`）を併用した際の実効金利の挙動が不明確だった問題に対応する。バックエンドのコアロジックにコメントを追記し、フロントエンドの UI に注釈を追加することでユーザーへ挙動を明示する。

## 変更内容

- `backend/internal/domain/loan.go`: `resolveRateForYear` 関数のコメントを強化。スケジュール適用後の金利にも `rateDelta`（ストレスΔ）が上乗せされることを具体例付きで説明
- `backend/internal/domain/cashflow.go`: `calcStressScenario` 関数にコメントを追加。RateAdjustmentSchedule 設定時の rateDelta の挙動をフロントエンド注釈との対応とともに明示
- `frontend/src/components/sections/ScenarioSection.tsx`:
  - 変動金利スケジュールの説明文に「ストレスΔはここで設定した金利にも加算されます」を追記
  - ストレステストセクションに amber 色の警告注釈を追加（スケジュールが 1 件以上設定されている場合に表示）

## 関連Issue

Closes #214

## テスト

- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み