### PR TITLE
fix(monitoring): ウォームアップアラートをcondition_absentに変更（メトリクスラベル検証エラー修正）

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -254,28 +254,24 @@ resource "google_monitoring_alert_policy" "cache_hit_rate" {
   }
 }
 
-# 4. Cloud Scheduler ウォームアップジョブが連続失敗
+# 4. Cloud Scheduler warmup-ping が 45 分間実行されない（3 回連続スキップ相当）
+# condition_absent: メトリクスデータの欠如を検知するため、ラベルフィルタ不要で初回から動作する
 resource "google_monitoring_alert_policy" "warmup_job_failure" {
-  display_name = "[Yield Guard] ウォームアップジョブが連続失敗"
+  display_name = "[Yield Guard] ウォームアップ ping ジョブが停止"
   combiner     = "OR"
 
   conditions {
-    display_name = "warmup-cache または warmup-ping が 30 分以内に 2 回以上失敗"
-    condition_threshold {
+    display_name = "warmup-ping-prod の実行データが 45 分間なし（3 回分スキップ相当）"
+    condition_absent {
       filter = join(" AND ", [
         "metric.type=\"cloudscheduler.googleapis.com/job/attempt_count\"",
         "resource.type=\"cloud_scheduler_job\"",
-        "metric.labels.status=\"FAILED\"",
-        "resource.labels.job_id=monitoring.regex.full_match(\"warmup-.*-${var.env}\")",
+        "resource.labels.job_id=\"warmup-ping-${var.env}\"",
       ])
-      comparison      = "COMPARISON_GT"
-      threshold_value = 1
-      duration        = "0s"
+      duration = "2700s"
       aggregations {
-        alignment_period     = "1800s"
-        per_series_aligner   = "ALIGN_COUNT_TRUE"
-        cross_series_reducer = "REDUCE_SUM"
-        group_by_fields      = ["resource.labels.job_id"]
+        alignment_period   = "300s"
+        per_series_aligner = "ALIGN_COUNT_TRUE"
       }
     }
   }


### PR DESCRIPTION
## 概要

#582 でマージしたアラートポリシーが `terraform apply` で以下のエラーになったため修正する。

## エラー

```
Error creating AlertPolicy: googleapi: Error 404:
Cannot find metric(s) that match type = "cloudscheduler.googleapis.com/job/attempt_count" label = "status"
```

## 原因

`metric.labels.status="FAILED"` フィルタを使用したが、ジョブがまだ一度も実行されていないためメトリクスデータが存在せず GCP がラベルを検証できなかった。

## 修正内容

`condition_threshold`（閾値超過）→ `condition_absent`（データ欠如）に変更。

| 変更前 | 変更後 |
|--------|--------|
| 30分以内に2回以上 FAILED | 45分間（3回分）データなし |
| `metric.labels.status="FAILED"` フィルタ必要 | ラベルフィルタ不要、初回から動作 |

**45分 = 15分周期 × 3回分スキップ相当。** ping が3回連続でスキップされた場合にアラートを発報する。

## 関連

- #582 の terraform apply 失敗を修正