### PR TITLE
docs(CLAUDE.md): ブランチ命名規則を種別プレフィックスで拡張

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -116,6 +116,7 @@ yield-guard/
   - `chore/<content>` — dependency updates, config changes
   - `docs/<content>` — documentation only
   - `refactor/<content>` — refactoring without behavior change
+  - `test/<content>` — test additions or fixes
 - **Commits**: English, small logical units (types / logic / API / frontend / tests)
 - **PR body**: Japanese, follow `.github/pull_request_template.md`
 - **PR title**: Japanese
@@ -139,7 +140,7 @@ These rules define the safety boundary for autonomous Claude Code operations.
 
 ### Git operations
 
-- **Never push directly to `main`** — always work on a typed branch (`feature/*`, `fix/*`, `chore/*`, `docs/*`, `refactor/*`) and open a PR
+- **Never push directly to `main`** — always work on a typed branch (`feature/*`, `fix/*`, `chore/*`, `docs/*`, `refactor/*`, `test/*`) and open a PR
 - **Never force-push** (`git push --force`) — prevents overwriting remote history
 - **Never skip hooks** (`git commit --no-verify`) — pre-commit hooks must always run
 - **`git reset --hard` only on explicit instruction** — prevents loss of uncommitted work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,15 @@ yield-guard/
 
 ## Conventions
 
-- **Branch**: `feature/<content>` (no issue numbers)
+- **Branch**: prefix by type, no issue numbers
+  - `feature/<content>` — new features
+  - `fix/<content>` — bug fixes
+  - `chore/<content>` — dependency updates, config changes
+  - `docs/<content>` — documentation only
+  - `refactor/<content>` — refactoring without behavior change
 - **Commits**: English, small logical units (types / logic / API / frontend / tests)
 - **PR body**: Japanese, follow `.github/pull_request_template.md`
+- **PR title**: Japanese
 - **No `Co-Authored-By`** lines in commits
 - **色は単独の情報源にしない** — Badge/アイコンを必ず併記する（WCAG 1.4.1）
 
@@ -133,7 +139,7 @@ These rules define the safety boundary for autonomous Claude Code operations.
 
 ### Git operations
 
-- **Never push directly to `main`** — always work on a `feature/*` branch and open a PR
+- **Never push directly to `main`** — always work on a typed branch (`feature/*`, `fix/*`, `chore/*`, `docs/*`, `refactor/*`) and open a PR
 - **Never force-push** (`git push --force`) — prevents overwriting remote history
 - **Never skip hooks** (`git commit --no-verify`) — pre-commit hooks must always run
 - **`git reset --hard` only on explicit instruction** — prevents loss of uncommitted work


### PR DESCRIPTION
## 概要

CLAUDE.md のブランチ命名規則を `feature/*` のみから種別プレフィックス形式に拡張します。

## 背景

現在すべてのブランチが `feature/*` に統一されており、バグ修正・設定変更・ドキュメント更新などもすべて同一プレフィックスとなっていました。ブランチ名だけでは作業種別の判断ができないため、コミットメッセージと同様に種別を明示するルールに変更します。

## 変更内容

**Conventions セクション**
- `feature/<content>` — 新機能
- `fix/<content>` — バグ修正
- `chore/<content>` — 依存関係更新・設定変更
- `docs/<content>` — ドキュメントのみ
- `refactor/<content>` — 振る舞いを変えないリファクタリング
- `test/<content>` — テストの追加・修正
- PR タイトルは日本語の規則を明文化

**Git operating rules セクション**
- `feature/*` のみの記述を全種別プレフィックスに更新（`test/*` 含む）

## 確認事項

- [ ] 既存のワークフロー・CI への影響がないこと（ブランチ名フィルタなし）