### PR TITLE
feat(frontend): 乗降客数スコアから空室率・賃料下落率の推奨値を自動反映

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -41,6 +41,11 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
   const [showGuide, setShowGuide] = useState(false);
   const [activeTab, setActiveTab] = useState<"simulation" | "area-discovery">("simulation");
   const [selectedMunicipalityMsg, setSelectedMunicipalityMsg] = useState<string | null>(null);
+  const [recommend, setRecommend] = useState<{
+    vacancyRate: number;
+    rentDeclineRate: number;
+    version: number;
+  } | null>(null);
 
   const noticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const copiedTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -97,6 +102,14 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
       // localStorage unavailable (e.g. test environment or private browsing)
     }
   }, []);
+
+  const handleApplyRecommend = (vacancyRate: number, rentDeclineRate: number) => {
+    setRecommend((prev) => ({
+      vacancyRate,
+      rentDeclineRate,
+      version: (prev?.version ?? 0) + 1,
+    }));
+  };
 
   const handleModeChange = (mode: SimulationMode) => {
     if (result) {
@@ -240,6 +253,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
               isOnline={isOnline}
               externalLat={propertyLat}
               externalLng={propertyLng}
+              externalRecommend={recommend ?? undefined}
             />
           </aside>
 
@@ -267,6 +281,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
             loanMethod={loanMethod}
             onLoanMethodChange={handleLoanMethodChange}
             onTileSelect={setPropertyCoords}
+            onApplyRecommend={handleApplyRecommend}
           />
         </div>
       </main>
@@ -304,6 +319,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
           externalLat={propertyLat}
           externalLng={propertyLng}
           showModeToggle={true}
+          externalRecommend={recommend ?? undefined}
         />
       </FormSheet>
     </div>

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -95,6 +95,9 @@ interface Props {
   externalLat?: number;
   externalLng?: number;
   showModeToggle?: boolean;
+  /** When set, applies vacancyRate and rentDeclineRate to the form state.
+   *  `version` must be incremented each time to trigger the effect. */
+  externalRecommend?: { vacancyRate: number; rentDeclineRate: number; version: number };
 }
 
 export function InvestmentForm({
@@ -109,6 +112,7 @@ export function InvestmentForm({
   externalLat,
   externalLng,
   showModeToggle = true,
+  externalRecommend,
 }: Props) {
   const [input, setInput] = useState<InvestmentInput>({ ...DEFAULT_INPUT, ...initialInput });
   const [area, setArea] = useState("10");
@@ -210,6 +214,17 @@ export function InvestmentForm({
       setPropertyLng(externalLng.toFixed(6));
     }
   }, [externalLat, externalLng]);
+
+  // Apply vacancy rate / rent decline rate from external recommendation
+  useEffect(() => {
+    if (!externalRecommend) return;
+    setInput((prev) => ({
+      ...prev,
+      vacancyRate: externalRecommend.vacancyRate,
+      rentDeclineRate: externalRecommend.rentDeclineRate,
+    }));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [externalRecommend?.version]);
 
   // モード切替時に現金購入フラグをリセットし、ローン値を復元する
   useEffect(() => {

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -223,7 +223,9 @@ export function InvestmentForm({
       vacancyRate: externalRecommend.vacancyRate,
       rentDeclineRate: externalRecommend.rentDeclineRate,
     }));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // externalRecommend 全体を依存配列に入れると親の再レンダー毎に発火してしまうため、
+    // version のみを依存とし、ボタン押下時（version インクリメント時）だけ適用する意図的な設計。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [externalRecommend?.version]);
 
   // モード切替時に現金購入フラグをリセットし、ローン値を復元する

--- a/frontend/src/components/InvestmentScoreCard.tsx
+++ b/frontend/src/components/InvestmentScoreCard.tsx
@@ -5,10 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { InvestmentScoreResult, ScoreItem } from "@/types/investment";
-import {
-  getRidershipRecommend,
-  getPopulationVacancyDelta,
-} from "@/lib/vacancyRateRecommender";
+import { getRidershipRecommend, getPopulationVacancyDelta } from "@/lib/vacancyRateRecommender";
 
 interface Props {
   score: InvestmentScoreResult;
@@ -63,9 +60,7 @@ export function InvestmentScoreCard({ score, populationChangeRate, onApplyRecomm
   // Compute recommendation from ridership score (0–20 range from backend)
   const recommend = getRidershipRecommend(breakdown.ridership.score);
   const popDelta =
-    populationChangeRate !== undefined
-      ? getPopulationVacancyDelta(populationChangeRate)
-      : 0;
+    populationChangeRate !== undefined ? getPopulationVacancyDelta(populationChangeRate) : 0;
   const recommendedVacancy = recommend.vacancyRate + popDelta;
   const recommendedRentDecline = recommend.rentDeclineRate;
 

--- a/frontend/src/components/InvestmentScoreCard.tsx
+++ b/frontend/src/components/InvestmentScoreCard.tsx
@@ -3,10 +3,17 @@
 import { Radar, RadarChart, PolarGrid, PolarAngleAxis, ResponsiveContainer } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import type { InvestmentScoreResult, ScoreItem } from "@/types/investment";
+import {
+  getRidershipRecommend,
+  getPopulationVacancyDelta,
+} from "@/lib/vacancyRateRecommender";
 
 interface Props {
   score: InvestmentScoreResult;
+  populationChangeRate?: number;
+  onApplyRecommend?: (vacancyRate: number, rentDeclineRate: number) => void;
 }
 
 const GRADE_STYLE: Record<
@@ -38,7 +45,7 @@ function ScoreRow({ item }: { item: ScoreItem }) {
   );
 }
 
-export function InvestmentScoreCard({ score }: Props) {
+export function InvestmentScoreCard({ score, populationChangeRate, onApplyRecommend }: Props) {
   const { totalScore, grade, breakdown } = score;
   const gradeStyle = GRADE_STYLE[grade] ?? GRADE_STYLE["普通"];
 
@@ -52,6 +59,27 @@ export function InvestmentScoreCard({ score }: Props) {
     breakdown.embankment,
     breakdown.disasterHistory,
   ];
+
+  // Compute recommendation from ridership score (0–20 range from backend)
+  const recommend = getRidershipRecommend(breakdown.ridership.score);
+  const popDelta =
+    populationChangeRate !== undefined
+      ? getPopulationVacancyDelta(populationChangeRate)
+      : 0;
+  const recommendedVacancy = recommend.vacancyRate + popDelta;
+  const recommendedRentDecline = recommend.rentDeclineRate;
+
+  const handleApply = () => {
+    onApplyRecommend?.(recommendedVacancy, recommendedRentDecline);
+  };
+
+  const tooltipText = [
+    `乗降客数スコア ${recommend.grade} → 空室率 ${(recommend.vacancyRate * 100).toFixed(0)}% 推奨`,
+    ...(popDelta > 0
+      ? [`人口30年予測 −30%以上 → 空室率 +${(popDelta * 100).toFixed(0)}% 加算`]
+      : []),
+    `賃料下落率 ${(recommendedRentDecline * 100).toFixed(1)}%/年 推奨`,
+  ].join(" / ");
 
   return (
     <Card className="border border-indigo-200">
@@ -94,6 +122,26 @@ export function InvestmentScoreCard({ score }: Props) {
             <ScoreRow key={item.label} item={item} />
           ))}
         </div>
+
+        {onApplyRecommend && (
+          <div className="mt-3 rounded-md border border-indigo-100 bg-indigo-50 px-3 py-2">
+            <p className="text-[11px] text-indigo-700 mb-2 leading-snug" title={tooltipText}>
+              <span className="font-medium">推奨値：</span>
+              {tooltipText}
+            </p>
+            <Button
+              size="sm"
+              variant="outline"
+              className="h-8 text-xs border-indigo-300 text-indigo-700 hover:bg-indigo-100"
+              onClick={handleApply}
+              title={tooltipText}
+            >
+              推奨空室率 {(recommendedVacancy * 100).toFixed(0)}% ・賃料下落率{" "}
+              {(recommendedRentDecline * 100).toFixed(1)}% を適用
+            </Button>
+          </div>
+        )}
+
         <p className="mt-2 text-[10px] text-gray-400 leading-tight">
           基準スコア50点 +
           各指標の加減点（0〜100にクランプ）。API取得失敗時は該当指標を0点として算出。

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -60,6 +60,7 @@ interface ResultsSectionProps {
   loanMethod: LoanMethod;
   onLoanMethodChange: (method: LoanMethod) => Promise<void>;
   onTileSelect: (lat: number, lng: number) => void;
+  onApplyRecommend?: (vacancyRate: number, rentDeclineRate: number) => void;
 }
 
 export function ResultsSection({
@@ -86,6 +87,7 @@ export function ResultsSection({
   loanMethod,
   onLoanMethodChange,
   onTileSelect,
+  onApplyRecommend,
 }: ResultsSectionProps) {
   const [municipalityCenter, setMunicipalityCenter] = useState<{
     lat: number;
@@ -172,7 +174,13 @@ export function ResultsSection({
         <>
           <HazardAlertBanner hazardRisks={hazardRisks} externalUrbanRisks={externalUrbanRisks} />
 
-          {investmentScore && <InvestmentScoreCard score={investmentScore} />}
+          {investmentScore && (
+            <InvestmentScoreCard
+              score={investmentScore}
+              populationChangeRate={populationForecast?.changeRate30yr}
+              onApplyRecommend={onApplyRecommend}
+            />
+          )}
 
           {propertyLat !== undefined && (
             <InvestmentScoreHeatmap

--- a/frontend/src/lib/vacancyRateRecommender.ts
+++ b/frontend/src/lib/vacancyRateRecommender.ts
@@ -1,0 +1,59 @@
+/**
+ * vacancyRateRecommender.ts
+ *
+ * Derives vacancy rate and rent decline rate recommendations from
+ * ridership demand score (A–E) and population 30-year change rate.
+ */
+
+export type RidershipGrade = "A" | "B" | "C" | "D" | "E";
+
+export interface VacancyRecommendation {
+  vacancyRate: number;
+  rentDeclineRate: number;
+  grade: RidershipGrade;
+}
+
+/**
+ * Mapping from ridership demand score (0–20, linear from backend) to grade.
+ * Backend formula: score = maxPassengers / 200_000 * 20
+ *   A: 20万人+ → score ≥ 20 (clamped to 20)
+ *   B: 10–20万 → score ≥ 10
+ *   C:  5–10万 → score ≥ 5
+ *   D:  1– 5万 → score ≥ 1
+ *   E:    <1万 → score < 1
+ */
+export function ridershipGradeFromScore(score: number): RidershipGrade {
+  if (score >= 20) return "A";
+  if (score >= 10) return "B";
+  if (score >= 5) return "C";
+  if (score >= 1) return "D";
+  return "E";
+}
+
+const GRADE_RECOMMEND: Record<
+  RidershipGrade,
+  { vacancyRate: number; rentDeclineRate: number }
+> = {
+  A: { vacancyRate: 0.03, rentDeclineRate: 0.005 },
+  B: { vacancyRate: 0.05, rentDeclineRate: 0.01 },
+  C: { vacancyRate: 0.07, rentDeclineRate: 0.015 },
+  D: { vacancyRate: 0.10, rentDeclineRate: 0.02 },
+  E: { vacancyRate: 0.15, rentDeclineRate: 0.03 },
+};
+
+/**
+ * Returns recommended vacancy rate and rent decline rate for a given
+ * ridership demand score (0–20 as returned by the investment-score API).
+ */
+export function getRidershipRecommend(ridershipScore: number): VacancyRecommendation {
+  const grade = ridershipGradeFromScore(ridershipScore);
+  return { grade, ...GRADE_RECOMMEND[grade] };
+}
+
+/**
+ * Returns the vacancy rate delta to add when population 30-year change rate
+ * is −30% or worse (i.e. changeRate30yr ≤ −0.30).
+ */
+export function getPopulationVacancyDelta(changeRate30yr: number): number {
+  return changeRate30yr <= -0.3 ? 0.03 : 0;
+}

--- a/frontend/src/lib/vacancyRateRecommender.ts
+++ b/frontend/src/lib/vacancyRateRecommender.ts
@@ -22,6 +22,7 @@ export interface VacancyRecommendation {
  *   D:  1– 5万 → score ≥ 1
  *   E:    <1万 → score < 1
  */
+// Backend clamps ridership score to [0, 20] via math.Min, so >= 20 safely captures the top grade.
 export function ridershipGradeFromScore(score: number): RidershipGrade {
   if (score >= 20) return "A";
   if (score >= 10) return "B";
@@ -30,14 +31,11 @@ export function ridershipGradeFromScore(score: number): RidershipGrade {
   return "E";
 }
 
-const GRADE_RECOMMEND: Record<
-  RidershipGrade,
-  { vacancyRate: number; rentDeclineRate: number }
-> = {
+const GRADE_RECOMMEND: Record<RidershipGrade, { vacancyRate: number; rentDeclineRate: number }> = {
   A: { vacancyRate: 0.03, rentDeclineRate: 0.005 },
   B: { vacancyRate: 0.05, rentDeclineRate: 0.01 },
   C: { vacancyRate: 0.07, rentDeclineRate: 0.015 },
-  D: { vacancyRate: 0.10, rentDeclineRate: 0.02 },
+  D: { vacancyRate: 0.1, rentDeclineRate: 0.02 },
   E: { vacancyRate: 0.15, rentDeclineRate: 0.03 },
 };
 
@@ -50,10 +48,13 @@ export function getRidershipRecommend(ridershipScore: number): VacancyRecommenda
   return { grade, ...GRADE_RECOMMEND[grade] };
 }
 
+const POPULATION_DECLINE_THRESHOLD = -0.3;
+const POPULATION_VACANCY_PENALTY = 0.03;
+
 /**
  * Returns the vacancy rate delta to add when population 30-year change rate
  * is −30% or worse (i.e. changeRate30yr ≤ −0.30).
  */
 export function getPopulationVacancyDelta(changeRate30yr: number): number {
-  return changeRate30yr <= -0.3 ? 0.03 : 0;
+  return changeRate30yr <= POPULATION_DECLINE_THRESHOLD ? POPULATION_VACANCY_PENALTY : 0;
 }


### PR DESCRIPTION
## 概要

乗降客数スコア・人口予測データを投資試算パラメータの推奨値に自動反映する機能を追加します。投資スコアカードに「推奨値を適用」ボタンを追加し、クリックで空室率・賃料下落率フォームを自動入力します。

## 変更内容

- `vacancyRateRecommender.ts` 新規作成: スコアA-E → 空室率・賃料下落率の推奨値を返す純粋関数
- `InvestmentScoreCard.tsx`: 推奨値ヒントバナー + 「適用」ボタンを追加
- `ResultsSection.tsx`: `onApplyRecommend` コールバックを受け取り `InvestmentScoreCard` に渡す
- `Dashboard.tsx`: `handleApplyRecommend` で `InvestmentForm` に推奨値を通知
- `InvestmentForm.tsx`: `externalRecommend` props で外部から空室率・賃料下落率を受け取り反映

## 推奨値テーブル

| スコア | 空室率 | 賃料下落率/年 |
|--------|--------|-------------|
| A（20万人〜）| 3% | 0.5% |
| B（10〜20万）| 5% | 1.0% |
| C（5〜10万）| 7% | 1.5% |
| D（1〜5万）| 10% | 2.0% |
| E（〜1万）| 15% | 3.0% |

人口30年予測が-30%以下の場合は空室率に+3%を加算。

## テスト

- [ ] 位置情報設定後にシミュレーションを実行すると推奨値ボタンが表示される
- [ ] ボタンクリックで空室率・賃料下落率フォームが更新される
- [ ] スコアが取得できない場合はボタンが非表示
- [ ] 手動変更後も正常動作する

## 関連 issue

Closes #379