### PR TITLE
fix(monitoring): ログベースメトリクスのalignerをALIGN_SUMに修正

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -290,7 +290,7 @@ resource "google_monitoring_alert_policy" "warmup_job_failure" {
       duration        = "0s"
       aggregations {
         alignment_period     = "1800s"
-        per_series_aligner   = "ALIGN_COUNT_TRUE"
+        per_series_aligner   = "ALIGN_SUM"
         cross_series_reducer = "REDUCE_SUM"
         group_by_fields      = ["metric.labels.job_id"]
       }


### PR DESCRIPTION
## 概要

`terraform apply` でアラートポリシー作成時に以下のエラーが発生したため修正。

## エラー

```
Field aggregation.perSeriesAligner had an invalid value of "ALIGN_COUNT_TRUE":
The aligner cannot be applied to metrics with kind DELTA and value type INT64.
```

## 原因

`ALIGN_COUNT_TRUE` はBOOLメトリクス用のaligner。ログベースメトリクスはDELTA/INT64のため `ALIGN_SUM` が正しい。

## 修正

`ALIGN_COUNT_TRUE` → `ALIGN_SUM`

## 関連

- #594 のアラートポリシー設定ミスを修正