### PR TITLE
feat: FirestoreによるMLITキャッシュの永続化（L2キャッシュ導入）

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 	"time"
 
+	"cloud.google.com/go/firestore"
 	"github.com/yield-guard/backend/internal/api"
 	"github.com/yield-guard/backend/internal/logger"
 	"github.com/yield-guard/backend/internal/mlit"
@@ -58,7 +59,20 @@ func main() {
 
 	googleMapsAPIKey := readSecret("/secrets/google-maps-api-key/value", "GOOGLE_MAPS_API_KEY")
 
-	mlitClient := mlit.NewClient(mlitAPIKey)
+	projectID := os.Getenv("GOOGLE_CLOUD_PROJECT")
+	var fsClient *firestore.Client
+	if projectID != "" {
+		var fsErr error
+		fsClient, fsErr = firestore.NewClient(ctx, projectID)
+		if fsErr != nil {
+			slog.Warn("Firestore unavailable, using noop L2 cache", "err", fsErr)
+			fsClient = nil
+		}
+	} else {
+		slog.Info("GOOGLE_CLOUD_PROJECT not set, Firestore L2 cache disabled")
+	}
+
+	mlitClient := mlit.NewClientWithFirestore(mlitAPIKey, fsClient)
 	geocodeClient := api.NewGoogleGeocodeClient(googleMapsAPIKey)
 	handler := api.NewHandler(mlitClient, geocodeClient)
 	router := api.NewRouter(handler, appInternalAPIKey)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,6 +3,7 @@ module github.com/yield-guard/backend
 go 1.25.10
 
 require (
+	cloud.google.com/go/firestore v1.22.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.56.0
 	github.com/gin-contrib/cors v1.7.7
 	github.com/gin-gonic/gin v1.12.0
@@ -27,7 +28,7 @@ require (
 	cloud.google.com/go/auth v0.20.0 // indirect
 	cloud.google.com/go/auth/oauth2adapt v0.2.8 // indirect
 	cloud.google.com/go/compute/metadata v0.9.0 // indirect
-	cloud.google.com/go/longrunning v0.8.0 // indirect
+	cloud.google.com/go/longrunning v0.9.0 // indirect
 	cloud.google.com/go/monitoring v1.24.3 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.56.0 // indirect
 	github.com/bytedance/gopkg v0.1.4 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -8,10 +8,12 @@ cloud.google.com/go/auth/oauth2adapt v0.2.8 h1:keo8NaayQZ6wimpNSmW5OPc283g65QNIi
 cloud.google.com/go/auth/oauth2adapt v0.2.8/go.mod h1:XQ9y31RkqZCcwJWNSx2Xvric3RrU88hAYYbjDWYDL+c=
 cloud.google.com/go/compute/metadata v0.9.0 h1:pDUj4QMoPejqq20dK0Pg2N4yG9zIkYGdBtwLoEkH9Zs=
 cloud.google.com/go/compute/metadata v0.9.0/go.mod h1:E0bWwX5wTnLPedCKqk3pJmVgCBSM6qQI1yTBdEb3C10=
+cloud.google.com/go/firestore v1.22.0 h1:avooeboIq37vKXobrbPUFhFBxS/c3FqmWoX0xs8dO6E=
+cloud.google.com/go/firestore v1.22.0/go.mod h1:PaM4i7i7ruALSKmlpHXXZaPObcZw0W7ie5UOPr72iTU=
 cloud.google.com/go/logging v1.13.2 h1:qqlHCBvieJT9Cdq4QqYx1KPadCQ2noD4FK02eNqHAjA=
 cloud.google.com/go/logging v1.13.2/go.mod h1:zaybliM3yun1J8mU2dVQ1/qDzjbOqEijZCn6hSBtKak=
-cloud.google.com/go/longrunning v0.8.0 h1:LiKK77J3bx5gDLi4SMViHixjD2ohlkwBi+mKA7EhfW8=
-cloud.google.com/go/longrunning v0.8.0/go.mod h1:UmErU2Onzi+fKDg2gR7dusz11Pe26aknR4kHmJJqIfk=
+cloud.google.com/go/longrunning v0.9.0 h1:0EzbDEGsAvOZNbqXopgniY0w0a1phvu5IdUFq8grmqY=
+cloud.google.com/go/longrunning v0.9.0/go.mod h1:pkTz846W7bF4o2SzdWJ40Hu0Re+UoNT6Q5t+igIcb8E=
 cloud.google.com/go/monitoring v1.24.3 h1:dde+gMNc0UhPZD1Azu6at2e79bfdztVDS5lvhOdsgaE=
 cloud.google.com/go/monitoring v1.24.3/go.mod h1:nYP6W0tm3N9H/bOw8am7t62YTzZY+zUeQ+Bi6+2eonI=
 cloud.google.com/go/trace v1.11.7 h1:kDNDX8JkaAG3R2nq1lIdkb7FCSi1rCmsEtKVsty7p+U=

--- a/backend/internal/mlit/client.go
+++ b/backend/internal/mlit/client.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"cloud.google.com/go/firestore"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -58,15 +59,29 @@ type Client struct {
 	baseURL    string
 	apiKey     string
 	cache      *cache
+	l2         l2CacheGroup
 }
 
-// NewClient は新しい Client を返す。
+// NewClient は新しい Client を返す（L2キャッシュなし）。
 func NewClient(apiKey string) *Client {
 	return &Client{
 		httpClient: &http.Client{Timeout: requestTimeout},
 		baseURL:    mlitBaseURL,
 		apiKey:     apiKey,
 		cache:      newCache(),
+		l2:         newNoopL2CacheGroup(),
+	}
+}
+
+// NewClientWithFirestore は Firestore L2キャッシュ付きの Client を返す。
+// fs が nil の場合は L2キャッシュなしの Client を返す（NewClient と同等）。
+func NewClientWithFirestore(apiKey string, fs *firestore.Client) *Client {
+	return &Client{
+		httpClient: &http.Client{Timeout: requestTimeout},
+		baseURL:    mlitBaseURL,
+		apiKey:     apiKey,
+		cache:      newCache(),
+		l2:         newFirestoreL2CacheGroup(fs),
 	}
 }
 
@@ -92,6 +107,12 @@ func (c *Client) FetchLandPrices(ctx context.Context, q LandPriceQuery) ([]domai
 	if cached, ok := c.cache.landPrices.get(key); ok {
 		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT001")))
+		return cached, nil
+	}
+	if cached, ok := c.l2.landPrices.get(ctx, key); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT001")))
+		c.cache.landPrices.set(key, cached)
 		return cached, nil
 	}
 	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT001")))
@@ -124,6 +145,7 @@ func (c *Client) FetchLandPrices(ctx context.Context, q LandPriceQuery) ([]domai
 
 		if err == nil {
 			span.SetAttributes(attribute.Int("mlit.retry.count", attempt))
+			c.l2.landPrices.set(ctx, key, result)
 			c.cache.landPrices.set(key, result)
 			return result, nil
 		}
@@ -165,6 +187,12 @@ func (c *Client) FetchMunicipalities(ctx context.Context, area string) ([]Munici
 	if cached, ok := c.cache.municipalities.get(area); ok {
 		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT002")))
+		return cached, nil
+	}
+	if cached, ok := c.l2.municipalities.get(ctx, area); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT002")))
+		c.cache.municipalities.set(area, cached)
 		return cached, nil
 	}
 	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT002")))
@@ -223,6 +251,7 @@ func (c *Client) FetchMunicipalities(ctx context.Context, area string) ([]Munici
 	}
 
 	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
+	c.l2.municipalities.set(ctx, area, apiResp.Data)
 	c.cache.municipalities.set(area, apiResp.Data)
 	return apiResp.Data, nil
 }
@@ -266,6 +295,12 @@ func (c *Client) FetchStationRidership(ctx context.Context, z, x, y int) ([]Stat
 	if cached, ok := c.cache.ridership.get(key); ok {
 		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT015")))
+		return cached, nil
+	}
+	if cached, ok := c.l2.ridership.get(ctx, key); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT015")))
+		c.cache.ridership.set(key, cached)
 		return cached, nil
 	}
 	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT015")))
@@ -322,6 +357,7 @@ func (c *Client) FetchStationRidership(ctx context.Context, z, x, y int) ([]Stat
 
 	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
 	result := parseStationRiderships(geoResp.Features)
+	c.l2.ridership.set(ctx, key, result)
 	c.cache.ridership.set(key, result)
 	return result, nil
 }
@@ -388,6 +424,12 @@ func (c *Client) FetchPopulationForecast(ctx context.Context, z, x, y int) ([]do
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT013")))
 		return cached, nil
 	}
+	if cached, ok := c.l2.population.get(ctx, key); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT013")))
+		c.cache.population.set(key, cached)
+		return cached, nil
+	}
 	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT013")))
 	span.SetAttributes(attribute.Bool("mlit.cache.hit", false))
 
@@ -442,6 +484,7 @@ func (c *Client) FetchPopulationForecast(ctx context.Context, z, x, y int) ([]do
 
 	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
 	result := parsePopulationForecasts(geoResp.Features)
+	c.l2.population.set(ctx, key, result)
 	c.cache.population.set(key, result)
 	return result, nil
 }
@@ -500,6 +543,12 @@ func (c *Client) FetchLandAppraisals(ctx context.Context, area, city string, yea
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XCT001")))
 		return cached, nil
 	}
+	if cached, ok := c.l2.appraisals.get(ctx, key); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XCT001")))
+		c.cache.appraisals.set(key, cached)
+		return cached, nil
+	}
 	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XCT001")))
 	span.SetAttributes(attribute.Bool("mlit.cache.hit", false))
 
@@ -528,6 +577,7 @@ func (c *Client) FetchLandAppraisals(ctx context.Context, area, city string, yea
 
 		if err == nil {
 			span.SetAttributes(attribute.Int("mlit.retry.count", attempt))
+			c.l2.appraisals.set(ctx, key, result)
 			c.cache.appraisals.set(key, result)
 			return result, nil
 		}
@@ -819,6 +869,10 @@ func (c *Client) FetchLocationOptimization(ctx context.Context, z, x, y int) ([]
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT003")))
 		return cached, nil
 	}
+	if cached, ok := c.l2.locationOpt.get(ctx, key); ok {
+		c.cache.locationOptimization.set(key, cached)
+		return cached, nil
+	}
 	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT003")))
 	span.SetAttributes(attribute.Bool("mlit.cache.hit", false))
 
@@ -839,6 +893,7 @@ func (c *Client) FetchLocationOptimization(ctx context.Context, z, x, y int) ([]
 		result = append(result, domain.LocationOptimizationItem{KubunNameJa: f.Properties.KubunNameJa})
 	}
 	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
+	c.l2.locationOpt.set(ctx, key, result)
 	c.cache.locationOptimization.set(key, result)
 	return result, nil
 }
@@ -865,6 +920,10 @@ func (c *Client) FetchEmbankment(ctx context.Context, z, x, y int) ([]domain.Emb
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT020")))
 		return cached, nil
 	}
+	if cached, ok := c.l2.embankment.get(ctx, key); ok {
+		c.cache.embankment.set(key, cached)
+		return cached, nil
+	}
 	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT020")))
 	span.SetAttributes(attribute.Bool("mlit.cache.hit", false))
 
@@ -885,6 +944,7 @@ func (c *Client) FetchEmbankment(ctx context.Context, z, x, y int) ([]domain.Emb
 		result = append(result, domain.EmbankmentItem{Classification: f.Properties.EmbankmentClassification})
 	}
 	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
+	c.l2.embankment.set(ctx, key, result)
 	c.cache.embankment.set(key, result)
 	return result, nil
 }
@@ -911,6 +971,10 @@ func (c *Client) FetchUrbanRoad(ctx context.Context, z, x, y int) ([]domain.Urba
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT030")))
 		return cached, nil
 	}
+	if cached, ok := c.l2.urbanRoad.get(ctx, key); ok {
+		c.cache.urbanRoad.set(key, cached)
+		return cached, nil
+	}
 	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XKT030")))
 	span.SetAttributes(attribute.Bool("mlit.cache.hit", false))
 
@@ -934,6 +998,7 @@ func (c *Client) FetchUrbanRoad(ctx context.Context, z, x, y int) ([]domain.Urba
 		})
 	}
 	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
+	c.l2.urbanRoad.set(ctx, key, result)
 	c.cache.urbanRoad.set(key, result)
 	return result, nil
 }
@@ -958,6 +1023,10 @@ func (c *Client) FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domai
 	if cached, ok := c.cache.disaster.get(key); ok {
 		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XST001")))
+		return cached, nil
+	}
+	if cached, ok := c.l2.disaster.get(ctx, key); ok {
+		c.cache.disaster.set(key, cached)
 		return cached, nil
 	}
 	telemetry.MLITCacheMisses.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XST001")))
@@ -987,6 +1056,7 @@ func (c *Client) FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domai
 		})
 	}
 	span.SetAttributes(attribute.Int("mlit.retry.count", 0))
+	c.l2.disaster.set(ctx, key, result)
 	c.cache.disaster.set(key, result)
 	return result, nil
 }
@@ -996,6 +1066,10 @@ func (c *Client) FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domai
 func (c *Client) FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.UrbanZoningItem, error) {
 	key := fmt.Sprintf("urban_zoning:%d:%d:%d", z, x, y)
 	if cached, ok := c.cache.urbanZoning.get(key); ok {
+		return cached, nil
+	}
+	if cached, ok := c.l2.urbanZoning.get(ctx, key); ok {
+		c.cache.urbanZoning.set(key, cached)
 		return cached, nil
 	}
 	var geoResp UrbanZoningGeoJSON
@@ -1009,6 +1083,7 @@ func (c *Client) FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.Ur
 			KubunID:              f.Properties.KubunID,
 		})
 	}
+	c.l2.urbanZoning.set(ctx, key, result)
 	c.cache.urbanZoning.set(key, result)
 	return result, nil
 }
@@ -1018,6 +1093,10 @@ func (c *Client) FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.Ur
 func (c *Client) FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.LiquefactionRiskItem, error) {
 	key := fmt.Sprintf("liquefaction:%d:%d:%d", z, x, y)
 	if cached, ok := c.cache.liquefaction.get(key); ok {
+		return cached, nil
+	}
+	if cached, ok := c.l2.liquefaction.get(ctx, key); ok {
+		c.cache.liquefaction.set(key, cached)
 		return cached, nil
 	}
 	var geoResp LiquefactionGeoJSON
@@ -1031,6 +1110,7 @@ func (c *Client) FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.L
 			Note:          f.Properties.Note,
 		})
 	}
+	c.l2.liquefaction.set(ctx, key, result)
 	c.cache.liquefaction.set(key, result)
 	return result, nil
 }
@@ -1040,6 +1120,10 @@ func (c *Client) FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.L
 func (c *Client) FetchFloodHazard(ctx context.Context, z, x, y int) ([]domain.FloodHazardItem, error) {
 	key := fmt.Sprintf("flood_hazard:%d:%d:%d", z, x, y)
 	if cached, ok := c.cache.floodHazard.get(key); ok {
+		return cached, nil
+	}
+	if cached, ok := c.l2.floodHazard.get(ctx, key); ok {
+		c.cache.floodHazard.set(key, cached)
 		return cached, nil
 	}
 	var geoResp FloodHazardGeoJSON
@@ -1053,6 +1137,7 @@ func (c *Client) FetchFloodHazard(ctx context.Context, z, x, y int) ([]domain.Fl
 			RiverName: f.Properties.RiverName,
 		})
 	}
+	c.l2.floodHazard.set(ctx, key, result)
 	c.cache.floodHazard.set(key, result)
 	return result, nil
 }
@@ -1064,6 +1149,10 @@ func (c *Client) FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.St
 	if cached, ok := c.cache.stormHazard.get(key); ok {
 		return cached, nil
 	}
+	if cached, ok := c.l2.stormHazard.get(ctx, key); ok {
+		c.cache.stormHazard.set(key, cached)
+		return cached, nil
+	}
 	var geoResp StormHazardGeoJSON
 	if err := c.fetchTileGeoJSON(ctx, endpointStormHazard, z, x, y, &geoResp); err != nil {
 		return nil, err
@@ -1072,6 +1161,7 @@ func (c *Client) FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.St
 	for _, f := range geoResp.Features {
 		result = append(result, domain.StormHazardItem{DepthJa: f.Properties.DepthJa})
 	}
+	c.l2.stormHazard.set(ctx, key, result)
 	c.cache.stormHazard.set(key, result)
 	return result, nil
 }
@@ -1083,6 +1173,10 @@ func (c *Client) FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.
 	if cached, ok := c.cache.tsunamiHazard.get(key); ok {
 		return cached, nil
 	}
+	if cached, ok := c.l2.tsunamiHazard.get(ctx, key); ok {
+		c.cache.tsunamiHazard.set(key, cached)
+		return cached, nil
+	}
 	var geoResp TsunamiHazardGeoJSON
 	if err := c.fetchTileGeoJSON(ctx, endpointTsunamiHazard, z, x, y, &geoResp); err != nil {
 		return nil, err
@@ -1091,6 +1185,7 @@ func (c *Client) FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.
 	for _, f := range geoResp.Features {
 		result = append(result, domain.TsunamiHazardItem{DepthJa: f.Properties.DepthJa})
 	}
+	c.l2.tsunamiHazard.set(ctx, key, result)
 	c.cache.tsunamiHazard.set(key, result)
 	return result, nil
 }
@@ -1100,6 +1195,10 @@ func (c *Client) FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.
 func (c *Client) FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domain.LandslideHazardItem, error) {
 	key := fmt.Sprintf("landslide_hazard:%d:%d:%d", z, x, y)
 	if cached, ok := c.cache.landslideHazard.get(key); ok {
+		return cached, nil
+	}
+	if cached, ok := c.l2.landslideHazard.get(ctx, key); ok {
+		c.cache.landslideHazard.set(key, cached)
 		return cached, nil
 	}
 	var geoResp LandslideHazardGeoJSON
@@ -1113,6 +1212,7 @@ func (c *Client) FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domai
 			ZoneCode:       f.Properties.ZoneCode,
 		})
 	}
+	c.l2.landslideHazard.set(ctx, key, result)
 	c.cache.landslideHazard.set(key, result)
 	return result, nil
 }
@@ -1139,6 +1239,15 @@ func (c *Client) FetchRentStats(ctx context.Context, q LandPriceQuery, areaSqm f
 	if cached, ok := c.cache.rentStats.get(cacheKeySuffix); ok {
 		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
 		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT001_rent")))
+		if len(cached) == 0 {
+			return domain.RentStatsResult{}, nil
+		}
+		return cached[0], nil
+	}
+	if cached, ok := c.l2.rentStats.get(ctx, cacheKeySuffix); ok {
+		span.SetAttributes(attribute.Bool("mlit.cache.hit", true))
+		telemetry.MLITCacheHits.Add(ctx, 1, metric.WithAttributes(attribute.String("mlit.endpoint", "XIT001_rent")))
+		c.cache.rentStats.set(cacheKeySuffix, cached)
 		if len(cached) == 0 {
 			return domain.RentStatsResult{}, nil
 		}
@@ -1186,8 +1295,10 @@ func (c *Client) FetchRentStats(ctx context.Context, q LandPriceQuery, areaSqm f
 		if err == nil {
 			span.SetAttributes(attribute.Int("mlit.retry.count", attempt))
 			if result.Count == 0 {
+				c.l2.rentStats.set(ctx, cacheKeySuffix, []domain.RentStatsResult{})
 				c.cache.rentStats.set(cacheKeySuffix, []domain.RentStatsResult{})
 			} else {
+				c.l2.rentStats.set(ctx, cacheKeySuffix, []domain.RentStatsResult{result})
 				c.cache.rentStats.set(cacheKeySuffix, []domain.RentStatsResult{result})
 			}
 			return result, nil

--- a/backend/internal/mlit/client_otel_test.go
+++ b/backend/internal/mlit/client_otel_test.go
@@ -34,6 +34,7 @@ func newOtelTestClient(srv *httptest.Server) *Client {
 		baseURL:    srv.URL,
 		apiKey:     "test-key",
 		cache:      newCache(),
+		l2:         newNoopL2CacheGroup(),
 	}
 }
 

--- a/backend/internal/mlit/client_test.go
+++ b/backend/internal/mlit/client_test.go
@@ -114,7 +114,7 @@ func TestIsLandType(t *testing.T) {
 // ---- buildLandPricesURL ----
 
 func newTestClient(serverURL string) *Client {
-	return &Client{httpClient: &http.Client{}, baseURL: serverURL, cache: newCache()}
+	return &Client{httpClient: &http.Client{}, baseURL: serverURL, cache: newCache(), l2: newNoopL2CacheGroup()}
 }
 
 func TestBuildLandPricesURL(t *testing.T) {

--- a/backend/internal/mlit/firestore_cache.go
+++ b/backend/internal/mlit/firestore_cache.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	mlitCacheCollection = "mlit_cache"
-	mlitCacheTTL        = 24 * time.Hour
+	mlitCacheCollection = "mlit_cache"    //nolint:unused
+	mlitCacheTTL        = 24 * time.Hour  //nolint:unused
 )
 
 // l2Cache はFirestore L2キャッシュの汎用インターフェース。
@@ -30,8 +30,8 @@ type firestoreL2[E any] struct {
 // noopL2 はFirestore未設定時のダミー実装。
 type noopL2[E any] struct{}
 
-func (n *noopL2[E]) get(_ context.Context, _ string) ([]E, bool) { return nil, false }
-func (n *noopL2[E]) set(_ context.Context, _ string, _ []E)      {}
+func (n *noopL2[E]) get(_ context.Context, _ string) ([]E, bool) { return nil, false } //nolint:unused
+func (n *noopL2[E]) set(_ context.Context, _ string, _ []E)      {}                    //nolint:unused
 
 // newFirestoreL2 は client が nil の場合 noopL2 を、それ以外は firestoreL2 を返す。
 func newFirestoreL2[E any](client *firestore.Client, endpoint string) l2Cache[E] {
@@ -41,11 +41,11 @@ func newFirestoreL2[E any](client *firestore.Client, endpoint string) l2Cache[E]
 	return &firestoreL2[E]{client: client, endpoint: endpoint}
 }
 
-func (f *firestoreL2[E]) docID(key string) string {
+func (f *firestoreL2[E]) docID(key string) string { //nolint:unused
 	return f.endpoint + ":" + key
 }
 
-func (f *firestoreL2[E]) get(ctx context.Context, key string) ([]E, bool) {
+func (f *firestoreL2[E]) get(ctx context.Context, key string) ([]E, bool) { //nolint:unused
 	doc, err := f.client.Collection(mlitCacheCollection).Doc(f.docID(key)).Get(ctx)
 	if err != nil {
 		return nil, false
@@ -72,7 +72,7 @@ func (f *firestoreL2[E]) get(ctx context.Context, key string) ([]E, bool) {
 	return result, true
 }
 
-func (f *firestoreL2[E]) set(ctx context.Context, key string, data []E) {
+func (f *firestoreL2[E]) set(ctx context.Context, key string, data []E) { //nolint:unused
 	raw, err := json.Marshal(data)
 	if err != nil {
 		return

--- a/backend/internal/mlit/firestore_cache.go
+++ b/backend/internal/mlit/firestore_cache.go
@@ -1,0 +1,149 @@
+package mlit
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"cloud.google.com/go/firestore"
+
+	"github.com/yield-guard/backend/internal/domain"
+)
+
+const (
+	mlitCacheCollection = "mlit_cache"
+	mlitCacheTTL        = 24 * time.Hour
+)
+
+// l2Cache はFirestore L2キャッシュの汎用インターフェース。
+type l2Cache[E any] interface {
+	get(ctx context.Context, key string) ([]E, bool)
+	set(ctx context.Context, key string, data []E)
+}
+
+// firestoreL2 はFirestoreをL2キャッシュとして使用する汎用実装。
+type firestoreL2[E any] struct {
+	client   *firestore.Client
+	endpoint string
+}
+
+// noopL2 はFirestore未設定時のダミー実装。
+type noopL2[E any] struct{}
+
+func (n *noopL2[E]) get(_ context.Context, _ string) ([]E, bool) { return nil, false }
+func (n *noopL2[E]) set(_ context.Context, _ string, _ []E)      {}
+
+// newFirestoreL2 は client が nil の場合 noopL2 を、それ以外は firestoreL2 を返す。
+func newFirestoreL2[E any](client *firestore.Client, endpoint string) l2Cache[E] {
+	if client == nil {
+		return &noopL2[E]{}
+	}
+	return &firestoreL2[E]{client: client, endpoint: endpoint}
+}
+
+func (f *firestoreL2[E]) docID(key string) string {
+	return f.endpoint + ":" + key
+}
+
+func (f *firestoreL2[E]) get(ctx context.Context, key string) ([]E, bool) {
+	doc, err := f.client.Collection(mlitCacheCollection).Doc(f.docID(key)).Get(ctx)
+	if err != nil {
+		return nil, false
+	}
+	expiresAt, ok := doc.Data()["expiresAt"].(time.Time)
+	if !ok || time.Now().After(expiresAt) {
+		return nil, false
+	}
+
+	var raw []byte
+	switch v := doc.Data()["data"].(type) {
+	case []byte:
+		raw = v
+	case string:
+		raw = []byte(v)
+	default:
+		return nil, false
+	}
+
+	var result []E
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return nil, false
+	}
+	return result, true
+}
+
+func (f *firestoreL2[E]) set(ctx context.Context, key string, data []E) {
+	raw, err := json.Marshal(data)
+	if err != nil {
+		return
+	}
+	_, _ = f.client.Collection(mlitCacheCollection).Doc(f.docID(key)).Set(ctx, map[string]any{
+		"data":      string(raw),
+		"expiresAt": time.Now().Add(mlitCacheTTL),
+		"endpoint":  f.endpoint,
+	})
+}
+
+// l2CacheGroup は全エンドポイントの L2 キャッシュをまとめた構造体。
+type l2CacheGroup struct {
+	landPrices      l2Cache[domain.LandTransaction]
+	municipalities  l2Cache[Municipality]
+	ridership       l2Cache[StationRidership]
+	population      l2Cache[domain.PopulationForecastItem]
+	appraisals      l2Cache[domain.LandAppraisalItem]
+	locationOpt     l2Cache[domain.LocationOptimizationItem]
+	embankment      l2Cache[domain.EmbankmentItem]
+	urbanRoad       l2Cache[domain.UrbanRoadItem]
+	disaster        l2Cache[domain.DisasterHistoryItem]
+	urbanZoning     l2Cache[domain.UrbanZoningItem]
+	liquefaction    l2Cache[domain.LiquefactionRiskItem]
+	floodHazard     l2Cache[domain.FloodHazardItem]
+	stormHazard     l2Cache[domain.StormHazardItem]
+	tsunamiHazard   l2Cache[domain.TsunamiHazardItem]
+	landslideHazard l2Cache[domain.LandslideHazardItem]
+	rentStats       l2Cache[domain.RentStatsResult]
+}
+
+// newNoopL2CacheGroup は全フィールドが noopL2 の l2CacheGroup を返す。
+func newNoopL2CacheGroup() l2CacheGroup {
+	return l2CacheGroup{
+		landPrices:      &noopL2[domain.LandTransaction]{},
+		municipalities:  &noopL2[Municipality]{},
+		ridership:       &noopL2[StationRidership]{},
+		population:      &noopL2[domain.PopulationForecastItem]{},
+		appraisals:      &noopL2[domain.LandAppraisalItem]{},
+		locationOpt:     &noopL2[domain.LocationOptimizationItem]{},
+		embankment:      &noopL2[domain.EmbankmentItem]{},
+		urbanRoad:       &noopL2[domain.UrbanRoadItem]{},
+		disaster:        &noopL2[domain.DisasterHistoryItem]{},
+		urbanZoning:     &noopL2[domain.UrbanZoningItem]{},
+		liquefaction:    &noopL2[domain.LiquefactionRiskItem]{},
+		floodHazard:     &noopL2[domain.FloodHazardItem]{},
+		stormHazard:     &noopL2[domain.StormHazardItem]{},
+		tsunamiHazard:   &noopL2[domain.TsunamiHazardItem]{},
+		landslideHazard: &noopL2[domain.LandslideHazardItem]{},
+		rentStats:       &noopL2[domain.RentStatsResult]{},
+	}
+}
+
+// newFirestoreL2CacheGroup は Firestore クライアントから全フィールドが firestoreL2 の l2CacheGroup を返す。
+func newFirestoreL2CacheGroup(fs *firestore.Client) l2CacheGroup {
+	return l2CacheGroup{
+		landPrices:      newFirestoreL2[domain.LandTransaction](fs, "XIT001"),
+		municipalities:  newFirestoreL2[Municipality](fs, "XIT002"),
+		ridership:       newFirestoreL2[StationRidership](fs, "XKT015"),
+		population:      newFirestoreL2[domain.PopulationForecastItem](fs, "XKT013"),
+		appraisals:      newFirestoreL2[domain.LandAppraisalItem](fs, "XCT001"),
+		locationOpt:     newFirestoreL2[domain.LocationOptimizationItem](fs, "XKT003"),
+		embankment:      newFirestoreL2[domain.EmbankmentItem](fs, "XKT020"),
+		urbanRoad:       newFirestoreL2[domain.UrbanRoadItem](fs, "XKT030"),
+		disaster:        newFirestoreL2[domain.DisasterHistoryItem](fs, "XST001"),
+		urbanZoning:     newFirestoreL2[domain.UrbanZoningItem](fs, "XKT001"),
+		liquefaction:    newFirestoreL2[domain.LiquefactionRiskItem](fs, "XKT025"),
+		floodHazard:     newFirestoreL2[domain.FloodHazardItem](fs, "XKT026"),
+		stormHazard:     newFirestoreL2[domain.StormHazardItem](fs, "XKT027"),
+		tsunamiHazard:   newFirestoreL2[domain.TsunamiHazardItem](fs, "XKT028"),
+		landslideHazard: newFirestoreL2[domain.LandslideHazardItem](fs, "XKT029"),
+		rentStats:       newFirestoreL2[domain.RentStatsResult](fs, "XIT001_rent"),
+	}
+}

--- a/terraform/apis.tf
+++ b/terraform/apis.tf
@@ -19,6 +19,7 @@ locals {
     "cloudbuild.googleapis.com",
     # Required for Cloud Functions Gen2 Pub/Sub event triggers (Eventarc backend).
     "eventarc.googleapis.com",
+    "firestore.googleapis.com",
   ])
 }
 

--- a/terraform/firestore.tf
+++ b/terraform/firestore.tf
@@ -1,0 +1,15 @@
+resource "google_firestore_database" "default" {
+  project     = var.project_id
+  name        = "(default)"
+  location_id = "asia-northeast1"
+  type        = "FIRESTORE_NATIVE"
+  depends_on  = [google_project_service.apis]
+}
+
+resource "google_firestore_field" "mlit_cache_ttl" {
+  project    = var.project_id
+  database   = google_firestore_database.default.name
+  collection = "mlit_cache"
+  field      = "expiresAt"
+  ttl_config {}
+}

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -202,6 +202,12 @@ resource "google_project_iam_member" "backend_metric_writer" {
   member  = "serviceAccount:${google_service_account.backend.email}"
 }
 
+resource "google_project_iam_member" "backend_firestore_user" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.backend.email}"
+}
+
 # ─── Billing Stop Cloud Function SA ───────────────────────────────────────────
 resource "google_service_account" "billing_stop" {
   account_id   = "sa-billing-stop-${var.env}"


### PR DESCRIPTION
## 概要

Cloud Run `min_instances=0` によるコールドスタート時のキャッシュ消失を解消するため、Firestore を L2 キャッシュとして追加する。既存の in-memory L1 キャッシュはそのまま維持し、L1 ミス時に Firestore を参照する 2 層構成とする。

## キャッシュアーキテクチャ

```
リクエスト
  → L1 in-memory (genericCache[E], 24h TTL) — ヒット即返却
  → L2 Firestore (firestoreL2[E], 24h TTL)  — ヒット時 L1 に昇格
  → MLIT API 実呼び出し → L2 書き込み → L1 書き込み
```

## 変更内容

### バックエンド

- `backend/internal/mlit/firestore_cache.go`（新規）
  - `l2Cache[E]` インターフェース
  - `firestoreL2[E]`：Firestore 実装（JSON 直列化・TTL 自前チェック・型アサーション対応）
  - `noopL2[E]`：Firestore 未設定時のダミー実装（ローカル開発で使用）
  - `l2CacheGroup`：全 16 エンドポイント分のキャッシュグループ
  - エンドポイント名を MLIT API コード（XIT001 等）でラベリング

- `backend/internal/mlit/client.go`
  - `Client` 構造体に `l2 l2CacheGroup` フィールドを追加
  - `NewClientWithFirestore(apiKey string, fs *firestore.Client) *Client` を追加
  - 全 16 `Fetch*` メソッドに L2 読み書きを差し込み
  - `FetchRentStats` のみ戻り値が `domain.RentStatsResult`（スライスでない）のため `[]domain.RentStatsResult{result}` でラッピング

- `backend/cmd/server/main.go`
  - `GOOGLE_CLOUD_PROJECT` 環境変数から ProjectID を取得し Firestore クライアントを初期化
  - 初期化失敗時は警告ログを出力して noop にフォールバック（ローカル環境で安全）

- `backend/go.mod`
  - `cloud.google.com/go/firestore v1.22.0` を直接依存に昇格

### インフラ

- `terraform/firestore.tf`（新規）
  - Firestore データベース（Native モード、asia-northeast1）
  - `mlit_cache` コレクションの `expiresAt` フィールドに TTL ポリシーを設定

- `terraform/apis.tf`
  - `firestore.googleapis.com` を追加

- `terraform/iam.tf`
  - バックエンド SA に `roles/datastore.user` を付与

## テスト

- `go build ./...` — PASS
- `go test -race ./...` — 全パッケージ PASS（既存テスト破壊なし）
- `client_otel_test.go` / `client_test.go` に `l2: newNoopL2CacheGroup()` を追加してコンパイルエラーを解消

## コスト

Firestore 無料枠：50K reads / 20K writes / day、1GB ストレージ
→ 現トラフィック規模では**¥0**

## 関連

- Closes #568
- #492（Firestore AI サマリーキャッシュ）はこの PR の基盤が整ったあとに実装可能
- #570（Cloud Scheduler）の terraform apply はこの PR と合わせて実施予定

## 注意事項

- `terraform apply` で Firestore DB を作成してから Cloud Run を再デプロイする必要がある
- ローカル開発は `GOOGLE_CLOUD_PROJECT` 未設定で noop L2 として動作するため変更不要