### PR TITLE
fix(iam): DeployerSAにlogging.configWriterロールを追加（ログベースメトリクス作成権限）

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -153,6 +153,13 @@ resource "google_project_iam_member" "deployer_cloudfunctions_admin" {
   member  = "serviceAccount:${google_service_account.deployer.email}"
 }
 
+resource "google_project_iam_member" "deployer_logging_config_writer" {
+  # Required to create and manage log-based metrics via terraform apply.
+  project = var.project_id
+  role    = "roles/logging.configWriter"
+  member  = "serviceAccount:${google_service_account.deployer.email}"
+}
+
 resource "google_project_iam_member" "deployer_firestore_owner" {
   # Required to create Firestore databases and TTL policies via terraform apply.
   project = var.project_id


### PR DESCRIPTION
## 概要

ウォームアップアラート（#594）の `terraform apply` が `logging.logMetrics.create` 権限不足で失敗したため、Deployer SA に `roles/logging.configWriter` を追加する。

## エラー

```
Error creating Metric: googleapi: Error 403:
Permission 'logging.logMetrics.create' denied on resource
```

## 変更内容

`terraform/iam.tf` に1ロールを追加：

| リソース | ロール | 用途 |
|---------|-------|------|
| `deployer_logging_config_writer` | `roles/logging.configWriter` | ログベースメトリクスの作成・管理 |

## マージ後

terraform apply で権限付与 → 再apply でログベースメトリクスとアラートが作成される。