### PR TITLE
fix: FirestoreアラートポリシーのGCP拒否エラーを修正

### DIFF
--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -345,7 +345,8 @@ resource "google_monitoring_alert_policy" "firestore_daily_reads" {
   conditions {
     display_name = "Firestore reads > 40,000/day"
     condition_threshold {
-      filter          = "metric.type=\"firestore.googleapis.com/document/read_count\" AND resource.type=\"firestore.googleapis.com/Database\""
+      # resource.type フィルタは GCP がメトリクスと組み合わせを検証して拒否するため除外
+      filter          = "metric.type=\"firestore.googleapis.com/document/read_count\""
       duration        = "0s"
       comparison      = "COMPARISON_GT"
       threshold_value = 40000


### PR DESCRIPTION
## 概要

Terraform CI で以下のエラーが発生していたため修正する。

```
Error creating AlertPolicy: googleapi: Error 400: The supplied filter does not specify
a valid combination of metric and monitored resource descriptors.
```

## 原因

`google_monitoring_alert_policy.firestore_daily_reads` の filter に `resource.type` を指定していたが、`firestore.googleapis.com/document/read_count` メトリクスに対して GCP が有効な組み合わせとして認めない。

`firestore_instance` → `firestore.googleapis.com/Database` に修正しても同様に拒否される。

## 対応

`resource.type` フィルタを除外し、メトリクスタイプのみで絞り込む形に変更した。Firestore の読み取りカウントの監視は引き続き機能する。

## 関連

- #639 GCP モニタリング設定