### PR TITLE
fix(docker): フロントエンド Node.js を 20 (EOL) から 22 LTS へアップグレード

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,19 +1,19 @@
 # syntax=docker/dockerfile:1
 # CVE-2026-31431 パッチ適用済み alpine3.22 以降を使用すること
-FROM node:20-alpine3.22 AS deps
+FROM node:22-alpine3.22 AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 # npmキャッシュをホストに永続化
 RUN --mount=type=cache,target=/root/.npm \
     npm ci
 
-FROM node:20-alpine3.22 AS builder
+FROM node:22-alpine3.22 AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
-FROM node:20-alpine3.22 AS runner
+FROM node:22-alpine3.22 AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 # root実行を避けるために専用ユーザーを作成


### PR DESCRIPTION
## 概要

Node.js 20 が 2026-04-30 に EOL を迎えたため、`frontend/Dockerfile` の全ステージを Node.js 22 LTS へアップグレードした。

## 変更内容

- `frontend/Dockerfile` の全 3 ステージ（deps / builder / runner）を `node:20-alpine3.22` → `node:22-alpine3.22` に変更

## 動作確認

- [ ] `make docker-up` でコンテナ正常起動
- [ ] `npm test` がパス
- [ ] `make build` がパス

## 関連

Closes #405

## 注意事項

alpine3.22 タグはそのまま維持（CVE-2026-31431 パッチ適用済みのため）。Node.js 24 は 2026年10月 LTS 入り予定のため、現時点では 22 LTS が安定選択。