### PR TITLE
fix(rent-stats): areaSqm を useRentValidation フック経由で API に渡す

### DIFF
--- a/frontend/src/components/QuickModeForm.tsx
+++ b/frontend/src/components/QuickModeForm.tsx
@@ -214,7 +214,12 @@ export function QuickModeForm({
                 onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
                 error={fieldError("monthlyRent")}
               />
-              <RentValidationHint monthlyRent={input.monthlyRent} area={area} city={city} landArea={input.landArea} />
+              <RentValidationHint
+                monthlyRent={input.monthlyRent}
+                area={area}
+                city={city}
+                landArea={input.landArea}
+              />
             </div>
             <div className="space-y-2">
               <label className="flex items-center gap-2 cursor-pointer select-none min-h-[44px]">

--- a/frontend/src/components/QuickModeForm.tsx
+++ b/frontend/src/components/QuickModeForm.tsx
@@ -214,7 +214,7 @@ export function QuickModeForm({
                 onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
                 error={fieldError("monthlyRent")}
               />
-              <RentValidationHint monthlyRent={input.monthlyRent} area={area} city={city} />
+              <RentValidationHint monthlyRent={input.monthlyRent} area={area} city={city} landArea={input.landArea} />
             </div>
             <div className="space-y-2">
               <label className="flex items-center gap-2 cursor-pointer select-none min-h-[44px]">

--- a/frontend/src/components/RentValidationHint.tsx
+++ b/frontend/src/components/RentValidationHint.tsx
@@ -6,6 +6,7 @@ interface RentValidationHintProps {
   monthlyRent: number;
   area: string;
   city: string;
+  landArea?: number;
 }
 
 function badge(
@@ -44,11 +45,12 @@ function badge(
   }
 }
 
-export function RentValidationHint({ monthlyRent, area, city }: RentValidationHintProps) {
+export function RentValidationHint({ monthlyRent, area, city, landArea }: RentValidationHintProps) {
   const { stats, deviationPct, level, loading, lowSample } = useRentValidation(
     monthlyRent,
     area,
-    city
+    city,
+    landArea
   );
 
   if (loading) {

--- a/frontend/src/components/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/sections/PropertyInfoSection.tsx
@@ -543,7 +543,12 @@ export function PropertyInfoSection({
               onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
               error={fieldError("monthlyRent")}
             />
-            <RentValidationHint monthlyRent={input.monthlyRent} area={area} city={city} landArea={input.landArea} />
+            <RentValidationHint
+              monthlyRent={input.monthlyRent}
+              area={area}
+              city={city}
+              landArea={input.landArea}
+            />
           </div>
           <Input
             label="現況空室率"

--- a/frontend/src/components/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/sections/PropertyInfoSection.tsx
@@ -543,7 +543,7 @@ export function PropertyInfoSection({
               onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
               error={fieldError("monthlyRent")}
             />
-            <RentValidationHint monthlyRent={input.monthlyRent} area={area} city={city} />
+            <RentValidationHint monthlyRent={input.monthlyRent} area={area} city={city} landArea={input.landArea} />
           </div>
           <Input
             label="現況空室率"

--- a/frontend/src/hooks/useRentValidation.ts
+++ b/frontend/src/hooks/useRentValidation.ts
@@ -25,7 +25,8 @@ const DEBOUNCE_MS = 600;
 export function useRentValidation(
   monthlyRent: number,
   area: string,
-  city: string
+  city: string,
+  areaSqm?: number
 ): RentValidationState {
   const [stats, setStats] = useState<RentStatsResult | null>(null);
   const [loading, setLoading] = useState(false);
@@ -49,6 +50,7 @@ export function useRentValidation(
         const result = await fetchRentStats({
           area,
           municipality: city || undefined,
+          areaSqm: areaSqm && areaSqm > 0 ? areaSqm : undefined,
         });
         setStats(result);
       } catch {
@@ -64,7 +66,7 @@ export function useRentValidation(
         clearTimeout(timerRef.current);
       }
     };
-  }, [monthlyRent, area, city]);
+  }, [monthlyRent, area, city, areaSqm]);
 
   if (!stats || !stats.median || monthlyRent <= 0) {
     return { stats, deviationPct: null, level: null, loading, lowSample: false };


### PR DESCRIPTION
## 概要

`useRentValidation` フックが `areaSqm` を受け取るインターフェースを持っていなかったため、`fetchRentStats` に面積パラメータが渡らず、バックエンドの `area_sqm ± 50%` フィルタリングが常に無効になっていた。フォームの `landArea` 値がフック→API まで正しく伝播するよう修正した。

## 変更内容

| ファイル | 変更内容 |
|---------|---------|
| `hooks/useRentValidation.ts` | `areaSqm?: number` 引数を追加、`fetchRentStats` に渡す、deps array に追加 |
| `components/RentValidationHint.tsx` | `landArea?: number` props を追加、フックに渡す |
| `components/QuickModeForm.tsx` | `<RentValidationHint>` に `landArea={input.landArea}` を追加 |
| `components/sections/PropertyInfoSection.tsx` | `<RentValidationHint>` に `landArea={input.landArea}` を追加 |

## テスト

- `tsc --noEmit` — 型エラーなし（変更ファイル対象）

Closes #533