### PR TITLE
fix(domain): ExpenseRate から固定資産税を除外し二重計上を防止

### DIFF
--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -85,7 +85,8 @@ type InvestmentInput struct {
 	AnnualLoanRate  float64      `json:"annualLoanRate"`  // 年利 (例: 0.015)
 	LoanYears       int          `json:"loanYears"`       // ローン期間 (年)
 	BuildingType    BuildingType `json:"buildingType"`    // 建物構造
-	// 運営経費率 (管理費・修繕・固定資産税・保険等。ローン利息は含まない)
+	// 運営経費率 (管理費・修繕・保険等。固定資産税・ローン利息は含まない)
+	// 固定資産税は AnnualPropertyTax で別途指定する
 	ExpenseRate   float64 `json:"expenseRate"`   // 例: 0.20
 	IncomeTaxRate float64 `json:"incomeTaxRate"` // 所得税率 (例: 0.33。給与との合算後実効税率)
 	HoldingYears  int     `json:"holdingYears"`  // 出口戦略: 売却年数 (例: 10)
@@ -99,7 +100,7 @@ type InvestmentInput struct {
 	VacancyRateDelta float64 `json:"vacancyRateDelta"` // 空室率上昇分 (例: +0.10)
 	LoanRateDelta    float64 `json:"loanRateDelta"`    // 金利上昇分 (例: +0.015)
 
-	// 固定資産税・都市計画税（年間合計）。0 の場合は ExpenseRate に含まれる想定。
+	// 年間固定資産税 (円)。ExpenseRate には含めないこと（二重計上になる）
 	AnnualPropertyTax float64 `json:"annualPropertyTax"`
 
 	// 賃料下落率: 毎年この割合だけ実効賃料が低下する（例: 0.01 = 年1%下落）


### PR DESCRIPTION
## 概要

`ExpenseRate` のコメントに「固定資産税を含む」と記載されていたため、`AnnualPropertyTax` と両方設定すると固定資産税が二重計上される問題があった。`ExpenseRate` の定義を「固定資産税を含まない」に統一し、両フィールドの役割を明確化した（ロジック変更なし）。

## 変更内容

`backend/internal/domain/types.go`

- `ExpenseRate` のコメント: 固定資産税をリストから除外し、`AnnualPropertyTax` で別途指定する旨を追記
- `AnnualPropertyTax` のコメント: `ExpenseRate` に含めると二重計上になる旨を明記

## テスト

- `go build ./...` — ビルド成功
- `go test -race ./... -timeout 120s` — 全パスを確認済み

Closes #507