### PR TITLE
refactor: useInvestmentSimulation フックを責務別サブフックに分割

### DIFF
--- a/frontend/src/hooks/useAnalyzeApi.ts
+++ b/frontend/src/hooks/useAnalyzeApi.ts
@@ -1,0 +1,118 @@
+"use client";
+import { useState, useCallback } from "react";
+import type { RefObject, MutableRefObject } from "react";
+import { analyze as analyzeOnline } from "@/lib/api";
+import { encodeUrlParams } from "@/lib/urlParams";
+import type {
+  InvestmentInput,
+  InvestmentResult,
+  LoanMethod,
+  SimulationMode,
+} from "@/types/investment";
+
+interface AnalyzeApiParams {
+  simulationMode: SimulationMode;
+  onUrlUpdate: (qs: string) => void;
+}
+
+function toErrorMessage(e: unknown, fallback: string): string {
+  if (e instanceof TypeError && e.message.toLowerCase().includes("fetch")) {
+    return "インターネット接続を確認してください";
+  }
+  return e instanceof Error ? e.message : fallback;
+}
+
+export interface UseAnalyzeApiResult {
+  loading: boolean;
+  error: string | null;
+  loanMethod: LoanMethod;
+  setLoanMethod: (method: LoanMethod) => void;
+  handleAnalyze: (input: InvestmentInput, quickTotalMan?: string) => Promise<void>;
+  handleLoanMethodChange: (method: LoanMethod) => Promise<void>;
+  setResult: (result: InvestmentResult | null) => void;
+  setLastInput: (input: InvestmentInput | null) => void;
+  clearMonteCarloResult: () => void;
+}
+
+export function useAnalyzeApi(
+  lastInputRef: RefObject<InvestmentInput | null>,
+  loanMethodRef: MutableRefObject<LoanMethod>,
+  paramsRef: RefObject<AnalyzeApiParams>,
+  onResult: (result: InvestmentResult | null) => void,
+  onLastInput: (input: InvestmentInput | null) => void,
+  onClearMonteCarloResult: () => void
+): UseAnalyzeApiResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [loanMethod, setLoanMethodState] = useState<LoanMethod>("equal-payment");
+
+  const setLoanMethod = useCallback((method: LoanMethod) => {
+    setLoanMethodState(method);
+    loanMethodRef.current = method;
+  }, [loanMethodRef]);
+
+  const handleAnalyze = useCallback(async (input: InvestmentInput, quickTotalMan?: string) => {
+    const { simulationMode, onUrlUpdate } = paramsRef.current!;
+    const currentLoanMethod = loanMethodRef.current;
+    setLoading(true);
+    setError(null);
+    onClearMonteCarloResult();
+    const inputWithMethod = { ...input, loanMethod: currentLoanMethod };
+    try {
+      const res = await analyzeOnline(inputWithMethod);
+      onResult(res);
+      onLastInput(inputWithMethod);
+      const urlParams = encodeUrlParams(simulationMode, inputWithMethod, quickTotalMan);
+      const qs = urlParams.toString();
+      onUrlUpdate(qs);
+    } catch (e) {
+      setError(toErrorMessage(e, "シミュレーションに失敗しました"));
+    } finally {
+      setLoading(false);
+    }
+  }, [loanMethodRef, paramsRef, onResult, onLastInput, onClearMonteCarloResult]);
+
+  const handleLoanMethodChange = useCallback(async (method: LoanMethod) => {
+    setLoanMethodState(method);
+    loanMethodRef.current = method;
+    const current = lastInputRef.current;
+    if (!current) return;
+    setLoading(true);
+    setError(null);
+    onClearMonteCarloResult();
+    try {
+      const updatedInput = { ...current, loanMethod: method };
+      const res = await analyzeOnline(updatedInput);
+      onResult(res);
+      onLastInput({ ...current, loanMethod: method });
+    } catch (e) {
+      setError(toErrorMessage(e, "シミュレーションに失敗しました"));
+    } finally {
+      setLoading(false);
+    }
+  }, [lastInputRef, loanMethodRef, onResult, onLastInput, onClearMonteCarloResult]);
+
+  const setResult = useCallback((result: InvestmentResult | null) => {
+    onResult(result);
+  }, [onResult]);
+
+  const setLastInput = useCallback((input: InvestmentInput | null) => {
+    onLastInput(input);
+  }, [onLastInput]);
+
+  const clearMonteCarloResult = useCallback(() => {
+    onClearMonteCarloResult();
+  }, [onClearMonteCarloResult]);
+
+  return {
+    loading,
+    error,
+    loanMethod,
+    setLoanMethod,
+    handleAnalyze,
+    handleLoanMethodChange,
+    setResult,
+    setLastInput,
+    clearMonteCarloResult,
+  };
+}

--- a/frontend/src/hooks/useExternalData.ts
+++ b/frontend/src/hooks/useExternalData.ts
@@ -1,0 +1,164 @@
+"use client";
+import { useState, useCallback } from "react";
+import type { RefObject } from "react";
+import {
+  compareLandPrice,
+  estimateLandPrice,
+  fetchStationRidership,
+  fetchPopulationForecast,
+  fetchLandAppraisals,
+  fetchUrbanRisks,
+  fetchHazardInfo,
+  fetchInvestmentScore,
+} from "@/lib/api";
+import type {
+  InvestmentInput,
+  LandPriceComparison,
+  TheoreticalPriceResult,
+  StationRidershipResult,
+  PopulationForecastResult,
+  AppraisalComparisonResult,
+  UrbanRisk,
+  InvestmentScoreResult,
+} from "@/types/investment";
+
+function getCurrentPeriods(): { year: number; quarter: number; toYear: number; toQuarter: number } {
+  const now = new Date();
+  const toYear = now.getFullYear();
+  const toQuarter = Math.ceil((now.getMonth() + 1) / 3);
+  return { year: toYear - 2, quarter: 1, toYear, toQuarter };
+}
+
+export interface UseExternalDataResult {
+  loading: boolean;
+  error: string | null;
+  comparison: LandPriceComparison | null;
+  theoreticalPrice: TheoreticalPriceResult | null;
+  landAppraisal: AppraisalComparisonResult | null;
+  stationRidership: StationRidershipResult[] | null;
+  populationForecast: PopulationForecastResult | null;
+  externalUrbanRisks: UrbanRisk[] | null;
+  investmentScore: InvestmentScoreResult | null;
+  hazardRisks: UrbanRisk[] | null;
+  propertyLat: number | undefined;
+  propertyLng: number | undefined;
+  setPropertyCoords: (lat: number, lng: number) => void;
+  handleFetchLandPrices: (area: string, city: string, lat?: number, lng?: number) => Promise<void>;
+}
+
+export function useExternalData(
+  lastInputRef: RefObject<InvestmentInput | null>
+): UseExternalDataResult {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [comparison, setComparison] = useState<LandPriceComparison | null>(null);
+  const [theoreticalPrice, setTheoreticalPrice] = useState<TheoreticalPriceResult | null>(null);
+  const [landAppraisal, setLandAppraisal] = useState<AppraisalComparisonResult | null>(null);
+  const [stationRidership, setStationRidership] = useState<StationRidershipResult[] | null>(null);
+  const [populationForecast, setPopulationForecast] = useState<PopulationForecastResult | null>(null);
+  const [externalUrbanRisks, setExternalUrbanRisks] = useState<UrbanRisk[] | null>(null);
+  const [investmentScore, setInvestmentScore] = useState<InvestmentScoreResult | null>(null);
+  const [hazardRisks, setHazardRisks] = useState<UrbanRisk[] | null>(null);
+  const [propertyLat, setPropertyLat] = useState<number | undefined>(undefined);
+  const [propertyLng, setPropertyLng] = useState<number | undefined>(undefined);
+
+  const setPropertyCoords = useCallback((lat: number, lng: number) => {
+    setPropertyLat(lat);
+    setPropertyLng(lng);
+  }, []);
+
+  const handleFetchLandPrices = useCallback(
+    async (area: string, city: string, lat?: number, lng?: number) => {
+      setLoading(true);
+      setError(null);
+      setStationRidership(null);
+      setPopulationForecast(null);
+      setLandAppraisal(null);
+      setExternalUrbanRisks(null);
+      setInvestmentScore(null);
+      setHazardRisks(null);
+
+      if (lat !== undefined && lng !== undefined) {
+        setPropertyLat(lat);
+        setPropertyLng(lng);
+      }
+      const { year, quarter, toYear, toQuarter } = getCurrentPeriods();
+      const current = lastInputRef.current;
+      try {
+        const baseParams = {
+          area,
+          city,
+          year,
+          quarter,
+          toYear,
+          toQuarter,
+          price: current?.landPrice ?? 5_000_000,
+          areaSqm: current?.landArea ?? 0,
+        };
+        const comp = await compareLandPrice(baseParams);
+        setComparison(comp);
+
+        if (current && current.landArea > 0) {
+          try {
+            const est = await estimateLandPrice({
+              ...baseParams,
+              buildingAge: current.buildingAge,
+              stationMinutes: current.stationMinutes,
+            });
+            setTheoreticalPrice(est);
+          } catch {
+            setTheoreticalPrice(null);
+          }
+        }
+
+        const [appraisal] = await Promise.allSettled([
+          fetchLandAppraisals({ area, year: toYear, city: city || undefined }),
+        ]);
+        setLandAppraisal(appraisal.status === "fulfilled" ? appraisal.value : null);
+
+        if (lat !== undefined && lng !== undefined) {
+          const [ridership, population, urbanRisks, scoreResult, hazard] = await Promise.allSettled(
+            [
+              fetchStationRidership({ lat, lng }),
+              fetchPopulationForecast({ lat, lng }),
+              fetchUrbanRisks(lat, lng),
+              fetchInvestmentScore({ lat, lng }),
+              fetchHazardInfo(lat, lng),
+            ]
+          );
+          setStationRidership(ridership.status === "fulfilled" ? ridership.value : null);
+          setPopulationForecast(population.status === "fulfilled" ? population.value : null);
+          setExternalUrbanRisks(urbanRisks.status === "fulfilled" ? urbanRisks.value : null);
+          setInvestmentScore(scoreResult.status === "fulfilled" ? scoreResult.value : null);
+          setHazardRisks(hazard.status === "fulfilled" ? hazard.value : null);
+        }
+      } catch (e) {
+        setError(
+          e instanceof Error
+            ? e.message
+            : "相場データの取得に失敗しました。しばらく後に再試行してください"
+        );
+      } finally {
+        setLoading(false);
+      }
+    },
+    [lastInputRef]
+  );
+
+  return {
+    loading,
+    error,
+    comparison,
+    theoreticalPrice,
+    landAppraisal,
+    stationRidership,
+    populationForecast,
+    externalUrbanRisks,
+    investmentScore,
+    hazardRisks,
+    propertyLat,
+    propertyLng,
+    setPropertyCoords,
+    handleFetchLandPrices,
+  };
+}

--- a/frontend/src/hooks/useInvestmentSimulation.ts
+++ b/frontend/src/hooks/useInvestmentSimulation.ts
@@ -1,34 +1,29 @@
 "use client";
 import { useState, useCallback, useRef, useEffect } from "react";
-import {
-  analyze as analyzeOnline,
-  compareLandPrice,
-  estimateLandPrice,
-  fetchStationRidership,
-  fetchPopulationForecast,
-  fetchLandAppraisals,
-  fetchUrbanRisks,
-  fetchHazardInfo,
-  fetchInvestmentScore,
-  simulate,
-} from "@/lib/api";
-import { encodeUrlParams } from "@/lib/urlParams";
 import type {
   InvestmentInput,
   InvestmentResult,
+  LoanMethod,
+  SimulationMode,
+  MonteCarloResult,
   LandPriceComparison,
   TheoreticalPriceResult,
   StationRidershipResult,
   PopulationForecastResult,
   AppraisalComparisonResult,
   UrbanRisk,
-  SimulationMode,
-  LoanMethod,
-  MonteCarloResult,
   InvestmentScoreResult,
 } from "@/types/investment";
+import { useAnalyzeApi } from "./useAnalyzeApi";
+import { useExternalData } from "./useExternalData";
+import { useMonteCarloSim } from "./useMonteCarloSim";
 
-interface AnalysisResult {
+export interface UseInvestmentSimulationParams {
+  simulationMode: SimulationMode;
+  onUrlUpdate: (qs: string) => void;
+}
+
+export interface UseInvestmentSimulationResult {
   result: InvestmentResult | null;
   comparison: LandPriceComparison | null;
   theoreticalPrice: TheoreticalPriceResult | null;
@@ -38,40 +33,6 @@ interface AnalysisResult {
   externalUrbanRisks: UrbanRisk[] | null;
   investmentScore: InvestmentScoreResult | null;
   hazardRisks: UrbanRisk[] | null;
-}
-
-const INITIAL_ANALYSIS_RESULT: AnalysisResult = {
-  result: null,
-  comparison: null,
-  theoreticalPrice: null,
-  stationRidership: null,
-  populationForecast: null,
-  landAppraisal: null,
-  externalUrbanRisks: null,
-  investmentScore: null,
-  hazardRisks: null,
-};
-
-function toErrorMessage(e: unknown, fallback: string): string {
-  if (e instanceof TypeError && e.message.toLowerCase().includes("fetch")) {
-    return "インターネット接続を確認してください";
-  }
-  return e instanceof Error ? e.message : fallback;
-}
-
-function getCurrentPeriods(): { year: number; quarter: number; toYear: number; toQuarter: number } {
-  const now = new Date();
-  const toYear = now.getFullYear();
-  const toQuarter = Math.ceil((now.getMonth() + 1) / 3);
-  return { year: toYear - 2, quarter: 1, toYear, toQuarter };
-}
-
-export interface UseInvestmentSimulationParams {
-  simulationMode: SimulationMode;
-  onUrlUpdate: (qs: string) => void;
-}
-
-export interface UseInvestmentSimulationResult extends AnalysisResult {
   loading: boolean;
   error: string | null;
   lastInput: InvestmentInput | null;
@@ -91,194 +52,82 @@ export interface UseInvestmentSimulationResult extends AnalysisResult {
 export function useInvestmentSimulation(
   params: UseInvestmentSimulationParams
 ): UseInvestmentSimulationResult {
-  const [analysisResult, setAnalysisResult] = useState<AnalysisResult>(INITIAL_ANALYSIS_RESULT);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
+  // Shared state owned by orchestrator
+  const [result, setResult] = useState<InvestmentResult | null>(null);
   const [lastInput, setLastInput] = useState<InvestmentInput | null>(null);
-  const [propertyLat, setPropertyLat] = useState<number | undefined>(undefined);
-  const [propertyLng, setPropertyLng] = useState<number | undefined>(undefined);
-  const [monteCarloResult, setMonteCarloResult] = useState<MonteCarloResult | null>(null);
-  const [monteCarloLoading, setMonteCarloLoading] = useState(false);
-  const [loanMethod, setLoanMethod] = useState<LoanMethod>("equal-payment");
 
-  // Stable refs for params to avoid stale closures in callbacks
+  // Stable refs for params and mutable values accessed inside async callbacks
   const paramsRef = useRef(params);
   useEffect(() => {
     paramsRef.current = params;
   });
 
-  // Refs for mutable values accessed inside async callbacks
-  const lastInputRef = useRef(lastInput);
+  const lastInputRef = useRef<InvestmentInput | null>(lastInput);
   useEffect(() => {
     lastInputRef.current = lastInput;
   }, [lastInput]);
+
   const loanMethodRef = useRef<LoanMethod>("equal-payment");
 
-  const handleAnalyze = useCallback(async (input: InvestmentInput, quickTotalMan?: string) => {
-    const { simulationMode, onUrlUpdate } = paramsRef.current;
-    const currentLoanMethod = loanMethodRef.current;
-    setLoading(true);
-    setError(null);
-    setMonteCarloResult(null);
-    const inputWithMethod = { ...input, loanMethod: currentLoanMethod };
-    try {
-      const res = await analyzeOnline(inputWithMethod);
-      setAnalysisResult((prev) => ({ ...prev, result: res }));
-      setLastInput(inputWithMethod);
-      const urlParams = encodeUrlParams(simulationMode, inputWithMethod, quickTotalMan);
-      const qs = urlParams.toString();
-      onUrlUpdate(qs);
-    } catch (e) {
-      setError(toErrorMessage(e, "シミュレーションに失敗しました"));
-    } finally {
-      setLoading(false);
-    }
+  // Sub-hook: Monte Carlo (declared first so its setter can be passed to analyze)
+  const monteCarlo = useMonteCarloSim(lastInputRef);
+
+  const handleClearMonteCarloResult = useCallback(() => {
+    monteCarlo.setMonteCarloResult(null);
+  }, [monteCarlo]);
+
+  const handleResult = useCallback((res: InvestmentResult | null) => {
+    setResult(res);
   }, []);
 
-  const handleMonteCarlo = useCallback(async () => {
-    const current = lastInputRef.current;
-    if (!current) return;
-    setMonteCarloLoading(true);
-    try {
-      const res = await simulate({ base: current, simulations: 1000 });
-      setMonteCarloResult(res);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "モンテカルロシミュレーションに失敗しました");
-    } finally {
-      setMonteCarloLoading(false);
-    }
+  const handleLastInput = useCallback((input: InvestmentInput | null) => {
+    setLastInput(input);
   }, []);
 
-  const handleLoanMethodChange = useCallback(async (method: LoanMethod) => {
-    setLoanMethod(method);
-    loanMethodRef.current = method;
-    const current = lastInputRef.current;
-    if (!current) return;
-    setLoading(true);
-    setError(null);
-    setMonteCarloResult(null);
-    try {
-      const updatedInput = { ...current, loanMethod: method };
-      const res = await analyzeOnline(updatedInput);
-      setAnalysisResult((prev) => ({ ...prev, result: res }));
-      setLastInput((prev) => (prev ? { ...prev, loanMethod: method } : prev));
-    } catch (e) {
-      setError(toErrorMessage(e, "シミュレーションに失敗しました"));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  const handleFetchLandPrices = useCallback(
-    async (area: string, city: string, lat?: number, lng?: number) => {
-      setLoading(true);
-      setError(null);
-      setAnalysisResult((prev) => ({
-        ...prev,
-        stationRidership: null,
-        populationForecast: null,
-        landAppraisal: null,
-        externalUrbanRisks: null,
-        investmentScore: null,
-        hazardRisks: null,
-      }));
-      if (lat !== undefined && lng !== undefined) {
-        setPropertyLat(lat);
-        setPropertyLng(lng);
-      }
-      const { year, quarter, toYear, toQuarter } = getCurrentPeriods();
-      const current = lastInputRef.current;
-      try {
-        const baseParams = {
-          area,
-          city,
-          year,
-          quarter,
-          toYear,
-          toQuarter,
-          price: current?.landPrice ?? 5_000_000,
-          areaSqm: current?.landArea ?? 0,
-        };
-        const comp = await compareLandPrice(baseParams);
-        setAnalysisResult((prev) => ({ ...prev, comparison: comp }));
-
-        if (current && current.landArea > 0) {
-          try {
-            const est = await estimateLandPrice({
-              ...baseParams,
-              buildingAge: current.buildingAge,
-              stationMinutes: current.stationMinutes,
-            });
-            setAnalysisResult((prev) => ({ ...prev, theoreticalPrice: est }));
-          } catch {
-            setAnalysisResult((prev) => ({ ...prev, theoreticalPrice: null }));
-          }
-        }
-
-        const [appraisal] = await Promise.allSettled([
-          fetchLandAppraisals({ area, year: toYear, city: city || undefined }),
-        ]);
-        setAnalysisResult((prev) => ({
-          ...prev,
-          landAppraisal: appraisal.status === "fulfilled" ? appraisal.value : null,
-        }));
-
-        if (lat !== undefined && lng !== undefined) {
-          const [ridership, population, urbanRisks, scoreResult, hazard] = await Promise.allSettled(
-            [
-              fetchStationRidership({ lat, lng }),
-              fetchPopulationForecast({ lat, lng }),
-              fetchUrbanRisks(lat, lng),
-              fetchInvestmentScore({ lat, lng }),
-              fetchHazardInfo(lat, lng),
-            ]
-          );
-          setAnalysisResult((prev) => ({
-            ...prev,
-            stationRidership: ridership.status === "fulfilled" ? ridership.value : null,
-            populationForecast: population.status === "fulfilled" ? population.value : null,
-            externalUrbanRisks: urbanRisks.status === "fulfilled" ? urbanRisks.value : null,
-            investmentScore: scoreResult.status === "fulfilled" ? scoreResult.value : null,
-            hazardRisks: hazard.status === "fulfilled" ? hazard.value : null,
-          }));
-        }
-      } catch (e) {
-        setError(
-          e instanceof Error
-            ? e.message
-            : "相場データの取得に失敗しました。しばらく後に再試行してください"
-        );
-      } finally {
-        setLoading(false);
-      }
-    },
-    []
+  // Sub-hook: analyze API
+  const analyze = useAnalyzeApi(
+    lastInputRef,
+    loanMethodRef,
+    paramsRef,
+    handleResult,
+    handleLastInput,
+    handleClearMonteCarloResult
   );
 
-  const setPropertyCoords = useCallback((lat: number, lng: number) => {
-    setPropertyLat(lat);
-    setPropertyLng(lng);
-  }, []);
+  // Sub-hook: external data (land prices, geo data)
+  const external = useExternalData(lastInputRef);
+
+  // Combine loading and error from both analyze and external data
+  const loading = analyze.loading || external.loading;
+  const error = analyze.error ?? external.error ?? monteCarlo.monteCarloError;
 
   const clearResult = useCallback(() => {
-    setAnalysisResult((prev) => ({ ...prev, result: null }));
+    setResult(null);
   }, []);
 
   return {
-    ...analysisResult,
+    result,
+    comparison: external.comparison,
+    theoreticalPrice: external.theoreticalPrice,
+    stationRidership: external.stationRidership,
+    populationForecast: external.populationForecast,
+    landAppraisal: external.landAppraisal,
+    externalUrbanRisks: external.externalUrbanRisks,
+    investmentScore: external.investmentScore,
+    hazardRisks: external.hazardRisks,
     loading,
     error,
     lastInput,
-    propertyLat,
-    propertyLng,
-    monteCarloResult,
-    monteCarloLoading,
-    loanMethod,
-    handleAnalyze,
-    handleFetchLandPrices,
-    handleMonteCarlo,
-    handleLoanMethodChange,
-    setPropertyCoords,
+    propertyLat: external.propertyLat,
+    propertyLng: external.propertyLng,
+    monteCarloResult: monteCarlo.monteCarloResult,
+    monteCarloLoading: monteCarlo.monteCarloLoading,
+    loanMethod: analyze.loanMethod,
+    handleAnalyze: analyze.handleAnalyze,
+    handleFetchLandPrices: external.handleFetchLandPrices,
+    handleMonteCarlo: monteCarlo.handleMonteCarlo,
+    handleLoanMethodChange: analyze.handleLoanMethodChange,
+    setPropertyCoords: external.setPropertyCoords,
     clearResult,
   };
 }

--- a/frontend/src/hooks/useMonteCarloSim.ts
+++ b/frontend/src/hooks/useMonteCarloSim.ts
@@ -1,0 +1,46 @@
+"use client";
+import { useState, useCallback } from "react";
+import type { RefObject } from "react";
+import { simulate } from "@/lib/api";
+import type { InvestmentInput, MonteCarloResult } from "@/types/investment";
+
+export interface UseMonteCarloSimResult {
+  monteCarloResult: MonteCarloResult | null;
+  monteCarloLoading: boolean;
+  monteCarloError: string | null;
+  handleMonteCarlo: () => Promise<void>;
+  setMonteCarloResult: (result: MonteCarloResult | null) => void;
+}
+
+export function useMonteCarloSim(
+  lastInputRef: RefObject<InvestmentInput | null>
+): UseMonteCarloSimResult {
+  const [monteCarloResult, setMonteCarloResult] = useState<MonteCarloResult | null>(null);
+  const [monteCarloLoading, setMonteCarloLoading] = useState(false);
+  const [monteCarloError, setMonteCarloError] = useState<string | null>(null);
+
+  const handleMonteCarlo = useCallback(async () => {
+    const current = lastInputRef.current;
+    if (!current) return;
+    setMonteCarloLoading(true);
+    setMonteCarloError(null);
+    try {
+      const res = await simulate({ base: current, simulations: 1000 });
+      setMonteCarloResult(res);
+    } catch (e) {
+      setMonteCarloError(
+        e instanceof Error ? e.message : "モンテカルロシミュレーションに失敗しました"
+      );
+    } finally {
+      setMonteCarloLoading(false);
+    }
+  }, [lastInputRef]);
+
+  return {
+    monteCarloResult,
+    monteCarloLoading,
+    monteCarloError,
+    handleMonteCarlo,
+    setMonteCarloResult,
+  };
+}


### PR DESCRIPTION
## 概要
`useInvestmentSimulation.ts`（284行）が API 呼び出し・外部データ取得・URL エンコード・ローン方式管理など複数の責務を持っており、単体テストが困難だった。責務ごとにサブフックへ分割し、オーケストレーターとして再構成する。

## 変更内容
**新規ファイル**
- `frontend/src/hooks/useAnalyzeApi.ts` — `handleAnalyze` / `handleLoanMethodChange` と loading/error/loanMethod 状態を管理
- `frontend/src/hooks/useExternalData.ts` — `handleFetchLandPrices` と地価・駅・ハザード等の全外部データ状態を管理
- `frontend/src/hooks/useMonteCarloSim.ts` — `handleMonteCarlo` / `monteCarloResult` / `monteCarloLoading` を管理

**変更ファイル**
- `frontend/src/hooks/useInvestmentSimulation.ts` — オーケストレーターに書き換え（公開インターフェース `UseInvestmentSimulationResult` は無変更）

## 関連Issue
Closes #625

## テスト
- [x] `tsc --noEmit` エラーなし
- [x] `npm test -- --run` 全パス（`Dashboard.test.tsx` 含む）
- [x] `Dashboard.tsx` の変更ゼロを確認

## 確認事項
- [x] `lastInputRef` / `loanMethodRef` / `paramsRef` はオーケストレーターが所有し、各サブフックへ参照渡し
- [x] `setMonteCarloResult(null)` の cross-hook 呼び出しはコールバック経由で解決