### PR TITLE
feat(pdf): 投資判定サマリー・KPIストリップ・複数保有年数出口比較テーブルをPDFに追加

### DIFF
--- a/frontend/e2e/fixtures/analyze-response-critical.json
+++ b/frontend/e2e/fixtures/analyze-response-critical.json
@@ -70,5 +70,29 @@
       "effectiveRate": 0.015
     }
   ],
-  "aiSummary": ""
+  "aiSummary": "",
+  "multiExitComparison": [
+    {
+      "year": 5,
+      "salePrice": 9000000,
+      "transferTaxRate": 0.3963,
+      "transferTax": 0,
+      "remainingLoan": 11421312,
+      "cumulativeCf": -466160,
+      "exitEquity": -3320000,
+      "irr": null,
+      "isShortTermWarn": true
+    },
+    {
+      "year": 10,
+      "salePrice": 8000000,
+      "transferTaxRate": 0.20315,
+      "transferTax": 0,
+      "remainingLoan": 9850000,
+      "cumulativeCf": -932320,
+      "exitEquity": -3600000,
+      "irr": null,
+      "isShortTermWarn": false
+    }
+  ]
 }

--- a/frontend/e2e/fixtures/analyze-response.json
+++ b/frontend/e2e/fixtures/analyze-response.json
@@ -208,5 +208,51 @@
       "effectiveRate": 0.015
     }
   ],
-  "aiSummary": ""
+  "aiSummary": "",
+  "multiExitComparison": [
+    {
+      "year": 5,
+      "salePrice": 13500000,
+      "transferTaxRate": 0.3963,
+      "transferTax": 892000,
+      "remainingLoan": 11421312,
+      "cumulativeCf": 3224547,
+      "exitEquity": 2490000,
+      "irr": 0.031,
+      "isShortTermWarn": true
+    },
+    {
+      "year": 10,
+      "salePrice": 12800000,
+      "transferTaxRate": 0.20315,
+      "transferTax": 480000,
+      "remainingLoan": 9850000,
+      "cumulativeCf": 6200000,
+      "exitEquity": 5200000,
+      "irr": 0.058,
+      "isShortTermWarn": false
+    },
+    {
+      "year": 15,
+      "salePrice": 11500000,
+      "transferTaxRate": 0.20315,
+      "transferTax": 380000,
+      "remainingLoan": 7800000,
+      "cumulativeCf": 8800000,
+      "exitEquity": 6900000,
+      "irr": 0.065,
+      "isShortTermWarn": false
+    },
+    {
+      "year": 20,
+      "salePrice": 10500000,
+      "transferTaxRate": 0.20315,
+      "transferTax": 290000,
+      "remainingLoan": 5200000,
+      "cumulativeCf": 11200000,
+      "exitEquity": 7800000,
+      "irr": 0.068,
+      "isShortTermWarn": false
+    }
+  ]
 }

--- a/frontend/e2e/pdf-export.spec.ts
+++ b/frontend/e2e/pdf-export.spec.ts
@@ -1,67 +1,53 @@
 import { test, expect } from "@playwright/test";
-import analyzeFixture from "./fixtures/analyze-response.json";
 import analyzeCriticalFixture from "./fixtures/analyze-response-critical.json";
 import { setupApiMocks } from "./helpers/routes";
 import { ONBOARDING_KEY } from "./helpers/constants";
 
-test.beforeEach(async ({ page }) => {
-  await setupApiMocks(page);
-  await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-  await page.goto("/");
-});
-
-test("@p3 PDF出力：ダウンロードイベントが発生しファイル名が .pdf で終わる", async ({ page }) => {
-  await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
-  await page.getByLabel("想定月額賃料").fill("15");
-  await page.getByText("シミュレーション実行").click();
-  await expect(page.getByText("9.89", { exact: true })).toBeVisible({ timeout: 10_000 });
-
-  const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
-  await page.getByText("PDFレポート出力").click();
-
-  const download = await downloadPromise;
-  expect(download.suggestedFilename()).toMatch(/\.pdf$/);
-});
-
-test("@p3 PDF出力：multiExitComparison ありでPDFが生成される", async ({ page }) => {
-  // analyze-response.json に multiExitComparison が含まれていることを前提とする
-  // PDF生成コード内の出口比較テーブルセクションが例外なく実行されることを確認
-  await setupApiMocks(page, {
-    analyze: { status: 200, body: analyzeFixture },
+// デフォルト fixture (analyze-response.json) には multiExitComparison が含まれるため
+// beforeEach のセットアップで判定サマリー・出口比較テーブルの両セクションをカバーできる
+test.describe("PDF出力 — デフォルト fixture (OK判定 / multiExitComparison あり)", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupApiMocks(page);
+    await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
+    await page.goto("/");
   });
-  await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-  await page.goto("/");
 
-  await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
-  await page.getByLabel("想定月額賃料").fill("15");
-  await page.getByText("シミュレーション実行").click();
-  await expect(page.getByText("9.89", { exact: true })).toBeVisible({ timeout: 10_000 });
+  test("@p3 ダウンロードイベントが発生しファイル名が .pdf で終わる", async ({ page }) => {
+    await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
+    await page.getByLabel("想定月額賃料").fill("15");
+    await page.getByText("シミュレーション実行").click();
+    await expect(page.getByText("9.89", { exact: true })).toBeVisible({ timeout: 10_000 });
 
-  const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
-  await page.getByText("PDFレポート出力").click();
+    const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
+    await page.getByText("PDFレポート出力").click();
 
-  const download = await downloadPromise;
-  expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+  });
 });
 
-test("@p3 PDF出力：RISK判定（criticalErrors=REJECT）でPDFが生成される", async ({ page }) => {
-  // analyze-response-critical.json: DSCR=0.72, criticalErrors=[REJECT]
-  // StatusSummary が "リスク" になる状態でPDF生成が例外なく完了することを確認
-  await setupApiMocks(page, {
-    analyze: { status: 200, body: analyzeCriticalFixture },
+// RISK判定（criticalErrors=REJECT）では StatusSummary が "リスク" になる
+// マイナスエクイティの multiExitComparison でも PDF が例外なく生成されることを確認
+test.describe("PDF出力 — RISK判定 fixture (criticalErrors=REJECT / マイナスエクイティ)", () => {
+  test.beforeEach(async ({ page }) => {
+    await setupApiMocks(page, {
+      analyze: { status: 200, body: analyzeCriticalFixture },
+    });
+    await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
+    await page.goto("/");
   });
-  await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-  await page.goto("/");
 
-  await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
-  await page.getByLabel("想定月額賃料").fill("15");
-  await page.getByText("シミュレーション実行").click();
-  // criticalFixture では grossYield=0.033 → "3.30%" が表示される
-  await expect(page.getByText("3.30", { exact: false })).toBeVisible({ timeout: 10_000 });
+  test("@p3 RISK判定でPDFが生成される", async ({ page }) => {
+    await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
+    await page.getByLabel("想定月額賃料").fill("15");
+    await page.getByText("シミュレーション実行").click();
+    // criticalFixture では grossYield=0.033 → "3.30%" が表示される
+    await expect(page.getByText("3.30", { exact: false })).toBeVisible({ timeout: 10_000 });
 
-  const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
-  await page.getByText("PDFレポート出力").click();
+    const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
+    await page.getByText("PDFレポート出力").click();
 
-  const download = await downloadPromise;
-  expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+    const download = await downloadPromise;
+    expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+  });
 });

--- a/frontend/e2e/pdf-export.spec.ts
+++ b/frontend/e2e/pdf-export.spec.ts
@@ -1,4 +1,6 @@
 import { test, expect } from "@playwright/test";
+import analyzeFixture from "./fixtures/analyze-response.json";
+import analyzeCriticalFixture from "./fixtures/analyze-response-critical.json";
 import { setupApiMocks } from "./helpers/routes";
 import { ONBOARDING_KEY } from "./helpers/constants";
 
@@ -13,6 +15,49 @@ test("@p3 PDF出力：ダウンロードイベントが発生しファイル名�
   await page.getByLabel("想定月額賃料").fill("15");
   await page.getByText("シミュレーション実行").click();
   await expect(page.getByText("9.89", { exact: true })).toBeVisible({ timeout: 10_000 });
+
+  const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
+  await page.getByText("PDFレポート出力").click();
+
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+});
+
+test("@p3 PDF出力：multiExitComparison ありでPDFが生成される", async ({ page }) => {
+  // analyze-response.json に multiExitComparison が含まれていることを前提とする
+  // PDF生成コード内の出口比較テーブルセクションが例外なく実行されることを確認
+  await setupApiMocks(page, {
+    analyze: { status: 200, body: analyzeFixture },
+  });
+  await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
+  await page.goto("/");
+
+  await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
+  await page.getByLabel("想定月額賃料").fill("15");
+  await page.getByText("シミュレーション実行").click();
+  await expect(page.getByText("9.89", { exact: true })).toBeVisible({ timeout: 10_000 });
+
+  const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
+  await page.getByText("PDFレポート出力").click();
+
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(/\.pdf$/);
+});
+
+test("@p3 PDF出力：RISK判定（criticalErrors=REJECT）でPDFが生成される", async ({ page }) => {
+  // analyze-response-critical.json: DSCR=0.72, criticalErrors=[REJECT]
+  // StatusSummary が "リスク" になる状態でPDF生成が例外なく完了することを確認
+  await setupApiMocks(page, {
+    analyze: { status: 200, body: analyzeCriticalFixture },
+  });
+  await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
+  await page.goto("/");
+
+  await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
+  await page.getByLabel("想定月額賃料").fill("15");
+  await page.getByText("シミュレーション実行").click();
+  // criticalFixture では grossYield=0.033 → "3.30%" が表示される
+  await expect(page.getByText("3.30", { exact: false })).toBeVisible({ timeout: 10_000 });
 
   const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
   await page.getByText("PDFレポート出力").click();

--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -662,7 +662,9 @@ export async function downloadReportPDF(
       // ── Page 6: Multi-Exit Comparison ─────────────────────────────
       ...(result.multiExitComparison && result.multiExitComparison.length > 0
         ? (() => {
-            const exitRows = result.multiExitComparison!;
+            const exitRows = result.multiExitComparison as NonNullable<
+              typeof result.multiExitComparison
+            >;
             const maxEquity = Math.max(...exitRows.map((r) => r.exitEquity));
             const maxEquityIdx = exitRows.findIndex((r) => r.exitEquity === maxEquity);
 

--- a/frontend/src/lib/generatePdf.ts
+++ b/frontend/src/lib/generatePdf.ts
@@ -130,6 +130,44 @@ export async function downloadReportPDF(
   // Limit rows to prevent unbounded table generation
   const cfRows: YearlyResult[] = result.yearlyResults.slice(0, Math.min(input.holdingYears, 10));
 
+  // ── StatusSummary level (mirrors StatusSummary.tsx getStatus logic) ──
+  const statusLevel: "OK" | "CAUTION" | "RISK" = result.criticalErrors.some(
+    (e) => e.status === "REJECT"
+  )
+    ? "RISK"
+    : result.criticalErrors.some((e) => e.status === "WARNING")
+      ? "CAUTION"
+      : "OK";
+  const statusMeta = {
+    OK: { label: "OK", color: "#16a34a" },
+    CAUTION: { label: "注意", color: "#d97706" },
+    RISK: { label: "リスク", color: "#dc2626" },
+  } as const;
+
+  // ── KpiStrip values (mirrors KpiStrip.tsx logic) ──
+  const grossYieldPct = result.grossYield * 100;
+  const yieldTarget = input.yieldTarget ?? 0.08;
+  const yieldDiff = grossYieldPct - yieldTarget * 100;
+  const yieldDiffStr = (yieldDiff >= 0 ? "+" : "") + yieldDiff.toFixed(2) + "pp vs 目標";
+
+  const dscrDiff = result.dscr - 1.0;
+  const dscrDiffStr = (dscrDiff >= 0 ? "+" : "") + dscrDiff.toFixed(2) + " vs 1.0";
+
+  const dcYear = result.deadCrossYear > 0 ? `${result.deadCrossYear}年目` : "なし";
+  const dcSub =
+    result.deadCrossYear > 0
+      ? result.deadCrossYear > input.holdingYears
+        ? "保有期間外（安全）"
+        : "保有期間内に発生"
+      : "デッドクロスなし";
+
+  const equityMan = Math.round(result.exitTotalEquity / 10_000);
+  const equityStr =
+    Math.abs(equityMan) >= 10_000
+      ? `${(equityMan / 10_000).toFixed(1)}億円`
+      : `${equityMan.toLocaleString()}万円`;
+  const equitySub = result.exitTotalEquity >= 0 ? "出口時プラス" : "出口時マイナス";
+
   const thCell = (text: string, align: "left" | "right" | "center" = "right") => ({
     text,
     fontSize: 8,
@@ -223,6 +261,127 @@ export async function downloadReportPDF(
       infoRow("分析実施日", date),
       infoRow("総投資額", fmtYen(result.totalInvestment)),
       infoRow("表面利回り", fmtPct(result.grossYield)),
+
+      // ── 投資判定サマリー (StatusSummary + KpiStrip) ─────────────────
+      {
+        text: "投資判定サマリー",
+        fontSize: 9,
+        bold: true,
+        color: C.muted,
+        marginBottom: 8,
+        marginTop: 16,
+      },
+      // Verdict badge row
+      {
+        columns: [
+          {
+            text: `[${statusMeta[statusLevel].label}]`,
+            fontSize: 14,
+            bold: true,
+            color: statusMeta[statusLevel].color,
+            width: "auto",
+            noWrap: true,
+          },
+          {
+            text:
+              result.criticalErrors.length > 0
+                ? result.criticalErrors.map((e) => sanitize(e.message)).join("　")
+                : `利回り ${fmtPct(result.grossYield)} / DSCR ${result.dscr.toFixed(2)} / デッドクロス ${dcYear}`,
+            fontSize: 8,
+            color: C.text,
+            margin: [8, 2, 0, 0],
+          },
+        ],
+        marginBottom: 10,
+      },
+      // KPI strip: 4 cells in a single row
+      {
+        columns: [
+          {
+            stack: [
+              { text: "表面利回り", fontSize: 7, color: C.muted, noWrap: true },
+              {
+                text: `${grossYieldPct.toFixed(2)}%`,
+                fontSize: 13,
+                bold: true,
+                color: yieldDiff >= 0 ? C.safe : C.danger,
+                noWrap: true,
+              },
+              {
+                text: yieldDiffStr,
+                fontSize: 6.5,
+                color: yieldDiff >= 0 ? C.safe : C.danger,
+                noWrap: true,
+              },
+            ],
+            margin: [0, 0, 6, 0],
+          },
+          {
+            stack: [
+              { text: "DSCR（1年目）", fontSize: 7, color: C.muted, noWrap: true },
+              {
+                text: result.dscr.toFixed(2),
+                fontSize: 13,
+                bold: true,
+                color: result.dscr >= 1.0 ? C.safe : C.danger,
+                noWrap: true,
+              },
+              {
+                text: dscrDiffStr,
+                fontSize: 6.5,
+                color: dscrDiff >= 0 ? C.safe : C.danger,
+                noWrap: true,
+              },
+            ],
+            margin: [0, 0, 6, 0],
+          },
+          {
+            stack: [
+              { text: "デッドクロス", fontSize: 7, color: C.muted, noWrap: true },
+              {
+                text: dcYear,
+                fontSize: 13,
+                bold: true,
+                color:
+                  result.deadCrossYear <= 0 || result.deadCrossYear > input.holdingYears
+                    ? C.safe
+                    : C.danger,
+                noWrap: true,
+              },
+              {
+                text: dcSub,
+                fontSize: 6.5,
+                color:
+                  result.deadCrossYear <= 0 || result.deadCrossYear > input.holdingYears
+                    ? C.safe
+                    : C.danger,
+                noWrap: true,
+              },
+            ],
+            margin: [0, 0, 6, 0],
+          },
+          {
+            stack: [
+              { text: "出口 Equity", fontSize: 7, color: C.muted, noWrap: true },
+              {
+                text: equityStr,
+                fontSize: 13,
+                bold: true,
+                color: result.exitTotalEquity >= 0 ? C.safe : C.danger,
+                noWrap: true,
+              },
+              {
+                text: equitySub,
+                fontSize: 6.5,
+                color: result.exitTotalEquity >= 0 ? C.safe : C.danger,
+                noWrap: true,
+              },
+            ],
+            margin: [0, 0, 0, 0],
+          },
+        ],
+        marginBottom: 12,
+      },
 
       // ── Page 2: Summary (Executive) ────────────────────────────────
       sectionTitle("P1 - 投資サマリー", true),
@@ -498,6 +657,134 @@ export async function downloadReportPDF(
                 ]
               : []),
           ]
+        : []),
+
+      // ── Page 6: Multi-Exit Comparison ─────────────────────────────
+      ...(result.multiExitComparison && result.multiExitComparison.length > 0
+        ? (() => {
+            const exitRows = result.multiExitComparison!;
+            const maxEquity = Math.max(...exitRows.map((r) => r.exitEquity));
+            const maxEquityIdx = exitRows.findIndex((r) => r.exitEquity === maxEquity);
+
+            const exitThCell = (text: string, align: "left" | "right" | "center" = "right") => ({
+              text,
+              fontSize: 7.5,
+              bold: true,
+              color: C.white,
+              fillColor: C.headerBg,
+              alignment: align,
+            });
+
+            const exitTdCell = (
+              text: string,
+              rowIdx: number,
+              colIdx: number,
+              options: { bold?: boolean; color?: string } = {}
+            ) => ({
+              text,
+              fontSize: 7.5,
+              alignment: "right" as const,
+              bold: options.bold ?? false,
+              color: options.color ?? C.text,
+              fillColor:
+                colIdx === maxEquityIdx ? "#f0fdf4" : rowIdx % 2 === 0 ? C.rowEven : C.white,
+            });
+
+            // Header row: 保有年数 column + one column per exit year
+            const headerRow = [
+              exitThCell("項目", "left"),
+              ...exitRows.map((r, ci) => ({
+                stack: [
+                  {
+                    text: `${r.year}年`,
+                    fontSize: 7.5,
+                    bold: true,
+                    color: C.white,
+                    alignment: "right" as const,
+                  },
+                  ...(r.isShortTermWarn
+                    ? [
+                        {
+                          text: "短期譲渡税",
+                          fontSize: 6,
+                          color: "#fef3c7",
+                          alignment: "right" as const,
+                          bold: false,
+                        },
+                      ]
+                    : []),
+                ],
+                fillColor: ci === maxEquityIdx ? "#1a6b3a" : C.headerBg,
+                alignment: "right" as const,
+              })),
+            ];
+
+            type DataRowDef = {
+              label: string;
+              getValue: (r: (typeof exitRows)[number]) => string;
+              isEquityRow?: boolean;
+            };
+
+            const dataRows: DataRowDef[] = [
+              { label: "想定売却価格", getValue: (r) => fmtYen(r.salePrice) },
+              { label: "譲渡税率", getValue: (r) => fmtPct(r.transferTaxRate) },
+              { label: "譲渡税額", getValue: (r) => fmtYen(r.transferTax) },
+              { label: "残債残高", getValue: (r) => fmtYen(r.remainingLoan) },
+              { label: "累積税引後CF", getValue: (r) => fmtYen(r.cumulativeCf) },
+              {
+                label: "出口エクイティ合計",
+                getValue: (r) => fmtYen(r.exitEquity),
+                isEquityRow: true,
+              },
+              {
+                label: "IRR",
+                getValue: (r) => (r.irr != null ? fmtPct(r.irr) : "－"),
+              },
+            ];
+
+            const tableBody = [
+              headerRow,
+              ...dataRows.map((def, rowIdx) => [
+                {
+                  text: def.label,
+                  fontSize: 7.5,
+                  alignment: "left" as const,
+                  color: C.text,
+                  fillColor: rowIdx % 2 === 0 ? C.rowEven : C.white,
+                },
+                ...exitRows.map((r, colIdx) => {
+                  const isMaxCol = colIdx === maxEquityIdx;
+                  const isEquityRow = def.isEquityRow ?? false;
+                  return exitTdCell(def.getValue(r), rowIdx, colIdx, {
+                    bold: isMaxCol && isEquityRow,
+                    color: isMaxCol && isEquityRow ? "#15803d" : C.text,
+                  });
+                }),
+              ]),
+            ];
+
+            const colWidths = ["*", ...exitRows.map(() => "auto" as const)];
+
+            return [
+              sectionTitle("P5 - 複数保有年数 出口比較", true),
+              {
+                table: {
+                  headerRows: 1,
+                  widths: colWidths,
+                  body: tableBody,
+                },
+                layout: tableLayout,
+                marginBottom: 10,
+              },
+              {
+                text: "※ 緑ハイライト列が出口エクイティ最大。短期譲渡税（保有5年以下）は税率39.63%、長期（5年超）は20.315%が適用されます。",
+                fontSize: 7,
+                color: C.muted,
+                italics: true,
+                marginBottom: 6,
+              },
+            ];
+          })()
         : []),
     ],
   };


### PR DESCRIPTION
## 概要

PDF出力に2つの情報セクションを追加した。

## 変更内容

### 投資判定サマリー（Closes #559）

- PDF冒頭（物件概要直後）に `StatusSummary` + `KpiStrip` 相当のセクションを追加
- 判定ラベル（OK / 注意 / リスク）と理由を1行で表示
- 表面利回り・DSCR・デッドクロス年・出口 Equity の4指標を横並びで表示
- `criticalErrors` から判定レベルを導出（`StatusSummary.tsx` と同ロジック）

### 複数保有年数 出口比較テーブル（Closes #558）

- `multiExitComparison`（5/10/15/20年）をテーブル形式でPDF末尾に追加
- 表示列: 想定売却価格 / 譲渡税率 / 譲渡税額 / 残債残高 / 累積税引後CF / 出口エクイティ合計 / IRR
- 出口エクイティ最大列を緑ハイライト + 太字
- 保有5年以下の列に「短期譲渡税」注記を表示
- `multiExitComparison` が空の場合はセクション自体を省略

## テスト

- [ ] PDF生成が正常に動作すること
- [ ] 各フィールドが正しくフォーマットされること

## 関連

Closes #558
Closes #559