### PR TITLE
fix(domain): 投資入力バリデーション強化（オーバーローン警告・CapexSchedule 範囲外チェック）

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -145,6 +145,19 @@ func calcCriticalErrors(input InvestmentInput, deadCrossYear, usefulLife int) []
 		})
 	}
 
+	// OVERLOAN: ローン金額が土地取得費＋建築費を超過
+	if input.LoanAmount > input.LandPrice+input.BuildingCost {
+		errs = append(errs, CriticalError{
+			Code:   "OVERLOAN",
+			Status: CriticalStatusWarning,
+			Message: fmt.Sprintf(
+				"ローン金額（%.0f万円）が物件取得費（%.0f万円）を超えています。"+
+					"オーバーローンは審査否決や担保割れリスクがあります。",
+				input.LoanAmount/10000, (input.LandPrice+input.BuildingCost)/10000,
+			),
+		})
+	}
+
 	if errs == nil {
 		errs = []CriticalError{}
 	}

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -3192,3 +3192,46 @@ func TestOverloanWarning(t *testing.T) {
 		}
 	})
 }
+
+// TestValidateCapexScheduleYear は CapexSchedule の年数が HoldingYears を超える場合にエラーが返ることを検証する。
+func TestValidateCapexScheduleYear(t *testing.T) {
+	base := InvestmentInput{
+		VacancyRate:  0.05,
+		LoanYears:    35,
+		HoldingYears: 10,
+	}
+
+	t.Run("capex year within HoldingYears", func(t *testing.T) {
+		in := base
+		in.CapexSchedule = []CapexEvent{{Year: 10, Amount: 1_000_000}}
+		if err := in.Validate(); err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("capex year exceeds HoldingYears", func(t *testing.T) {
+		in := base
+		in.CapexSchedule = []CapexEvent{{Year: 11, Amount: 1_000_000}}
+		if err := in.Validate(); err == nil {
+			t.Error("expected error for CapexSchedule year exceeding HoldingYears")
+		}
+	})
+
+	t.Run("multiple capex events with one exceeding", func(t *testing.T) {
+		in := base
+		in.CapexSchedule = []CapexEvent{
+			{Year: 5, Amount: 500_000},
+			{Year: 15, Amount: 1_000_000}, // 15 > HoldingYears(10)
+		}
+		if err := in.Validate(); err == nil {
+			t.Error("expected error for CapexSchedule year 15 exceeding HoldingYears 10")
+		}
+	})
+
+	t.Run("empty capex schedule passes", func(t *testing.T) {
+		in := base
+		if err := in.Validate(); err != nil {
+			t.Errorf("unexpected error for empty CapexSchedule: %v", err)
+		}
+	})
+}

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -3138,3 +3138,57 @@ func TestCalcAnnualTurnoverCost(t *testing.T) {
 		})
 	}
 }
+
+// TestOverloanWarning はローン金額が物件取得費を超える場合に OVERLOAN WARNING が返されることを検証する。
+func TestOverloanWarning(t *testing.T) {
+	t.Run("overloan emits WARNING", func(t *testing.T) {
+		input := InvestmentInput{
+			LandPrice:       5_000_000,
+			BuildingCost:    10_000_000,
+			LoanAmount:      16_000_000, // 土地+建物(15,000,000)を超過
+			MonthlyRent:     100_000,
+			VacancyRate:     0.05,
+			AnnualLoanRate:  0.015,
+			LoanYears:       35,
+			BuildingType:    BuildingTypeWood,
+			ExpenseRate:     0.20,
+			IncomeTaxRate:   0.33,
+			HoldingYears:    10,
+			ExitYieldTarget: 0.06,
+		}
+		result := Analyze(context.Background(), input)
+		var found bool
+		for _, ce := range result.CriticalErrors {
+			if ce.Code == "OVERLOAN" && ce.Status == CriticalStatusWarning {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected OVERLOAN WARNING in CriticalErrors, got: %v", result.CriticalErrors)
+		}
+	})
+
+	t.Run("no overloan within limit", func(t *testing.T) {
+		input := InvestmentInput{
+			LandPrice:       5_000_000,
+			BuildingCost:    10_000_000,
+			LoanAmount:      15_000_000, // 土地+建物と同額: 超過なし
+			MonthlyRent:     100_000,
+			VacancyRate:     0.05,
+			AnnualLoanRate:  0.015,
+			LoanYears:       35,
+			BuildingType:    BuildingTypeWood,
+			ExpenseRate:     0.20,
+			IncomeTaxRate:   0.33,
+			HoldingYears:    10,
+			ExitYieldTarget: 0.06,
+		}
+		result := Analyze(context.Background(), input)
+		for _, ce := range result.CriticalErrors {
+			if ce.Code == "OVERLOAN" {
+				t.Errorf("unexpected OVERLOAN in CriticalErrors: %v", ce)
+			}
+		}
+	})
+}

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -216,6 +216,18 @@ func (i *InvestmentInput) Validate() error {
 			"建物の償却方法は定額法のみです（1998年4月以降取得の建物は定率法を選択できません）",
 		)
 	}
+	holdingYears := i.HoldingYears
+	if holdingYears == 0 {
+		holdingYears = 10 // Defaults() 適用前に呼ばれる場合の保護
+	}
+	for _, ev := range i.CapexSchedule {
+		if ev.Year > holdingYears {
+			return fmt.Errorf(
+				"CapexSchedule: year %d exceeds HoldingYears %d",
+				ev.Year, holdingYears,
+			)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## 概要

`backend/internal/domain/types.go` の `Validate()` および `calcCriticalErrors()` に2件のバリデーション強化を実施した。

- issue #590: オーバーローン時に `CriticalErrors` へ WARNING を追加
- issue #593: `CapexSchedule[i].Year > HoldingYears` の場合に `Validate()` がエラーを返す

## 変更内容

- `calcCriticalErrors()` に OVERLOAN チェックを追加（`LoanAmount > LandPrice + BuildingCost` → `CriticalStatusWarning`）
- `Validate()` に CapexSchedule 範囲外チェックを追加（`ev.Year > HoldingYears` → `fmt.Errorf`）
- `investment_test.go` に `TestOverloanWarning`・`TestValidateCapexScheduleYear` を追加

## 関連Issue

Closes #590
Closes #593

## テスト

- [x] 既存テストが通ること
- [x] 新規テストを追加した場合、全ケースがPASSすること

```
ok  github.com/yield-guard/backend/internal/domain  3.507s
```

## 確認事項

- [x] コードレビュー観点での自己レビュー済み