### PR TITLE
fix: クイックモードに目標利回りのバリデーションを追加

### DIFF
--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -80,6 +80,8 @@ function validateQuick(quickTotalPriceMan: string, input: InvestmentInput): Form
     e.quickTotalPrice = "1〜100億円の範囲で入力してください";
   if (input.monthlyRent <= 0) e.monthlyRent = "正の値を入力してください";
   if (input.loanAmount < 0) e.loanAmount = "0以上の値を入力してください";
+  if (input.yieldTarget <= 0 || input.yieldTarget > 0.5)
+    e.yieldTarget = "目標利回りは0〜50%の範囲で入力してください";
   return e;
 }
 


### PR DESCRIPTION
## 概要

クイックモード（`validateQuick()`）で `yieldTarget` のバリデーションが欠落しており、負値や50%超の値でもシミュレーションが実行される問題を修正します。

## 変更内容

- `validateQuick()` 内に `yieldTarget` の範囲チェックを追加
  - 条件: `yieldTarget <= 0 || yieldTarget > 0.5`（0%超〜50%）
  - エラーメッセージ: `"目標利回りは0〜50%の範囲で入力してください"`
  - `validateFull()` の同フィールドチェックと同等の制約に統一

## 関連Issue

Closes #591

## テスト

- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み