### PR TITLE
test(e2e): Page Object Model でシミュレーション操作を集約する

### DIFF
--- a/frontend/e2e/full-mode.spec.ts
+++ b/frontend/e2e/full-mode.spec.ts
@@ -1,29 +1,24 @@
 import { test, expect } from "@playwright/test";
 import analyzeFixture from "./fixtures/analyze-response.json";
-import { setupApiMocks } from "./helpers/routes";
-import { ONBOARDING_KEY } from "./helpers/constants";
+import { SimulationPage } from "./pages/simulation.page";
 
 test.describe("Full mode ハッピーパス", () => {
-  test.beforeEach(async ({ page }) => {
-    await setupApiMocks(page);
-    await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-    await page.goto("/");
-    await page.getByRole("radio", { name: "詳細" }).click();
-  });
-
   test("@p1 利回りとチャートが描画される", async ({ page }) => {
-    await page.getByLabel("土地取得価格").fill("1200");
-    await page.getByLabel("建物価格").fill("800");
-    await page.getByLabel("築年数").fill("20");
-    await page.getByLabel("想定月額賃料").fill("15");
-    await page.getByLabel("ローン金額").fill("1600");
-    await page.getByText("シミュレーション実行").click();
+    const sim = new SimulationPage(page);
+    await sim.setup();
+    await sim.runFullSimulation({
+      landPrice: "1200",
+      buildingCost: "800",
+      buildingAge: "20",
+      monthlyRent: "15",
+      loanAmount: "1600",
+    });
 
-    await expect(page.getByTestId("gross-yield-value")).toHaveText("9.89", { timeout: 10_000 });
-    await expect(page.getByTestId("yield-threshold-badge")).toBeVisible({ timeout: 5_000 });
+    await expect(sim.grossYield()).toHaveText("9.89");
+    await expect(sim.yieldBadge()).toBeVisible({ timeout: 5_000 });
 
-    await expect(page.getByTestId("cashflow-chart-heading")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("dead-cross-chart-heading")).toBeVisible({ timeout: 5_000 });
+    await expect(sim.cashflowChartHeading()).toBeVisible({ timeout: 5_000 });
+    await expect(sim.deadCrossChartHeading()).toBeVisible({ timeout: 5_000 });
   });
 });
 
@@ -31,7 +26,8 @@ test.describe("Full mode リクエストボディ検証", () => {
   test("@p1 送信時にリクエストボディが正しく構成される", async ({ page }) => {
     let capturedBody: Record<string, unknown> | null = null;
 
-    await setupApiMocks(page, {
+    const sim = new SimulationPage(page);
+    await sim.setup({
       analyze: {
         status: 200,
         body: analyzeFixture,
@@ -40,17 +36,15 @@ test.describe("Full mode リクエストボディ検証", () => {
         },
       },
     });
-    await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-    await page.goto("/");
-    await page.getByRole("radio", { name: "詳細" }).click();
 
-    await page.getByLabel("土地取得価格").fill("1200");
-    await page.getByLabel("建物価格").fill("800");
-    await page.getByLabel("築年数").fill("20");
-    await page.getByLabel("想定月額賃料").fill("150000");
-    await page.getByText("シミュレーション実行").click();
+    await sim.runFullSimulation({
+      landPrice: "1200",
+      buildingCost: "800",
+      buildingAge: "20",
+      monthlyRent: "150000",
+    });
 
-    await expect(page.getByTestId("gross-yield-value")).toHaveText("9.89", { timeout: 10_000 });
+    await expect(sim.grossYield()).toHaveText("9.89");
 
     expect(capturedBody).not.toBeNull();
     expect(capturedBody!["landPrice"]).toBe(12000000);

--- a/frontend/e2e/mode-switch.spec.ts
+++ b/frontend/e2e/mode-switch.spec.ts
@@ -1,20 +1,17 @@
 import { test, expect } from "@playwright/test";
-import { setupApiMocks } from "./helpers/routes";
-import { ONBOARDING_KEY } from "./helpers/constants";
+import { SimulationPage } from "./pages/simulation.page";
 
 test.beforeEach(async ({ page }) => {
-  await setupApiMocks(page);
-  await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-  await page.goto("/");
+  const sim = new SimulationPage(page);
+  await sim.setup();
 });
 
 test("@p2 モード切替：Quick分析後に詳細へ切り替えると結果がクリアされバナーが表示される", async ({
   page,
 }) => {
-  await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
-  await page.getByLabel("想定月額賃料").fill("15");
-  await page.getByText("シミュレーション実行").click();
-  await expect(page.getByTestId("gross-yield-value")).toHaveText("9.89", { timeout: 10_000 });
+  const sim = new SimulationPage(page);
+  await sim.runQuickSimulation("1700", "15");
+  await expect(sim.grossYield()).toHaveText("9.89");
 
   // 詳細モードに切り替え
   await page.getByRole("radio", { name: "詳細" }).click();
@@ -25,5 +22,5 @@ test("@p2 モード切替：Quick分析後に詳細へ切り替えると結果�
     )
   ).toBeVisible({ timeout: 3_000 });
   // 結果値が消えている
-  await expect(page.getByTestId("gross-yield-value")).toBeHidden();
+  await expect(sim.grossYield()).toBeHidden();
 });

--- a/frontend/e2e/pages/simulation.page.ts
+++ b/frontend/e2e/pages/simulation.page.ts
@@ -1,0 +1,76 @@
+import type { Page } from "@playwright/test";
+import { expect } from "@playwright/test";
+import { setupApiMocks, type ApiOverrides } from "../helpers/routes";
+import { ONBOARDING_KEY } from "../helpers/constants";
+
+export class SimulationPage {
+  constructor(private page: Page) {}
+
+  async setup(overrides: ApiOverrides = {}) {
+    await setupApiMocks(this.page, overrides);
+    await this.page.addInitScript(
+      (key) => localStorage.setItem(key, "1"),
+      ONBOARDING_KEY
+    );
+    await this.page.goto("/");
+  }
+
+  /** API モックと onboarding フラグだけ設定し、navigate しない（別の URL に goto する直前に使う） */
+  async setupMocksOnly(overrides: ApiOverrides = {}) {
+    await setupApiMocks(this.page, overrides);
+    await this.page.addInitScript(
+      (key) => localStorage.setItem(key, "1"),
+      ONBOARDING_KEY
+    );
+  }
+
+  async runQuickSimulation(price: string, rent: string) {
+    await this.page.getByLabel("物件価格（土地＋建物の総額）").fill(price);
+    await this.page.getByLabel("想定月額賃料").fill(rent);
+    await this.page.getByText("シミュレーション実行").click();
+    await expect(this.page.getByTestId("gross-yield-value")).toHaveText(/.+/, {
+      timeout: 10_000,
+    });
+  }
+
+  async runFullSimulation(params: {
+    landPrice: string;
+    buildingCost: string;
+    buildingAge: string;
+    monthlyRent: string;
+    loanAmount?: string;
+  }) {
+    await this.page.getByRole("radio", { name: "詳細" }).click();
+    await this.page.getByLabel("土地取得価格").fill(params.landPrice);
+    await this.page.getByLabel("建物価格").fill(params.buildingCost);
+    await this.page.getByLabel("築年数").fill(params.buildingAge);
+    await this.page.getByLabel("想定月額賃料").fill(params.monthlyRent);
+    if (params.loanAmount) {
+      await this.page.getByLabel("ローン金額").fill(params.loanAmount);
+    }
+    await this.page.getByText("シミュレーション実行").click();
+    await expect(this.page.getByTestId("gross-yield-value")).toHaveText(/.+/, {
+      timeout: 10_000,
+    });
+  }
+
+  grossYield() {
+    return this.page.getByTestId("gross-yield-value");
+  }
+
+  yieldBadge() {
+    return this.page.getByTestId("yield-threshold-badge");
+  }
+
+  dscrValue() {
+    return this.page.getByTestId("dscr-value");
+  }
+
+  cashflowChartHeading() {
+    return this.page.getByTestId("cashflow-chart-heading");
+  }
+
+  deadCrossChartHeading() {
+    return this.page.getByTestId("dead-cross-chart-heading");
+  }
+}

--- a/frontend/e2e/pdf-export.spec.ts
+++ b/frontend/e2e/pdf-export.spec.ts
@@ -1,22 +1,15 @@
 import { test, expect } from "@playwright/test";
 import analyzeCriticalFixture from "./fixtures/analyze-response-critical.json";
-import { setupApiMocks } from "./helpers/routes";
-import { ONBOARDING_KEY } from "./helpers/constants";
+import { SimulationPage } from "./pages/simulation.page";
 
 // デフォルト fixture (analyze-response.json) には multiExitComparison が含まれるため
 // beforeEach のセットアップで判定サマリー・出口比較テーブルの両セクションをカバーできる
 test.describe("PDF出力 — デフォルト fixture (OK判定 / multiExitComparison あり)", () => {
-  test.beforeEach(async ({ page }) => {
-    await setupApiMocks(page);
-    await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-    await page.goto("/");
-  });
-
   test("@p3 ダウンロードイベントが発生しファイル名が .pdf で終わる", async ({ page }) => {
-    await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
-    await page.getByLabel("想定月額賃料").fill("15");
-    await page.getByText("シミュレーション実行").click();
-    await expect(page.getByTestId("gross-yield-value")).toHaveText("9.89", { timeout: 10_000 });
+    const sim = new SimulationPage(page);
+    await sim.setup();
+    await sim.runQuickSimulation("1700", "15");
+    await expect(sim.grossYield()).toHaveText("9.89");
 
     const downloadPromise = page.waitForEvent("download", { timeout: 30_000 });
     await page.getByText("PDFレポート出力").click();
@@ -29,15 +22,11 @@ test.describe("PDF出力 — デフォルト fixture (OK判定 / multiExitCompar
 // RISK判定（criticalErrors=REJECT）では StatusSummary が "リスク" になる
 // マイナスエクイティの multiExitComparison でも PDF が例外なく生成されることを確認
 test.describe("PDF出力 — RISK判定 fixture (criticalErrors=REJECT / マイナスエクイティ)", () => {
-  test.beforeEach(async ({ page }) => {
-    await setupApiMocks(page, {
+  test("@p3 RISK判定でPDFが生成される", async ({ page }) => {
+    const sim = new SimulationPage(page);
+    await sim.setup({
       analyze: { status: 200, body: analyzeCriticalFixture },
     });
-    await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-    await page.goto("/");
-  });
-
-  test("@p3 RISK判定でPDFが生成される", async ({ page }) => {
     await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
     await page.getByLabel("想定月額賃料").fill("15");
     await page.getByText("シミュレーション実行").click();

--- a/frontend/e2e/quick-mode.spec.ts
+++ b/frontend/e2e/quick-mode.spec.ts
@@ -1,23 +1,16 @@
 import { test, expect } from "@playwright/test";
 import analyzeFixture from "./fixtures/analyze-response.json";
-import { setupApiMocks } from "./helpers/routes";
-import { ONBOARDING_KEY } from "./helpers/constants";
+import { SimulationPage } from "./pages/simulation.page";
 
 test.describe("Quick mode ハッピーパス", () => {
-  test.beforeEach(async ({ page }) => {
-    await setupApiMocks(page);
-    await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-    await page.goto("/");
-  });
-
   test("@p1 利回りバッジが緑でDSCRが表示される", async ({ page }) => {
-    await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
-    await page.getByLabel("想定月額賃料").fill("15");
-    await page.getByText("シミュレーション実行").click();
+    const sim = new SimulationPage(page);
+    await sim.setup();
+    await sim.runQuickSimulation("1700", "15");
 
-    await expect(page.getByTestId("gross-yield-value")).toHaveText("9.89", { timeout: 10_000 });
-    await expect(page.getByTestId("yield-threshold-badge")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("dscr-value").first()).toBeVisible();
+    await expect(sim.grossYield()).toHaveText("9.89");
+    await expect(sim.yieldBadge()).toBeVisible({ timeout: 5_000 });
+    await expect(sim.dscrValue().first()).toBeVisible();
   });
 });
 
@@ -25,7 +18,8 @@ test.describe("Quick mode リクエストボディ検証", () => {
   test("@p1 送信時にリクエストボディが正しく構成される", async ({ page }) => {
     let capturedBody: Record<string, unknown> | null = null;
 
-    await setupApiMocks(page, {
+    const sim = new SimulationPage(page);
+    await sim.setup({
       analyze: {
         status: 200,
         body: analyzeFixture,
@@ -34,14 +28,10 @@ test.describe("Quick mode リクエストボディ検証", () => {
         },
       },
     });
-    await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-    await page.goto("/");
 
-    await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
-    await page.getByLabel("想定月額賃料").fill("150000");
-    await page.getByText("シミュレーション実行").click();
+    await sim.runQuickSimulation("1700", "150000");
 
-    await expect(page.getByTestId("gross-yield-value")).toHaveText("9.89", { timeout: 10_000 });
+    await expect(sim.grossYield()).toHaveText("9.89");
 
     expect(capturedBody).not.toBeNull();
     expect(capturedBody!["monthlyRent"]).toBe(150000);

--- a/frontend/e2e/url-sharing.spec.ts
+++ b/frontend/e2e/url-sharing.spec.ts
@@ -1,19 +1,14 @@
 import { test, expect } from "@playwright/test";
-import { setupApiMocks } from "./helpers/routes";
-import { ONBOARDING_KEY } from "./helpers/constants";
+import { SimulationPage } from "./pages/simulation.page";
 
 test("@p2 URL共有：分析後のURLを開くとフォームが復元され結果が表示される", async ({
   page,
   context,
 }) => {
-  await setupApiMocks(page);
-  await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-  await page.goto("/");
-
-  await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
-  await page.getByLabel("想定月額賃料").fill("15");
-  await page.getByText("シミュレーション実行").click();
-  await expect(page.getByTestId("gross-yield-value")).toHaveText("9.89", { timeout: 10_000 });
+  const sim = new SimulationPage(page);
+  await sim.setup();
+  await sim.runQuickSimulation("1700", "15");
+  await expect(sim.grossYield()).toHaveText("9.89");
 
   // Clipboard 権限を付与してシェアボタンをクリック
   await context.grantPermissions(["clipboard-read", "clipboard-write"]);
@@ -26,8 +21,8 @@ test("@p2 URL共有：分析後のURLを開くとフォームが復元され結�
 
   // 新しいページで URL を開く
   const newPage = await context.newPage();
-  await setupApiMocks(newPage);
-  await newPage.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
+  const newSim = new SimulationPage(newPage);
+  await newSim.setupMocksOnly();
   await newPage.goto(sharedUrl);
 
   // フォームが復元されている（quickTotalPriceMan パラメータ経由）
@@ -36,5 +31,5 @@ test("@p2 URL共有：分析後のURLを開くとフォームが復元され結�
   });
   // 再度シミュレーション実行して結果を表示
   await newPage.getByText("シミュレーション実行").click();
-  await expect(newPage.getByTestId("gross-yield-value")).toHaveText("9.89", { timeout: 10_000 });
+  await expect(newSim.grossYield()).toHaveText("9.89", { timeout: 10_000 });
 });

--- a/frontend/e2e/watchlist.spec.ts
+++ b/frontend/e2e/watchlist.spec.ts
@@ -1,23 +1,14 @@
 import { test, expect } from "@playwright/test";
-import type { Page } from "@playwright/test";
-import { setupApiMocks } from "./helpers/routes";
-import { ONBOARDING_KEY } from "./helpers/constants";
+import { SimulationPage } from "./pages/simulation.page";
 
 test.beforeEach(async ({ page }) => {
-  await setupApiMocks(page);
-  await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
-  await page.goto("/");
+  const sim = new SimulationPage(page);
+  await sim.setup();
 });
 
-async function runQuickAnalysis(page: Page) {
-  await page.getByLabel("物件価格（土地＋建物の総額）").fill("1700");
-  await page.getByLabel("想定月額賃料").fill("15");
-  await page.getByText("シミュレーション実行").click();
-  await expect(page.getByTestId("gross-yield-value")).toHaveText("9.89", { timeout: 10_000 });
-}
-
 test("@p2 ウォッチリスト：追加するとトーストが表示される", async ({ page }) => {
-  await runQuickAnalysis(page);
+  const sim = new SimulationPage(page);
+  await sim.runQuickSimulation("1700", "15");
 
   await page.getByRole("textbox", { name: "物件名" }).fill("渋谷区テスト物件");
   await page.getByTestId("watchlist-add-button").click();
@@ -29,7 +20,8 @@ test("@p2 ウォッチリスト：追加するとトーストが表示される"
 });
 
 test("@p2 ウォッチリスト：ページリロード後もエントリが残る", async ({ page }) => {
-  await runQuickAnalysis(page);
+  const sim = new SimulationPage(page);
+  await sim.runQuickSimulation("1700", "15");
 
   await page.getByRole("textbox", { name: "物件名" }).fill("永続化テスト物件");
   await page.getByTestId("watchlist-add-button").click();


### PR DESCRIPTION
## 概要

各 E2E spec に重複していたシミュレーション操作コード（API モック設定・onboarding フラグ設定・フォーム入力・実行ボタンクリック）を `SimulationPage` Page Object Model クラスに集約し、1 箇所の変更で全 spec に反映できる構造にした。

Closes #608

## 変更内容

- `frontend/e2e/pages/simulation.page.ts` を新規作成
  - `setup(overrides?)` — API モック・onboarding・`goto("/")` をまとめて実行
  - `setupMocksOnly(overrides?)` — モック設定のみ（URL 共有テストの 2 ページ目向け）
  - `runQuickSimulation(price, rent)` — Quick モードの入力・実行・待機
  - `runFullSimulation(params)` — Full モードの入力・実行・待機
  - `grossYield()` / `yieldBadge()` / `dscrValue()` / `cashflowChartHeading()` / `deadCrossChartHeading()` — ロケーターゲッター
- 以下の 6 spec を `SimulationPage` 経由に移行
  - `quick-mode.spec.ts`
  - `full-mode.spec.ts`
  - `watchlist.spec.ts`（`runQuickAnalysis` ヘルパー関数を POM に統合）
  - `pdf-export.spec.ts`
  - `url-sharing.spec.ts`
  - `mode-switch.spec.ts`

## テスト

- [x] 既存テストが通ること
- [x] `npx tsc --noEmit` でエラーなし

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] 過度な抽象化を避け、複数 spec で重複している箇所のみを対象にした
- [x] 1 箇所でしか使われていない操作（PDF ダウンロード待機・ウォッチリスト操作等）は POM に取り込んでいない