### PR TITLE
軽微な技術負債の修正（Gemini cache eviction / AlertDialog / バリデーション整理）

### DIFF
--- a/backend/internal/ai/gemini.go
+++ b/backend/internal/ai/gemini.go
@@ -82,6 +82,10 @@ func NewSummarizer() Summarizer {
 	return s
 }
 
+// evictLoop は期限切れエントリを定期削除する。
+// GeminiSummarizer は Cloud Run プロセスと同じライフサイクルを持つシングルトンであり、
+// goroutine はプロセス終了まで稼働し続けることを意図している。
+// テスト時は GEMINI_API_KEY が未設定のため noopSummarizer が返され、この goroutine は起動しない。
 func (s *GeminiSummarizer) evictLoop() {
 	ticker := time.NewTicker(aiCacheEvictInterval)
 	defer ticker.Stop()

--- a/backend/internal/ai/gemini.go
+++ b/backend/internal/ai/gemini.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	aiCacheTTL         = 24 * time.Hour
-	aiCallTimeout      = 5 * time.Second
-	defaultGeminiModel = "gemini-2.5-flash"
+	aiCacheTTL          = 24 * time.Hour
+	aiCacheEvictInterval = time.Hour
+	aiCallTimeout        = 5 * time.Second
+	defaultGeminiModel   = "gemini-2.5-flash"
 )
 
 const systemPrompt = `あなたは日本の不動産投資専門アドバイザーです。
@@ -73,9 +74,26 @@ func NewSummarizer() Summarizer {
 		slog.Warn("Gemini init failed, AI summary disabled", "error", err)
 		return noopSummarizer{}
 	}
-	return &GeminiSummarizer{
+	s := &GeminiSummarizer{
 		client:  client,
 		entries: make(map[string]cacheEntry),
+	}
+	go s.evictLoop()
+	return s
+}
+
+func (s *GeminiSummarizer) evictLoop() {
+	ticker := time.NewTicker(aiCacheEvictInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		now := time.Now()
+		s.mu.Lock()
+		for k, e := range s.entries {
+			if now.After(e.expiresAt) {
+				delete(s.entries, k)
+			}
+		}
+		s.mu.Unlock()
 	}
 }
 

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -18,6 +18,10 @@ import (
 	"github.com/yield-guard/backend/internal/mlit"
 )
 
+// areaDiscoveryLimit はエリア探索で並列取得する市区町村の上限数。
+// 全市区町村を対象にするとタイムアウトリスクがあるため制限する（東京都は62市区町村）。
+const areaDiscoveryLimit = 30
+
 // MLITClient は国交省APIクライアントのインターフェース（テスト時にモック注入可能）
 type MLITClient interface {
 	FetchLandPrices(ctx context.Context, q mlit.LandPriceQuery) ([]domain.LandTransaction, error)
@@ -125,8 +129,7 @@ func (h *Handler) HandleAreaDiscovery(c *gin.Context) {
 		err  error
 	}
 
-	// 上位30市区町村に絞る（全件だとタイムアウトリスク）
-	limit := 30
+	limit := areaDiscoveryLimit
 	if len(municipalities) < limit {
 		limit = len(municipalities)
 	}

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -365,11 +365,6 @@ func TestValidateInvestmentInput_Boundaries(t *testing.T) {
 		{"holdingYears=0 → ok", withField(validBase, func(i *domain.InvestmentInput) { i.HoldingYears = 0 }), false},
 		{"holdingYears=50 → ok", withField(validBase, func(i *domain.InvestmentInput) { i.HoldingYears = 50 }), false},
 		{"holdingYears=51 → error", withField(validBase, func(i *domain.InvestmentInput) { i.HoldingYears = 51 }), true},
-		// RentDeclineRate
-		{"rentDeclineRate=-0.001 → error", withField(validBase, func(i *domain.InvestmentInput) { i.RentDeclineRate = -0.001 }), true},
-		{"rentDeclineRate=0 → ok", withField(validBase, func(i *domain.InvestmentInput) { i.RentDeclineRate = 0 }), false},
-		{"rentDeclineRate=0.2 → ok", withField(validBase, func(i *domain.InvestmentInput) { i.RentDeclineRate = 0.2 }), false},
-		{"rentDeclineRate=0.201 → error", withField(validBase, func(i *domain.InvestmentInput) { i.RentDeclineRate = 0.201 }), true},
 		// BuildingType: アローリスト外は拒否（プロンプトインジェクション対策）
 		{"buildingType=木造 → ok", withField(validBase, func(i *domain.InvestmentInput) { i.BuildingType = domain.BuildingTypeWood }), false},
 		{"buildingType=RC造 → ok", withField(validBase, func(i *domain.InvestmentInput) { i.BuildingType = domain.BuildingTypeRC }), false},

--- a/backend/internal/api/investment_handler.go
+++ b/backend/internal/api/investment_handler.go
@@ -123,7 +123,9 @@ func (h *Handler) GetRentDeclineHint(c *gin.Context) {
 	c.JSON(http.StatusOK, hint)
 }
 
-// validateInvestmentInput は投資入力値の範囲チェックを行う
+// validateInvestmentInput は HTTP 境界での入力値の範囲チェックを行う。
+// ここでは Defaults() 適用前に必須フィールドと上限値を検証する。
+// クロスフィールド検証・ドメイン不変条件は Defaults() 後に呼ぶ input.Validate() が担う。
 func validateInvestmentInput(in domain.InvestmentInput) error {
 	if in.BuildingType != "" && !in.BuildingType.IsValid() {
 		return errors.New("buildingType が不正な値です")
@@ -164,9 +166,6 @@ func validateInvestmentInput(in domain.InvestmentInput) error {
 	if in.HoldingYears < 0 || in.HoldingYears > 50 {
 		return errors.New("holdingYears は 0〜50 年の範囲で指定してください")
 	}
-	if in.RentDeclineRate < 0 || in.RentDeclineRate > 0.2 {
-		return errors.New("rentDeclineRate は 0.0〜0.2 の範囲で指定してください")
-	}
 	// DiscountRate == 0 は「未指定」扱い: Defaults() で 0.05 に補完される
 	if in.DiscountRate < 0 || in.DiscountRate > 0.30 {
 		return errors.New("discountRate は 0〜30% の範囲で指定してください")
@@ -174,6 +173,7 @@ func validateInvestmentInput(in domain.InvestmentInput) error {
 	if in.PriceDeclineRate < 0 || in.PriceDeclineRate > 0.10 {
 		return errors.New("priceDeclineRate は 0〜10% の範囲で指定してください")
 	}
+	// depreciationMethod の名前妥当性のみ確認（建物への定率法禁止は domain.Validate() が検証）
 	if in.DepreciationMethod != "" &&
 		in.DepreciationMethod != domain.DepreciationMethodStraightLine &&
 		in.DepreciationMethod != domain.DepreciationMethodDecliningBalance {

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -170,7 +170,7 @@ func (i *InvestmentInput) Validate() error {
 	}
 	if i.RentDeclineRate < 0 || i.RentDeclineRate > 0.2 {
 		return fmt.Errorf(
-			"RentDeclineRate(%.3f) must be between 0.0 and 0.2",
+			"rentDeclineRate は 0.0〜0.2 の範囲で指定してください（指定値: %.3f）",
 			i.RentDeclineRate,
 		)
 	}

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -126,6 +126,7 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
     const target = items.find((item) => item.id === pendingDeleteId);
     setItems((prev) => prev.filter((item) => item.id !== pendingDeleteId));
     setSelectedIds((prev) => prev.filter((id) => id !== pendingDeleteId));
+    // setPendingDeleteId(null) は AlertDialog の onClose コールバックが担う
     toast({
       message: target ? `「${target.name}」を削除しました` : "削除しました",
       variant: "warning",

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
-import { Modal } from "@/components/ui/modal";
+import { AlertDialog } from "@/components/ui/alert-dialog";
 import { useToast } from "@/components/ui/toast";
 import {
   Trash2,
@@ -126,7 +126,6 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
     const target = items.find((item) => item.id === pendingDeleteId);
     setItems((prev) => prev.filter((item) => item.id !== pendingDeleteId));
     setSelectedIds((prev) => prev.filter((id) => id !== pendingDeleteId));
-    setPendingDeleteId(null);
     toast({
       message: target ? `「${target.name}」を削除しました` : "削除しました",
       variant: "warning",
@@ -328,29 +327,14 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
       {/* Comparison table */}
       {compareMode && selectedItems.length >= 2 && <WatchlistCompareTable items={selectedItems} />}
 
-      {/* Delete confirmation modal */}
-      <Modal
+      <AlertDialog
         open={pendingDeleteId !== null}
         onClose={() => setPendingDeleteId(null)}
         title="削除の確認"
-      >
-        <p className="text-sm text-foreground">
-          「{pendingDeleteName}」をウォッチリストから削除しますか？
-        </p>
-        <div className="mt-4 flex gap-2 justify-end">
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            onClick={() => setPendingDeleteId(null)}
-          >
-            キャンセル
-          </Button>
-          <Button type="button" variant="destructive" size="sm" onClick={handleDeleteConfirm}>
-            削除
-          </Button>
-        </div>
-      </Modal>
+        description={`「${pendingDeleteName}」をウォッチリストから削除しますか？`}
+        confirmLabel="削除"
+        onConfirm={handleDeleteConfirm}
+      />
     </>
   );
 }

--- a/frontend/src/components/__tests__/alert-dialog.test.tsx
+++ b/frontend/src/components/__tests__/alert-dialog.test.tsx
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { AlertDialog } from "@/components/ui/alert-dialog";
+
+describe("AlertDialog", () => {
+  afterEach(() => {
+    document.body.style.overflow = "";
+    delete document.body.dataset.modalCount;
+  });
+
+  it("open=true → role=alertdialog が表示される", () => {
+    render(
+      <AlertDialog
+        open={true}
+        onClose={vi.fn()}
+        title="削除の確認"
+        description="本当に削除しますか？"
+        onConfirm={vi.fn()}
+      />
+    );
+    expect(screen.getByRole("alertdialog")).toBeInTheDocument();
+    expect(screen.getByText("削除の確認")).toBeInTheDocument();
+    expect(screen.getByText("本当に削除しますか？")).toBeInTheDocument();
+  });
+
+  it("open=false → 何も描画されない", () => {
+    const { container } = render(
+      <AlertDialog
+        open={false}
+        onClose={vi.fn()}
+        title="削除の確認"
+        description="本当に削除しますか？"
+        onConfirm={vi.fn()}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("確認ボタン押下 → onConfirm と onClose が呼ばれる", () => {
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <AlertDialog
+        open={true}
+        onClose={onClose}
+        title="削除の確認"
+        description="本当に削除しますか？"
+        confirmLabel="削除"
+        onConfirm={onConfirm}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "削除" }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("キャンセルボタン押下 → onClose が呼ばれ onConfirm は呼ばれない", () => {
+    const onConfirm = vi.fn();
+    const onClose = vi.fn();
+    render(
+      <AlertDialog
+        open={true}
+        onClose={onClose}
+        title="削除の確認"
+        description="本当に削除しますか？"
+        onConfirm={onConfirm}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: "キャンセル" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onConfirm).not.toHaveBeenCalled();
+  });
+
+  it("ESC キー → onClose が呼ばれる", () => {
+    const onClose = vi.fn();
+    render(
+      <AlertDialog
+        open={true}
+        onClose={onClose}
+        title="削除の確認"
+        description="本当に削除しますか？"
+        onConfirm={vi.fn()}
+      />
+    );
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("backdrop クリック → onClose は呼ばれない（WAI-ARIA alertdialog）", () => {
+    const onClose = vi.fn();
+    render(
+      <AlertDialog
+        open={true}
+        onClose={onClose}
+        title="削除の確認"
+        description="本当に削除しますか？"
+        onConfirm={vi.fn()}
+      />
+    );
+    const backdrop = document.querySelector('[aria-hidden="true"]') as HTMLElement;
+    fireEvent.click(backdrop);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("open=true → document.body.style.overflow === 'hidden'", () => {
+    render(
+      <AlertDialog
+        open={true}
+        onClose={vi.fn()}
+        title="削除の確認"
+        description="本当に削除しますか？"
+        onConfirm={vi.fn()}
+      />
+    );
+    expect(document.body.style.overflow).toBe("hidden");
+  });
+
+  it("variant=destructive → AlertTriangle アイコンが表示される", () => {
+    render(
+      <AlertDialog
+        open={true}
+        onClose={vi.fn()}
+        title="削除の確認"
+        description="本当に削除しますか？"
+        onConfirm={vi.fn()}
+        variant="destructive"
+      />
+    );
+    // AlertTriangle は aria-hidden なので role でなく存在確認
+    const dialog = screen.getByRole("alertdialog");
+    const svgs = dialog.querySelectorAll('svg[aria-hidden="true"]');
+    expect(svgs.length).toBeGreaterThan(0);
+  });
+
+  it("aria-labelledby と aria-describedby が正しく設定されている", () => {
+    render(
+      <AlertDialog
+        open={true}
+        onClose={vi.fn()}
+        title="削除の確認"
+        description="本当に削除しますか？"
+        onConfirm={vi.fn()}
+      />
+    );
+    const dialog = screen.getByRole("alertdialog");
+    const labelledBy = dialog.getAttribute("aria-labelledby");
+    const describedBy = dialog.getAttribute("aria-describedby");
+    expect(labelledBy).toBeTruthy();
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(labelledBy!)).toHaveTextContent("削除の確認");
+    expect(document.getElementById(describedBy!)).toHaveTextContent("本当に削除しますか？");
+  });
+});

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import * as React from "react";
+import { AlertTriangle, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+interface AlertDialogProps {
+  open: boolean;
+  onClose: () => void;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  variant?: "destructive" | "default";
+}
+
+export function AlertDialog({
+  open,
+  onClose,
+  title,
+  description,
+  confirmLabel = "確認",
+  cancelLabel = "キャンセル",
+  onConfirm,
+  variant = "destructive",
+}: AlertDialogProps) {
+  const titleId = React.useId();
+  const descId = React.useId();
+  const panelRef = React.useRef<HTMLDivElement>(null);
+  const onCloseRef = React.useRef(onClose);
+  React.useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
+  React.useEffect(() => {
+    if (!open) return;
+    const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+    function getFocusables() {
+      return Array.from(panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []);
+    }
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onCloseRef.current();
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const focusables = getFocusables();
+      if (focusables.length === 0) return;
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (e.shiftKey) {
+        if (document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        }
+      } else {
+        if (document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    const count = Number(document.body.dataset.modalCount ?? 0) + 1;
+    document.body.dataset.modalCount = String(count);
+    document.body.style.overflow = "hidden";
+    return () => {
+      const next = Number(document.body.dataset.modalCount ?? 1) - 1;
+      document.body.dataset.modalCount = String(next);
+      if (next === 0) document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  React.useEffect(() => {
+    if (!open) return;
+    panelRef.current
+      ?.querySelector<HTMLElement>(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      )
+      ?.focus();
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center"
+      role="alertdialog"
+      aria-modal="true"
+      aria-labelledby={titleId}
+      aria-describedby={descId}
+    >
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={() => onCloseRef.current()}
+        aria-hidden="true"
+      />
+      <div
+        ref={panelRef}
+        className={cn(
+          "relative z-10 w-full bg-background shadow-xl",
+          "rounded-t-2xl sm:rounded-xl sm:max-w-md",
+          "animate-in slide-in-from-bottom-4 sm:slide-in-from-bottom-0 sm:zoom-in-95 fade-in-0"
+        )}
+      >
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <div className="flex items-center gap-2">
+            {variant === "destructive" && (
+              <AlertTriangle className="h-4 w-4 text-destructive" aria-hidden="true" />
+            )}
+            <h2 id={titleId} className="text-sm font-semibold text-foreground">
+              {title}
+            </h2>
+          </div>
+          <button
+            type="button"
+            onClick={() => onCloseRef.current()}
+            className="rounded-md p-1 text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+            aria-label="閉じる"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        <div className="px-4 py-4">
+          <p id={descId} className="text-sm text-foreground">
+            {description}
+          </p>
+          <div className="mt-4 flex gap-2 justify-end">
+            <Button type="button" variant="outline" size="sm" onClick={() => onCloseRef.current()}>
+              {cancelLabel}
+            </Button>
+            <Button
+              type="button"
+              variant={variant === "destructive" ? "destructive" : "default"}
+              size="sm"
+              onClick={() => {
+                onConfirm();
+                onCloseRef.current();
+              }}
+            >
+              {confirmLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/alert-dialog.tsx
+++ b/frontend/src/components/ui/alert-dialog.tsx
@@ -5,6 +5,8 @@ import { AlertTriangle, X } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 
+const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
 interface AlertDialogProps {
   open: boolean;
   onClose: () => void;
@@ -36,7 +38,6 @@ export function AlertDialog({
 
   React.useEffect(() => {
     if (!open) return;
-    const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
     function getFocusables() {
       return Array.from(panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []);
     }
@@ -80,11 +81,7 @@ export function AlertDialog({
 
   React.useEffect(() => {
     if (!open) return;
-    panelRef.current
-      ?.querySelector<HTMLElement>(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      )
-      ?.focus();
+    panelRef.current?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
   }, [open]);
 
   if (!open) return null;
@@ -97,11 +94,8 @@ export function AlertDialog({
       aria-labelledby={titleId}
       aria-describedby={descId}
     >
-      <div
-        className="absolute inset-0 bg-black/50"
-        onClick={() => onCloseRef.current()}
-        aria-hidden="true"
-      />
+      {/* alertdialog は backdrop クリックで閉じない（WAI-ARIA: ユーザーに明示的な選択を求める） */}
+      <div className="absolute inset-0 bg-black/50" aria-hidden="true" />
       <div
         ref={panelRef}
         className={cn(


### PR DESCRIPTION
## 変更内容

### backend: Gemini キャッシュの eviction 追加 (#622)
- `GeminiSummarizer` に1時間周期の eviction goroutine を追加
- 期限切れエントリが蓄積してメモリが増加し続ける問題を解消

### backend: AreaDiscovery の上限値を定数化 (#626)
- マジックナンバー `30` を `areaDiscoveryLimit` 定数に抽出
- コメントで制限理由（タイムアウトリスク）を明記

### backend: 重複バリデーション除去 (#627)
- `validateInvestmentInput` から `RentDeclineRate` チェックを削除
  （`domain.Validate()` が同じ検証を担うため）
- 2層バリデーション設計の意図をコメントで明示
- 対応するテストケースも整理

### frontend: AlertDialog コンポーネント追加 (#623)
- `ui/alert-dialog.tsx` を新規作成（`role="alertdialog"`・`AlertTriangle` アイコン付き）
- `WatchlistPanel` の削除確認を `Modal` から `AlertDialog` に置換
- CLAUDE.md「削除操作は AlertDialog で確認ステップを挟む」ルールを適用

## テスト

- `go test ./internal/api/...` 全件通過
- `vitest run` 全件通過（345 tests）

## 関連 Issue

Closes #622, #623, #626, #627