### PR TITLE
fix: ResultsSection の Skeleton UI 未実装と免責事項ブロック未表示を修正

### DIFF
--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -20,6 +20,7 @@ import WatchlistPanel from "@/components/WatchlistPanel";
 import DueDiligenceChecklist from "@/components/DueDiligenceChecklist";
 import { AreaDiscovery } from "@/components/AreaDiscovery";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import dynamic from "next/dynamic";
 import { BarChart3, ChevronDown, ChevronUp, ShieldAlert } from "lucide-react";
 import { PREFECTURE_CENTERS } from "@/lib/prefectureCenters";
@@ -180,7 +181,15 @@ export function ResultsSection({
         </>
       )}
 
-      {activeTab === "simulation" && !result && !comparison && (
+      {activeTab === "simulation" && loading && !result && (
+        <div className="space-y-4">
+          <Skeleton className="h-16 w-full rounded-xl" />
+          <Skeleton className="h-32 w-full rounded-xl" />
+          <Skeleton className="h-48 w-full rounded-xl" />
+        </div>
+      )}
+
+      {activeTab === "simulation" && !loading && !result && !comparison && (
         <div className="flex h-64 items-center justify-center rounded-xl border-2 border-dashed border-muted-foreground/20 lg:h-80">
           <div className="text-center text-muted-foreground">
             <ShieldAlert className="mx-auto mb-3 h-10 w-10 opacity-30 lg:h-12 lg:w-12" />

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -19,10 +19,11 @@ import NegotiationPanel from "@/components/NegotiationPanel";
 import WatchlistPanel from "@/components/WatchlistPanel";
 import DueDiligenceChecklist from "@/components/DueDiligenceChecklist";
 import { AreaDiscovery } from "@/components/AreaDiscovery";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import dynamic from "next/dynamic";
-import { BarChart3, ChevronDown, ChevronUp, ShieldAlert } from "lucide-react";
+import { AlertTriangle, BarChart3, ChevronDown, ChevronUp, ShieldAlert } from "lucide-react";
 import { PREFECTURE_CENTERS } from "@/lib/prefectureCenters";
 import type {
   InvestmentInput,
@@ -316,6 +317,12 @@ export function ResultsSection({
                   <p className="font-medium mt-1">詳細モードで利用できます</p>
                 </div>
               )}
+              <Alert>
+                <AlertTriangle className="h-4 w-4" />
+                <AlertDescription className="text-xs text-muted-foreground">
+                  計算結果は参考値です。実際の投資判断は専門家にご相談ください。本シミュレーションは消費税・損益通算の詳細を考慮しない場合があります。
+                </AlertDescription>
+              </Alert>
             </div>
           )}
 


### PR DESCRIPTION
## 概要

CLAUDE.md の必須ルール違反を2件修正します。

- **Issue #587**: ローディング中に `<Spinner>` の代わりに Skeleton UI を表示していなかった（未実装）
- **Issue #586**: 投資シミュレーション結果に免責事項ブロック（`<Alert>`）が表示されていなかった

## 変更内容

- `loading === true && result === null` の状態で結果エリアに `<Skeleton>` を3段表示するよう実装（CLAUDE.md: 「ローディング中は Skeleton UI を使用する」）
- 財務分析タブの末尾に `<Alert>` + `AlertTriangle` アイコン付きの免責事項ブロックを追加（CLAUDE.md: 「投資シミュレーション結果には必ず免責事項ブロックを表示する」）
- 免責事項文: 「計算結果は参考値です。実際の投資判断は専門家にご相談ください。本シミュレーションは消費税・損益通算の詳細を考慮しない場合があります。」
- アイコンは `lucide-react` の `AlertTriangle` を使用（WCAG 1.4.1 準拠）

## 関連Issue

Closes #586
Closes #587

## テスト
- [ ] 既存テストが通ること
- [ ] シミュレーション実行中に Skeleton が表示されることを目視確認
- [ ] シミュレーション結果表示後、財務分析タブ末尾に免責事項 Alert が表示されることを目視確認

## 確認事項
- [ ] コードレビュー観点での自己レビュー済み