### PR TITLE
feat(backend/frontend): 複数保有年数（5/10/15/20年）の出口比較テーブルの追加

### DIFF
--- a/backend/internal/domain/exit.go
+++ b/backend/internal/domain/exit.go
@@ -142,6 +142,92 @@ func calcIRRNPV(
 	return irrNPVResult{irr: irr, npv: npv}
 }
 
+// calcMultiExitComparison は複数保有年数（デフォルト: 5/10/15/20年）の出口比較テーブルを生成する。
+// ExitYears が空なら [5, 10, 15, 20] を使用し、データが存在しない年はスキップする。
+func calcMultiExitComparison(input InvestmentInput, yearly []YearlyResult, accumulatedDepreciation float64, miscExpenses float64) []MultiExitRow {
+	years := input.ExitYears
+	if len(years) == 0 {
+		years = []int{5, 10, 15, 20}
+	}
+
+	equity := input.LandPrice + input.BuildingCost + miscExpenses - input.LoanAmount
+
+	var rows []MultiExitRow
+	for _, yr := range years {
+		if yr <= 0 || yr > len(yearly) {
+			continue
+		}
+		idx := yr - 1
+		exitYear := yearly[idx]
+
+		// 累積CF（税引後）
+		cumCF := exitYear.CumulativeCashFlow
+
+		// 売却価格: NOI / exitYieldTarget（その年のNOIを使用）
+		noi := exitYear.AnnualRent - exitYear.AnnualExpenses
+		salePrice := 0.0
+		if input.ExitYieldTarget > 0 {
+			salePrice = noi / input.ExitYieldTarget
+		}
+
+		// 売却費用（仲介手数料上限・消費税込み）
+		sellExpenses := (salePrice*0.03 + 60_000) * 1.10
+
+		// 建物の税務上の簿価（年次シミュレーション時点の累計減価償却は accumulatedDepreciation が保有年数終了時点）
+		// 各年の簿価は比例按分で近似する
+		bookValueBuilding := input.BuildingCost - accumulatedDepreciation
+		if bookValueBuilding < 0 {
+			bookValueBuilding = 0
+		}
+
+		// 取得費 = 土地 + 建物簿価 + 諸経費
+		acquisitionCost := input.LandPrice + bookValueBuilding + miscExpenses
+
+		// 譲渡所得 = 売却価格 - 売却費用 - 取得費
+		capitalGain := salePrice - sellExpenses - acquisitionCost
+
+		// 譲渡税率: 5年以下=短期(39.63%)、5年超=長期(20.315%)
+		var taxRate float64
+		isShortTerm := yr <= 5
+		if isShortTerm {
+			taxRate = shortTermTransferTaxRate
+		} else {
+			taxRate = longTermTransferTaxRate
+		}
+
+		transferTax := 0.0
+		if capitalGain > 0 {
+			transferTax = capitalGain * taxRate
+		}
+
+		remainingLoan := exitYear.RemainingLoanBalance
+
+		// 出口エクイティ = 売却価格 - 売却費用 - 残債 - 譲渡税 + 累積税引後CF
+		exitEquity := salePrice - sellExpenses - remainingLoan - transferTax + cumCF
+
+		// IRR 計算
+		irrCFs := make([]float64, yr)
+		for i := 0; i < yr; i++ {
+			irrCFs[i] = yearly[i].AfterTaxCashFlow
+		}
+		netProceeds := salePrice - sellExpenses - transferTax - remainingLoan
+		irr, _ := CalcIRR(irrCFs, netProceeds, equity)
+
+		rows = append(rows, MultiExitRow{
+			Year:            yr,
+			SalePrice:       salePrice,
+			TransferTaxRate: taxRate,
+			TransferTax:     transferTax,
+			RemainingLoan:   remainingLoan,
+			CumulativeCF:    cumCF,
+			ExitEquity:      exitEquity,
+			IRR:             irr,
+			IsShortTermWarn: isShortTerm,
+		})
+	}
+	return rows
+}
+
 // CalcNPV は将来キャッシュフロー・ターミナルバリュー・割引率・初期投資から NPV を計算する
 func CalcNPV(cfs []float64, terminalValue, discountRate, initialInvestment float64) float64 {
 	pv := 0.0

--- a/backend/internal/domain/exit.go
+++ b/backend/internal/domain/exit.go
@@ -163,19 +163,24 @@ func calcMultiExitComparison(input InvestmentInput, yearly []YearlyResult, accum
 		// 累積CF（税引後）
 		cumCF := exitYear.CumulativeCashFlow
 
+		// ExitYieldTarget が 0 以下の場合は売却価格が未定義になるためスキップ
+		if input.ExitYieldTarget <= 0 {
+			continue
+		}
+
 		// 売却価格: NOI / exitYieldTarget（その年のNOIを使用）
 		noi := exitYear.AnnualRent - exitYear.AnnualExpenses
-		salePrice := 0.0
-		if input.ExitYieldTarget > 0 {
-			salePrice = noi / input.ExitYieldTarget
-		}
+		salePrice := noi / input.ExitYieldTarget
 
 		// 売却費用（仲介手数料上限・消費税込み）
 		sellExpenses := (salePrice*0.03 + 60_000) * 1.10
 
-		// 建物の税務上の簿価（年次シミュレーション時点の累計減価償却は accumulatedDepreciation が保有年数終了時点）
-		// 各年の簿価は比例按分で近似する
-		bookValueBuilding := input.BuildingCost - accumulatedDepreciation
+		// 建物の税務上の簿価: yearly[0..yr-1] の AnnualDepreciation を積算
+		yearDepreciation := 0.0
+		for i := 0; i < yr; i++ {
+			yearDepreciation += yearly[i].AnnualDepreciation
+		}
+		bookValueBuilding := input.BuildingCost - yearDepreciation
 		if bookValueBuilding < 0 {
 			bookValueBuilding = 0
 		}

--- a/backend/internal/domain/exit.go
+++ b/backend/internal/domain/exit.go
@@ -144,7 +144,7 @@ func calcIRRNPV(
 
 // calcMultiExitComparison は複数保有年数（デフォルト: 5/10/15/20年）の出口比較テーブルを生成する。
 // ExitYears が空なら [5, 10, 15, 20] を使用し、データが存在しない年はスキップする。
-func calcMultiExitComparison(input InvestmentInput, yearly []YearlyResult, accumulatedDepreciation float64, miscExpenses float64) []MultiExitRow {
+func calcMultiExitComparison(input InvestmentInput, yearly []YearlyResult, miscExpenses float64) []MultiExitRow {
 	years := input.ExitYears
 	if len(years) == 0 {
 		years = []int{5, 10, 15, 20}

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -80,6 +80,8 @@ func Analyze(ctx context.Context, input InvestmentInput) InvestmentResult {
 	irrNPV := calcIRRNPV(input, sim.yearlyResults, equity, exitNet,
 		exitSalePrice, sim.accumulatedDepreciation, yp.miscExpenses)
 
+	multiExit := calcMultiExitComparison(input, sim.yearlyResults, sim.accumulatedDepreciation, yp.miscExpenses)
+
 	return InvestmentResult{
 		TotalInvestment:       yp.totalInvestment,
 		MiscExpenses:          yp.miscExpenses,
@@ -105,6 +107,7 @@ func Analyze(ctx context.Context, input InvestmentInput) InvestmentResult {
 		IRR:                   irrNPV.irr,
 		NPV:                   irrNPV.npv,
 		TotalInterest:         sim.totalInterest,
+		MultiExitComparison:   multiExit,
 	}
 }
 

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -80,7 +80,7 @@ func Analyze(ctx context.Context, input InvestmentInput) InvestmentResult {
 	irrNPV := calcIRRNPV(input, sim.yearlyResults, equity, exitNet,
 		exitSalePrice, sim.accumulatedDepreciation, yp.miscExpenses)
 
-	multiExit := calcMultiExitComparison(input, sim.yearlyResults, sim.accumulatedDepreciation, yp.miscExpenses)
+	multiExit := calcMultiExitComparison(input, sim.yearlyResults, yp.miscExpenses)
 
 	return InvestmentResult{
 		TotalInvestment:       yp.totalInvestment,

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -134,6 +134,9 @@ type InvestmentInput struct {
 
 	// 融資諸費用率（保証料・登記費用等の合算）。LoanAmount × LoanFeeRate を取得費に加算。
 	LoanFeeRate float64 `json:"loanFeeRate,omitempty"`
+
+	// 複数保有年数の出口比較: 空の場合は [5, 10, 15, 20] をデフォルトとして使用
+	ExitYears []int `json:"exitYears,omitempty"`
 }
 
 // CapexEvent は大規模修繕費の発生スケジュール1件
@@ -304,6 +307,19 @@ type LTVSensitivityRow struct {
 	CFYield    float64 `json:"cfYield"`    // CF利回り（AnnualCF / 総投資額）
 }
 
+// MultiExitRow は複数保有年数の出口比較テーブルの1行
+type MultiExitRow struct {
+	Year            int      `json:"year"`
+	SalePrice       float64  `json:"salePrice"`
+	TransferTaxRate float64  `json:"transferTaxRate"`
+	TransferTax     float64  `json:"transferTax"`
+	RemainingLoan   float64  `json:"remainingLoan"`
+	CumulativeCF    float64  `json:"cumulativeCf"`
+	ExitEquity      float64  `json:"exitEquity"`
+	IRR             *float64 `json:"irr,omitempty"`
+	IsShortTermWarn bool     `json:"isShortTermWarn"`
+}
+
 // InvestmentResult は収支シミュレーションの結果
 type InvestmentResult struct {
 	TotalInvestment float64 `json:"totalInvestment"` // 総投資額（土地+建物+諸経費）
@@ -339,6 +355,8 @@ type InvestmentResult struct {
 	TotalInterest  float64             `json:"totalInterest"`  // 保有期間の総支払利息
 
 	AISummary string `json:"aiSummary"` // Gemini 生成の投資サマリー（空文字 = 未生成）
+
+	MultiExitComparison []MultiExitRow `json:"multiExitComparison,omitempty"` // 複数保有年数の出口比較
 }
 
 // AcquisitionCostBreakdown は物件取得時の諸経費内訳

--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -35,7 +35,7 @@ interface FullModeFormProps {
   input: InvestmentInput;
   setNum: (key: keyof InvestmentInput, value: number) => void;
   setStr: (key: keyof InvestmentInput, value: string) => void;
-  setField: (key: keyof InvestmentInput, value: unknown) => void;
+  setField: <K extends keyof InvestmentInput>(key: K, value: InvestmentInput[K]) => void;
   fieldError: (key: string) => string | undefined;
   rentHint: RentDeclineHint | null;
   rentHintLoading: boolean;

--- a/frontend/src/components/FullModeForm.tsx
+++ b/frontend/src/components/FullModeForm.tsx
@@ -35,6 +35,7 @@ interface FullModeFormProps {
   input: InvestmentInput;
   setNum: (key: keyof InvestmentInput, value: number) => void;
   setStr: (key: keyof InvestmentInput, value: string) => void;
+  setField: (key: keyof InvestmentInput, value: unknown) => void;
   fieldError: (key: string) => string | undefined;
   rentHint: RentDeclineHint | null;
   rentHintLoading: boolean;
@@ -70,6 +71,7 @@ export function FullModeForm({
   input,
   setNum,
   setStr,
+  setField,
   fieldError,
   rentHint,
   rentHintLoading,
@@ -140,6 +142,7 @@ export function FullModeForm({
           <ScenarioSection
             input={input}
             setNum={setNum}
+            setField={setField}
             rateSchedule={rateSchedule}
             capex={capex}
           />

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -204,7 +204,7 @@ export function InvestmentForm({
   const setStr = (key: keyof InvestmentInput, value: string) =>
     setInput((prev) => ({ ...prev, [key]: value }));
 
-  const setField = (key: keyof InvestmentInput, value: unknown) =>
+  const setField = <K extends keyof InvestmentInput>(key: K, value: InvestmentInput[K]) =>
     setInput((prev) => ({ ...prev, [key]: value }));
 
   useEffect(() => {

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -204,6 +204,9 @@ export function InvestmentForm({
   const setStr = (key: keyof InvestmentInput, value: string) =>
     setInput((prev) => ({ ...prev, [key]: value }));
 
+  const setField = (key: keyof InvestmentInput, value: unknown) =>
+    setInput((prev) => ({ ...prev, [key]: value }));
+
   useEffect(() => {
     if (externalLat !== undefined && externalLng !== undefined) {
       setPropertyLat(externalLat.toFixed(6));
@@ -566,6 +569,7 @@ export function InvestmentForm({
           input={input}
           setNum={setNum}
           setStr={setStr}
+          setField={setField}
           fieldError={fieldError}
           rentHint={rentHint}
           rentHintLoading={rentHintLoading}

--- a/frontend/src/components/MultiExitCompareTable.tsx
+++ b/frontend/src/components/MultiExitCompareTable.tsx
@@ -9,8 +9,8 @@ interface MultiExitCompareTableProps {
 
 function formatYen(value: number): string {
   const abs = Math.abs(value);
-  if (abs >= 1_0000_0000) {
-    return `${(value / 1_0000_0000).toFixed(2)}億円`;
+  if (abs >= 100_000_000) {
+    return `${(value / 100_000_000).toFixed(2)}億円`;
   }
   if (abs >= 1_0000) {
     return `${Math.round(value / 1_0000)}万円`;
@@ -111,7 +111,8 @@ export default function MultiExitCompareTable({ rows }: MultiExitCompareTablePro
         </table>
       </div>
       <p className="mt-3 text-xs text-muted-foreground">
-        ※ 緑ハイライト列が出口エクイティ最大。短期譲渡税（5年以下）は税率39.63%が適用されます。
+        ※
+        緑ハイライト列が出口エクイティ最大。短期譲渡税（保有5年以下）は税率39.63%、長期（5年超）は20.315%が適用されます。
       </p>
     </div>
   );

--- a/frontend/src/components/MultiExitCompareTable.tsx
+++ b/frontend/src/components/MultiExitCompareTable.tsx
@@ -1,0 +1,118 @@
+"use client";
+import React from "react";
+import { AlertTriangle } from "lucide-react";
+import type { MultiExitRow } from "@/types/investment";
+
+interface MultiExitCompareTableProps {
+  rows: MultiExitRow[];
+}
+
+function formatYen(value: number): string {
+  const abs = Math.abs(value);
+  if (abs >= 1_0000_0000) {
+    return `${(value / 1_0000_0000).toFixed(2)}億円`;
+  }
+  if (abs >= 1_0000) {
+    return `${Math.round(value / 1_0000)}万円`;
+  }
+  return `${Math.round(value).toLocaleString()}円`;
+}
+
+function formatPct(value: number): string {
+  return `${(value * 100).toFixed(2)}%`;
+}
+
+export default function MultiExitCompareTable({ rows }: MultiExitCompareTableProps) {
+  if (!rows || rows.length === 0) return null;
+
+  // 出口エクイティが最大の列インデックスを特定
+  const maxEquity = Math.max(...rows.map((r) => r.exitEquity));
+  const maxEquityIdx = rows.findIndex((r) => r.exitEquity === maxEquity);
+
+  const labels = [
+    "想定売却価格",
+    "譲渡税率",
+    "譲渡税額",
+    "残債残高",
+    "累積税引後CF",
+    "出口エクイティ合計",
+    "IRR",
+  ];
+
+  return (
+    <div className="rounded-xl border bg-white p-5 shadow-sm">
+      <h3 className="text-base font-semibold text-foreground mb-4">複数保有年数 出口比較</h3>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm border-collapse">
+          <thead>
+            <tr>
+              <th className="text-left py-2 pr-4 font-medium text-muted-foreground whitespace-nowrap border-b">
+                項目
+              </th>
+              {rows.map((row, i) => (
+                <th
+                  key={row.year}
+                  className={`text-right py-2 px-3 font-medium border-b whitespace-nowrap ${
+                    i === maxEquityIdx ? "bg-green-50" : ""
+                  }`}
+                >
+                  <div className="flex flex-col items-end gap-1">
+                    <span>{row.year}年</span>
+                    {row.isShortTermWarn && (
+                      <span className="inline-flex items-center gap-0.5 rounded-full bg-amber-100 px-1.5 py-0.5 text-xs font-medium text-amber-800">
+                        <AlertTriangle className="h-3 w-3" aria-hidden="true" />
+                        短期譲渡税
+                      </span>
+                    )}
+                  </div>
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {labels.map((label, labelIdx) => (
+              <tr key={label} className={labelIdx % 2 === 0 ? "bg-muted/20" : ""}>
+                <td className="py-2 pr-4 text-muted-foreground whitespace-nowrap">{label}</td>
+                {rows.map((row, colIdx) => {
+                  let value: string;
+                  let className = "text-right py-2 px-3 tabular-nums";
+                  if (colIdx === maxEquityIdx) {
+                    className += " bg-green-50";
+                  }
+                  if (label === "想定売却価格") {
+                    value = formatYen(row.salePrice);
+                  } else if (label === "譲渡税率") {
+                    value = formatPct(row.transferTaxRate);
+                  } else if (label === "譲渡税額") {
+                    value = formatYen(row.transferTax);
+                  } else if (label === "残債残高") {
+                    value = formatYen(row.remainingLoan);
+                  } else if (label === "累積税引後CF") {
+                    value = formatYen(row.cumulativeCf);
+                  } else if (label === "出口エクイティ合計") {
+                    value = formatYen(row.exitEquity);
+                    if (colIdx === maxEquityIdx) {
+                      className += " font-semibold text-green-700";
+                    }
+                  } else if (label === "IRR") {
+                    value = row.irr != null ? formatPct(row.irr) : "-";
+                  } else {
+                    value = "-";
+                  }
+                  return (
+                    <td key={row.year} className={className}>
+                      {value}
+                    </td>
+                  );
+                })}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-3 text-xs text-muted-foreground">
+        ※ 緑ハイライト列が出口エクイティ最大。短期譲渡税（5年以下）は税率39.63%が適用されます。
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -8,6 +8,7 @@ import CostBreakdown from "@/components/CostBreakdown";
 import { LoanOptimizationPanel } from "@/components/LoanOptimizationPanel";
 import { LoanComparePanel } from "@/components/LoanComparePanel";
 import RenovationPanel from "@/components/RenovationPanel";
+import MultiExitCompareTable from "@/components/MultiExitCompareTable";
 import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 import { HazardAlertBanner } from "@/components/HazardAlertBanner";
@@ -241,6 +242,9 @@ export function ResultsSection({
                   </div>
                   {monteCarloResult && <MonteCarloChart result={monteCarloResult} />}
                 </>
+              )}
+              {result.multiExitComparison && result.multiExitComparison.length > 0 && (
+                <MultiExitCompareTable rows={result.multiExitComparison} />
               )}
             </>
           )}

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -5,6 +5,8 @@ import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { Plus, Trash2 } from "lucide-react";
 import type { InvestmentInput, RateAdjustment } from "@/types/investment";
+
+const ALL_EXIT_YEARS = [5, 10, 15, 20] as const;
 import { formatPct } from "@/lib/utils";
 
 export interface RateScheduleHandlers {
@@ -25,11 +27,18 @@ export interface CapexHandlers {
 interface ScenarioSectionProps {
   input: InvestmentInput;
   setNum: (key: keyof InvestmentInput, value: number) => void;
+  setField: (key: keyof InvestmentInput, value: unknown) => void;
   rateSchedule: RateScheduleHandlers;
   capex: CapexHandlers;
 }
 
-export function ScenarioSection({ input, setNum, rateSchedule, capex }: ScenarioSectionProps) {
+export function ScenarioSection({ input, setNum, setField, rateSchedule, capex }: ScenarioSectionProps) {
+  const exitYears: number[] = input.exitYears ?? [...ALL_EXIT_YEARS];
+
+  function toggleExitYear(yr: number) {
+    const next = exitYears.includes(yr) ? exitYears.filter((y) => y !== yr) : [...exitYears, yr].sort((a, b) => a - b);
+    setField("exitYears", next.length > 0 ? next : [...ALL_EXIT_YEARS]);
+  }
   return (
     <>
       {/* 変動金利シミュレーション */}
@@ -145,6 +154,25 @@ export function ScenarioSection({ input, setNum, rateSchedule, capex }: Scenario
             金利上昇分はスケジュール後の金利にも上乗せされます
           </p>
         )}
+      </div>
+
+      {/* 複数保有年数 出口比較 */}
+      <div className="border-t pt-4 space-y-2">
+        <p className="text-sm font-semibold text-foreground">出口比較（保有年数）</p>
+        <p className="text-xs text-muted-foreground">比較する保有年数を選択してください</p>
+        <div className="flex gap-4 flex-wrap">
+          {ALL_EXIT_YEARS.map((yr) => (
+            <label key={yr} className="flex items-center gap-1.5 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={exitYears.includes(yr)}
+                onChange={() => toggleExitYear(yr)}
+                className="h-4 w-4 rounded border-gray-300"
+              />
+              <span className="text-sm">{yr}年</span>
+            </label>
+          ))}
+        </div>
       </div>
 
       {/* 大規模修繕費スケジュール */}

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -5,9 +5,9 @@ import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { Plus, Trash2 } from "lucide-react";
 import type { InvestmentInput, RateAdjustment } from "@/types/investment";
+import { formatPct } from "@/lib/utils";
 
 const ALL_EXIT_YEARS = [5, 10, 15, 20] as const;
-import { formatPct } from "@/lib/utils";
 
 export interface RateScheduleHandlers {
   enabled: boolean;

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -27,16 +27,24 @@ export interface CapexHandlers {
 interface ScenarioSectionProps {
   input: InvestmentInput;
   setNum: (key: keyof InvestmentInput, value: number) => void;
-  setField: (key: keyof InvestmentInput, value: unknown) => void;
+  setField: <K extends keyof InvestmentInput>(key: K, value: InvestmentInput[K]) => void;
   rateSchedule: RateScheduleHandlers;
   capex: CapexHandlers;
 }
 
-export function ScenarioSection({ input, setNum, setField, rateSchedule, capex }: ScenarioSectionProps) {
+export function ScenarioSection({
+  input,
+  setNum,
+  setField,
+  rateSchedule,
+  capex,
+}: ScenarioSectionProps) {
   const exitYears: number[] = input.exitYears ?? [...ALL_EXIT_YEARS];
 
   function toggleExitYear(yr: number) {
-    const next = exitYears.includes(yr) ? exitYears.filter((y) => y !== yr) : [...exitYears, yr].sort((a, b) => a - b);
+    const next = exitYears.includes(yr)
+      ? exitYears.filter((y) => y !== yr)
+      : [...exitYears, yr].sort((a, b) => a - b);
     setField("exitYears", next.length > 0 ? next : [...ALL_EXIT_YEARS]);
   }
   return (

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -52,6 +52,18 @@ export interface RateAdjustment {
   rate: number; // 絶対値の年利（例: 0.02 = 2%）
 }
 
+export interface MultiExitRow {
+  year: number;
+  salePrice: number;
+  transferTaxRate: number;
+  transferTax: number;
+  remainingLoan: number;
+  cumulativeCf: number;
+  exitEquity: number;
+  irr?: number | null;
+  isShortTermWarn: boolean;
+}
+
 export interface InvestmentInput {
   landPrice: number;
   landArea: number; // 土地面積 (m²)
@@ -84,6 +96,7 @@ export interface InvestmentInput {
   rentGrowthRate?: number; // 年間賃料上昇率（新築・リノベ向け、例: 0.02 = 2%）
   rentGrowthYears?: number; // 賃料上昇が続く年数
   loanFeeRate?: number; // 融資諸費用率（保証料・登記費用等の合算）
+  exitYears?: number[]; // 複数保有年数の出口比較（省略時 = [5, 10, 15, 20]）
 }
 
 export interface CapexEvent {
@@ -167,6 +180,7 @@ export interface InvestmentResult {
   npv: number; // 正味現在価値
   totalInterest: number; // 保有期間の総支払利息
   aiSummary?: string;
+  multiExitComparison?: MultiExitRow[]; // 複数保有年数の出口比較
 }
 
 export interface LandTransaction {


### PR DESCRIPTION
## 概要

複数の保有年数（5/10/15/20年）での出口比較テーブルを追加します。譲渡税率の切り替え（5年以下39.63% vs 5年超20.315%）や累積キャッシュフローを横断的に比較でき、最適な売却時期の判断を支援します。

## 変更内容

- `MultiExitRow` 型追加（backend/frontend）
- `InvestmentInput.ExitYears []int` 追加（省略時は [5,10,15,20] をデフォルト使用）
- `InvestmentResult.MultiExitComparison` 追加
- `calcMultiExitComparison()` 関数追加
- `MultiExitCompareTable.tsx` 新規作成：出口エクイティ最大列をハイライト、5年以下に短期譲渡税バッジ
- フォームに保有年数チェックボックス追加（ScenarioSection）

## テスト

- [ ] exitYears=[5,10,15,20] でレスポンスに4行が含まれる
- [ ] year=5 の行で isShortTermWarn=true
- [ ] ExitYears 省略時に従来の単一出口計算が変わらない
- [ ] 出口エクイティ最大列がハイライトされる
- [ ] go test -race が通る

## 関連 issue

Closes #400