### PR TITLE
fix(e2e): ハザードテストのジオコード成功アサーション修正

### DIFF
--- a/frontend/e2e/error-handling.spec.ts
+++ b/frontend/e2e/error-handling.spec.ts
@@ -70,7 +70,7 @@ test("@p3 ハザードアラートバナー：洪水リスクが表示される"
   // （hazard API は座標設定済みの「相場データを取得」経由でのみ呼ばれる）
   await page.getByLabel("物件住所").fill("東京都渋谷区");
   await page.getByRole("button", { name: "座標を取得" }).click();
-  await expect(page.locator("p.text-green-600")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("近似位置で取得（精度低）")).toBeVisible({ timeout: 10_000 });
 
   const hazardResponse = page.waitForResponse("**/api/hazard**");
   await page.getByRole("button", { name: "相場データを取得" }).click();

--- a/frontend/e2e/error-handling.spec.ts
+++ b/frontend/e2e/error-handling.spec.ts
@@ -70,7 +70,7 @@ test("@p3 ハザードアラートバナー：洪水リスクが表示される"
   // （hazard API は座標設定済みの「相場データを取得」経由でのみ呼ばれる）
   await page.getByLabel("物件住所").fill("東京都渋谷区");
   await page.getByRole("button", { name: "座標を取得" }).click();
-  await expect(page.getByText("座標を取得しました")).toBeVisible({ timeout: 10_000 });
+  await expect(page.locator("p.text-green-600")).toBeVisible({ timeout: 10_000 });
 
   const hazardResponse = page.waitForResponse("**/api/hazard**");
   await page.getByRole("button", { name: "相場データを取得" }).click();


### PR DESCRIPTION
## 概要

PR #561 で追加したハザードアラートバナーE2EテストのアサーションがCIで失敗していた問題を修正します。

## 問題の原因

`ed44876` で追加した以下のアサーションが原因：

```ts
await expect(page.getByText("座標を取得しました")).toBeVisible({ timeout: 10_000 });
```

`LocationSection.tsx` の成功表示ロジック：

```tsx
✓ {LOCATION_TYPE_LABEL[geocode.locationType] ?? "座標を取得しました"}
```

`routes.ts` の geocode モックは `locationType: "APPROXIMATE"` を返すため、
`LOCATION_TYPE_LABEL["APPROXIMATE"]`（= `"近似位置で取得（精度低）"`）が表示される。
フォールバックの `"座標を取得しました"` は未知の `locationType` のときのみ表示されるため、
アサーションが常に失敗していた。

## 変更内容

テキスト一致の代わりに CSS クラス `p.text-green-600` でジオコード成功状態を確認するよう変更。

## テスト確認

- [ ] `frontend/e2e/error-handling.spec.ts` — ハザードアラートバナーテスト