### PR TITLE
fix(e2e): ハザードレスポンス後のシミュレーション実行ボタン待機を追加してCIフレーキーを修正

### DIFF
--- a/frontend/e2e/error-handling.spec.ts
+++ b/frontend/e2e/error-handling.spec.ts
@@ -76,7 +76,9 @@ test("@p3 ハザードアラートバナー：洪水リスクが表示される"
   await page.getByRole("button", { name: "相場データを取得" }).click();
   await hazardResponse;
 
-  await page.getByText("シミュレーション実行").click();
+  const simulateBtn = page.getByText("シミュレーション実行");
+  await expect(simulateBtn).toBeVisible({ timeout: 10_000 });
+  await simulateBtn.click();
 
   const hazardBanner = page.getByRole("alert", { name: "ハザード警告" });
   await expect(hazardBanner).toBeVisible({ timeout: 10_000 });


### PR DESCRIPTION
## 背景

PR #614・#615 のmainマージ時にCIが継続的に失敗していた。

## 現状の問題

\`error-handling.spec.ts\` の \`@p3 ハザードアラートバナー：洪水リスクが表示される\` テストが、CIで30秒タイムアウトを繰り返していた。

\`\`\`
Error: locator.click: Test timeout of 30000ms exceeded.
waiting for getByText('シミュレーション実行')
\`\`\`

**原因**: \`waitForResponse("**/api/hazard**")\` の解決はネットワーク完了を意味するが、その後のUI再レンダリングが完了する前に \`.click()\` を呼び出していたため、ボタンが見つからない・操作不能な状態でタイムアウトしていた。

## 変更内容

- \`frontend/e2e/error-handling.spec.ts\`
  - ハザードAPIレスポンス受信後、「シミュレーション実行」ボタンの \`toBeVisible\` を待機してからクリックするよう変更

\`\`\`ts
// 変更前
await hazardResponse;
await page.getByText("シミュレーション実行").click();

// 変更後
await hazardResponse;
const simulateBtn = page.getByText("シミュレーション実行");
await expect(simulateBtn).toBeVisible({ timeout: 10_000 }); // UI安定待機を追加
await simulateBtn.click();
\`\`\`

## 関連

- PR #614 のCIで初めて発覚
- PR #615 のCIでも同じ箇所で失敗

## テスト

- [ ] 既存テストが引き続きパスする
- [ ] \`@p3 ハザードアラートバナー\` テストがCIで安定してパスする