### PR TITLE
fix: HandleAreaDiscovery の goroutine リーク修正（errgroup によるキャンセル伝播）

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/sdk/metric v1.43.0
 	go.opentelemetry.io/otel/trace v1.43.0
 	golang.org/x/oauth2 v0.36.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/time v0.15.0
 	google.golang.org/api v0.279.0
 )
@@ -72,7 +73,6 @@ require (
 	golang.org/x/arch v0.25.0 // indirect
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
-	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -9,13 +9,13 @@ import (
 	"net/url"
 	"sort"
 	"strconv"
-	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/yield-guard/backend/internal/ai"
 	"github.com/yield-guard/backend/internal/domain"
 	"github.com/yield-guard/backend/internal/mlit"
+	"golang.org/x/sync/errgroup"
 )
 
 // areaDiscoveryLimit はエリア探索で並列取得する市区町村の上限数。
@@ -148,17 +148,23 @@ func (h *Handler) HandleAreaDiscovery(c *gin.Context) {
 	}
 
 	results := make([]result, limit)
-	var wg sync.WaitGroup
 	sem := make(chan struct{}, 5) // 並列5件上限
+	g, gctx := errgroup.WithContext(ctx)
 
 	for i := 0; i < limit; i++ {
-		wg.Add(1)
-		go func(idx int, m mlit.Municipality) {
-			defer wg.Done()
+		idx, m := i, municipalities[i]
+		g.Go(func() error {
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
 			sem <- struct{}{}
 			defer func() { <-sem }()
 
-			transactions, fetchErr := h.mlitClient.FetchLandPrices(ctx, mlit.LandPriceQuery{
+			if gctx.Err() != nil {
+				return gctx.Err()
+			}
+
+			transactions, fetchErr := h.mlitClient.FetchLandPrices(gctx, mlit.LandPriceQuery{
 				Area:      prefecture,
 				City:      m.ID,
 				Year:      fromYear,
@@ -178,10 +184,10 @@ func (h *Handler) HandleAreaDiscovery(c *gin.Context) {
 				item.YieldDifficulty = "difficult"
 				item.YieldDifficultyLabel = "データ不足"
 				results[idx] = result{item: item}
-				return
+				return nil
 			}
 
-			stats := domain.CalcLandPriceStats(ctx, transactions)
+			stats := domain.CalcLandPriceStats(gctx, transactions)
 
 			item.MedianTsubo = stats.MedianTsubo
 			item.TransactionCount = stats.Count
@@ -214,9 +220,10 @@ func (h *Handler) HandleAreaDiscovery(c *gin.Context) {
 
 			item.LandPriceTrend = "データなし"
 			results[idx] = result{item: item}
-		}(i, municipalities[i])
+			return nil
+		})
 	}
-	wg.Wait()
+	_ = g.Wait()
 
 	items := make([]domain.AreaDiscoveryItem, 0, limit)
 	for _, r := range results {


### PR DESCRIPTION
## 概要

`HandleAreaDiscovery` ハンドラーの並列 goroutine にコンテキストキャンセルが伝播しておらず、クライアント切断後も全 goroutine が完了するまで待ち続ける goroutine リークが発生していた。`sync.WaitGroup` を `golang.org/x/sync/errgroup` に置き換え、キャンセル伝播と早期リターンを実装した。

## 変更内容

- `sync.WaitGroup` + bare `go func` を `errgroup.WithContext` + `g.Go` に置き換え
- セマフォ取得前後に `gctx.Err() != nil` チェックを追加し、コンテキストキャンセル時に早期リターン
- `FetchLandPrices` および `CalcLandPriceStats` に渡す ctx を `gctx` に変更
- ループ変数キャプチャを `idx, m := i, municipalities[i]` で安全化
- `golang.org/x/sync` を indirect → direct 依存に昇格（`go.mod`）
- 並列5件制限のセマフォチャネルはそのまま維持

## 関連Issue

Closes #596

## テスト

- [x] 既存テストが通ること（`go test -race ./... -timeout 120s` 全パス）
- [x] race detector で data race なし

## 確認事項

- [x] コードレビュー観点での自己レビュー済み