### PR TITLE
feat(backend/frontend): 入退去コスト（原状回復・AD・フリーレント）のキャッシュフロー反映

### DIFF
--- a/backend/internal/domain/cashflow.go
+++ b/backend/internal/domain/cashflow.go
@@ -246,11 +246,8 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 
 		capex := capexForYear(input.CapexSchedule, year)
 		// 年間ターンオーバーコスト（入退去に伴う原状回復費・AD・フリーレント損失）
-		// monthlyRent は当年の実効月額賃料を元にする（空室率は考慮しない）
-		monthlyRentForYear := yearAnnualRent / (12 * (1 - math.Min(input.VacancyRate+input.VacancyRateDelta, 0.99)))
-		if math.IsNaN(monthlyRentForYear) || math.IsInf(monthlyRentForYear, 0) {
-			monthlyRentForYear = input.MonthlyRent
-		}
+		// yearAnnualRent はすでに空室率を加味した実効年間賃料のため、12で割るだけで月額賃料を得る
+		monthlyRentForYear := yearAnnualRent / 12
 		annualTurnoverCost := calcAnnualTurnoverCost(input, monthlyRentForYear)
 		cashFlow := yearAnnualRent - annualLoanPayment - yearExpenses - capex - annualTurnoverCost
 		afterTaxCF := cashFlow - incomeTax
@@ -427,7 +424,11 @@ func calcStressScenario(ctx context.Context, base InvestmentInput, label string,
 			}
 		}
 
-		cf := yearNOI - yearLoan
+		// 年間ターンオーバーコスト（simulateYears と同様のロジックで算出）
+		monthlyRentForYear := yearRent / 12
+		annualTurnoverCost := calcAnnualTurnoverCost(in, monthlyRentForYear)
+
+		cf := yearNOI - yearLoan - annualTurnoverCost
 		// 減価償却は省略した保守的近似（簡略ストレス計算のため過大に税を見積もる）
 		taxableIncome := yearNOI - yearInterest
 		incomeTax := 0.0

--- a/backend/internal/domain/cashflow.go
+++ b/backend/internal/domain/cashflow.go
@@ -116,6 +116,18 @@ func calcEffectiveExpenseRate(input InvestmentInput) float64 {
 	return input.ExpenseRate
 }
 
+// calcAnnualTurnoverCost は平均入居期間・原状回復費・AD・フリーレントから
+// 年間のターンオーバーコストを算出して返す。
+// AvgTenancyYears が 0 以下の場合は 0 を返す（後方互換）。
+func calcAnnualTurnoverCost(input InvestmentInput, monthlyRent float64) float64 {
+	if input.AvgTenancyYears <= 0 {
+		return 0
+	}
+	turnoverPerYear := 1.0 / input.AvgTenancyYears
+	freeLeaseLoss := monthlyRent * input.RentFreePeriod * turnoverPerYear
+	return (input.RestorationCost+input.AdFee)*turnoverPerYear + freeLeaseLoss
+}
+
 // capexForYear は CapexSchedule から指定年の修繕費合計を返す。
 func capexForYear(schedule []CapexEvent, year int) float64 {
 	total := 0.0
@@ -233,7 +245,14 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 		incomeTax := taxableIncome * input.IncomeTaxRate
 
 		capex := capexForYear(input.CapexSchedule, year)
-		cashFlow := yearAnnualRent - annualLoanPayment - yearExpenses - capex
+		// 年間ターンオーバーコスト（入退去に伴う原状回復費・AD・フリーレント損失）
+		// monthlyRent は当年の実効月額賃料を元にする（空室率は考慮しない）
+		monthlyRentForYear := yearAnnualRent / (12 * (1 - math.Min(input.VacancyRate+input.VacancyRateDelta, 0.99)))
+		if math.IsNaN(monthlyRentForYear) || math.IsInf(monthlyRentForYear, 0) {
+			monthlyRentForYear = input.MonthlyRent
+		}
+		annualTurnoverCost := calcAnnualTurnoverCost(input, monthlyRentForYear)
+		cashFlow := yearAnnualRent - annualLoanPayment - yearExpenses - capex - annualTurnoverCost
 		afterTaxCF := cashFlow - incomeTax
 		cumulativeCF += afterTaxCF
 

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -3062,6 +3062,12 @@ func TestCalcAnnualTurnoverCost(t *testing.T) {
 			// (150000+60000)*0.5 + 100000*0.5*0.5 = 105000 + 25000 = 130000
 			want: 130000,
 		},
+		{
+			name:        "negative avgTenancyYears returns 0 (treated as invalid)",
+			input:       InvestmentInput{AvgTenancyYears: -1.0},
+			monthlyRent: 100000,
+			want:        0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2951,6 +2951,7 @@ func TestCalcStressScenario_IsSafe_DSCR_Between1And1_2(t *testing.T) {
 	t.Logf("DSCR=%.4f, BreakEvenYear=%d, IsSafe=%v", result.DSCR, result.BreakEvenYear, result.IsSafe)
 }
 
+<<<<<<< HEAD
 // TestAnalyze_LossOffsetting は不動産所得が赤字の場合に損益通算（税還付）が
 // キャッシュフローに反映されることを検証する（所得税法69条）。
 // 設計: 高額建物（木造・大きな減価償却）＋高金利ローンで taxableIncome を意図的に負にする。
@@ -3032,5 +3033,42 @@ func TestAnalyze_LossOffsetting_ZeroRate(t *testing.T) {
 	if yr.AfterTaxCashFlow != yr.CashFlow {
 		t.Errorf("AfterTaxCashFlow (%.0f) != CashFlow (%.0f) when IncomeTaxRate=0",
 			yr.AfterTaxCashFlow, yr.CashFlow)
+	}
+}
+
+func TestCalcAnnualTurnoverCost(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       InvestmentInput
+		monthlyRent float64
+		want        float64
+	}{
+		{
+			name:        "avgTenancyYears=0 returns 0 (backward compat)",
+			input:       InvestmentInput{AvgTenancyYears: 0},
+			monthlyRent: 100000,
+			want:        0,
+		},
+		{
+			name: "normal calculation",
+			input: InvestmentInput{
+				AvgTenancyYears: 2.0,
+				RestorationCost: 150000,
+				AdFee:           60000,
+				RentFreePeriod:  0.5,
+			},
+			monthlyRent: 100000,
+			// turnoverPerYear = 0.5
+			// (150000+60000)*0.5 + 100000*0.5*0.5 = 105000 + 25000 = 130000
+			want: 130000,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calcAnnualTurnoverCost(tt.input, tt.monthlyRent)
+			if math.Abs(got-tt.want) > 1 {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2951,7 +2951,6 @@ func TestCalcStressScenario_IsSafe_DSCR_Between1And1_2(t *testing.T) {
 	t.Logf("DSCR=%.4f, BreakEvenYear=%d, IsSafe=%v", result.DSCR, result.BreakEvenYear, result.IsSafe)
 }
 
-<<<<<<< HEAD
 // TestAnalyze_LossOffsetting は不動産所得が赤字の場合に損益通算（税還付）が
 // キャッシュフローに反映されることを検証する（所得税法69条）。
 // 設計: 高額建物（木造・大きな減価償却）＋高金利ローンで taxableIncome を意図的に負にする。

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -145,6 +145,12 @@ type InvestmentInput struct {
 	InsuranceFeeRate     float64 `json:"insuranceFeeRate,omitempty"`     // 保険料率 (例: 0.003 = 0.3%)
 	OtherExpenseRate     float64 `json:"otherExpenseRate,omitempty"`     // その他経費率 (例: 0.005 = 0.5%)
 	ExpenseInflationRate float64 `json:"expenseInflationRate,omitempty"` // 経費インフレ率/年 (例: 0.01 = 1%)
+
+	// 入退去コスト（全て optional。0 または未入力の場合はターンオーバーコスト = 0）
+	AvgTenancyYears float64 `json:"avgTenancyYears,omitempty"` // 平均入居期間（年）例: 2.0
+	RestorationCost float64 `json:"restorationCost,omitempty"` // 原状回復費（円/回）例: 150000
+	AdFee           float64 `json:"adFee,omitempty"`           // 入居者募集 AD（円/回）例: 家賃1ヶ月分
+	RentFreePeriod  float64 `json:"rentFreePeriod,omitempty"`  // フリーレント（ヶ月）例: 0.5
 }
 
 // CapexEvent は大規模修繕費の発生スケジュール1件

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -280,7 +280,11 @@ export function ScenarioSection({
               step="0.5"
               placeholder="例: 2.0"
               value={input.avgTenancyYears != null ? String(input.avgTenancyYears) : ""}
-              onChange={(e) => setNum("avgTenancyYears", parseFloat(e.target.value) || 0)}
+              onChange={(e) => {
+                // Treat empty input as 0 (backward compat; setNum requires number)
+                const v = parseFloat(e.target.value);
+                setNum("avgTenancyYears", isNaN(v) ? 0 : v);
+              }}
             />
             <Input
               label="原状回復費（1回あたり）"
@@ -295,9 +299,11 @@ export function ScenarioSection({
                   ? String(Math.round(input.restorationCost / 10_000))
                   : ""
               }
-              onChange={(e) =>
-                setNum("restorationCost", (parseFloat(e.target.value) || 0) * 10_000)
-              }
+              onChange={(e) => {
+                // Treat empty input as 0 (backward compat; setNum requires number)
+                const v = parseFloat(e.target.value);
+                setNum("restorationCost", (isNaN(v) ? 0 : v) * 10_000);
+              }}
             />
             <Input
               label="AD（広告料・1回あたり）"
@@ -308,7 +314,11 @@ export function ScenarioSection({
               step="1"
               placeholder="例: 10"
               value={input.adFee != null ? String(Math.round(input.adFee / 10_000)) : ""}
-              onChange={(e) => setNum("adFee", (parseFloat(e.target.value) || 0) * 10_000)}
+              onChange={(e) => {
+                // Treat empty input as 0 (backward compat; setNum requires number)
+                const v = parseFloat(e.target.value);
+                setNum("adFee", (isNaN(v) ? 0 : v) * 10_000);
+              }}
             />
             <Input
               label="フリーレント"
@@ -320,7 +330,11 @@ export function ScenarioSection({
               step="0.5"
               placeholder="例: 0.5"
               value={input.rentFreePeriod != null ? String(input.rentFreePeriod) : ""}
-              onChange={(e) => setNum("rentFreePeriod", parseFloat(e.target.value) || 0)}
+              onChange={(e) => {
+                // Treat empty input as 0 (backward compat; setNum requires number)
+                const v = parseFloat(e.target.value);
+                setNum("rentFreePeriod", isNaN(v) ? 0 : v);
+              }}
             />
           </div>
         )}

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -306,7 +306,7 @@ export function ScenarioSection({
               suffix="万円"
               min="0"
               step="1"
-              placeholder="例: 家賃1ヶ月分"
+              placeholder="例: 10"
               value={input.adFee != null ? String(Math.round(input.adFee / 10_000)) : ""}
               onChange={(e) => setNum("adFee", (parseFloat(e.target.value) || 0) * 10_000)}
             />

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -1,9 +1,9 @@
 "use client";
-import React from "react";
+import React, { useState } from "react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
-import { Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus, Trash2 } from "lucide-react";
 import type { InvestmentInput, RateAdjustment } from "@/types/investment";
 import { formatPct } from "@/lib/utils";
 
@@ -39,6 +39,7 @@ export function ScenarioSection({
   rateSchedule,
   capex,
 }: ScenarioSectionProps) {
+  const [turnoverOpen, setTurnoverOpen] = useState(false);
   const exitYears: number[] = input.exitYears ?? [...ALL_EXIT_YEARS];
 
   function toggleExitYear(yr: number) {
@@ -243,6 +244,84 @@ export function ScenarioSection({
                 </Button>
               </div>
             ))}
+          </div>
+        )}
+      </div>
+      {/* 入退去コスト（任意） */}
+      <div className="border-t pt-4">
+        <button
+          type="button"
+          className="flex items-center gap-2 w-full text-left"
+          onClick={() => setTurnoverOpen((v) => !v)}
+          aria-expanded={turnoverOpen}
+        >
+          {turnoverOpen ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground shrink-0" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground shrink-0" />
+          )}
+          <p className="text-sm font-semibold text-foreground">入退去コスト（任意）</p>
+          <span className="text-xs text-muted-foreground ml-1">原状回復・AD・フリーレント</span>
+        </button>
+
+        {turnoverOpen && (
+          <div className="mt-3 space-y-3">
+            <p className="text-xs text-muted-foreground">
+              入居期間・退去時コストを入力すると、年間ターンオーバーコストがキャッシュフローに反映されます。
+              未入力の場合はコスト = 0（後方互換）。
+            </p>
+            <Input
+              label="平均入居期間"
+              type="number"
+              inputMode="decimal"
+              suffix="年"
+              min="0.5"
+              max="30"
+              step="0.5"
+              placeholder="例: 2.0"
+              value={input.avgTenancyYears != null ? String(input.avgTenancyYears) : ""}
+              onChange={(e) => setNum("avgTenancyYears", parseFloat(e.target.value) || 0)}
+            />
+            <Input
+              label="原状回復費（1回あたり）"
+              type="number"
+              inputMode="numeric"
+              suffix="万円"
+              min="0"
+              step="1"
+              placeholder="例: 15"
+              value={
+                input.restorationCost != null
+                  ? String(Math.round(input.restorationCost / 10_000))
+                  : ""
+              }
+              onChange={(e) =>
+                setNum("restorationCost", (parseFloat(e.target.value) || 0) * 10_000)
+              }
+            />
+            <Input
+              label="AD（広告料・1回あたり）"
+              type="number"
+              inputMode="numeric"
+              suffix="万円"
+              min="0"
+              step="1"
+              placeholder="例: 家賃1ヶ月分"
+              value={input.adFee != null ? String(Math.round(input.adFee / 10_000)) : ""}
+              onChange={(e) => setNum("adFee", (parseFloat(e.target.value) || 0) * 10_000)}
+            />
+            <Input
+              label="フリーレント"
+              type="number"
+              inputMode="decimal"
+              suffix="ヶ月"
+              min="0"
+              max="6"
+              step="0.5"
+              placeholder="例: 0.5"
+              value={input.rentFreePeriod != null ? String(input.rentFreePeriod) : ""}
+              onChange={(e) => setNum("rentFreePeriod", parseFloat(e.target.value) || 0)}
+            />
           </div>
         )}
       </div>

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -103,6 +103,12 @@ export interface InvestmentInput {
   insuranceFeeRate?: number; // 保険料率 (例: 0.003 = 0.3%)
   otherExpenseRate?: number; // その他経費率 (例: 0.005 = 0.5%)
   expenseInflationRate?: number; // 経費インフレ率/年 (例: 0.01 = 1%)
+
+  // 入退去コスト（全て optional。0 または未入力の場合はターンオーバーコスト = 0）
+  avgTenancyYears?: number; // 平均入居期間（年）例: 2.0
+  restorationCost?: number; // 原状回復費（円/回）例: 150000
+  adFee?: number; // 入居者募集 AD（円/回）例: 家賃1ヶ月分
+  rentFreePeriod?: number; // フリーレント（ヶ月）例: 0.5
 }
 
 export interface CapexEvent {


### PR DESCRIPTION
## 概要

入退去コスト（原状回復・AD・フリーレント）をキャッシュフローシミュレーションに反映する。
空室率を年平均の「率」として扱うだけでなく、退去→募集→入居サイクルに伴うコストを年間コストとして差し引く。

## 変更内容

- `backend/internal/domain/types.go` — `InvestmentInput` に 4 フィールド追加（`omitempty` / 後方互換）
  - `avgTenancyYears`: 平均入居期間（年）
  - `restorationCost`: 原状回復費（円/回）
  - `adFee`: 入居者募集 AD（円/回）
  - `rentFreePeriod`: フリーレント（ヶ月）
- `backend/internal/domain/cashflow.go` — `calcAnnualTurnoverCost()` を追加し `simulateYears()` の `cashFlow` 計算から差し引く
  ```
  turnoverPerYear = 1 / avgTenancyYears
  freeLeaseLoss   = monthlyRent × rentFreePeriod × turnoverPerYear
  annualTurnoverCost = (restorationCost + adFee) × turnoverPerYear + freeLeaseLoss
  ```
- `frontend/src/types/investment.ts` — `InvestmentInput` に同 4 フィールドを optional で追加
- `frontend/src/components/sections/ScenarioSection.tsx` — 「入退去コスト（任意）」折りたたみセクションを追加（デフォルト閉じ）

## 関連Issue

Closes #398

> **注意: #380 より後にマージしてください（cashflow.go 競合のため rebase 必要）**
> マージ前に `git rebase main` を実行してコンフリクトを解消してください。

## テスト

- [x] `go test -race ./internal/domain/...` 全件 PASS
- [x] `avgTenancyYears <= 0` の場合はターンオーバーコスト = 0（後方互換）
- [ ] フロントエンド型チェック（node_modules 未インストール環境のため CI で確認）

## 確認事項

- [x] 全フィールド `omitempty` / `optional` で後方互換を維持
- [x] `avgTenancyYears = 0` 時はコスト計算をスキップ（除算を保護）
- [x] Tailwind CSS v4 / Shadcn/UI スタイルに準拠
- [x] WCAG 1.4.1 準拠（色のみに依存しない情報提示）
- [x] コミットメッセージ英語・論理単位ごとに分割（型/ロジック/フロント）