### PR TITLE
feat(backend/frontend): 運営経費の詳細化（固定費・変動費の分離入力と経費インフレ率）

### DIFF
--- a/backend/internal/domain/cashflow.go
+++ b/backend/internal/domain/cashflow.go
@@ -56,6 +56,9 @@ func initYieldParams(input InvestmentInput) yieldParams {
 	if totalInvestment > 0 {
 		grossYield = (input.MonthlyRent * 12) / totalInvestment
 	}
+	// initYieldParams は初年度の利回り指標を計算する。
+	// 経費インフレ率は年次シミュレーション（simulateYears）で複利適用するため、
+	// ここでは適用しない（初年度スナップショットとして扱う）。
 	annualExpenses := annualRent * calcEffectiveExpenseRate(input)
 	netYield := 0.0
 	if totalInvestment > 0 {

--- a/backend/internal/domain/cashflow.go
+++ b/backend/internal/domain/cashflow.go
@@ -201,6 +201,7 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 		}
 
 		yearAnnualRent := rentForYear(yp.annualRent, input.RentDeclineRate, input.RentGrowthRate, input.RentGrowthYears, y)
+		// y は 0-indexed のため float64(y) で 1年目は乗数 1.0 になる（スタート時点の経費率を維持）
 		yearExpenseRate := calcEffectiveExpenseRate(input) * math.Pow(1+input.ExpenseInflationRate, float64(y))
 		yearExpenses := yearAnnualRent*yearExpenseRate + input.AnnualPropertyTax
 
@@ -392,6 +393,7 @@ func calcStressScenario(ctx context.Context, base InvestmentInput, label string,
 		// RentGrowthRate を考慮した楽観シナリオはメインの Analyze() で rentForYear() が担う。
 		declineFactor := math.Pow(1-in.RentDeclineRate, float64(y-1))
 		yearRent := annualRent * declineFactor
+		// y は 1-indexed のため float64(y-1) で 1年目は乗数 1.0 になる（simulateYears と同一の挙動）
 		stressExpenseRate := calcEffectiveExpenseRate(in) * math.Pow(1+in.ExpenseInflationRate, float64(y-1))
 		yearExpenses := yearRent*stressExpenseRate + in.AnnualPropertyTax
 		yearNOI := yearRent - yearExpenses

--- a/backend/internal/domain/cashflow.go
+++ b/backend/internal/domain/cashflow.go
@@ -56,7 +56,7 @@ func initYieldParams(input InvestmentInput) yieldParams {
 	if totalInvestment > 0 {
 		grossYield = (input.MonthlyRent * 12) / totalInvestment
 	}
-	annualExpenses := annualRent * input.ExpenseRate
+	annualExpenses := annualRent * calcEffectiveExpenseRate(input)
 	netYield := 0.0
 	if totalInvestment > 0 {
 		netYield = (annualRent - annualExpenses) / totalInvestment
@@ -101,6 +101,16 @@ func initDepreciationParams(input InvestmentInput) depreciationParams {
 		bookValue:          bookValue,
 		decliningRate:      decliningRate,
 	}
+}
+
+// calcEffectiveExpenseRate は詳細経費フィールドの合計が 0 より大きければその合計を返し、
+// 合計が 0 の場合は従来の ExpenseRate にフォールバックする（後方互換）。
+func calcEffectiveExpenseRate(input InvestmentInput) float64 {
+	detail := input.ManagementFeeRate + input.RepairReserveRate + input.InsuranceFeeRate + input.OtherExpenseRate
+	if detail > 0 {
+		return detail
+	}
+	return input.ExpenseRate
 }
 
 // capexForYear は CapexSchedule から指定年の修繕費合計を返す。
@@ -191,7 +201,8 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 		}
 
 		yearAnnualRent := rentForYear(yp.annualRent, input.RentDeclineRate, input.RentGrowthRate, input.RentGrowthYears, y)
-		yearExpenses := yearAnnualRent*input.ExpenseRate + input.AnnualPropertyTax
+		yearExpenseRate := calcEffectiveExpenseRate(input) * math.Pow(1+input.ExpenseInflationRate, float64(y))
+		yearExpenses := yearAnnualRent*yearExpenseRate + input.AnnualPropertyTax
 
 		// 減価償却（定額法または定率法）
 		var yearDepreciation float64
@@ -381,7 +392,8 @@ func calcStressScenario(ctx context.Context, base InvestmentInput, label string,
 		// RentGrowthRate を考慮した楽観シナリオはメインの Analyze() で rentForYear() が担う。
 		declineFactor := math.Pow(1-in.RentDeclineRate, float64(y-1))
 		yearRent := annualRent * declineFactor
-		yearExpenses := yearRent*in.ExpenseRate + in.AnnualPropertyTax
+		stressExpenseRate := calcEffectiveExpenseRate(in) * math.Pow(1+in.ExpenseInflationRate, float64(y-1))
+		yearExpenses := yearRent*stressExpenseRate + in.AnnualPropertyTax
 		yearNOI := yearRent - yearExpenses
 
 		if yearLoan > 0 {

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2085,6 +2085,40 @@ func TestValidateRateAdjustmentSchedule(t *testing.T) {
 	})
 }
 
+// TestCalcEffectiveExpenseRate は詳細経費フィールドのフォールバック挙動を検証する
+func TestCalcEffectiveExpenseRate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input InvestmentInput
+		want  float64
+	}{
+		{
+			name:  "all detail fields zero falls back to ExpenseRate",
+			input: InvestmentInput{ExpenseRate: 0.15},
+			want:  0.15,
+		},
+		{
+			name: "detail fields sum used when non-zero",
+			input: InvestmentInput{
+				ExpenseRate:       0.15,
+				ManagementFeeRate: 0.05,
+				RepairReserveRate: 0.01,
+				InsuranceFeeRate:  0.003,
+				OtherExpenseRate:  0.005,
+			},
+			want: 0.068, // 0.05+0.01+0.003+0.005
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calcEffectiveExpenseRate(tt.input)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 // TestAnalyzeWithRateSchedule は変動金利スケジュール適用後の動作を検証する
 func TestAnalyzeWithRateSchedule(t *testing.T) {
 	base := InvestmentInput{

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -138,6 +138,13 @@ type InvestmentInput struct {
 
 	// 複数保有年数の出口比較: 空の場合は [5, 10, 15, 20] をデフォルトとして使用
 	ExitYears []int `json:"exitYears,omitempty"`
+
+	// 詳細経費内訳（全てoptional・後方互換）。合計 > 0 の場合は ExpenseRate より優先される。
+	ManagementFeeRate    float64 `json:"managementFeeRate,omitempty"`    // 管理委託費率 (例: 0.05 = 5%)
+	RepairReserveRate    float64 `json:"repairReserveRate,omitempty"`    // 修繕積立費率 (例: 0.01 = 1%)
+	InsuranceFeeRate     float64 `json:"insuranceFeeRate,omitempty"`     // 保険料率 (例: 0.003 = 0.3%)
+	OtherExpenseRate     float64 `json:"otherExpenseRate,omitempty"`     // その他経費率 (例: 0.005 = 0.5%)
+	ExpenseInflationRate float64 `json:"expenseInflationRate,omitempty"` // 経費インフレ率/年 (例: 0.01 = 1%)
 }
 
 // CapexEvent は大規模修繕費の発生スケジュール1件

--- a/frontend/src/components/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/sections/PropertyInfoSection.tsx
@@ -608,7 +608,8 @@ export function PropertyInfoSection({
               </summary>
               <div className="mt-2 pl-2 border-l-2 border-muted space-y-3">
                 <p className="text-xs text-muted-foreground">
-                  合計が 0% の場合は上記「運営経費率」を使用します。設定した場合は合計値が優先されます。
+                  合計が 0%
+                  の場合は上記「運営経費率」を使用します。設定した場合は合計値が優先されます。
                 </p>
                 <div className="grid grid-cols-2 gap-3">
                   <Input
@@ -656,19 +657,25 @@ export function PropertyInfoSection({
                     onChange={(e) => setNum("otherExpenseRate", fromPct(e.target.value))}
                   />
                 </div>
-                <div className="flex items-center justify-between">
-                  <p className="text-xs font-medium text-foreground">
-                    合計経費率:{" "}
-                    {toPct(
-                      (input.managementFeeRate ?? 0) +
-                        (input.repairReserveRate ?? 0) +
-                        (input.insuranceFeeRate ?? 0) +
-                        (input.otherExpenseRate ?? 0),
-                      1
-                    )}
-                    %
-                  </p>
-                </div>
+                {/* 合計経費率の表示と検証 */}
+                {(() => {
+                  const total =
+                    (input.managementFeeRate ?? 0) +
+                    (input.repairReserveRate ?? 0) +
+                    (input.insuranceFeeRate ?? 0) +
+                    (input.otherExpenseRate ?? 0);
+                  const totalPct = total * 100;
+                  return (
+                    <>
+                      <p
+                        className={`text-xs font-medium ${totalPct > 50 ? "text-amber-600" : "text-foreground"}`}
+                      >
+                        合計経費率: {toPct(total, 1)}%
+                        {totalPct > 50 && " ⚠ 合計が50%を超えています"}
+                      </p>
+                    </>
+                  );
+                })()}
                 <Input
                   label="経費インフレ率/年"
                   type="number"

--- a/frontend/src/components/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/sections/PropertyInfoSection.tsx
@@ -601,6 +601,91 @@ export function PropertyInfoSection({
               />
             </div>
           </div>
+          <div className="col-span-full">
+            <details className="group">
+              <summary className="cursor-pointer text-xs text-muted-foreground hover:text-foreground select-none">
+                ▶ 詳細経費入力（任意）— 管理委託費・修繕積立・保険料を個別設定
+              </summary>
+              <div className="mt-2 pl-2 border-l-2 border-muted space-y-3">
+                <p className="text-xs text-muted-foreground">
+                  合計が 0% の場合は上記「運営経費率」を使用します。設定した場合は合計値が優先されます。
+                </p>
+                <div className="grid grid-cols-2 gap-3">
+                  <Input
+                    label="管理委託費率"
+                    type="number"
+                    inputMode="decimal"
+                    suffix="%"
+                    step="0.1"
+                    min="0"
+                    max="30"
+                    value={toPct(input.managementFeeRate ?? 0, 1)}
+                    onChange={(e) => setNum("managementFeeRate", fromPct(e.target.value))}
+                  />
+                  <Input
+                    label="修繕積立費率"
+                    type="number"
+                    inputMode="decimal"
+                    suffix="%"
+                    step="0.1"
+                    min="0"
+                    max="20"
+                    value={toPct(input.repairReserveRate ?? 0, 1)}
+                    onChange={(e) => setNum("repairReserveRate", fromPct(e.target.value))}
+                  />
+                  <Input
+                    label="保険料率"
+                    type="number"
+                    inputMode="decimal"
+                    suffix="%"
+                    step="0.1"
+                    min="0"
+                    max="10"
+                    value={toPct(input.insuranceFeeRate ?? 0, 1)}
+                    onChange={(e) => setNum("insuranceFeeRate", fromPct(e.target.value))}
+                  />
+                  <Input
+                    label="その他経費率"
+                    type="number"
+                    inputMode="decimal"
+                    suffix="%"
+                    step="0.1"
+                    min="0"
+                    max="20"
+                    value={toPct(input.otherExpenseRate ?? 0, 1)}
+                    onChange={(e) => setNum("otherExpenseRate", fromPct(e.target.value))}
+                  />
+                </div>
+                <div className="flex items-center justify-between">
+                  <p className="text-xs font-medium text-foreground">
+                    合計経費率:{" "}
+                    {toPct(
+                      (input.managementFeeRate ?? 0) +
+                        (input.repairReserveRate ?? 0) +
+                        (input.insuranceFeeRate ?? 0) +
+                        (input.otherExpenseRate ?? 0),
+                      1
+                    )}
+                    %
+                  </p>
+                </div>
+                <Input
+                  label="経費インフレ率/年"
+                  type="number"
+                  inputMode="decimal"
+                  suffix="%"
+                  step="0.1"
+                  min="0"
+                  max="10"
+                  value={toPct(input.expenseInflationRate ?? 0, 1)}
+                  onChange={(e) => setNum("expenseInflationRate", fromPct(e.target.value))}
+                />
+                <p className="text-xs text-muted-foreground">
+                  経費インフレ率: 毎年この割合だけ実質経費が増加します（例: 1% = 物価上昇分）
+                </p>
+              </div>
+            </details>
+          </div>
           <Input
             label="諸経費率"
             type="number"

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -97,6 +97,12 @@ export interface InvestmentInput {
   rentGrowthYears?: number; // 賃料上昇が続く年数
   loanFeeRate?: number; // 融資諸費用率（保証料・登記費用等の合算）
   exitYears?: number[]; // 複数保有年数の出口比較（省略時 = [5, 10, 15, 20]）
+  // 詳細経費内訳（全てoptional・後方互換）。合計 > 0 の場合は expenseRate より優先される。
+  managementFeeRate?: number; // 管理委託費率 (例: 0.05 = 5%)
+  repairReserveRate?: number; // 修繕積立費率 (例: 0.01 = 1%)
+  insuranceFeeRate?: number; // 保険料率 (例: 0.003 = 0.3%)
+  otherExpenseRate?: number; // その他経費率 (例: 0.005 = 0.5%)
+  expenseInflationRate?: number; // 経費インフレ率/年 (例: 0.01 = 1%)
 }
 
 export interface CapexEvent {


### PR DESCRIPTION
## 概要

運営経費の詳細化（固定費・変動費の分離入力）を実装しました。現在の `expenseRate` に加え、管理委託費・修繕積立費・保険料・その他経費を個別に入力できる詳細フィールドを追加しています。フォールバック設計により、詳細フィールドの合計が 0 の場合は既存の `expenseRate` を使用するため、完全な後方互換性を保ちます。

**このPRは #398 より先にマージしてください**（`cashflow.go` が競合する可能性があります）。

## 変更内容

- **backend `types.go`**: `InvestmentInput` に `managementFeeRate` / `repairReserveRate` / `insuranceFeeRate` / `otherExpenseRate` / `expenseInflationRate` を optional フィールドとして追加
- **backend `cashflow.go`**: `calcEffectiveExpenseRate()` ヘルパーを追加（詳細合計 > 0 なら優先、そうでなければ `expenseRate` にフォールバック）。`simulateYears` ・ `calcStressScenario` ・ `initYieldParams` 内の経費計算を更新し、`expenseInflationRate` を年次複利で適用
- **frontend `types/investment.ts`**: `InvestmentInput` インターフェースに同フィールドを optional で追加
- **frontend `PropertyInfoSection.tsx`**: 「詳細経費入力（任意）」の `<details>` 折りたたみセクションを追加。管理委託費率・修繕積立費率・保険料率・その他経費率・経費インフレ率を個別入力でき、合計経費率をリアルタイム表示

## 関連Issue

Closes #380

## テスト

- [x] 既存テストが通ること（`go test -race ./internal/domain/... -timeout 120s` → pass）
- [x] TypeScript コンパイルエラーなし（`npm run type-check` → pass）
- [x] フォールバック動作: 詳細フィールド未入力時は `expenseRate` が引き続き使用される

## 確認事項

- [x] コードレビュー観点での自己レビュー済み