### PR TITLE
fix(frontend): tsconfig から e2e/ を除外して Vercel ビルドの型エラーを解消

### DIFF
--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -36,6 +36,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "e2e"
   ]
 }


### PR DESCRIPTION
## 概要

Vercel クラウドビルドで `e2e/fixtures/*.ts` が TypeScript チェック対象に含まれ、`@/types/api.generated` が解決できずビルドが失敗する問題を修正する。

## 原因の連鎖

1. `api.generated.ts` は gitignore 対象のため Vercel 環境に存在しない
2. PR #634 で prebuild を `swagger.json` 不在時にスキップするよう修正 → prebuild は exit 0
3. しかし Next.js TypeScript チェックが `tsconfig.json` の `"**/*.ts"` に従い `e2e/fixtures/` を走査
4. `e2e/fixtures/*.ts` が `@/types/api.generated` をインポートしているため型エラーで失敗

## 修正内容

`tsconfig.json` の `exclude` に `"e2e"` を追加。

```json
"exclude": [
  "node_modules",
  "e2e"
]
```

## 影響範囲

- Next.js / Vercel の TypeScript チェックから `e2e/` が除外される
- Playwright は独自の型解決を使うため E2E テストへの影響なし
- CI の `npm run generate:types` 実行後は `api.generated.ts` が生成されるため、ローカルおよび CI の `tsc --noEmit` は引き続き正常動作

## 関連

- PR #634（prebuild スキップ修正）
- `frontend/tsconfig.json`