### PR TITLE
feat(frontend): 結果画面へのステータスサマリ（StatusSummary）とKPIストリップの追加

### DIFF
--- a/frontend/src/components/KpiStrip.tsx
+++ b/frontend/src/components/KpiStrip.tsx
@@ -41,21 +41,20 @@ function KpiCell({ icon, label, value, sub, subPositive }: KpiCellProps) {
 export function KpiStrip({ result, yieldTarget = 0.08 }: KpiStripProps) {
   const grossYieldPct = result.grossYield * 100;
   const yieldDiff = grossYieldPct - yieldTarget * 100;
-  const yieldDiffStr =
-    (yieldDiff >= 0 ? "+" : "") + yieldDiff.toFixed(2) + "pp vs 目標";
+  const yieldDiffStr = (yieldDiff >= 0 ? "+" : "") + yieldDiff.toFixed(2) + "pp vs 目標";
 
   const dscrDiff = result.dscr - 1.0;
   const dscrDiffStr = (dscrDiff >= 0 ? "+" : "") + dscrDiff.toFixed(2) + " vs 1.0";
 
+  // deadCrossYear: -1 or 0 = なし、正の数 = 発生年
   const dcYear = result.deadCrossYear > 0 ? `${result.deadCrossYear}年目` : "なし";
   const dcSub =
     result.deadCrossYear > 0
-      ? result.deadCrossYear >= 10
+      ? result.deadCrossYear > 10
         ? "保有期間内は安全圏"
         : "保有期間内に発生"
       : "デッドクロスなし";
-  const dcPositive =
-    result.deadCrossYear <= 0 || result.deadCrossYear >= 10;
+  const dcPositive = result.deadCrossYear <= 0 || result.deadCrossYear > 10;
 
   const equityMan = Math.round(result.exitTotalEquity / 10_000);
   const equityStr =
@@ -66,10 +65,7 @@ export function KpiStrip({ result, yieldTarget = 0.08 }: KpiStripProps) {
   const equitySub = equityPositive ? "出口時プラス" : "出口時マイナス";
 
   return (
-    <div
-      aria-label="KPIサマリ"
-      className="grid grid-cols-2 gap-3 sm:grid-cols-4"
-    >
+    <div aria-label="KPIサマリ" className="grid grid-cols-2 gap-3 sm:grid-cols-4">
       <KpiCell
         icon={<TrendingUp className="h-3.5 w-3.5" aria-hidden />}
         label="表面利回り"

--- a/frontend/src/components/KpiStrip.tsx
+++ b/frontend/src/components/KpiStrip.tsx
@@ -5,6 +5,7 @@ import type { InvestmentResult } from "@/types/investment";
 interface KpiStripProps {
   result: InvestmentResult;
   yieldTarget?: number;
+  holdingYears?: number;
 }
 
 interface KpiCellProps {
@@ -38,7 +39,7 @@ function KpiCell({ icon, label, value, sub, subPositive }: KpiCellProps) {
   );
 }
 
-export function KpiStrip({ result, yieldTarget = 0.08 }: KpiStripProps) {
+export function KpiStrip({ result, yieldTarget = 0.08, holdingYears = 30 }: KpiStripProps) {
   const grossYieldPct = result.grossYield * 100;
   const yieldDiff = grossYieldPct - yieldTarget * 100;
   const yieldDiffStr = (yieldDiff >= 0 ? "+" : "") + yieldDiff.toFixed(2) + "pp vs 目標";
@@ -50,11 +51,11 @@ export function KpiStrip({ result, yieldTarget = 0.08 }: KpiStripProps) {
   const dcYear = result.deadCrossYear > 0 ? `${result.deadCrossYear}年目` : "なし";
   const dcSub =
     result.deadCrossYear > 0
-      ? result.deadCrossYear > 10
-        ? "保有期間内は安全圏"
+      ? result.deadCrossYear > holdingYears
+        ? "保有期間外（安全）"
         : "保有期間内に発生"
       : "デッドクロスなし";
-  const dcPositive = result.deadCrossYear <= 0 || result.deadCrossYear > 10;
+  const dcPositive = result.deadCrossYear <= 0 || result.deadCrossYear > holdingYears;
 
   const equityMan = Math.round(result.exitTotalEquity / 10_000);
   const equityStr =

--- a/frontend/src/components/KpiStrip.tsx
+++ b/frontend/src/components/KpiStrip.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { TrendingUp, ShieldCheck, AlertCircle, Banknote } from "lucide-react";
+import type { InvestmentResult } from "@/types/investment";
+
+interface KpiStripProps {
+  result: InvestmentResult;
+  yieldTarget?: number;
+}
+
+interface KpiCellProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  sub: string;
+  subPositive?: boolean;
+}
+
+function KpiCell({ icon, label, value, sub, subPositive }: KpiCellProps) {
+  return (
+    <div className="flex flex-col gap-1 rounded-lg border bg-white p-3 shadow-sm">
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        {icon}
+        <span>{label}</span>
+      </div>
+      <p className="text-xl font-bold leading-none">{value}</p>
+      <p
+        className={`text-xs font-medium ${
+          subPositive === undefined
+            ? "text-muted-foreground"
+            : subPositive
+              ? "text-green-600"
+              : "text-red-600"
+        }`}
+      >
+        {sub}
+      </p>
+    </div>
+  );
+}
+
+export function KpiStrip({ result, yieldTarget = 0.08 }: KpiStripProps) {
+  const grossYieldPct = result.grossYield * 100;
+  const yieldDiff = grossYieldPct - yieldTarget * 100;
+  const yieldDiffStr =
+    (yieldDiff >= 0 ? "+" : "") + yieldDiff.toFixed(2) + "pp vs 目標";
+
+  const dscrDiff = result.dscr - 1.0;
+  const dscrDiffStr = (dscrDiff >= 0 ? "+" : "") + dscrDiff.toFixed(2) + " vs 1.0";
+
+  const dcYear = result.deadCrossYear > 0 ? `${result.deadCrossYear}年目` : "なし";
+  const dcSub =
+    result.deadCrossYear > 0
+      ? result.deadCrossYear >= 10
+        ? "保有期間内は安全圏"
+        : "保有期間内に発生"
+      : "デッドクロスなし";
+  const dcPositive =
+    result.deadCrossYear <= 0 || result.deadCrossYear >= 10;
+
+  const equityMan = Math.round(result.exitTotalEquity / 10_000);
+  const equityStr =
+    Math.abs(equityMan) >= 10_000
+      ? `${(equityMan / 10_000).toFixed(1)}億円`
+      : `${equityMan.toLocaleString()}万円`;
+  const equityPositive = result.exitTotalEquity >= 0;
+  const equitySub = equityPositive ? "出口時プラス" : "出口時マイナス";
+
+  return (
+    <div
+      aria-label="KPIサマリ"
+      className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+    >
+      <KpiCell
+        icon={<TrendingUp className="h-3.5 w-3.5" aria-hidden />}
+        label="表面利回り"
+        value={`${grossYieldPct.toFixed(2)}%`}
+        sub={yieldDiffStr}
+        subPositive={yieldDiff >= 0}
+      />
+      <KpiCell
+        icon={<ShieldCheck className="h-3.5 w-3.5" aria-hidden />}
+        label="DSCR（1年目）"
+        value={result.dscr.toFixed(2)}
+        sub={dscrDiffStr}
+        subPositive={dscrDiff >= 0}
+      />
+      <KpiCell
+        icon={<AlertCircle className="h-3.5 w-3.5" aria-hidden />}
+        label="デッドクロス"
+        value={dcYear}
+        sub={dcSub}
+        subPositive={dcPositive}
+      />
+      <KpiCell
+        icon={<Banknote className="h-3.5 w-3.5" aria-hidden />}
+        label="出口 Equity"
+        value={equityStr}
+        sub={equitySub}
+        subPositive={equityPositive}
+      />
+    </div>
+  );
+}

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -201,7 +201,11 @@ export function ResultsSection({
             <>
               <CriticalErrorBanner errors={result.criticalErrors} />
               <StatusSummary result={result} />
-              <KpiStrip result={result} yieldTarget={lastInput.yieldTarget} />
+              <KpiStrip
+                result={result}
+                yieldTarget={lastInput.yieldTarget}
+                holdingYears={lastInput.holdingYears}
+              />
               <YieldAnalysis
                 result={result}
                 input={lastInput}

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -1,6 +1,8 @@
 "use client";
 import React, { useCallback, useState } from "react";
 import { YieldAnalysis } from "@/components/YieldAnalysis";
+import { StatusSummary } from "@/components/StatusSummary";
+import { KpiStrip } from "@/components/KpiStrip";
 import CashFlowChart from "@/components/CashFlowChart";
 import DeadCrossChart from "@/components/DeadCrossChart";
 import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
@@ -198,6 +200,8 @@ export function ResultsSection({
           {result && lastInput && (
             <>
               <CriticalErrorBanner errors={result.criticalErrors} />
+              <StatusSummary result={result} />
+              <KpiStrip result={result} yieldTarget={lastInput.yieldTarget} />
               <YieldAnalysis
                 result={result}
                 input={lastInput}

--- a/frontend/src/components/StatusSummary.tsx
+++ b/frontend/src/components/StatusSummary.tsx
@@ -41,7 +41,7 @@ export function StatusSummary({ result }: StatusSummaryProps) {
 
   const grossYieldPct = (result.grossYield * 100).toFixed(2);
   const dscrVal = result.dscr.toFixed(2);
-  const dcYear = result.deadCrossYear > 0 ? `Y${result.deadCrossYear}年目` : "なし";
+  const dcYear = result.deadCrossYear > 0 ? `${result.deadCrossYear}年目` : "なし";
 
   return (
     <div

--- a/frontend/src/components/StatusSummary.tsx
+++ b/frontend/src/components/StatusSummary.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { CheckCircle2, AlertTriangle, XOctagon } from "lucide-react";
+import type { InvestmentResult } from "@/types/investment";
+
+interface StatusSummaryProps {
+  result: InvestmentResult;
+}
+
+type StatusLevel = "OK" | "CAUTION" | "RISK";
+
+function getStatus(result: InvestmentResult): StatusLevel {
+  if (result.criticalErrors.some((e) => e.status === "REJECT")) return "RISK";
+  if (result.criticalErrors.some((e) => e.status === "WARNING")) return "CAUTION";
+  return "OK";
+}
+
+const STATUS_CONFIG: Record<
+  StatusLevel,
+  { label: string; icon: React.ReactNode; className: string }
+> = {
+  OK: {
+    label: "OK",
+    icon: <CheckCircle2 className="h-4 w-4 shrink-0 text-green-600" aria-hidden />,
+    className: "border-green-300 bg-green-50 text-green-900",
+  },
+  CAUTION: {
+    label: "注意",
+    icon: <AlertTriangle className="h-4 w-4 shrink-0 text-yellow-600" aria-hidden />,
+    className: "border-yellow-300 bg-yellow-50 text-yellow-900",
+  },
+  RISK: {
+    label: "リスク",
+    icon: <XOctagon className="h-4 w-4 shrink-0 text-red-600" aria-hidden />,
+    className: "border-red-300 bg-red-50 text-red-900",
+  },
+};
+
+export function StatusSummary({ result }: StatusSummaryProps) {
+  const status = getStatus(result);
+  const { label, icon, className } = STATUS_CONFIG[status];
+
+  const grossYieldPct = (result.grossYield * 100).toFixed(2);
+  const dscrVal = result.dscr.toFixed(2);
+  const dcYear = result.deadCrossYear > 0 ? `Y${result.deadCrossYear}年目` : "なし";
+
+  return (
+    <div
+      role="status"
+      aria-label={`投資判定: ${label}`}
+      className={`flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm font-medium ${className}`}
+    >
+      {icon}
+      <span className="font-semibold">[{label}]</span>
+      <span className="hidden sm:inline text-muted-foreground">|</span>
+      <span>
+        利回り {grossYieldPct}% / DSCR {dscrVal} / デッドクロス {dcYear}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

結果画面の冒頭に StatusSummary（1行ステータス表示）と KpiStrip（主要4指標）を追加します。

## 変更内容

- `StatusSummary.tsx` 新規作成：criticalErrors に基づき Risk/Caution/OK を1行表示
- `KpiStrip.tsx` 新規作成：表面利回り・DSCR・デッドクロス年・出口Equityを4セルで表示
- `ResultsSection.tsx`：YieldAnalysis 直前に2コンポーネントを挿入（非破壊）

## テスト

- [ ] シミュレーション実行後に StatusSummary と KpiStrip が表示される
- [ ] criticalErrors が REJECT のとき Risk（赤）表示
- [ ] モバイルで2×2グリッド表示
- [ ] 既存の YieldAnalysis が正常動作

## 関連 issue

closes #208