### PR TITLE
fix(ci): Vercel プレビュー URL 抽出を Vercel CLI v51 出力形式に対応させる

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -156,7 +156,8 @@ jobs:
         if: github.event_name == 'pull_request'
         id: preview
         run: |
-          OUTPUT=$(vercel deploy --yes 2>&1)
+          # || true prevents set -e from exiting before we can inspect the output
+          OUTPUT=$(vercel deploy --yes 2>&1) || true
           echo "$OUTPUT"
           # Vercel CLI v51 outputs "✅  Preview: https://xxx.vercel.app [3s]"
           # tail -1 picks the Preview URL; the Inspect URL (vercel.com) is excluded by the pattern

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -157,9 +157,9 @@ jobs:
         run: |
           OUTPUT=$(vercel deploy --yes 2>&1)
           echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -E '^https://' | tail -1)
+          URL=$(echo "$OUTPUT" | grep -oE 'https://[^ ]+\.vercel\.app' | tail -1)
           if [ -z "$URL" ]; then
-            echo "::error::Vercel deploy failed or URL not found"
+            echo "::error::Vercel deploy failed or preview URL not found in output"
             exit 1
           fi
           echo "url=$URL" >> $GITHUB_OUTPUT
@@ -168,6 +168,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          NO_COLOR: "1"
 
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request'

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -150,6 +150,7 @@ jobs:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          NO_COLOR: "1"
 
       - name: Deploy to Vercel (preview)
         if: github.event_name == 'pull_request'
@@ -157,7 +158,9 @@ jobs:
         run: |
           OUTPUT=$(vercel deploy --yes 2>&1)
           echo "$OUTPUT"
-          URL=$(echo "$OUTPUT" | grep -oE 'https://[^ ]+\.vercel\.app' | tail -1)
+          # Vercel CLI v51 outputs "✅  Preview: https://xxx.vercel.app [3s]"
+          # tail -1 picks the Preview URL; the Inspect URL (vercel.com) is excluded by the pattern
+          URL=$(echo "$OUTPUT" | grep -oE 'https://[a-zA-Z0-9._-]+\.vercel\.app' | tail -1)
           if [ -z "$URL" ]; then
             echo "::error::Vercel deploy failed or preview URL not found in output"
             exit 1


### PR DESCRIPTION
## 概要

Issue #629 に対応。

`Deploy to Vercel (preview)` ジョブが CI で失敗する原因は、URL 抽出の grep パターンが Vercel CLI v51 の出力形式に対応していなかったため。

## 原因

Vercel CLI v51 の出力形式：

```
✅  Preview: https://project-git-branch-hash-org.vercel.app [3s]
```

旧パターン `grep -E '^https://'` は行頭が `https://` であることを前提としていたが、実際の出力では絵文字＋ラベルが先行するためマッチしなかった。また ANSI カラーコードも含まれる場合があり、さらにマッチが困難になっていた。

## 変更内容

| 変更点 | 修正前 | 修正後 |
|--------|--------|--------|
| URL 抽出パターン | `grep -E '^https://'` | `grep -oE 'https://[^ ]+\.vercel\.app'` |
| ANSI コード対策 | なし | `NO_COLOR: "1"` 環境変数を追加 |
| エラーメッセージ | `Vercel deploy failed or URL not found` | `Vercel deploy failed or preview URL not found in output` |

## 動作確認

- `grep -oE 'https://[^ ]+\.vercel\.app'` は行内の任意の位置にある `.vercel.app` URL を抽出できる
- `NO_COLOR: "1"` により Vercel CLI が ANSI エスケープシーケンスを出力しなくなる
- 複数 URL が含まれる場合は `tail -1` で最後（Preview URL）を取得する
- URL が取得できない場合は引き続き exit 1 で CI を失敗させる

## 関連

- Issue #629
- `.github/workflows/frontend-ci.yml` の `Deploy to Vercel (preview)` ジョブ