### PR TITLE
fix(e2e): エリア探索検索ボタンのクリックとハザードテストの座標設定を修正

### DIFF
--- a/frontend/e2e/area-discovery.spec.ts
+++ b/frontend/e2e/area-discovery.spec.ts
@@ -9,7 +9,11 @@ test.beforeEach(async ({ page }) => {
 });
 
 test("@p3 エリア探索タブ：市区町村ランキングが表示される", async ({ page }) => {
-  await page.getByText("エリアを探す").click();
+  // タブを切り替え（最初の「エリアを探す」はタブボタン）
+  await page.getByRole("button", { name: "エリアを探す" }).first().click();
+
+  // AreaDiscovery 内の検索ボタンをクリックしてデータを取得
+  await page.getByRole("button", { name: "エリアを探す" }).last().click();
 
   // フィクスチャの市区町村データが表示される
   await expect(page.getByText("前橋市")).toBeVisible({ timeout: 10_000 });

--- a/frontend/e2e/error-handling.spec.ts
+++ b/frontend/e2e/error-handling.spec.ts
@@ -65,6 +65,17 @@ test("@p3 ハザードアラートバナー：洪水リスクが表示される"
   await page.getByLabel("建物価格").fill("800");
   await page.getByLabel("築年数").fill("20");
   await page.getByLabel("想定月額賃料").fill("15");
+
+  // 住所から座標を取得してハザード情報フェッチをトリガー
+  // （hazard API は座標設定済みの「相場データを取得」経由でのみ呼ばれる）
+  await page.getByLabel("物件住所").fill("東京都渋谷区");
+  await page.getByRole("button", { name: "座標を取得" }).click();
+  await expect(page.getByText("座標を取得しました")).toBeVisible({ timeout: 10_000 });
+
+  const hazardResponse = page.waitForResponse("**/api/hazard**");
+  await page.getByRole("button", { name: "相場データを取得" }).click();
+  await hazardResponse;
+
   await page.getByText("シミュレーション実行").click();
 
   const hazardBanner = page.getByRole("alert", { name: "ハザード警告" });


### PR DESCRIPTION
## 概要

main ブランチで継続的に失敗していた E2E テスト2件を修正します。

## 原因と修正内容

### 1. `e2e/area-discovery.spec.ts`

**原因**: `AreaDiscovery` コンポーネントはタブを切り替えただけではデータを取得しない。タブ切り替え後にコンポーネント内の「エリアを探す」検索ボタンを押して初めて `/api/area-discovery` が呼ばれる。タブボタンと検索ボタンが同じ「エリアを探す」テキストを持つため、テストが検索ボタンをクリックできていなかった。

**修正**: `getByRole("button", { name: "エリアを探す" }).first()` でタブを切り替え、`.last()` でコンポーネント内の検索ボタンをクリックするよう変更。

### 2. `e2e/error-handling.spec.ts` — ハザードアラートバナーテスト

**原因**: `fetchHazardInfo` は `handleFetchLandPrices(area, city, lat, lng)` 内で座標が設定されている場合にのみ呼ばれる。シミュレーション実行だけでは座標が未設定のため hazard API が一切呼ばれず、バナーが表示されなかった。

**修正**:
1. 「物件住所」に住所を入力し「座標を取得」ボタンをクリック（geocode モックが `lat/lng` を返す）
2. 「相場データを取得」ボタンをクリック（これにより `handleFetchLandPrices` が座標付きで実行され hazard API が呼ばれる）
3. `waitForResponse("**/api/hazard**")` で hazard レスポンスを待機してからシミュレーション実行

## テスト

- [ ] `e2e/area-discovery.spec.ts` PASS
- [ ] `e2e/error-handling.spec.ts` PASS（ハザードバナーテスト含む）

## 関連

既存バグ — 今回の機能追加 PR とは無関係の設計上の問題