### PR TITLE
fix: ゲージの背景グラデーションを段階的固定色セグメントに変更

### DIFF
--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -288,7 +288,9 @@ export function YieldAnalysis({
               <span>{maxYieldPct}%+</span>
             </div>
             <div className="relative h-3 rounded-full bg-muted overflow-hidden">
-              <div className="absolute inset-y-0 left-0 rounded-full bg-gradient-to-r from-red-400 via-yellow-400 to-green-400 w-full" />
+              <div className="absolute inset-y-0 left-0 w-1/3 bg-red-400" />
+              <div className="absolute inset-y-0 left-1/3 w-1/3 bg-yellow-400" />
+              <div className="absolute inset-y-0 left-2/3 w-1/3 bg-green-500" />
               {/* 現在値マーカー */}
               <div
                 className="absolute top-0 h-full w-1 bg-foreground/80 rounded"


### PR DESCRIPTION
## 概要
`YieldAnalysis.tsx` のゲージ背景に使用していた `bg-gradient-to-r`（グラデーション）を、CLAUDE.md のデザインルールに従い削除し、3つの固定色セグメントに置き換えた。

## 変更内容
- `frontend/src/components/YieldAnalysis.tsx` L291 付近のゲージ背景を修正
- 変更前: グラデーション1枚の `<div>` (`bg-gradient-to-r from-red-400 via-yellow-400 to-green-400`)
- 変更後: 等幅（`w-1/3`）の3セグメント構成に分割
  - 左1/3: `bg-red-400`（危険ゾーン）
  - 中1/3: `bg-yellow-400`（警戒ゾーン）
  - 右1/3: `bg-green-500`（良好ゾーン）
- 現在値マーカー（`gaugePosition`）と目標ラインマーカー（`targetPosition`）は変更なし

## 関連Issue
Closes #588

## テスト
- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [ ] コードレビュー観点での自己レビュー済み