### PR TITLE
chore(ci): PR時はE2Eスモークテストのみ、main pushでフルスイートを実行

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -100,13 +100,15 @@ jobs:
       - name: Install Playwright Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Run E2E tests
-        run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            npm run e2e:ci -- --grep "@p1[^0-9]|@p2[^0-9]"
-          else
-            npm run e2e:ci
-          fi
+      - name: E2E smoke tests
+        if: github.event_name == 'pull_request'
+        run: npm run e2e:ci -- --grep "@p1|@p2"
+        env:
+          CI: "true"
+
+      - name: E2E full suite
+        if: github.ref == 'refs/heads/main'
+        run: npm run e2e:ci
         env:
           CI: "true"
 


### PR DESCRIPTION
## 概要

PR時の全E2Eテスト実行によるCI時間の増大を解消するため、テストの優先度タグ（`@p1`/`@p2`/`@p3`）を活用してCIステップを分割する。

## 変更内容

- `.github/workflows/frontend-ci.yml`
  - E2Eステップをシェルの `if` 分岐から GitHub Actions の `if:` 条件付き個別ステップへ変更
  - **E2E smoke tests**（PR時）: `--grep "@p1|@p2"` でクリティカルパス・重要機能のみ実行
  - **E2E full suite**（`main` push時）: `--grep` なしで全スペックを実行

### タグ戦略（既存）

| タグ | 対象 | 該当スペック |
|------|------|-------------|
| `@p1` | クリティカルパス | quick-mode, full-mode, error-handling (503) |
| `@p2` | 重要機能 | watchlist, url-sharing, land-price-fetch, mode-switch, error-handling (429) |
| `@p3` | オプション機能 | pdf-export, area-discovery, error-handling (critical/hazard) |

> すべてのスペックはすでに適切なタグが付与済みのため、スペックファイル自体の変更はなし。

## 関連Issue

Closes #607

## テスト

- [ ] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み