### PR TITLE
docs: バックエンド/APIドキュメント 5件の誤記修正（監査対応）

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -485,7 +485,8 @@ DeviationPct         = (price - TheoreticalPrice) / TheoreticalPrice × 100
   "miscExpenses": 1050000,
   "grossYield": 0.0897,
   "netYield": 0.0673,
-  "isAbove8Percent": true,
+  "isAboveYieldTarget": true,
+  "yieldTarget": 0.08,
   "requiredCostReduction": 0,
   "requiredMonthlyRent": 107000,
   "deadCrossYear": 12,
@@ -833,25 +834,6 @@ vacancyRateDelta = max(0, -changeRate30yr × 0.5)
 
 ---
 
-## GET /api/prefectures
-
-都道府県一覧をコード順（昇順）で返す。
-
-### レスポンス
-
-```json
-[
-  { "code": "01", "name": "北海道" },
-  { "code": "02", "name": "青森県" },
-  ...
-  { "code": "47", "name": "沖縄県" }
-]
-```
-
-47都道府県すべてを含む。コードは2桁ゼロパディング。
-
----
-
 ## POST /api/investment/simulate
 
 モンテカルロ法による確率的ストレステストを実行する。空室率・金利を正規分布でサンプリングした N 試行を実施し、IRR・最終純資産の分布と統計量を返す。
@@ -1027,7 +1009,7 @@ vacancyRateDelta = max(0, -changeRate30yr × 0.5)
 | `maxLat` | 必須 | 緯度上限（20〜46、minLat より大きい値） |
 | `minLng` | 必須 | 経度下限（122〜154） |
 | `maxLng` | 必須 | 経度上限（122〜154、minLng より大きい値） |
-| `z` | 任意 | ズームレベル（11〜15、デフォルト: 13）。z=15 時のタイル上限は 25 に縮小 |
+| `z` | 任意 | ズームレベル（11〜15、デフォルト: 13）。タイル上限はズームに応じて変化: z≤12: 20、z≤14: 30、z=15: 50 |
 
 ### レスポンス: `HeatmapResponse`
 
@@ -1072,7 +1054,7 @@ vacancyRateDelta = max(0, -changeRate30yr × 0.5)
 | コード | 条件 |
 |--------|------|
 | 400 | 必須パラメータ未指定・範囲外・minLat ≥ maxLat など |
-| 400 | タイル数が上限（z≤14: 50、z=15: 25）を超える場合 |
+| 400 | タイル数が上限（z≤12: 20、z≤14: 30、z=15: 50）を超える場合 |
 
 ---
 

--- a/docs/domain-depreciation-dead-cross.md
+++ b/docs/domain-depreciation-dead-cross.md
@@ -96,7 +96,7 @@ accumulatedDepreciation += yearDepreciation
 ```go
 // DepreciationMethodDecliningBalance の場合のみ使用
 bookValue  := input.BuildingCost          // ループ前に初期化
-decliningRate := 1.5 / float64(usefulLife) // 定率 = 1/耐用年数 × 1.5
+decliningRate := 2.0 / float64(usefulLife) // 定率 = 1/耐用年数 × 2.0
 
 // 年次ループ内
 if bookValue > 1.0 {
@@ -108,7 +108,7 @@ if bookValue > 1.0 {
 }
 ```
 
-- **率の根拠**: 旧定率法の `1/耐用年数` に対し、現行（2007年改正後）の定率法は `1/耐用年数 × 250%` が法定。本ツールは `1.5倍` を採用（概算）
+- **率の根拠**: 200%定率法（法人税法施行令第48条の2）に基づき、`1/耐用年数 × 2.0倍` を採用
 - **収束保証**: `bookValue` が 1円を下回るタイミングで端数を全額計上し、以後ゼロ
 - **定額法との違い**: 初期に償却額が大きく、後半に逓減。デッドクロス発生タイミングが定額法と異なる
 

--- a/docs/domain-investment-calculation.md
+++ b/docs/domain-investment-calculation.md
@@ -207,27 +207,25 @@ NOI          = 1,041,600 − 276,240 = 765,360円
 
 ---
 
-## 8%逆算ロジック（`calcRequired8pct`）
+## 目標利回り逆算ロジック（`calcRequiredForTarget`）
 
-**8%の根拠**: 不動産投資の実務において、表面利回り8%は「最低限の投資妥当性」を示す経験則的ベンチマーク。
-
-> **根拠・出典**: 日本不動産研究所「不動産投資家調査」（各年次）によると、住宅系投資物件の期待利回り（NOI利回り）は首都圏で5〜6%台、地方圏で6〜8%台。表面利回りはこれより1〜2%高くなるため、8%を「許容できる最低ライン」として業界で広く参照される。本ツールはこの8%をハードコードした警告閾値として採用している。
-
-8%境界線（`targetYield8pct = 0.08`）を基準に2つの逆算値を返す。
+`input.YieldTarget`（デフォルト 0.08 = 8%）を基準に2つの逆算値を返す（`backend/internal/domain/sensitivity.go`）。
 
 ```go
-// 目標年収 = 総投資額 × 8%
-requiredMonthlyRent = (totalInvestment × 0.08) / 12
+target := input.YieldTarget          // 目標表面利回り（例: 0.08）
 
-// 現賃料で8%達成に必要な総投資額
-requiredTotalInvestment = (MonthlyRent × 12) / 0.08
+// 目標年収 = 総投資額 × 目標利回り
+requiredMonthlyRent = (totalInvestment × target) / 12
+
+// 現賃料で目標利回り達成に必要な総投資額
+requiredTotalInvestment = (MonthlyRent × 12) / target
 
 // 過剰投資額（削減が必要な額）
 costReduction = max(totalInvestment - requiredTotalInvestment, 0)
 ```
 
-- `RequiredMonthlyRent`: 現在の投資額で8%を達成するために必要な月額賃料
-- `RequiredCostReduction`: 現在の賃料で8%を達成するために土地 **または** 建築費いずれか一方を削減すべき額
+- `RequiredMonthlyRent`: 現在の投資額で目標利回りを達成するために必要な月額賃料
+- `RequiredCostReduction`: 現在の賃料で目標利回りを達成するために土地 **または** 建築費いずれか一方を削減すべき額
 
 ---
 
@@ -445,8 +443,8 @@ yearAnnualRent = baseAnnualRent × (1 - RentDeclineRate)^y
 | `NetYield` | 実質利回り |
 | `IsAboveYieldTarget` | 表面利回り ≥ 目標利回り（`yieldTarget`）かどうか |
 | `YieldTarget` | 判定に使用した目標利回り（例: 0.08 = 8%） |
-| `RequiredCostReduction` | 8%達成に必要なコスト削減額（いずれか一方） |
-| `RequiredMonthlyRent` | 8%達成に必要な月額賃料 |
+| `RequiredCostReduction` | 目標利回り達成に必要なコスト削減額（いずれか一方） |
+| `RequiredMonthlyRent` | 目標利回り達成に必要な月額賃料 |
 | `DeadCrossYear` | デッドクロス初年度（-1 = 35年以内なし） |
 | `YearlyResults` | 年次結果配列（`max(LoanYears, HoldingYears, 35)` 件） |
 | `ExitSalePrice` | 売却価格（NOI / ExitYieldTarget） |

--- a/docs/domain-investment-calculation.md
+++ b/docs/domain-investment-calculation.md
@@ -29,8 +29,20 @@
 | `DiscountRate` | float64 | 率 | NPV/IRR計算の割引率（0.05 = 5%）。`0` 指定時は `Defaults()` で 0.05 に補完 | 0.05 |
 | `PriceDeclineRate` | float64 | 率 | 物件価格の年間下落率（0.02 = 年2%）。IRR/NPVのターミナルバリューにのみ反映 | 0 |
 | `DepreciationMethod` | string | — | 減価償却方式: `"straight-line"` または `"declining-balance"` | `"straight-line"` |
+| `YieldTarget` | float64 | 率 | 目標表面利回り（例: 0.08 = 8%）。`IsAboveYieldTarget` の判定基準。0 指定時は `Defaults()` で 0.08 に補完 | 0.08 |
+| `RateAdjustmentSchedule` | []RateAdjustment | — | 変動金利スケジュール。各要素に `afterYear`（適用開始年）と `rate`（適用金利、絶対値）を持つ。空配列 = 固定金利 | [] |
+| `CapexSchedule` | []CapexEvent | — | 大規模修繕費スケジュール（最大5件）。各要素に `year`（発生年）と `amount`（円）を持つ | [] |
+| `RentGrowthRate` | float64 | 率 | 年間賃料上昇率（例: 0.02 = 2%）。`RentGrowthYears` と組み合わせ新築・リノベ物件の賃料上昇期を表現 | 0 |
+| `RentGrowthYears` | int | 年 | 賃料が `RentGrowthRate` で上昇し続ける年数。この年数を超えると `RentDeclineRate` のみ適用 | 0 |
 
 **注意**: `VacancyRate`・`ExpenseRate`・`IncomeTaxRate` は 0 が有効値のため `Defaults()` では初期化されない。呼び出し側で必ず指定する。
+
+**`RateAdjustment` 型**（`RateAdjustmentSchedule` の要素）:
+
+| フィールド | 型 | 説明 |
+|-----------|-----|------|
+| `afterYear` | int | この金利を適用する開始年（最小 2）。それ以前は `LoanRate` を使用 |
+| `rate` | float64 | 適用金利（絶対値。例: 0.020 = 2%）。`LoanRateDelta` は常に加算される |
 
 ---
 
@@ -431,7 +443,8 @@ yearAnnualRent = baseAnnualRent × (1 - RentDeclineRate)^y
 | `MiscExpenses` | 諸経費額 |
 | `GrossYield` | 表面利回り |
 | `NetYield` | 実質利回り |
-| `IsAbove8Percent` | 表面利回り ≥ 8% かどうか |
+| `IsAboveYieldTarget` | 表面利回り ≥ 目標利回り（`yieldTarget`）かどうか |
+| `YieldTarget` | 判定に使用した目標利回り（例: 0.08 = 8%） |
 | `RequiredCostReduction` | 8%達成に必要なコスト削減額（いずれか一方） |
 | `RequiredMonthlyRent` | 8%達成に必要な月額賃料 |
 | `DeadCrossYear` | デッドクロス初年度（-1 = 35年以内なし） |


### PR DESCRIPTION
## 概要

ドキュメント監査で発見した5件の誤記・不正確な情報をソースコードと照合して修正。

## 変更内容

- **Fix 1 — ヒートマップタイル上限の誤記修正** (`docs/api-reference.md`)
  - `z` クエリパラメータの説明を実装（`location_handler.go` L389-397）と一致するよう修正
  - 旧: "z=15時のタイル上限は25に縮小" → 新: z≤12:20、z≤14:30、z=15:50
  - エラーテーブルも同様に修正: "z≤14:50、z=15:25" → "z≤12:20、z≤14:30、z=15:50"

- **Fix 2 — レスポンスフィールド名の誤記修正** (`docs/api-reference.md`, `docs/domain-investment-calculation.md`)
  - `isAbove8Percent` → `isAboveYieldTarget` + `yieldTarget`（`types.go` L343-344 と一致）
  - JSONサンプルおよびフィールド解説テーブル両方を修正

- **Fix 3 — 存在しない `/api/prefectures` エンドポイントを削除** (`docs/api-reference.md`)
  - ルーターに登録されていないファントムエンドポイントのセクションを全削除
  - 前後の `---` セパレータが重複しないよう調整

- **Fix 4 — InvestmentInput の5フィールド追記** (`docs/domain-investment-calculation.md`)
  - `types.go` L117-134 に定義されている未記載フィールドを追加:
    `YieldTarget`, `RateAdjustmentSchedule`, `CapexSchedule`, `RentGrowthRate`, `RentGrowthYears`
  - `RateAdjustment` サブ型の説明テーブルも追記

- **Fix 5 — 定率法の乗数 1.5 → 2.0 に修正** (`docs/domain-depreciation-dead-cross.md`)
  - `cashflow.go` L99 の実装（`2.0 / float64(usefulLife)`）と一致するよう修正
  - 根拠を「200%定率法（法人税法施行令第48条の2）」に更新

## 確認方法

- [ ] `docs/api-reference.md` のヒートマップセクションでタイル上限が z≤12:20、z≤14:30、z=15:50 になっている
- [ ] `POST /api/investment/analyze` のレスポンスJSONに `isAboveYieldTarget` と `yieldTarget` が含まれている
- [ ] `/api/prefectures` セクションが存在しない
- [ ] `InvestmentInput 全フィールド解説` テーブルに5フィールドと `RateAdjustment` サブ型が追記されている
- [ ] 定率法コードブロックのレートが `2.0 / float64(usefulLife)` になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)