### PR TITLE
CLAUDE.md の API エンドポイント補完と UI デザインルール追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,10 @@ Copy `.env.example` → `.env` (project root).
 | `GET` | `/api/investment-score` | Investment suitability score (tile coords) |
 | `GET` | `/api/investment-score-heatmap` | Batch investment scores for viewport bbox (minLat, maxLat, minLng, maxLng, z=11-15) |
 | `GET` | `/api/rent-stats` | Area rent market stats: median/average/count from MLIT rental data (area, municipality, area_sqm) |
+| `POST` | `/api/renovation/analyze` | Renovation cost & yield impact analysis |
+| `POST` | `/api/investment/simulate` | Monte Carlo cash-flow simulation |
+| `GET` | `/api/area-discovery` | Discover investment areas by tile coords |
+| `GET` | `/api/geocode` | Geocoding: address → lat/lng |
 
 ## Directory structure
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,6 @@ yield-guard/
 - **Commits**: English, small logical units (types / logic / API / frontend / tests)
 - **PR body**: Japanese, follow `.github/pull_request_template.md`
 - **No `Co-Authored-By`** lines in commits
-- **色は単独の情報源にしない** — Badge/アイコンを必ず併記する（WCAG 1.4.1）
 
 ### UI デザインルール
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,22 @@ yield-guard/
 - **No `Co-Authored-By`** lines in commits
 - **色は単独の情報源にしない** — Badge/アイコンを必ず併記する（WCAG 1.4.1）
 
+### UI デザインルール
+
+**Don't**
+- グラデーション（`bg-gradient-*`）を背景色に使用しない — ブランドカラーのみ使用する
+- Lucide 以外のアイコンライブラリを混在させない（`lucide-react` 統一）
+- 色のみで状態（エラー・警告・成功）を表現しない — Badge やアイコンを必ず併記する（WCAG 1.4.1）
+- ネストされた可変幅コンテナを3段以上重ねない — レイアウト崩れの原因になる
+- ラベルなしのアイコンボタンを使用しない — `aria-label` か `Tooltip` を必ず付ける
+
+**Must**
+- 投資シミュレーション結果には必ず免責事項ブロック（`<Alert>`）を表示する（`YieldAnalysis.tsx` 参照）
+- ステータス表示は `<Badge>` + アイコンを併記する（`WatchlistPanel.tsx` 参照）
+- `Recharts` の `<ResponsiveContainer>` で必ずチャートをラップする（`DeadCrossChart.tsx` 参照）
+- 削除・リセット系操作は `AlertDialog` で確認ステップを挟む
+- ローディング中は Skeleton UI を使用する（`<Spinner>` は使わない）
+
 ## CI (GitHub Actions)
 
 | Workflow | Trigger paths | Checks |


### PR DESCRIPTION
## 概要

CLAUDE.md に2件のドキュメント更新を行いました。

## 変更内容

### #485 API エンドポイント表の補完
実装済みだが未記載だった4エンドポイントを追加しました。
- `POST /api/renovation/analyze`
- `POST /api/investment/simulate`
- `GET /api/area-discovery`
- `GET /api/geocode`

### #415 UI デザインルールチェックリスト追加
Conventions セクションに UI デザインの Do/Don't ルール10項目を追加しました。

## テスト
- ドキュメント変更のみ、コード変更なし

Closes #485
Closes #415