### PR TITLE
E2EテストをfullyParallel実行に切り替える

### DIFF
--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
-  fullyParallel: false,
+  fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 2 : undefined,


### PR DESCRIPTION
## 概要

`playwright.config.ts` の `fullyParallel: false` を `fullyParallel: true` に変更し、E2Eテストを完全並列実行に切り替えます。

各E2EテストはAPIモックと独自ページインスタンスを持ち互いに独立しているため、並列実行しても干渉しません。テスト数の増加に伴うフィードバック時間の増大を抑制します。

## 変更内容

- `frontend/playwright.config.ts`: `fullyParallel: false` → `fullyParallel: true`

## 関連Issue

Closes #605

## テスト

- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み