### PR TITLE
chore(deps): dependabot のメジャーバージョン更新を個別PRに分割

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,11 +31,14 @@ updates:
       interval: weekly
       day: monday
       timezone: "Asia/Tokyo"
-    open-pull-requests-limit: 1
+    open-pull-requests-limit: 5
     groups:
-      all-dependencies:
+      minor-and-patch:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"
     ignore:
       - dependency-name: "next"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,7 @@ updates:
           - "minor"
           - "patch"
     ignore:
+      # メジャーアップは破壊的変更リスクが高いため個別で判断する
       - dependency-name: "next"
         update-types: ["version-update:semver-major"]
       - dependency-name: "react"


### PR DESCRIPTION
## 概要

dependabot の npm グループ設定を変更し、メジャーバージョンアップを個別PRとして発行されるよう修正します。

## 背景

PR #531（dependabot による17パッケージ一括更新）が ESLint 9→10 のメジャーアップに起因してCIが失敗しました。
`eslint-config-next` 内蔵の `eslint-plugin-react` が ESLint 10 の API 変更（`getFilename()` 削除）に未対応であることが原因です。

メジャーバージョンのパッケージが複数まとまると破壊的変更の切り分けが困難なため、個別PRに分割する方針に変更します。

## 変更内容

- `all-dependencies` グループを `minor-and-patch` に改名し、`update-types: [minor, patch]` に限定
- メジャーバージョンアップは個別PRとして発行される（グループ外）
- `open-pull-requests-limit` を 1 → 5 に拡張（個別PRが複数立つことを想定）
- `next` / `react` / `react-dom` のメジャー無視ルールは既存のまま維持

## 確認事項

- [ ] dependabot.yml の構文が正しいこと
- [ ] 次回の週次スキャンでメジャー更新が個別PRとして発行されること