### PR TITLE
Firestore 無料枠超過・月次コスト早期検知アラートを Terraform で IaC 管理

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,6 +1,27 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version     = "2.8.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:WB6H5ksIZiyq1lQlD/PWeh+tn4FLsbSjVnRW3+4xe2Y=",
+    "zh:0d14713fdc259fb377d0b899ad3c650a34194bd52194c863303ef22a65a580e2",
+    "zh:369b56040c7a8085d04e7e8ffac1e2b321a3170e502f788819bc34b868ec016f",
+    "zh:4d1a3b983ed6af5a52bfe12794674ae55cbadfa6021b37106ade68b433ad216a",
+    "zh:5c547549e26e083573c78a966ca68ce6d7df6bb8f3948f66a575f07da46b74ea",
+    "zh:6de093e62a975eb19a5e3017ce38e6e3cb639c17b79648d2000e0a8348f0e997",
+    "zh:7267936c2cdbc448efeb594d73e6b56a53d6a7ae14fe88cdd2a4133adc3302f0",
+    "zh:7482f023050ed426b4b45116e1761643bc33b1fd4ce4a6fab207ae2571f35940",
+    "zh:76bbd93b234e5a2927d98b511d86565700f549b570871a194c35f944b96cefb7",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:c6afc4bc1f002bac9c173007dd4da05fde788cd14c2916089f958c33fedb0dfa",
+    "zh:d3ba40bd806a3a08e9237dece679193c99afb2085de6b45d7f5d1f673cfcd368",
+    "zh:e1ad7ded53ecd6f0e5b473a3b44eae2b2e885653a56050ab583d387332be02e4",
+    "zh:e93e78575ce82be6084cc153c24ba8f385dc8d6880888ee66e918460c870953d",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/google" {
   version     = "6.50.0"
   constraints = "~> 6.0"

--- a/terraform/billing.tf
+++ b/terraform/billing.tf
@@ -7,6 +7,51 @@
 #     --member="serviceAccount:<deployer-sa-email>" \
 #     --role="roles/billing.admin"
 # ─────────────────────────────────────────────────────
+# Firestore 3機能（AIサマリーキャッシュ・ジオコードキャッシュ・ウォッチリスト）導入に伴う
+# 月次コスト早期検知アラート: 1,000円 (80%/100%予測) で通知する。
+resource "google_billing_budget" "firestore_early_alert" {
+  provider        = google.billing
+  billing_account = var.billing_account_id
+  display_name    = "Yield Guard Firestore 早期コストアラート"
+
+  budget_filter {
+    projects = ["projects/${var.project_id}"]
+    services = ["services/95FF-2EF5-5EA1"] # Cloud Firestore
+  }
+
+  amount {
+    specified_amount {
+      currency_code = "JPY"
+      units         = "1000"
+    }
+  }
+
+  threshold_rules {
+    threshold_percent = 0.8
+  }
+  threshold_rules {
+    threshold_percent = 1.0
+    spend_basis       = "FORECASTED_SPEND"
+  }
+
+  all_updates_rule {
+    monitoring_notification_channels = [
+      google_monitoring_notification_channel.email.id,
+    ]
+    disable_default_iam_recipients = true
+  }
+
+  depends_on = [google_project_service.billingbudgets]
+
+  lifecycle {
+    ignore_changes = [
+      amount,
+      threshold_rules,
+      all_updates_rule,
+    ]
+  }
+}
+
 resource "google_billing_budget" "monthly" {
   provider        = google.billing
   billing_account = var.billing_account_id

--- a/terraform/billing.tf
+++ b/terraform/billing.tf
@@ -26,9 +26,11 @@ resource "google_billing_budget" "firestore_early_alert" {
     }
   }
 
+  # 80%: 実際の支出が上限の 80% に達したら通知（CURRENT_SPEND）
   threshold_rules {
     threshold_percent = 0.8
   }
+  # 100%: 月末予測が上限を超えた時点で早期通知（FORECASTED_SPEND）
   threshold_rules {
     threshold_percent = 1.0
     spend_basis       = "FORECASTED_SPEND"
@@ -43,6 +45,10 @@ resource "google_billing_budget" "firestore_early_alert" {
 
   depends_on = [google_project_service.billingbudgets]
 
+  # The Billing Budgets API rejects write operations from WIF-issued service account
+  # tokens (403), even with billing.admin on the billing account. Human user credentials
+  # (gcloud / GCP Console) succeed. This is a known limitation of WIF + personal billing
+  # accounts. Budget values must be changed manually outside of CI.
   lifecycle {
     ignore_changes = [
       amount,

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -330,3 +330,36 @@ resource "google_monitoring_alert_policy" "cloudrun_max_instances" {
     auto_close = "3600s"
   }
 }
+
+# ─────────────────────────────────────────────────────
+# Firestore アラート (Firestore 3機能導入)
+# AIサマリーキャッシュ・ジオコードキャッシュ・ウォッチリストの導入に伴い
+# 無料枠(50,000読み取り/日)の 80% = 40,000 件超過を検知する。
+# ─────────────────────────────────────────────────────
+
+# 6. Firestore 日次読み取り数が無料枠の 80% (40,000件/日) を超過
+resource "google_monitoring_alert_policy" "firestore_daily_reads" {
+  display_name = "[Yield Guard] Firestore 日次読み取りが無料枠 80% に到達 (40,000件/日)"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "Firestore reads > 40,000/day"
+    condition_threshold {
+      filter          = "metric.type=\"firestore.googleapis.com/document/read_count\" AND resource.type=\"firestore_instance\""
+      duration        = "0s"
+      comparison      = "COMPARISON_GT"
+      threshold_value = 40000
+      aggregations {
+        alignment_period   = "86400s"
+        per_series_aligner = "ALIGN_SUM"
+      }
+    }
+  }
+
+  notification_channels = [google_monitoring_notification_channel.email.id]
+  alert_strategy {
+    auto_close = "604800s"
+  }
+
+  depends_on = [google_firestore_database.default]
+}

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -345,19 +345,22 @@ resource "google_monitoring_alert_policy" "firestore_daily_reads" {
   conditions {
     display_name = "Firestore reads > 40,000/day"
     condition_threshold {
-      filter          = "metric.type=\"firestore.googleapis.com/document/read_count\" AND resource.type=\"firestore_instance\""
+      filter          = "metric.type=\"firestore.googleapis.com/document/read_count\" AND resource.type=\"firestore.googleapis.com/Database\""
       duration        = "0s"
       comparison      = "COMPARISON_GT"
       threshold_value = 40000
       aggregations {
-        alignment_period   = "86400s"
-        per_series_aligner = "ALIGN_SUM"
+        alignment_period     = "86400s"
+        per_series_aligner   = "ALIGN_SUM"
+        cross_series_reducer = "REDUCE_SUM"
+        group_by_fields      = ["resource.labels.project_id"]
       }
     }
   }
 
   notification_channels = [google_monitoring_notification_channel.email.id]
   alert_strategy {
+    # コスト超過アラートは短時間でクローズすると見落としリスクがあるため 7 日間保持
     auto_close = "604800s"
   }
 


### PR DESCRIPTION
## 概要

AIサマリーキャッシュ・ジオコードキャッシュ・ウォッチリストの3機能導入により Firestore を使用し始めたため、無料枠超過と月次コスト増加を早期に検知する GCP モニタリング設定を Terraform で IaC 管理する。

## 変更内容

- **`terraform/monitoring.tf`**: Firestore 日次読み取りアラートポリシーを追加
  - 無料枠 50,000件/日 の 80% = **40,000件/日** を超えた時点でメール通知
  - `alignment_period = "86400s"` で日次集計、`ALIGN_SUM` で合計カウント
  - `auto_close = "604800s"`（7日）で自動クローズ
  - `depends_on = [google_firestore_database.default]` で Firestore 作成後に適用

- **`terraform/billing.tf`**: Firestore 早期コスト検知用の予算アラートを追加
  - `google_billing_budget.firestore_early_alert`: **1,000円/月** の Firestore 専用予算
  - 80% 到達時通知 + 100% 予測支出到達時通知（`FORECASTED_SPEND`）
  - Firestore サービス ID（`95FF-2EF5-5EA1`）でフィルタリング
  - 既存の `google_billing_budget.monthly`（10,000円の全体予算）と共存

- **`terraform/.terraform.lock.hcl`**: `archive` provider のハッシュを追記（`terraform init` で自動更新）

### 既存リソースとの整合性

| 設計書の指定 | 実装方針 |
|---|---|
| `var.alert_email` / `email_alert` チャンネル | 既存の `var.notification_email` / `google_monitoring_notification_channel.email` を再利用（同目的の重複を排除） |
| `google_billing_budget.yield_guard`（1,000円） | `google_billing_budget.firestore_early_alert` として追加。既存の `monthly`（10,000円）と共存 |

## 関連Issue

<!-- Closes # -->

## テスト

- [x] `terraform validate` 成功を確認（`Success! The configuration is valid.`）
- [x] `billing.tf` / `monitoring.tf` それぞれ論理単位でコミット

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] 既存の `google_monitoring_notification_channel.email` / `var.notification_email` を再利用し重複変数を排除
- [x] `billing.tf` の `ignore_changes` ライフサイクルを踏襲（WIF + 個人請求アカウントの API 制約に対応）
- [x] Firestore サービス ID `95FF-2EF5-5EA1` は GCP の公式 SKU ID を使用