### PR TITLE
feat(frontend): ウォッチリスト横並び比較テーブルの実装（最大4件）

### DIFF
--- a/frontend/src/components/WatchlistCompareTable.tsx
+++ b/frontend/src/components/WatchlistCompareTable.tsx
@@ -1,0 +1,224 @@
+"use client";
+
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { BarChart2, TrendingUp, TrendingDown, Minus } from "lucide-react";
+import type { WatchlistItem, WatchlistMetrics } from "@/types/investment";
+
+interface WatchlistCompareTableProps {
+  items: WatchlistItem[]; // 2–4 items already selected
+}
+
+type MetricKey = keyof WatchlistMetrics;
+
+interface MetricRow {
+  label: string;
+  key: MetricKey;
+  format: (v: number | null | undefined) => string;
+  best: "max" | "min";
+}
+
+const METRIC_ROWS: MetricRow[] = [
+  {
+    label: "表面利回り",
+    key: "grossYield",
+    format: (v) => (v != null ? `${(Number(v) * 100).toFixed(1)}%` : "-"),
+    best: "max",
+  },
+  {
+    label: "実質利回り",
+    key: "netYield",
+    format: (v) => (v != null ? `${(Number(v) * 100).toFixed(1)}%` : "-"),
+    best: "max",
+  },
+  {
+    label: "DSCR",
+    key: "dscr",
+    format: (v) => (v != null ? Number(v).toFixed(2) : "-"),
+    best: "max",
+  },
+  {
+    label: "IRR",
+    key: "irr",
+    format: (v) => (v != null ? `${(Number(v) * 100).toFixed(1)}%` : "-"),
+    best: "max",
+  },
+  {
+    label: "総投資額",
+    key: "totalInvestment",
+    format: (v) =>
+      v != null
+        ? `${(Number(v) / 10_000).toLocaleString("ja-JP", { maximumFractionDigits: 0 })}万円`
+        : "-",
+    best: "min",
+  },
+  {
+    label: "出口エクイティ",
+    key: "exitTotalEquity",
+    format: (v) =>
+      v != null
+        ? `${(Number(v) / 10_000).toLocaleString("ja-JP", { maximumFractionDigits: 0 })}万円`
+        : "-",
+    best: "max",
+  },
+  {
+    label: "デッドクロス年",
+    key: "deadCrossYear",
+    format: (v) => {
+      if (v == null) return "-";
+      return Number(v) === -1 ? "なし（最良）" : `${Number(v)}年目`;
+    },
+    best: "max", // -1 (none) is best, larger deadCrossYear means it arrives later = better
+  },
+  {
+    label: "NPV",
+    key: "npv",
+    format: (v) =>
+      v != null
+        ? `${(Number(v) / 10_000).toLocaleString("ja-JP", { maximumFractionDigits: 0 })}万円`
+        : "-",
+    best: "max",
+  },
+];
+
+function getValue(metrics: WatchlistMetrics | undefined, key: MetricKey): number | null {
+  if (!metrics) return null;
+  const v = metrics[key];
+  if (v == null) return null;
+  return Number(v);
+}
+
+/**
+ * Find the index of the best value among items for a given metric row.
+ * Returns -1 if no valid values exist or if all values are equal.
+ */
+function findBestIndex(items: WatchlistItem[], row: MetricRow): number {
+  const values = items.map((item) => getValue(item.metrics, row.key));
+  const validValues = values.filter((v): v is number => v !== null);
+  if (validValues.length === 0) return -1;
+
+  const bestValue =
+    row.best === "max" ? Math.max(...validValues) : Math.min(...validValues);
+
+  // Only highlight if there's a unique best (no tie)
+  const bestCount = validValues.filter((v) => v === bestValue).length;
+  if (bestCount > 1) return -1;
+
+  return values.indexOf(bestValue);
+}
+
+function DscrTrendIcon({ dscr }: { dscr: number | null }) {
+  if (dscr === null) return <Minus className="h-3 w-3 text-muted-foreground" />;
+  if (dscr >= 1.2) return <TrendingUp className="h-3 w-3 text-green-600" aria-hidden="true" />;
+  if (dscr >= 1.0) return <Minus className="h-3 w-3 text-yellow-600" aria-hidden="true" />;
+  return <TrendingDown className="h-3 w-3 text-red-600" aria-hidden="true" />;
+}
+
+export default function WatchlistCompareTable({ items }: WatchlistCompareTableProps) {
+  return (
+    <Card className="rounded-xl shadow-sm">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base font-semibold">
+          <BarChart2 className="h-4 w-4 text-primary" aria-hidden="true" />
+          物件比較表（{items.length}件）
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[480px] text-sm">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="py-2 pr-3 text-left text-xs font-medium text-muted-foreground w-32">
+                  指標
+                </th>
+                {items.map((item) => (
+                  <th
+                    key={item.id}
+                    className="py-2 px-2 text-center text-xs font-medium max-w-[120px]"
+                  >
+                    <span className="block truncate" title={item.name}>
+                      {item.name}
+                    </span>
+                    <span
+                      className={`mt-0.5 inline-block rounded px-1.5 py-0.5 text-xs font-medium ${
+                        item.status === "検討中"
+                          ? "bg-blue-100 text-blue-800"
+                          : item.status === "見送り"
+                            ? "bg-gray-100 text-gray-600"
+                            : "bg-emerald-100 text-emerald-800"
+                      }`}
+                    >
+                      {item.status}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {METRIC_ROWS.map((row) => {
+                const bestIdx = findBestIndex(items, row);
+                return (
+                  <tr key={row.key} className="border-b border-border/60 last:border-0">
+                    <td className="py-2 pr-3 text-xs text-muted-foreground whitespace-nowrap">
+                      {row.label}
+                    </td>
+                    {items.map((item, colIdx) => {
+                      const raw = getValue(item.metrics, row.key);
+                      const isBest = bestIdx !== -1 && colIdx === bestIdx;
+                      const isUnavailable = raw === null;
+                      return (
+                        <td
+                          key={item.id}
+                          className={`py-2 px-2 text-center text-xs ${
+                            isBest
+                              ? "bg-green-50 font-bold text-green-800 rounded"
+                              : isUnavailable
+                                ? "text-muted-foreground"
+                                : ""
+                          }`}
+                          aria-label={
+                            isBest
+                              ? `${item.name} ${row.label}: ${row.format(raw)} (最優位)`
+                              : undefined
+                          }
+                        >
+                          {/* DSCR行はアイコンを併記してWCAG 1.4.1準拠 */}
+                          {row.key === "dscr" ? (
+                            <span className="inline-flex items-center justify-center gap-1">
+                              <DscrTrendIcon dscr={raw} />
+                              <span>{row.format(raw)}</span>
+                              {isBest && (
+                                <span className="sr-only">（最優位）</span>
+                              )}
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center justify-center gap-1">
+                              {row.format(raw)}
+                              {isBest && (
+                                <span
+                                  className="text-green-600"
+                                  title="最優位"
+                                  aria-hidden="true"
+                                >
+                                  ★
+                                </span>
+                              )}
+                              {isBest && <span className="sr-only">（最優位）</span>}
+                            </span>
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+        <p className="mt-2 text-xs text-muted-foreground">
+          ★ は各指標の最優位物件を示します。同値の場合はハイライトなし。
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/WatchlistCompareTable.tsx
+++ b/frontend/src/components/WatchlistCompareTable.tsx
@@ -85,6 +85,8 @@ function getValue(metrics: WatchlistMetrics | undefined, key: MetricKey): number
   if (!metrics) return null;
   const v = metrics[key];
   if (v == null) return null;
+  // deadCrossYear: -1 means "no dead cross" which is the best possible value
+  if (key === "deadCrossYear" && Number(v) === -1) return Infinity;
   return Number(v);
 }
 
@@ -97,8 +99,7 @@ function findBestIndex(items: WatchlistItem[], row: MetricRow): number {
   const validValues = values.filter((v): v is number => v !== null);
   if (validValues.length === 0) return -1;
 
-  const bestValue =
-    row.best === "max" ? Math.max(...validValues) : Math.min(...validValues);
+  const bestValue = row.best === "max" ? Math.max(...validValues) : Math.min(...validValues);
 
   // Only highlight if there's a unique best (no tie)
   const bestCount = validValues.filter((v) => v === bestValue).length;
@@ -108,7 +109,7 @@ function findBestIndex(items: WatchlistItem[], row: MetricRow): number {
 }
 
 function DscrTrendIcon({ dscr }: { dscr: number | null }) {
-  if (dscr === null) return <Minus className="h-3 w-3 text-muted-foreground" />;
+  if (dscr === null) return <Minus className="h-3 w-3 text-muted-foreground" aria-hidden="true" />;
   if (dscr >= 1.2) return <TrendingUp className="h-3 w-3 text-green-600" aria-hidden="true" />;
   if (dscr >= 1.0) return <Minus className="h-3 w-3 text-yellow-600" aria-hidden="true" />;
   return <TrendingDown className="h-3 w-3 text-red-600" aria-hidden="true" />;
@@ -163,7 +164,11 @@ export default function WatchlistCompareTable({ items }: WatchlistCompareTablePr
                       {row.label}
                     </td>
                     {items.map((item, colIdx) => {
+                      // raw: comparison value (Infinity for deadCrossYear=-1)
                       const raw = getValue(item.metrics, row.key);
+                      // displayValue: original metric value, used for formatting only
+                      const metricVal = item.metrics?.[row.key];
+                      const displayValue = metricVal != null ? Number(metricVal) : null;
                       const isBest = bestIdx !== -1 && colIdx === bestIdx;
                       const isUnavailable = raw === null;
                       return (
@@ -178,28 +183,22 @@ export default function WatchlistCompareTable({ items }: WatchlistCompareTablePr
                           }`}
                           aria-label={
                             isBest
-                              ? `${item.name} ${row.label}: ${row.format(raw)} (最優位)`
+                              ? `${item.name} ${row.label}: ${row.format(displayValue)} (最優位)`
                               : undefined
                           }
                         >
                           {/* DSCR行はアイコンを併記してWCAG 1.4.1準拠 */}
                           {row.key === "dscr" ? (
                             <span className="inline-flex items-center justify-center gap-1">
-                              <DscrTrendIcon dscr={raw} />
-                              <span>{row.format(raw)}</span>
-                              {isBest && (
-                                <span className="sr-only">（最優位）</span>
-                              )}
+                              <DscrTrendIcon dscr={displayValue} />
+                              <span>{row.format(displayValue)}</span>
+                              {isBest && <span className="sr-only">（最優位）</span>}
                             </span>
                           ) : (
                             <span className="inline-flex items-center justify-center gap-1">
-                              {row.format(raw)}
+                              {row.format(displayValue)}
                               {isBest && (
-                                <span
-                                  className="text-green-600"
-                                  title="最優位"
-                                  aria-hidden="true"
-                                >
+                                <span className="text-green-600" title="最優位" aria-hidden="true">
                                   ★
                                 </span>
                               )}

--- a/frontend/src/components/WatchlistCompareTable.tsx
+++ b/frontend/src/components/WatchlistCompareTable.tsx
@@ -66,9 +66,9 @@ const METRIC_ROWS: MetricRow[] = [
     key: "deadCrossYear",
     format: (v) => {
       if (v == null) return "-";
-      return Number(v) === -1 ? "なし（最良）" : `${Number(v)}年目`;
+      return Number(v) <= 0 ? "なし（最良）" : `${Number(v)}年目`;
     },
-    best: "max", // -1 (none) is best, larger deadCrossYear means it arrives later = better
+    best: "max", // <=0 (none) is best, larger deadCrossYear means it arrives later = better
   },
   {
     label: "NPV",
@@ -85,8 +85,8 @@ function getValue(metrics: WatchlistMetrics | undefined, key: MetricKey): number
   if (!metrics) return null;
   const v = metrics[key];
   if (v == null) return null;
-  // deadCrossYear: -1 means "no dead cross" which is the best possible value
-  if (key === "deadCrossYear" && Number(v) === -1) return Infinity;
+  // deadCrossYear: -1 or 0 means "no dead cross" which is the best possible value
+  if (key === "deadCrossYear" && Number(v) <= 0) return Infinity;
   return Number(v);
 }
 

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -5,8 +5,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
 import { useToast } from "@/components/ui/toast";
-import { Trash2, ClipboardList, CheckCircle2, AlertTriangle, XCircle } from "lucide-react";
+import { Trash2, ClipboardList, CheckCircle2, AlertTriangle, XCircle, BarChart2 } from "lucide-react";
 import type { WatchlistItem, WatchlistStatus, InvestmentResult } from "@/types/investment";
+import WatchlistCompareTable from "@/components/WatchlistCompareTable";
 
 const STORAGE_KEY = "yg_watchlist";
 
@@ -64,6 +65,8 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
   const [memoInput, setMemoInput] = useState("");
   const [nameError, setNameError] = useState("");
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
+  const [compareMode, setCompareMode] = useState(false);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const { toast } = useToast();
 
   useEffect(() => {
@@ -95,6 +98,8 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
               irr: currentResult.irr ?? null,
               totalInvestment: currentResult.totalInvestment,
               exitTotalEquity: currentResult.exitTotalEquity,
+              deadCrossYear: currentResult.deadCrossYear,
+              npv: currentResult.npv,
             },
           }
         : {}),
@@ -124,16 +129,46 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
     if (e.key === "Enter") handleAdd();
   }
 
+  function toggleCompareMode() {
+    setCompareMode((prev) => {
+      if (prev) setSelectedIds([]);
+      return !prev;
+    });
+  }
+
+  function toggleSelectItem(id: string) {
+    setSelectedIds((prev) => {
+      if (prev.includes(id)) return prev.filter((x) => x !== id);
+      if (prev.length >= 4) return prev; // max 4
+      return [...prev, id];
+    });
+  }
+
+  const selectedItems = items.filter((item) => selectedIds.includes(item.id));
   const pendingDeleteName = items.find((item) => item.id === pendingDeleteId)?.name ?? "";
 
   return (
     <>
       <Card className="rounded-xl shadow-sm">
         <CardHeader className="pb-2">
-          <CardTitle className="flex items-center gap-2 text-base font-semibold">
-            <ClipboardList className="h-4 w-4 text-primary" />
-            物件候補ウォッチリスト
-          </CardTitle>
+          <div className="flex items-center justify-between">
+            <CardTitle className="flex items-center gap-2 text-base font-semibold">
+              <ClipboardList className="h-4 w-4 text-primary" />
+              物件候補ウォッチリスト
+            </CardTitle>
+            {items.length >= 2 && (
+              <Button
+                type="button"
+                size="sm"
+                variant={compareMode ? "default" : "outline"}
+                onClick={toggleCompareMode}
+                className="flex items-center gap-1.5 text-xs"
+              >
+                <BarChart2 className="h-3.5 w-3.5" />
+                {compareMode ? "比較終了" : "比較表示"}
+              </Button>
+            )}
+          </div>
         </CardHeader>
         <CardContent className="space-y-4">
           {/* Add form */}
@@ -169,6 +204,13 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
             />
           </div>
 
+          {/* Compare mode hint */}
+          {compareMode && (
+            <p className="rounded-md bg-blue-50 px-3 py-2 text-xs text-blue-700">
+              比較する物件を最大4件選択してください（{selectedIds.length}/4 件選択中）
+            </p>
+          )}
+
           {/* List */}
           {items.length === 0 ? (
             <p className="py-6 text-center text-sm text-muted-foreground">
@@ -181,6 +223,20 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
                   key={item.id}
                   className="flex flex-col gap-2 py-3 sm:flex-row sm:items-start sm:gap-3"
                 >
+                  {/* Compare mode checkbox */}
+                  {compareMode && (
+                    <div className="flex shrink-0 items-center pt-0.5">
+                      <input
+                        type="checkbox"
+                        id={`compare-${item.id}`}
+                        checked={selectedIds.includes(item.id)}
+                        onChange={() => toggleSelectItem(item.id)}
+                        disabled={!selectedIds.includes(item.id) && selectedIds.length >= 4}
+                        className="h-4 w-4 rounded border-input accent-primary"
+                        aria-label={`${item.name} を比較対象に追加`}
+                      />
+                    </div>
+                  )}
                   {/* Left: name + meta */}
                   <div className="min-w-0 flex-1 space-y-0.5">
                     <div className="flex flex-wrap items-center gap-2">
@@ -249,6 +305,11 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
           )}
         </CardContent>
       </Card>
+
+      {/* Comparison table */}
+      {compareMode && selectedItems.length >= 2 && (
+        <WatchlistCompareTable items={selectedItems} />
+      )}
 
       {/* Delete confirmation modal */}
       <Modal

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -5,7 +5,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Modal } from "@/components/ui/modal";
 import { useToast } from "@/components/ui/toast";
-import { Trash2, ClipboardList, CheckCircle2, AlertTriangle, XCircle, BarChart2 } from "lucide-react";
+import {
+  Trash2,
+  ClipboardList,
+  CheckCircle2,
+  AlertTriangle,
+  XCircle,
+  BarChart2,
+} from "lucide-react";
 import type { WatchlistItem, WatchlistStatus, InvestmentResult } from "@/types/investment";
 import WatchlistCompareTable from "@/components/WatchlistCompareTable";
 
@@ -118,6 +125,7 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
     if (!pendingDeleteId) return;
     const target = items.find((item) => item.id === pendingDeleteId);
     setItems((prev) => prev.filter((item) => item.id !== pendingDeleteId));
+    setSelectedIds((prev) => prev.filter((id) => id !== pendingDeleteId));
     setPendingDeleteId(null);
     toast({
       message: target ? `「${target.name}」を削除しました` : "削除しました",
@@ -307,9 +315,7 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
       </Card>
 
       {/* Comparison table */}
-      {compareMode && selectedItems.length >= 2 && (
-        <WatchlistCompareTable items={selectedItems} />
-      )}
+      {compareMode && selectedItems.length >= 2 && <WatchlistCompareTable items={selectedItems} />}
 
       {/* Delete confirmation modal */}
       <Modal

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -437,6 +437,8 @@ export interface WatchlistMetrics {
   irr: number | null;
   totalInvestment: number;
   exitTotalEquity: number;
+  deadCrossYear?: number; // -1 = none (best)
+  npv?: number;
 }
 
 export interface WatchlistItem {


### PR DESCRIPTION
## 概要

ウォッチリストに登録した物件を横並びで比較できる比較表機能を追加します（issue #397 + #381 統合実装）。2件以上の物件がある場合に「比較表示」ボタンが表示され、最大4件を選択して8指標の比較テーブルを表示できます。

## 変更内容

- `WatchlistMetrics` に `deadCrossYear?` と `npv?` を追加（optional、後方互換）
- `WatchlistPanel`: 比較モード state・チェックボックス・「比較表示」ボタンを追加
- `WatchlistPanel`: `handleAdd` で `deadCrossYear` と `npv` も metrics に保存
- `WatchlistCompareTable`: 新規コンポーネント — 最大4件を横軸に並べた比較テーブル
  - 各行の最優位セルを `bg-green-50` + 太字 + ★アイコンでハイライト（WCAG 1.4.1準拠）
  - `deadCrossYear === -1` は「なし（最良）」と表示
  - 同値の場合はハイライトなし
  - レスポンシブ（モバイルではスクロール可能）

## テスト

- [ ] ウォッチリストに2件以上登録後、「比較表示」ボタンが表示される
- [ ] 最大4件まで選択でき、5件目はチェック不可
- [ ] 最優位セルがハイライトされる
- [ ] 既存のウォッチリスト機能が正常動作する

## 関連 issue

Closes #397
Closes #381