### PR TITLE
refactor: 表示専用コンポーネントから不要な use client を除去

### DIFF
--- a/frontend/src/components/MultiExitCompareTable.tsx
+++ b/frontend/src/components/MultiExitCompareTable.tsx
@@ -1,4 +1,3 @@
-"use client";
 import React from "react";
 import { AlertTriangle } from "lucide-react";
 import type { MultiExitRow } from "@/types/investment";


### PR DESCRIPTION
## 概要
`MultiExitCompareTable` は `useState` / `useEffect` 等のフックを一切使用しない純粋な表示コンポーネントだが、不要な `"use client"` ディレクティブが付いていた。

## 変更内容
- `frontend/src/components/MultiExitCompareTable.tsx` の先頭行 `"use client";` を削除

## 関連Issue
Closes #603

## テスト
- [x] 既存テストが通ること (`npm test -- --run` パス)
- [x] `tsc --noEmit` でエラーなし

## 確認事項
- [x] フックなし・ブラウザ API なしであることを確認してから除去