### PR TITLE
fix(iam): DeployerサービスアカウントにFirestoreとCloud Schedulerの権限を追加

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -153,6 +153,20 @@ resource "google_project_iam_member" "deployer_cloudfunctions_admin" {
   member  = "serviceAccount:${google_service_account.deployer.email}"
 }
 
+resource "google_project_iam_member" "deployer_firestore_owner" {
+  # Required to create Firestore databases and TTL policies via terraform apply.
+  project = var.project_id
+  role    = "roles/datastore.owner"
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
+resource "google_project_iam_member" "deployer_cloudscheduler_admin" {
+  # Required to create and manage Cloud Scheduler jobs via terraform apply.
+  project = var.project_id
+  role    = "roles/cloudscheduler.admin"
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
 resource "google_billing_account_iam_member" "deployer_billing_admin" {
   provider = google.billing
   # Required to create and update Billing Budgets via terraform apply.


### PR DESCRIPTION
## 概要

`terraform apply` が以下の権限不足で失敗したため、Deployer SAに必要なロールを追加する。

## エラー内容

```
Error creating Database: googleapi: Error 403: The caller does not have permission
Error creating Job: Error 403: IAM permission "cloudscheduler.jobs.create" lacking
```

## 変更内容

`terraform/iam.tf` に2ロールを追加：

| リソース | ロール | 用途 |
|---------|-------|------|
| `deployer_firestore_owner` | `roles/datastore.owner` | Firestore DB・TTLポリシーの作成 |
| `deployer_cloudscheduler_admin` | `roles/cloudscheduler.admin` | Cloud Schedulerジョブの作成・管理 |

## マージ後の手順

1. `terraform apply` を再実行
2. Firestore DB（Native モード、asia-northeast1）の作成を確認
3. Cloud Scheduler ジョブ 2 本（warmup-ping・warmup-cache）の作成を確認

## 関連

- #568（Firestoreキャッシュ）/ #570（Cloud Scheduler）の `terraform apply` が完了する