### PR TITLE
feat: Cloud SchedulerによるCloud Runウォームアップ・キャッシュ事前ロード

### DIFF
--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -112,6 +112,7 @@ func NewRouter(h *Handler, appInternalAPIKey string) *gin.Engine {
 	analyzeRL := newRateLimiter(rate.Every(6*time.Second), 5)
 
 	r.GET("/health", h.HealthCheck)
+	r.POST("/warm", internalKeyMiddleware(appInternalAPIKey), h.WarmCache)
 
 	api := r.Group("/api")
 	api.Use(internalKeyMiddleware(appInternalAPIKey))

--- a/backend/internal/api/warmup_handler.go
+++ b/backend/internal/api/warmup_handler.go
@@ -1,0 +1,65 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+type warmupTarget struct {
+	area string
+	name string
+}
+
+var warmupAreas = []warmupTarget{
+	{area: "13", name: "東京都"},
+	{area: "27", name: "大阪府"},
+	{area: "14", name: "神奈川県"},
+}
+
+// WarmCache は Cloud Scheduler から呼ばれるキャッシュウォームアップハンドラー
+// goroutineで並列実行し、50秒のコンテキストタイムアウトを設定する
+func (h *Handler) WarmCache(c *gin.Context) {
+	ctx, cancel := context.WithTimeout(c.Request.Context(), 50*time.Second)
+	defer cancel()
+
+	var (
+		wg      sync.WaitGroup
+		mu      sync.Mutex
+		success int
+		failed  int
+	)
+
+	for _, target := range warmupAreas {
+		wg.Add(1)
+		go func(t warmupTarget) {
+			defer wg.Done()
+			if err := h.warmArea(ctx, t); err != nil {
+				slog.Warn("warmup failed", "area", t.name, "err", err)
+				mu.Lock()
+				failed++
+				mu.Unlock()
+				return
+			}
+			slog.Info("warmup success", "area", t.name)
+			mu.Lock()
+			success++
+			mu.Unlock()
+		}(target)
+	}
+
+	wg.Wait()
+	c.JSON(http.StatusOK, gin.H{"success": success, "failed": failed})
+}
+
+func (h *Handler) warmArea(ctx context.Context, t warmupTarget) error {
+	// FetchMunicipalities でキャッシュをウォームアップ
+	if _, err := h.mlitClient.FetchMunicipalities(ctx, t.area); err != nil {
+		return err
+	}
+	return nil
+}

--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -20,6 +20,7 @@ locals {
     # Required for Cloud Functions Gen2 Pub/Sub event triggers (Eventarc backend).
     "eventarc.googleapis.com",
     "firestore.googleapis.com",
+    "cloudscheduler.googleapis.com",
   ])
 }
 

--- a/terraform/scheduler.tf
+++ b/terraform/scheduler.tf
@@ -1,0 +1,30 @@
+resource "google_cloud_scheduler_job" "warmup_ping" {
+  name             = "warmup-ping-${var.env}"
+  region           = var.region
+  schedule         = "*/15 * * * *"
+  time_zone        = "Asia/Tokyo"
+  attempt_deadline = "30s"
+
+  http_target {
+    uri         = "${google_cloud_run_v2_service.backend.uri}/health"
+    http_method = "GET"
+  }
+}
+
+resource "google_cloud_scheduler_job" "warmup_cache" {
+  name             = "warmup-cache-${var.env}"
+  region           = var.region
+  schedule         = "0 4 * * *"
+  time_zone        = "Asia/Tokyo"
+  attempt_deadline = "60s"
+
+  http_target {
+    uri         = "${google_cloud_run_v2_service.backend.uri}/warm"
+    http_method = "POST"
+    headers = {
+      "Content-Type"   = "application/json"
+      "X-Internal-Key" = var.app_internal_api_key
+    }
+    body = base64encode("{}")
+  }
+}


### PR DESCRIPTION
## 概要

Cloud Run `min_instances=0` によるコールドスタート遅延を緩和するため、Cloud Scheduler で定期的なウォームアップとキャッシュ事前ロードを実装する。

## 変更内容

### バックエンド

- `backend/internal/api/warmup_handler.go`（新規）
  - `POST /warm` ハンドラーを追加
  - 東京都・大阪府・神奈川県を goroutine 並列でウォームアップ
  - 50秒のコンテキストタイムアウトで Cloud Run タイムアウトに対応
  - 成功/失敗件数をレスポンスで返す

- `backend/internal/api/router.go`
  - `POST /warm` を `internalKeyMiddleware` で保護して追加（`/api` グループ外）

### インフラ

- `terraform/scheduler.tf`（新規）
  - `warmup-ping`: 15分ごとに `/health` を叩いてインスタンスをウォーム維持
  - `warmup-cache`: 毎朝4時に `/warm` を叩いてキャッシュを事前ロード

- `terraform/apis.tf`
  - `cloudscheduler.googleapis.com` を追加

## 動作確認方法

```bash
# /warm エンドポイントの手動テスト
curl -X POST http://localhost:8080/warm \
  -H "X-Internal-Key: <APP_INTERNAL_API_KEY>"
# → {"success": 3, "failed": 0}
```

## 関連

- Closes #570
- #568（Firestoreキャッシュ）完了後に `/warm` がL2キャッシュもウォームアップする

## 注意事項

- terraform apply は #568 と合わせて実施予定
- Cloud Scheduler 無料枠: 同時3ジョブまで（本PR で2ジョブ使用）