### PR TITLE
feat(backend): 未計装4エンドポイントへのOTelトレース追加 + GetRentDeclineHintハンドラテスト

### DIFF
--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -1692,3 +1692,143 @@ func TestGetRentStats_FetchError(t *testing.T) {
 		t.Errorf("expected null response on error, got %s", body)
 	}
 }
+
+// ---- GetRentDeclineHint ----
+
+func TestGetRentDeclineHint_MissingArea(t *testing.T) {
+	r := newTestRouter(&mockMLITClient{}, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/investment/rent-decline-hint", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetRentDeclineHint_AllYearsAPIError_Returns502(t *testing.T) {
+	client := &mockMLITClient{
+		appraisalFunc: func(_ context.Context, _, _ string, _ int, _ string) ([]domain.LandAppraisalItem, error) {
+			return nil, errors.New("upstream API error")
+		},
+	}
+	r := newTestRouter(client, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/investment/rent-decline-hint?area=13", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("expected 502 when all years fail, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestGetRentDeclineHint_DecliningTrend_ReturnsBasisLandAppraisal(t *testing.T) {
+	// Provide enough data points (>= 5) across multiple years with declining prices.
+	// appraisalFunc is called concurrently for multiple years, so no shared mutable state here.
+	client := &mockMLITClient{
+		appraisalFunc: func(_ context.Context, area, city string, year int, division string) ([]domain.LandAppraisalItem, error) {
+			// Return declining prices: earlier years have higher prices.
+			basePrice := float64(1_000_000 - (year-2022)*20_000)
+			return []domain.LandAppraisalItem{
+				{Year: year, PricePerSqm: basePrice, ChangeRate: -0.02, District: "千代田"},
+				{Year: year, PricePerSqm: basePrice * 0.98, ChangeRate: -0.02, District: "中央"},
+			}, nil
+		},
+	}
+	r := newTestRouter(client, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/investment/rent-decline-hint?area=13", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var hint domain.RentDeclineHint
+	if err := json.NewDecoder(w.Body).Decode(&hint); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if hint.Basis != "land_appraisal" {
+		t.Errorf("expected basis='land_appraisal', got %q", hint.Basis)
+	}
+	if hint.HintRate <= 0 {
+		t.Errorf("expected hintRate > 0 for declining trend, got %f", hint.HintRate)
+	}
+	if hint.FallbackUsed {
+		t.Error("expected FallbackUsed=false for land_appraisal basis")
+	}
+}
+
+func TestGetRentDeclineHint_RisingTrend_ReturnsFallback(t *testing.T) {
+	// Provide enough data across multiple years with rising prices → cagr >= 0 → fallback.
+	client := &mockMLITClient{
+		appraisalFunc: func(_ context.Context, area, city string, year int, division string) ([]domain.LandAppraisalItem, error) {
+			// Rising prices: later years have higher prices.
+			basePrice := float64(800_000 + (year-2022)*30_000)
+			return []domain.LandAppraisalItem{
+				{Year: year, PricePerSqm: basePrice, ChangeRate: 0.03, District: "千代田"},
+				{Year: year, PricePerSqm: basePrice * 1.02, ChangeRate: 0.03, District: "中央"},
+			}, nil
+		},
+	}
+	r := newTestRouter(client, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/investment/rent-decline-hint?area=13", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var hint domain.RentDeclineHint
+	if err := json.NewDecoder(w.Body).Decode(&hint); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if hint.Basis != "fallback" {
+		t.Errorf("expected basis='fallback' for rising trend, got %q", hint.Basis)
+	}
+	if !hint.FallbackUsed {
+		t.Error("expected FallbackUsed=true for rising trend")
+	}
+}
+
+func TestGetRentDeclineHint_InsufficientData_ReturnsFallback(t *testing.T) {
+	// Return fewer than 5 data points total across all years.
+	// appraisalFunc is called concurrently for multiple years, so no shared mutable state here.
+	client := &mockMLITClient{
+		appraisalFunc: func(_ context.Context, area, city string, year int, division string) ([]domain.LandAppraisalItem, error) {
+			// Only return data for one specific year to keep total count < 5.
+			if year == 2024 {
+				return []domain.LandAppraisalItem{
+					{Year: year, PricePerSqm: 900_000, ChangeRate: -0.01, District: "千代田"},
+				}, nil
+			}
+			return nil, errors.New("no data")
+		},
+	}
+	r := newTestRouter(client, nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/investment/rent-decline-hint?area=13", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var hint domain.RentDeclineHint
+	if err := json.NewDecoder(w.Body).Decode(&hint); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	if hint.Basis != "fallback" {
+		t.Errorf("expected basis='fallback' for insufficient data, got %q", hint.Basis)
+	}
+	if !hint.FallbackUsed {
+		t.Error("expected FallbackUsed=true for insufficient data")
+	}
+	if hint.DataPointCount >= 5 {
+		t.Errorf("expected DataPointCount < 5, got %d", hint.DataPointCount)
+	}
+}

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -800,13 +800,37 @@ func (c *Client) fetchTileGeoJSON(ctx context.Context, endpoint string, z, x, y 
 // FetchLocationOptimization はタイル座標で XKT003 を呼び出し立地適正化計画区域情報を取得する。
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchLocationOptimization(ctx context.Context, z, x, y int) ([]domain.LocationOptimizationItem, error) {
+	ctx, span := otel.Tracer(mlitTracerName).Start(ctx, "mlit.FetchLocationOptimization")
+	defer span.End()
+
+	span.SetAttributes(
+		semconv.ServerAddress("www.reinfolib.mlit.go.jp"),
+		semconv.ServerPort(443),
+		semconv.URLScheme("https"),
+		attribute.String("mlit.endpoint", "XKT003"),
+		attribute.Int("mlit.query.tile_z", z),
+		attribute.Int("mlit.query.tile_x", x),
+		attribute.Int("mlit.query.tile_y", y),
+	)
+
 	key := fmt.Sprintf("location_optimization:%d:%d:%d", z, x, y)
 	if cached, ok := c.cache.locationOptimization.get(key); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT003")))
 		return cached, nil
 	}
+	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT003")))
+	span.SetAttributes(attribute.Bool("mlit.cache.hit", false))
 
+	start := time.Now()
 	var geoResp LocationOptimizationGeoJSON
-	if err := c.fetchTileGeoJSON(ctx, endpointLocationOptimization, z, x, y, &geoResp); err != nil {
+	err := c.fetchTileGeoJSON(ctx, endpointLocationOptimization, z, x, y, &geoResp)
+	latencySec := time.Since(start).Seconds()
+	telemetry.MLITAPILatencyHistogram.Record(ctx, latencySec,
+		metric.WithAttributes(attribute.String("mlit.endpoint", "XKT003")))
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
@@ -814,6 +838,7 @@ func (c *Client) FetchLocationOptimization(ctx context.Context, z, x, y int) ([]
 	for _, f := range geoResp.Features {
 		result = append(result, domain.LocationOptimizationItem{KubunNameJa: f.Properties.KubunNameJa})
 	}
+	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
 	c.cache.locationOptimization.set(key, result)
 	return result, nil
 }
@@ -821,13 +846,37 @@ func (c *Client) FetchLocationOptimization(ctx context.Context, z, x, y int) ([]
 // FetchEmbankment はタイル座標で XKT020 を呼び出し大規模盛土造成地情報を取得する。
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchEmbankment(ctx context.Context, z, x, y int) ([]domain.EmbankmentItem, error) {
+	ctx, span := otel.Tracer(mlitTracerName).Start(ctx, "mlit.FetchEmbankment")
+	defer span.End()
+
+	span.SetAttributes(
+		semconv.ServerAddress("www.reinfolib.mlit.go.jp"),
+		semconv.ServerPort(443),
+		semconv.URLScheme("https"),
+		attribute.String("mlit.endpoint", "XKT020"),
+		attribute.Int("mlit.query.tile_z", z),
+		attribute.Int("mlit.query.tile_x", x),
+		attribute.Int("mlit.query.tile_y", y),
+	)
+
 	key := fmt.Sprintf("embankment:%d:%d:%d", z, x, y)
 	if cached, ok := c.cache.embankment.get(key); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT020")))
 		return cached, nil
 	}
+	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT020")))
+	span.SetAttributes(attribute.Bool("mlit.cache.hit", false))
 
+	start := time.Now()
 	var geoResp EmbankmentGeoJSON
-	if err := c.fetchTileGeoJSON(ctx, endpointEmbankment, z, x, y, &geoResp); err != nil {
+	err := c.fetchTileGeoJSON(ctx, endpointEmbankment, z, x, y, &geoResp)
+	latencySec := time.Since(start).Seconds()
+	telemetry.MLITAPILatencyHistogram.Record(ctx, latencySec,
+		metric.WithAttributes(attribute.String("mlit.endpoint", "XKT020")))
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
@@ -835,6 +884,7 @@ func (c *Client) FetchEmbankment(ctx context.Context, z, x, y int) ([]domain.Emb
 	for _, f := range geoResp.Features {
 		result = append(result, domain.EmbankmentItem{Classification: f.Properties.EmbankmentClassification})
 	}
+	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
 	c.cache.embankment.set(key, result)
 	return result, nil
 }
@@ -842,13 +892,37 @@ func (c *Client) FetchEmbankment(ctx context.Context, z, x, y int) ([]domain.Emb
 // FetchUrbanRoad はタイル座標で XKT030 を呼び出し都市計画道路情報を取得する。
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchUrbanRoad(ctx context.Context, z, x, y int) ([]domain.UrbanRoadItem, error) {
+	ctx, span := otel.Tracer(mlitTracerName).Start(ctx, "mlit.FetchUrbanRoad")
+	defer span.End()
+
+	span.SetAttributes(
+		semconv.ServerAddress("www.reinfolib.mlit.go.jp"),
+		semconv.ServerPort(443),
+		semconv.URLScheme("https"),
+		attribute.String("mlit.endpoint", "XKT030"),
+		attribute.Int("mlit.query.tile_z", z),
+		attribute.Int("mlit.query.tile_x", x),
+		attribute.Int("mlit.query.tile_y", y),
+	)
+
 	key := fmt.Sprintf("urban_road:%d:%d:%d", z, x, y)
 	if cached, ok := c.cache.urbanRoad.get(key); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT030")))
 		return cached, nil
 	}
+	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT030")))
+	span.SetAttributes(attribute.Bool("mlit.cache.hit", false))
 
+	start := time.Now()
 	var geoResp UrbanRoadGeoJSON
-	if err := c.fetchTileGeoJSON(ctx, endpointUrbanRoad, z, x, y, &geoResp); err != nil {
+	err := c.fetchTileGeoJSON(ctx, endpointUrbanRoad, z, x, y, &geoResp)
+	latencySec := time.Since(start).Seconds()
+	telemetry.MLITAPILatencyHistogram.Record(ctx, latencySec,
+		metric.WithAttributes(attribute.String("mlit.endpoint", "XKT030")))
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
@@ -859,6 +933,7 @@ func (c *Client) FetchUrbanRoad(ctx context.Context, z, x, y int) ([]domain.Urba
 			KubunID:        f.Properties.KubunID,
 		})
 	}
+	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
 	c.cache.urbanRoad.set(key, result)
 	return result, nil
 }
@@ -866,13 +941,37 @@ func (c *Client) FetchUrbanRoad(ctx context.Context, z, x, y int) ([]domain.Urba
 // FetchDisasterHistory はタイル座標で XST001 を呼び出し災害履歴情報を取得する。
 // キャッシュヒット時はAPIコールをスキップする（TTL: 24時間）。
 func (c *Client) FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domain.DisasterHistoryItem, error) {
+	ctx, span := otel.Tracer(mlitTracerName).Start(ctx, "mlit.FetchDisasterHistory")
+	defer span.End()
+
+	span.SetAttributes(
+		semconv.ServerAddress("www.reinfolib.mlit.go.jp"),
+		semconv.ServerPort(443),
+		semconv.URLScheme("https"),
+		attribute.String("mlit.endpoint", "XST001"),
+		attribute.Int("mlit.query.tile_z", z),
+		attribute.Int("mlit.query.tile_x", x),
+		attribute.Int("mlit.query.tile_y", y),
+	)
+
 	key := fmt.Sprintf("disaster:%d:%d:%d", z, x, y)
 	if cached, ok := c.cache.disaster.get(key); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XST001")))
 		return cached, nil
 	}
+	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XST001")))
+	span.SetAttributes(attribute.Bool("mlit.cache.hit", false))
 
+	start := time.Now()
 	var geoResp DisasterHistoryGeoJSON
-	if err := c.fetchTileGeoJSON(ctx, endpointDisasterHistory, z, x, y, &geoResp); err != nil {
+	err := c.fetchTileGeoJSON(ctx, endpointDisasterHistory, z, x, y, &geoResp)
+	latencySec := time.Since(start).Seconds()
+	telemetry.MLITAPILatencyHistogram.Record(ctx, latencySec,
+		metric.WithAttributes(attribute.String("mlit.endpoint", "XST001")))
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
 		return nil, err
 	}
 
@@ -887,6 +986,7 @@ func (c *Client) FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domai
 			Year: year,
 		})
 	}
+	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
 	c.cache.disaster.set(key, result)
 	return result, nil
 }

--- a/backend/internal/mlit/client_otel_test.go
+++ b/backend/internal/mlit/client_otel_test.go
@@ -180,3 +180,431 @@ func spanNames(spans tracetest.SpanStubs) []string {
 
 // Ensure domain import is used (referenced by makeSuccessHandler indirectly through parseTransactions).
 var _ = domain.LandTransaction{}
+
+// makeGeoJSONHandler returns an httptest handler that responds with the given GeoJSON body.
+func makeGeoJSONHandler(body []byte) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}
+}
+
+// ---- FetchLocationOptimization (XKT003) ----
+
+func TestFetchLocationOptimization_SpanCreated(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	resp := LocationOptimizationGeoJSON{
+		Type: "FeatureCollection",
+		Features: []LocationOptimizationFeature{
+			{Properties: LocationOptimizationProperties{KubunNameJa: "居住誘導区域"}},
+		},
+	}
+	body, _ := json.Marshal(resp)
+	srv := httptest.NewServer(makeGeoJSONHandler(body))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	_, err := client.FetchLocationOptimization(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("FetchLocationOptimization returned unexpected error: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var found bool
+	for _, s := range spans {
+		if s.Name == "mlit.FetchLocationOptimization" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("span 'mlit.FetchLocationOptimization' not found; got: %v", spanNames(spans))
+	}
+}
+
+func TestFetchLocationOptimization_CacheHitAttribute(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	resp := LocationOptimizationGeoJSON{Type: "FeatureCollection", Features: []LocationOptimizationFeature{}}
+	body, _ := json.Marshal(resp)
+	srv := httptest.NewServer(makeGeoJSONHandler(body))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	// First call — cache miss.
+	_, err := client.FetchLocationOptimization(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+
+	exp.Reset()
+
+	// Second call — cache hit.
+	_, err = client.FetchLocationOptimization(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var cacheHit *bool
+	for _, s := range spans {
+		if s.Name != "mlit.FetchLocationOptimization" {
+			continue
+		}
+		for _, attr := range s.Attributes {
+			if string(attr.Key) == "mlit.cache.hit" {
+				v := attr.Value.AsBool()
+				cacheHit = &v
+			}
+		}
+	}
+	if cacheHit == nil {
+		t.Fatal("attribute 'mlit.cache.hit' not found on span")
+	}
+	if !*cacheHit {
+		t.Errorf("expected mlit.cache.hit=true on second call, got false")
+	}
+}
+
+func TestFetchLocationOptimization_ErrorSpanStatus(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	_, err := client.FetchLocationOptimization(context.Background(), 14, 14547, 6451)
+	if err == nil {
+		t.Fatal("expected error from 500 server, got nil")
+	}
+
+	spans := exp.GetSpans()
+	var foundError bool
+	for _, s := range spans {
+		if s.Name == "mlit.FetchLocationOptimization" && s.Status.Code.String() == "Error" {
+			foundError = true
+			break
+		}
+	}
+	if !foundError {
+		t.Errorf("expected span with Error status; spans: %v", spanNames(spans))
+	}
+}
+
+// ---- FetchEmbankment (XKT020) ----
+
+func TestFetchEmbankment_SpanCreated(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	resp := EmbankmentGeoJSON{
+		Type: "FeatureCollection",
+		Features: []EmbankmentFeature{
+			{Properties: EmbankmentProperties{EmbankmentClassification: "谷埋め型"}},
+		},
+	}
+	body, _ := json.Marshal(resp)
+	srv := httptest.NewServer(makeGeoJSONHandler(body))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	_, err := client.FetchEmbankment(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("FetchEmbankment returned unexpected error: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var found bool
+	for _, s := range spans {
+		if s.Name == "mlit.FetchEmbankment" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("span 'mlit.FetchEmbankment' not found; got: %v", spanNames(spans))
+	}
+}
+
+func TestFetchEmbankment_CacheHitAttribute(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	resp := EmbankmentGeoJSON{Type: "FeatureCollection", Features: []EmbankmentFeature{}}
+	body, _ := json.Marshal(resp)
+	srv := httptest.NewServer(makeGeoJSONHandler(body))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	// First call — cache miss.
+	_, err := client.FetchEmbankment(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+
+	exp.Reset()
+
+	// Second call — cache hit.
+	_, err = client.FetchEmbankment(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var cacheHit *bool
+	for _, s := range spans {
+		if s.Name != "mlit.FetchEmbankment" {
+			continue
+		}
+		for _, attr := range s.Attributes {
+			if string(attr.Key) == "mlit.cache.hit" {
+				v := attr.Value.AsBool()
+				cacheHit = &v
+			}
+		}
+	}
+	if cacheHit == nil {
+		t.Fatal("attribute 'mlit.cache.hit' not found on span")
+	}
+	if !*cacheHit {
+		t.Errorf("expected mlit.cache.hit=true on second call, got false")
+	}
+}
+
+func TestFetchEmbankment_ErrorSpanStatus(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	_, err := client.FetchEmbankment(context.Background(), 14, 14547, 6451)
+	if err == nil {
+		t.Fatal("expected error from 500 server, got nil")
+	}
+
+	spans := exp.GetSpans()
+	var foundError bool
+	for _, s := range spans {
+		if s.Name == "mlit.FetchEmbankment" && s.Status.Code.String() == "Error" {
+			foundError = true
+			break
+		}
+	}
+	if !foundError {
+		t.Errorf("expected span with Error status; spans: %v", spanNames(spans))
+	}
+}
+
+// ---- FetchUrbanRoad (XKT030) ----
+
+func TestFetchUrbanRoad_SpanCreated(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	resp := UrbanRoadGeoJSON{
+		Type: "FeatureCollection",
+		Features: []UrbanRoadFeature{
+			{Properties: UrbanRoadProperties{PlanningRoadJa: "都市計画道路A", KubunID: 3011}},
+		},
+	}
+	body, _ := json.Marshal(resp)
+	srv := httptest.NewServer(makeGeoJSONHandler(body))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	_, err := client.FetchUrbanRoad(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("FetchUrbanRoad returned unexpected error: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var found bool
+	for _, s := range spans {
+		if s.Name == "mlit.FetchUrbanRoad" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("span 'mlit.FetchUrbanRoad' not found; got: %v", spanNames(spans))
+	}
+}
+
+func TestFetchUrbanRoad_CacheHitAttribute(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	resp := UrbanRoadGeoJSON{Type: "FeatureCollection", Features: []UrbanRoadFeature{}}
+	body, _ := json.Marshal(resp)
+	srv := httptest.NewServer(makeGeoJSONHandler(body))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	// First call — cache miss.
+	_, err := client.FetchUrbanRoad(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+
+	exp.Reset()
+
+	// Second call — cache hit.
+	_, err = client.FetchUrbanRoad(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var cacheHit *bool
+	for _, s := range spans {
+		if s.Name != "mlit.FetchUrbanRoad" {
+			continue
+		}
+		for _, attr := range s.Attributes {
+			if string(attr.Key) == "mlit.cache.hit" {
+				v := attr.Value.AsBool()
+				cacheHit = &v
+			}
+		}
+	}
+	if cacheHit == nil {
+		t.Fatal("attribute 'mlit.cache.hit' not found on span")
+	}
+	if !*cacheHit {
+		t.Errorf("expected mlit.cache.hit=true on second call, got false")
+	}
+}
+
+func TestFetchUrbanRoad_ErrorSpanStatus(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	_, err := client.FetchUrbanRoad(context.Background(), 14, 14547, 6451)
+	if err == nil {
+		t.Fatal("expected error from 500 server, got nil")
+	}
+
+	spans := exp.GetSpans()
+	var foundError bool
+	for _, s := range spans {
+		if s.Name == "mlit.FetchUrbanRoad" && s.Status.Code.String() == "Error" {
+			foundError = true
+			break
+		}
+	}
+	if !foundError {
+		t.Errorf("expected span with Error status; spans: %v", spanNames(spans))
+	}
+}
+
+// ---- FetchDisasterHistory (XST001) ----
+
+func TestFetchDisasterHistory_SpanCreated(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	resp := DisasterHistoryGeoJSON{
+		Type: "FeatureCollection",
+		Features: []DisasterHistoryFeature{
+			{Properties: DisasterHistoryProperties{DisasterNameJa: "浸水域", DisasterDate: "20190101"}},
+		},
+	}
+	body, _ := json.Marshal(resp)
+	srv := httptest.NewServer(makeGeoJSONHandler(body))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	_, err := client.FetchDisasterHistory(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("FetchDisasterHistory returned unexpected error: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var found bool
+	for _, s := range spans {
+		if s.Name == "mlit.FetchDisasterHistory" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("span 'mlit.FetchDisasterHistory' not found; got: %v", spanNames(spans))
+	}
+}
+
+func TestFetchDisasterHistory_CacheHitAttribute(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	resp := DisasterHistoryGeoJSON{Type: "FeatureCollection", Features: []DisasterHistoryFeature{}}
+	body, _ := json.Marshal(resp)
+	srv := httptest.NewServer(makeGeoJSONHandler(body))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	// First call — cache miss.
+	_, err := client.FetchDisasterHistory(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("first call error: %v", err)
+	}
+
+	exp.Reset()
+
+	// Second call — cache hit.
+	_, err = client.FetchDisasterHistory(context.Background(), 14, 14547, 6451)
+	if err != nil {
+		t.Fatalf("second call error: %v", err)
+	}
+
+	spans := exp.GetSpans()
+	var cacheHit *bool
+	for _, s := range spans {
+		if s.Name != "mlit.FetchDisasterHistory" {
+			continue
+		}
+		for _, attr := range s.Attributes {
+			if string(attr.Key) == "mlit.cache.hit" {
+				v := attr.Value.AsBool()
+				cacheHit = &v
+			}
+		}
+	}
+	if cacheHit == nil {
+		t.Fatal("attribute 'mlit.cache.hit' not found on span")
+	}
+	if !*cacheHit {
+		t.Errorf("expected mlit.cache.hit=true on second call, got false")
+	}
+}
+
+func TestFetchDisasterHistory_ErrorSpanStatus(t *testing.T) {
+	exp := setupTestTracer(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	client := newOtelTestClient(srv)
+	_, err := client.FetchDisasterHistory(context.Background(), 14, 14547, 6451)
+	if err == nil {
+		t.Fatal("expected error from 500 server, got nil")
+	}
+
+	spans := exp.GetSpans()
+	var foundError bool
+	for _, s := range spans {
+		if s.Name == "mlit.FetchDisasterHistory" && s.Status.Code.String() == "Error" {
+			foundError = true
+			break
+		}
+	}
+	if !foundError {
+		t.Errorf("expected span with Error status; spans: %v", spanNames(spans))
+	}
+}


### PR DESCRIPTION
## 概要

2つの関連する改善をまとめて対応した。

## 変更内容

### OTelトレース追加（Closes #254）

`backend/internal/mlit/client.go` の以下4関数にトレース計装を追加した（既存の `FetchLandPrices` 等と同パターン）:

| 関数 | API |
|---|---|
| `FetchLocationOptimization` | XKT003 |
| `FetchEmbankment` | XKT020 |
| `FetchUrbanRoad` | XKT030 |
| `FetchDisasterHistory` | XST001 |

各関数で以下を計装:
- `otel.Tracer("mlit-client").Start(ctx, "<FuncName>")` によるスパン生成
- `mlit.endpoint` 属性の付与
- キャッシュヒット/ミスのメトリクス記録
- `mlit.api.request.duration` ヒストグラム記録
- `client_otel_test.go` に対応テストを追加

### GetRentDeclineHint ハンドラテスト（Closes #284）

`backend/internal/api/handler_test.go` に以下5ケースのモックテストを追加:

- `area` パラメータ未指定 → 400
- 全年APIエラー → 502
- 地価下落傾向 → 200、`basis: "land_appraisal"`、`hintRate > 0`
- 地価上昇傾向 → 200、`basis: "fallback"`、`fallbackUsed: true`
- データ不足（件数 < 5） → 200、`basis: "fallback"`

ハンドラが5年分を並列goroutineで呼ぶため、テストのモック関数内に共有可変変数を置かないよう修正済み（race condition対策）。

## テスト

- [x] `go test -race ./...` 全パス

## 関連

Closes #254
Closes #284