### PR TITLE
fix(domain): 不動産所得の損益通算（給与所得との相殺）を実装

### DIFF
--- a/backend/internal/domain/cashflow.go
+++ b/backend/internal/domain/cashflow.go
@@ -213,10 +213,9 @@ func simulateYears(input InvestmentInput, years int, yp yieldParams, lp loanPara
 
 		// 課税所得 = 収入 - 利息 - 減価償却 - 経費
 		taxableIncome := yearAnnualRent - annualInterest - yearDepreciation - yearExpenses
-		incomeTax := 0.0
-		if taxableIncome > 0 {
-			incomeTax = taxableIncome * input.IncomeTaxRate
-		}
+		// 損益通算: 不動産所得が赤字の場合、給与所得との通算により税還付が発生する（負値）
+		// 所得税法69条に基づき、負の課税所得は負の incomeTax（税還付）として扱う
+		incomeTax := taxableIncome * input.IncomeTaxRate
 
 		capex := capexForYear(input.CapexSchedule, year)
 		cashFlow := yearAnnualRent - annualLoanPayment - yearExpenses - capex

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2916,3 +2916,87 @@ func TestCalcStressScenario_IsSafe_DSCR_Between1And1_2(t *testing.T) {
 	}
 	t.Logf("DSCR=%.4f, BreakEvenYear=%d, IsSafe=%v", result.DSCR, result.BreakEvenYear, result.IsSafe)
 }
+
+// TestAnalyze_LossOffsetting は不動産所得が赤字の場合に損益通算（税還付）が
+// キャッシュフローに反映されることを検証する（所得税法69条）。
+// 設計: 高額建物（木造・大きな減価償却）＋高金利ローンで taxableIncome を意図的に負にする。
+func TestAnalyze_LossOffsetting(t *testing.T) {
+	input := InvestmentInput{
+		LandPrice:       5_000_000,
+		BuildingCost:    20_000_000, // 木造22年 → 年間償却 ≈ 909,090円
+		MiscExpenseRate: 0.07,
+		MonthlyRent:     80_000,    // 低家賃: 年間実効賃料 ≈ 912,000円
+		VacancyRate:     0.05,
+		LoanAmount:      15_000_000,
+		AnnualLoanRate:  0.03,      // 高金利: 1年目利息 ≈ 450,000円
+		LoanYears:       35,
+		BuildingType:    BuildingTypeWood,
+		ExpenseRate:     0.20,      // 経費 ≈ 182,400円
+		IncomeTaxRate:   0.33,
+		HoldingYears:    5,
+		ExitYieldTarget: 0.06,
+	}
+	// 1年目の taxableIncome ≈ 912,000 - 450,000 - 909,090 - 182,400 ≈ -629,490（赤字）
+
+	result := Analyze(context.Background(), input)
+	if len(result.YearlyResults) == 0 {
+		t.Fatal("YearlyResults is empty")
+	}
+
+	yr := result.YearlyResults[0]
+
+	// 損益通算: 課税所得が負 → IncomeTax も負（税還付）
+	if yr.IncomeTax >= 0 {
+		t.Errorf("IncomeTax = %.0f, want negative (tax refund from loss offsetting)", yr.IncomeTax)
+	}
+
+	// 税還付分だけ AfterTaxCashFlow > CashFlow になる
+	if yr.AfterTaxCashFlow <= yr.CashFlow {
+		t.Errorf("AfterTaxCashFlow (%.0f) <= CashFlow (%.0f): loss offsetting should increase after-tax CF",
+			yr.AfterTaxCashFlow, yr.CashFlow)
+	}
+
+	// 税還付額の近似検証: |IncomeTax| ≈ |taxableIncome| * IncomeTaxRate
+	// taxableIncome は直接取得できないため AfterTaxCashFlow - CashFlow = -incomeTax で逆算
+	taxBenefit := yr.AfterTaxCashFlow - yr.CashFlow
+	if taxBenefit <= 0 {
+		t.Errorf("tax benefit (AfterTaxCF - CashFlow) = %.0f, want positive", taxBenefit)
+	}
+	t.Logf("IncomeTax=%.0f, CashFlow=%.0f, AfterTaxCashFlow=%.0f, TaxBenefit=%.0f",
+		yr.IncomeTax, yr.CashFlow, yr.AfterTaxCashFlow, taxBenefit)
+}
+
+// TestAnalyze_LossOffsetting_ZeroRate は IncomeTaxRate=0 のとき
+// 課税所得が負でも税効果がゼロになることを検証する。
+func TestAnalyze_LossOffsetting_ZeroRate(t *testing.T) {
+	input := InvestmentInput{
+		LandPrice:       5_000_000,
+		BuildingCost:    20_000_000,
+		MiscExpenseRate: 0.07,
+		MonthlyRent:     80_000,
+		VacancyRate:     0.05,
+		LoanAmount:      15_000_000,
+		AnnualLoanRate:  0.03,
+		LoanYears:       35,
+		BuildingType:    BuildingTypeWood,
+		ExpenseRate:     0.20,
+		IncomeTaxRate:   0, // 税率ゼロ → 損益通算効果なし
+		HoldingYears:    5,
+		ExitYieldTarget: 0.06,
+	}
+
+	result := Analyze(context.Background(), input)
+	if len(result.YearlyResults) == 0 {
+		t.Fatal("YearlyResults is empty")
+	}
+
+	yr := result.YearlyResults[0]
+
+	if yr.IncomeTax != 0 {
+		t.Errorf("IncomeTax = %.0f, want 0 when IncomeTaxRate=0", yr.IncomeTax)
+	}
+	if yr.AfterTaxCashFlow != yr.CashFlow {
+		t.Errorf("AfterTaxCashFlow (%.0f) != CashFlow (%.0f) when IncomeTaxRate=0",
+			yr.AfterTaxCashFlow, yr.CashFlow)
+	}
+}


### PR DESCRIPTION
## 概要

不動産所得が赤字（ローン利息＋減価償却が賃料を上回る）の場合、現状では `incomeTax = 0` としていたが、所得税法69条に基づく損益通算（給与所得との相殺による税還付）が反映されていなかった。負の課税所得に対しても税率を乗算することで、税還付相当額（負の `incomeTax`）をキャッシュフローに反映するよう修正した。

## 変更内容

`backend/internal/domain/cashflow.go`

```go
// 修正前
incomeTax := 0.0
if taxableIncome > 0 {
    incomeTax = taxableIncome * input.IncomeTaxRate
}

// 修正後（条件分岐を削除、負値は税還付として扱う）
// 損益通算: 不動産所得が赤字の場合、給与所得との通算により税還付が発生する（負値）
// 所得税法69条に基づき、負の課税所得は負の incomeTax（税還付）として扱う
incomeTax := taxableIncome * input.IncomeTaxRate
```

`IncomeTaxRate == 0` の場合は引き続き効果ゼロ（既存動作を維持）。

## ⚠️ 既知の制約（後続 Issue で対応）

**所得税法41条の4（土地取得ローン利息の損益通算除外）は未実装。**

土地取得に充てた借入金の利息は損益通算の対象外。物件の土地・建物比率に応じて利息を按分し、土地分の利息は通算対象から除外する必要がある。現状の実装は全利息を通算対象とするため、**土地割合が高い物件では節税効果を過大評価する可能性がある。**

```
// 将来の正確な実装イメージ
landRatio := input.LandPrice / (input.LandPrice + input.BuildingCost)
nonDeductibleInterest := annualInterest * landRatio
adjustedTaxableIncome := taxableIncome + nonDeductibleInterest
incomeTax := adjustedTaxableIncome * input.IncomeTaxRate
```

## 影響

- 保有初期の税引後キャッシュフローが実態に即した値になる（土地利息制約あり）
- IRR・NPV の精度が向上する
- `IncomeTaxRate` を設定していないユーザーへの影響なし

## テスト

- `TestAnalyze_LossOffsetting`: 課税所得が負の場合に `IncomeTax < 0`、`AfterTaxCashFlow > CashFlow` を検証
- `TestAnalyze_LossOffsetting_ZeroRate`: `IncomeTaxRate=0` 時は `IncomeTax=0` を検証
- `go test -race ./... -timeout 120s` — 全パスを確認済み

Closes #505