### PR TITLE
fix(domain): IRR二分法の収束判定を絶対誤差から相対誤差に変更

### DIFF
--- a/backend/internal/domain/exit.go
+++ b/backend/internal/domain/exit.go
@@ -251,12 +251,15 @@ func CalcNPV(cfs []float64, terminalValue, discountRate, initialInvestment float
 }
 
 // CalcIRR は二分法で IRR を求める。収束しない場合は nil と error を返す。
+// 収束判定は相対誤差ベース（|NPV| / |initialInvestment| < 1e-6）で行う。
+// initialInvestment がゼロの場合は絶対誤差（|NPV| < 1.0）にフォールバックする。
 func CalcIRR(cfs []float64, terminalValue, initialInvestment float64) (*float64, error) {
 	const (
 		lo      = -0.50
 		hi      = 2.00
 		maxIter = 200
-		tol     = 1.0
+		relTol  = 1e-6
+		absTol  = 1.0
 	)
 	npvLo := CalcNPV(cfs, terminalValue, lo, initialInvestment)
 	npvHi := CalcNPV(cfs, terminalValue, hi, initialInvestment)
@@ -267,7 +270,13 @@ func CalcIRR(cfs []float64, terminalValue, initialInvestment float64) (*float64,
 	for i := 0; i < maxIter; i++ {
 		mid := (low + high) / 2
 		npvMid := CalcNPV(cfs, terminalValue, mid, initialInvestment)
-		if math.Abs(npvMid) < tol {
+		var converged bool
+		if math.Abs(initialInvestment) > 0 {
+			converged = math.Abs(npvMid)/math.Abs(initialInvestment) < relTol
+		} else {
+			converged = math.Abs(npvMid) < absTol
+		}
+		if converged {
 			v := mid
 			return &v, nil
 		}


### PR DESCRIPTION
## 概要
`CalcIRR()` の収束判定が絶対誤差（±1円）固定だったため、投資規模によって精度が変動していた。相対誤差（`|NPV| / |initialInvestment| < 1e-6`）ベースに変更し、スケール非依存の収束判定を実現する。

## 変更内容
- `backend/internal/domain/exit.go` の `CalcIRR()` 収束条件を変更
  - 旧: `math.Abs(npvMid) < 1.0`（絶対誤差 ±1円）
  - 新: `math.Abs(npvMid) / math.Abs(initialInvestment) < 1e-6`（相対誤差）
  - `initialInvestment` がゼロの場合は絶対誤差（±1円）にフォールバック
- `tol` 定数を `relTol = 1e-6` / `absTol = 1.0` に分割
- 関数コメントに収束判定ロジックを記載

## 関連Issue
Closes #589

## テスト
- [x] 既存テストが通ること（`go test -race ./internal/domain/... -timeout 120s` PASS）
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み