### PR TITLE
feat: ダークモード CSS トークンとテーマ切替UI を追加

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -58,6 +58,7 @@
     --chart-primary: 221 83% 53%;
     --chart-secondary: 199 89% 48%;
     --chart-muted: 215 16% 47%;
+    --chart-orange: 25 95% 53%;
   }
 
   .dark {
@@ -87,6 +88,7 @@
     --chart-primary: 217 91% 60%;
     --chart-secondary: 199 89% 50%;
     --chart-muted: 215 20% 65%;
+    --chart-orange: 25 90% 55%;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -52,6 +52,41 @@
     --success: 142 71% 45%;
     --warning: 38 92% 50%;
     --danger: 0 84% 60%;
+    --chart-danger: 0 84% 60%;
+    --chart-warning: 38 92% 50%;
+    --chart-success: 142 71% 45%;
+    --chart-primary: 221 83% 53%;
+    --chart-secondary: 199 89% 48%;
+    --chart-muted: 215 16% 47%;
+  }
+
+  .dark {
+    --background: 222 47% 8%;
+    --foreground: 210 40% 96%;
+    --card: 222 47% 11%;
+    --card-foreground: 210 40% 96%;
+    --primary: 217 91% 60%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 217 33% 17%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 217 33% 17%;
+    --muted-foreground: 215 20% 65%;
+    --accent: 217 33% 17%;
+    --accent-foreground: 210 40% 96%;
+    --destructive: 0 63% 31%;
+    --destructive-foreground: 210 40% 96%;
+    --border: 217 33% 17%;
+    --input: 217 33% 17%;
+    --ring: 217 91% 60%;
+    --success: 142 71% 40%;
+    --warning: 38 92% 45%;
+    --danger: 0 63% 50%;
+    --chart-danger: 0 63% 50%;
+    --chart-warning: 38 92% 45%;
+    --chart-success: 142 71% 40%;
+    --chart-primary: 217 91% 60%;
+    --chart-secondary: 199 89% 50%;
+    --chart-muted: 215 20% 65%;
   }
 }
 

--- a/frontend/src/components/AreaDiscovery.tsx
+++ b/frontend/src/components/AreaDiscovery.tsx
@@ -66,7 +66,7 @@ function DifficultyBadge({ difficulty, label }: { difficulty: string; label: str
     "slightly-difficult": "bg-yellow-100 text-yellow-800 border border-yellow-200",
     difficult: "bg-red-100 text-red-800 border border-red-200",
   };
-  const cls = colorMap[difficulty] ?? "bg-gray-100 text-gray-800 border border-gray-200";
+  const cls = colorMap[difficulty] ?? "bg-muted text-foreground border border";
   return (
     <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}>
       {label}
@@ -106,7 +106,7 @@ export function AreaDiscovery({ onMunicipalitySelect }: Props) {
   };
 
   return (
-    <div className="rounded-xl border bg-white p-5 shadow-sm space-y-4">
+    <div className="rounded-xl border bg-card p-5 shadow-sm space-y-4">
       <h2 className="text-base font-semibold text-foreground">エリアを探す</h2>
       <p className="text-xs text-muted-foreground">
         予算と目標利回りを入力して、候補エリアをランキング表示します。

--- a/frontend/src/components/AreaDiscovery.tsx
+++ b/frontend/src/components/AreaDiscovery.tsx
@@ -66,7 +66,7 @@ function DifficultyBadge({ difficulty, label }: { difficulty: string; label: str
     "slightly-difficult": "bg-yellow-100 text-yellow-800 border border-yellow-200",
     difficult: "bg-red-100 text-red-800 border border-red-200",
   };
-  const cls = colorMap[difficulty] ?? "bg-muted text-foreground border border";
+  const cls = colorMap[difficulty] ?? "bg-muted text-foreground border";
   return (
     <span className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${cls}`}>
       {label}

--- a/frontend/src/components/CashFlowChart.tsx
+++ b/frontend/src/components/CashFlowChart.tsx
@@ -16,6 +16,7 @@ import {
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import type { InvestmentResult } from "@/types/investment";
 import { formatMan } from "@/lib/utils";
+import { chartColors } from "@/lib/chartColors";
 import { TrendingUp } from "lucide-react";
 import { TermTooltip } from "@/components/ui/TermTooltip";
 import { useResponsiveChart } from "@/lib/useChartHeight";
@@ -114,7 +115,7 @@ function CashFlowChart({ result, equityInvested }: Props) {
               orientation="right"
               domain={[0, 3]}
               tickFormatter={(v: number) => v.toFixed(1)}
-              tick={{ fontSize: 10, fill: "#8b5cf6" }}
+              tick={{ fontSize: 10, fill: chartColors.secondary }}
               width={isMobile ? 28 : 36}
               dx={isMobile ? 28 : 40}
               label={
@@ -125,7 +126,7 @@ function CashFlowChart({ result, equityInvested }: Props) {
                       angle: 90,
                       position: "insideRight",
                       fontSize: 10,
-                      fill: "#8b5cf6",
+                      fill: chartColors.secondary,
                       dx: 12,
                     }
               }
@@ -141,15 +142,15 @@ function CashFlowChart({ result, equityInvested }: Props) {
               labelStyle={{ fontWeight: "bold" }}
             />
             <Legend />
-            <ReferenceLine yAxisId="left" y={0} stroke="#9ca3af" />
-            <ReferenceLine yAxisId="right" y={0} stroke="#9ca3af" strokeDasharray="4 2" />
+            <ReferenceLine yAxisId="left" y={0} stroke={chartColors.muted} />
+            <ReferenceLine yAxisId="right" y={0} stroke={chartColors.muted} strokeDasharray="4 2" />
             {breakEvenYear && (
               <ReferenceLine
                 yAxisId="right"
                 x={`${breakEvenYear}年`}
-                stroke="#22c55e"
+                stroke={chartColors.success}
                 strokeDasharray="4 4"
-                label={{ value: "回収", position: "top", fontSize: 10, fill: "#22c55e" }}
+                label={{ value: "回収", position: "top", fontSize: 10, fill: chartColors.success }}
               />
             )}
             {rateChangeYears.map(({ year, rate }) => (
@@ -157,58 +158,58 @@ function CashFlowChart({ result, equityInvested }: Props) {
                 key={year}
                 yAxisId="left"
                 x={year}
-                stroke="#f97316"
+                stroke={chartColors.warning}
                 strokeDasharray="4 3"
                 label={{
                   value: `${(rate * 100).toFixed(2)}%`,
                   position: "insideTopRight",
                   fontSize: 9,
-                  fill: "#f97316",
+                  fill: chartColors.warning,
                 }}
               />
             ))}
             <Bar yAxisId="left" dataKey="税引後CF" maxBarSize={20} radius={[2, 2, 0, 0]}>
               {data.map((entry, index) => (
-                <Cell key={index} fill={entry.isDeadCrossZone ? "#fca5a5" : "#60a5fa"} />
+                <Cell key={index} fill={entry.isDeadCrossZone ? chartColors.danger : chartColors.primary} />
               ))}
             </Bar>
             <Line
               yAxisId="right"
               type="monotone"
               dataKey="累積CF"
-              stroke="#f59e0b"
+              stroke={chartColors.warning}
               strokeWidth={2}
               dot={false}
             />
             <ReferenceLine
               yAxisId="dscr"
               y={1.0}
-              stroke="#ef4444"
+              stroke={chartColors.danger}
               strokeDasharray="3 3"
               label={{
                 value: "危険",
                 position: "insideTopRight",
                 fontSize: 9,
-                fill: "#ef4444",
+                fill: chartColors.danger,
               }}
             />
             <ReferenceLine
               yAxisId="dscr"
               y={1.2}
-              stroke="#22c55e"
+              stroke={chartColors.success}
               strokeDasharray="3 3"
               label={{
                 value: "安全",
                 position: "insideTopRight",
                 fontSize: 9,
-                fill: "#22c55e",
+                fill: chartColors.success,
               }}
             />
             <Line
               yAxisId="dscr"
               type="monotone"
               dataKey="DSCR"
-              stroke="#8b5cf6"
+              stroke={chartColors.secondary}
               strokeWidth={2}
               dot={false}
               connectNulls

--- a/frontend/src/components/CostBreakdown.tsx
+++ b/frontend/src/components/CostBreakdown.tsx
@@ -24,7 +24,7 @@ const COLORS = [
   chartColors.danger,
   chartColors.secondary,
   chartColors.muted,
-  chartColors.warning,
+  chartColors.orange,
 ];
 
 export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }: Props) {
@@ -72,18 +72,18 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="flex items-center justify-between text-sm font-semibold">
-            <span className="text-gray-700">最低必要額</span>
-            <span className="font-mono text-lg text-gray-900">{fmt(minimumRequired)}</span>
+            <span className="text-foreground">最低必要額</span>
+            <span className="font-mono text-lg text-foreground">{fmt(minimumRequired)}</span>
           </div>
           <div className="border-t pt-3 space-y-2">
-            <p className="text-xs font-medium text-gray-500 uppercase tracking-wide">内訳</p>
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">内訳</p>
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">頭金（借入控除後）</span>
-              <span className="font-mono text-gray-900">{fmt(downPayment)}</span>
+              <span className="text-muted-foreground">頭金（借入控除後）</span>
+              <span className="font-mono text-foreground">{fmt(downPayment)}</span>
             </div>
             <div className="flex items-center justify-between text-sm">
-              <span className="text-gray-600">諸費用合計</span>
-              <span className="font-mono text-gray-900">{fmt(acquisitionCosts.total)}</span>
+              <span className="text-muted-foreground">諸費用合計</span>
+              <span className="font-mono text-foreground">{fmt(acquisitionCosts.total)}</span>
             </div>
           </div>
           <div className="border-t pt-3">
@@ -107,7 +107,7 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
 
       {/* 初期投資内訳 */}
       <div>
-        <h3 className="text-sm font-medium text-gray-600 mb-3">
+        <h3 className="text-sm font-medium text-muted-foreground mb-3">
           初期投資の内訳（合計: {fmt(totalInitial)}）
         </h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
@@ -138,11 +138,11 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
                     className="inline-block w-3 h-3 rounded-sm"
                     style={{ background: COLORS[idx % COLORS.length] }}
                   />
-                  <span className="text-gray-700">{item.name}</span>
+                  <span className="text-foreground">{item.name}</span>
                 </div>
-                <span className="font-mono text-gray-900">
+                <span className="font-mono text-foreground">
                   {fmt(item.value)}
-                  <span className="text-xs text-gray-400 ml-1">
+                  <span className="text-xs text-muted-foreground ml-1">
                     ({((item.value / totalInitial) * 100).toFixed(1)}%)
                   </span>
                 </span>
@@ -154,8 +154,8 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
 
       {/* 諸経費明細テーブル */}
       <div>
-        <h3 className="text-sm font-medium text-gray-600 mb-2">取得時諸経費の明細</h3>
-        <div className="rounded-lg border border-gray-200 overflow-hidden text-sm">
+        <h3 className="text-sm font-medium text-muted-foreground mb-2">取得時諸経費の明細</h3>
+        <div className="rounded-lg border border overflow-hidden text-sm">
           <table className="w-full">
             <tbody className="divide-y divide-gray-100">
               {[
@@ -172,16 +172,16 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
                     ]
                   : []),
               ].map(([label, value]) => (
-                <tr key={label as string} className="hover:bg-gray-50">
-                  <td className="px-4 py-2 text-gray-600">{label as string}</td>
-                  <td className="px-4 py-2 text-right font-mono text-gray-900">
+                <tr key={label as string} className="hover:bg-muted/30">
+                  <td className="px-4 py-2 text-muted-foreground">{label as string}</td>
+                  <td className="px-4 py-2 text-right font-mono text-foreground">
                     {fmt(value as number)}
                   </td>
                 </tr>
               ))}
-              <tr className="bg-gray-50 font-semibold">
-                <td className="px-4 py-2 text-gray-800">合計</td>
-                <td className="px-4 py-2 text-right font-mono text-gray-900">
+              <tr className="bg-muted/40 font-semibold">
+                <td className="px-4 py-2 text-foreground">合計</td>
+                <td className="px-4 py-2 text-right font-mono text-foreground">
                   {fmt(acquisitionCosts.total)}
                 </td>
               </tr>
@@ -193,7 +193,7 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
       {/* 1年目の年間費用内訳 */}
       {annualCostItems.length > 0 && (
         <div>
-          <h3 className="text-sm font-medium text-gray-600 mb-3">年間費用の内訳（1年目）</h3>
+          <h3 className="text-sm font-medium text-muted-foreground mb-3">年間費用の内訳（1年目）</h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
             <ResponsiveContainer width="100%" height={annualPieHeight}>
               <PieChart>
@@ -225,11 +225,11 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
                         className="inline-block w-3 h-3 rounded-sm"
                         style={{ background: COLORS[idx % COLORS.length] }}
                       />
-                      <span className="text-gray-700">{item.name}</span>
+                      <span className="text-foreground">{item.name}</span>
                     </div>
-                    <span className="font-mono text-gray-900">
+                    <span className="font-mono text-foreground">
                       {fmt(item.value)}
-                      <span className="text-xs text-gray-400 ml-1">
+                      <span className="text-xs text-muted-foreground ml-1">
                         ({((item.value / total) * 100).toFixed(1)}%)
                       </span>
                     </span>

--- a/frontend/src/components/CostBreakdown.tsx
+++ b/frontend/src/components/CostBreakdown.tsx
@@ -4,6 +4,7 @@ import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from "recha
 import { AcquisitionCostBreakdown, InvestmentInput, YearlyResult } from "@/types/investment";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useChartHeight } from "@/lib/useChartHeight";
+import { chartColors } from "@/lib/chartColors";
 
 interface Props {
   input: InvestmentInput;
@@ -16,7 +17,15 @@ const fmt = (n: number) =>
     ? `${(n / 10_000_000).toFixed(1)}千万円`
     : `${Math.round(n / 10_000).toLocaleString()}万円`;
 
-const COLORS = ["#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6", "#06b6d4", "#f97316"];
+const COLORS = [
+  chartColors.primary,
+  chartColors.success,
+  chartColors.warning,
+  chartColors.danger,
+  chartColors.secondary,
+  chartColors.muted,
+  chartColors.warning,
+];
 
 export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }: Props) {
   const initialPieHeight = useChartHeight(180, 200, 220);

--- a/frontend/src/components/CostBreakdown.tsx
+++ b/frontend/src/components/CostBreakdown.tsx
@@ -155,9 +155,9 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
       {/* 諸経費明細テーブル */}
       <div>
         <h3 className="text-sm font-medium text-muted-foreground mb-2">取得時諸経費の明細</h3>
-        <div className="rounded-lg border border overflow-hidden text-sm">
+        <div className="rounded-lg border overflow-hidden text-sm">
           <table className="w-full">
-            <tbody className="divide-y divide-gray-100">
+            <tbody className="divide-y divide-border">
               {[
                 ["仲介手数料（税込）", acquisitionCosts.brokerageFee],
                 ["印紙税", acquisitionCosts.stampDuty],

--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -19,6 +19,7 @@ import { FirstTimerGuide } from "@/components/FirstTimerGuide";
 import { SAMPLE_PROPERTY, ONBOARDING_KEY } from "@/lib/sampleProperty";
 import { FormSheet } from "@/components/FormSheet";
 import { ResultsSection } from "@/components/ResultsSection";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import { useNetworkStatus } from "@/hooks/useNetworkStatus";
 import { useInvestmentSimulation } from "@/hooks/useInvestmentSimulation";
 
@@ -145,7 +146,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
           }}
         />
       )}
-      <header className="border-b bg-white px-4 py-3 shadow-sm lg:px-6 lg:py-4">
+      <header className="border-b bg-card px-4 py-3 shadow-sm lg:px-6 lg:py-4">
         <div className="mx-auto flex max-w-7xl items-center gap-3">
           <ShieldAlert className="h-6 w-6 text-primary lg:h-7 lg:w-7" />
           <div>
@@ -153,6 +154,7 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
             <p className="text-xs text-muted-foreground">不動産投資リスク可視化ツール</p>
           </div>
           <div className="ml-auto flex items-center gap-2 lg:gap-3">
+            <ThemeToggle />
             {result && lastInput && (
               <button
                 onClick={handleShare}

--- a/frontend/src/components/DeadCrossChart.tsx
+++ b/frontend/src/components/DeadCrossChart.tsx
@@ -16,6 +16,7 @@ import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import type { CriticalError, InvestmentResult } from "@/types/investment";
 import { formatMan } from "@/lib/utils";
+import { chartColors } from "@/lib/chartColors";
 import { Skull, ShieldCheck } from "lucide-react";
 import { TermTooltip } from "@/components/ui/TermTooltip";
 import { useResponsiveChart } from "@/lib/useChartHeight";
@@ -140,16 +141,16 @@ function DeadCrossChart({ result }: Props) {
               <ReferenceArea
                 x1={`${deadCrossYear}年`}
                 x2={`${deadCrossEndYear}年`}
-                fill="#fee2e2"
-                fillOpacity={0.5}
+                fill={chartColors.danger}
+                fillOpacity={0.15}
               />
             )}
 
-            <Line type="monotone" dataKey="元金返済" stroke="#ef4444" strokeWidth={2} dot={false} />
+            <Line type="monotone" dataKey="元金返済" stroke={chartColors.danger} strokeWidth={2} dot={false} />
             <Line
               type="monotone"
               dataKey="減価償却費"
-              stroke="#3b82f6"
+              stroke={chartColors.primary}
               strokeWidth={2}
               dot={false}
               strokeDasharray="5 5"
@@ -158,13 +159,13 @@ function DeadCrossChart({ result }: Props) {
             {hasDeadCross && (
               <ReferenceLine
                 x={`${deadCrossYear}年`}
-                stroke="#f97316"
+                stroke={chartColors.warning}
                 strokeWidth={2}
                 label={{
                   value: `開始(${deadCrossYear}年)`,
                   position: "top",
                   fontSize: 11,
-                  fill: "#f97316",
+                  fill: chartColors.warning,
                 }}
               />
             )}

--- a/frontend/src/components/FirstTimerGuide.tsx
+++ b/frontend/src/components/FirstTimerGuide.tsx
@@ -36,7 +36,7 @@ const STEPS = [
 export function FirstTimerGuide({ onUseSample, onDismiss, sampleProperty }: Props) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
-      <div className="relative w-full max-w-lg rounded-2xl bg-white shadow-2xl">
+      <div className="relative w-full max-w-lg rounded-2xl bg-card shadow-2xl">
         <button
           onClick={onDismiss}
           className="absolute right-4 top-4 rounded-full p-1 text-muted-foreground hover:bg-muted"

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -539,7 +539,7 @@ export function InvestmentForm({
             <button
               type="button"
               onClick={handleDiscardDraft}
-              className="rounded bg-gray-200 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-300"
+              className="rounded bg-muted px-3 py-1 text-xs font-medium text-foreground hover:bg-muted/80"
             >
               破棄する
             </button>

--- a/frontend/src/components/InvestmentScoreCard.tsx
+++ b/frontend/src/components/InvestmentScoreCard.tsx
@@ -28,16 +28,16 @@ function ScoreRow({ item }: { item: ScoreItem }) {
   const isPositive = item.score > 0;
   const isNegative = item.score < 0;
   return (
-    <div className="flex items-start justify-between gap-2 py-1 text-xs border-b border-gray-100 last:border-0">
-      <span className="text-gray-600 min-w-[6rem]">{item.label}</span>
+    <div className="flex items-start justify-between gap-2 py-1 text-xs border-b border last:border-0">
+      <span className="text-muted-foreground min-w-[6rem]">{item.label}</span>
       <span
         className={`font-semibold tabular-nums min-w-[3rem] text-right ${
-          isPositive ? "text-green-600" : isNegative ? "text-red-600" : "text-gray-500"
+          isPositive ? "text-green-600" : isNegative ? "text-red-600" : "text-muted-foreground"
         }`}
       >
         {isPositive ? `+${item.score}` : item.score}
       </span>
-      <span className="text-gray-500 flex-1 text-right leading-tight">{item.description}</span>
+      <span className="text-muted-foreground flex-1 text-right leading-tight">{item.description}</span>
     </div>
   );
 }
@@ -85,7 +85,7 @@ export function InvestmentScoreCard({ score, populationChangeRate, onApplyRecomm
             <span className={`text-3xl font-bold tabular-nums ${gradeStyle.color}`}>
               {totalScore}
             </span>
-            <span className="text-gray-400 text-sm font-normal">/ 100</span>
+            <span className="text-muted-foreground text-sm font-normal">/ 100</span>
             <Badge variant={gradeStyle.badge}>{grade}</Badge>
           </div>
         </CardTitle>
@@ -137,7 +137,7 @@ export function InvestmentScoreCard({ score, populationChangeRate, onApplyRecomm
           </div>
         )}
 
-        <p className="mt-2 text-[10px] text-gray-400 leading-tight">
+        <p className="mt-2 text-[10px] text-muted-foreground leading-tight">
           基準スコア50点 +
           各指標の加減点（0〜100にクランプ）。API取得失敗時は該当指標を0点として算出。
         </p>

--- a/frontend/src/components/KpiStrip.tsx
+++ b/frontend/src/components/KpiStrip.tsx
@@ -18,7 +18,7 @@ interface KpiCellProps {
 
 function KpiCell({ icon, label, value, sub, subPositive }: KpiCellProps) {
   return (
-    <div className="flex flex-col gap-1 rounded-lg border bg-white p-3 shadow-sm">
+    <div className="flex flex-col gap-1 rounded-lg border bg-card p-3 shadow-sm">
       <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
         {icon}
         <span>{label}</span>

--- a/frontend/src/components/LandPriceAnalysis.tsx
+++ b/frontend/src/components/LandPriceAnalysis.tsx
@@ -492,7 +492,7 @@ export function LandPriceAnalysis({
               {stationRidership.slice(0, 5).map((s) => {
                 const scoreInfo = RIDERSHIP_SCORE_LABEL[s.demandScore] ?? {
                   label: s.demandScore,
-                  color: "text-gray-700",
+                  color: "text-foreground",
                 };
                 return (
                   <div

--- a/frontend/src/components/LoanOptimizationPanel.tsx
+++ b/frontend/src/components/LoanOptimizationPanel.tsx
@@ -65,7 +65,7 @@ export function LoanOptimizationPanel({
             </p>
           </div>
           {!hasLoan ? (
-            <Badge className="flex items-center gap-1 bg-gray-100 text-gray-500 border-gray-200 ml-auto">
+            <Badge className="flex items-center gap-1 bg-muted text-muted-foreground border ml-auto">
               非適用（ローンなし）
             </Badge>
           ) : dscrSafe ? (

--- a/frontend/src/components/MultiExitCompareTable.tsx
+++ b/frontend/src/components/MultiExitCompareTable.tsx
@@ -40,7 +40,7 @@ export default function MultiExitCompareTable({ rows }: MultiExitCompareTablePro
   ];
 
   return (
-    <div className="rounded-xl border bg-white p-5 shadow-sm">
+    <div className="rounded-xl border bg-card p-5 shadow-sm">
       <h3 className="text-base font-semibold text-foreground mb-4">複数保有年数 出口比較</h3>
       <div className="overflow-x-auto">
         <table className="w-full text-sm border-collapse">

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -133,7 +133,7 @@ export function ResultsSection({
           onClick={() => setActiveTab("simulation")}
           className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
             activeTab === "simulation"
-              ? "bg-white shadow-sm text-foreground"
+              ? "bg-card shadow-sm text-foreground"
               : "text-muted-foreground hover:text-foreground"
           }`}
         >
@@ -147,7 +147,7 @@ export function ResultsSection({
           }}
           className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors ${
             activeTab === "area-discovery"
-              ? "bg-white shadow-sm text-foreground"
+              ? "bg-card shadow-sm text-foreground"
               : "text-muted-foreground hover:text-foreground"
           }`}
         >
@@ -263,7 +263,7 @@ export function ResultsSection({
                   onClick={() => handleResultsTabChange(id)}
                   className={`rounded-md px-4 py-1.5 text-sm font-medium transition-colors whitespace-nowrap ${
                     resultsTab === id
-                      ? "bg-white shadow-sm text-foreground"
+                      ? "bg-card shadow-sm text-foreground"
                       : "text-muted-foreground hover:text-foreground"
                   }`}
                 >
@@ -289,7 +289,7 @@ export function ResultsSection({
               {simulationMode === "full" && (
                 <>
                   {result.acquisitionCosts && (
-                    <div className="rounded-xl border bg-white p-5 shadow-sm">
+                    <div className="rounded-xl border bg-card p-5 shadow-sm">
                       <CostBreakdown
                         input={lastInput}
                         acquisitionCosts={result.acquisitionCosts}

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,40 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Sun, Moon } from "lucide-react";
+
+export function ThemeToggle() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    try {
+      const stored = localStorage.getItem("theme");
+      const prefersDark = window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
+      const isDark = stored ? stored === "dark" : prefersDark;
+      setDark(isDark);
+      document.documentElement.classList.toggle("dark", isDark);
+    } catch {
+      // localStorage/matchMedia unavailable (SSR or test env)
+    }
+  }, []);
+
+  function toggle() {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    try {
+      localStorage.setItem("theme", next ? "dark" : "light");
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      aria-label={dark ? "ライトモードに切り替え" : "ダークモードに切り替え"}
+      className="rounded-md p-2 hover:bg-secondary"
+    >
+      {dark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+    </button>
+  );
+}

--- a/frontend/src/components/WatchlistCompareTable.tsx
+++ b/frontend/src/components/WatchlistCompareTable.tsx
@@ -145,7 +145,7 @@ export default function WatchlistCompareTable({ items }: WatchlistCompareTablePr
                         item.status === "検討中"
                           ? "bg-blue-100 text-blue-800"
                           : item.status === "見送り"
-                            ? "bg-gray-100 text-gray-600"
+                            ? "bg-muted text-muted-foreground"
                             : "bg-emerald-100 text-emerald-800"
                       }`}
                     >

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -710,7 +710,7 @@ export function YieldAnalysis({
             </CardTitle>
           </CardHeader>
           <CardContent className="space-y-3">
-            <div className="rounded-md bg-white/70 p-3">
+            <div className="rounded-md bg-card/70 p-3">
               <p className="text-xs text-muted-foreground">
                 土地価格 <strong>または</strong> 建築費のどちらか一方を削減する必要がある額
               </p>
@@ -718,7 +718,7 @@ export function YieldAnalysis({
                 ▼ {formatMan(result.requiredCostReduction)}
               </p>
             </div>
-            <div className="rounded-md bg-white/70 p-3">
+            <div className="rounded-md bg-card/70 p-3">
               <p className="text-xs text-muted-foreground">または、必要な月額賃料（満室想定）</p>
               <p className="text-xl font-bold text-orange-700">
                 ▲ {formatYen(result.requiredMonthlyRent)}/月

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -59,7 +59,7 @@ export function ScenarioSection({
               type="checkbox"
               checked={rateSchedule.enabled}
               onChange={(e) => rateSchedule.onToggle(e.target.checked)}
-              className="h-4 w-4 rounded border-gray-300"
+              className="h-4 w-4 rounded border"
             />
             <span className="text-xs text-muted-foreground">有効にする</span>
           </label>
@@ -181,7 +181,7 @@ export function ScenarioSection({
                 type="checkbox"
                 checked={exitYears.includes(yr)}
                 onChange={() => toggleExitYear(yr)}
-                className="h-4 w-4 rounded border-gray-300"
+                className="h-4 w-4 rounded border"
               />
               <span className="text-sm">{yr}年</span>
             </label>

--- a/frontend/src/components/ui/slider.tsx
+++ b/frontend/src/components/ui/slider.tsx
@@ -49,7 +49,7 @@ export function Slider({
           className="absolute inset-0 h-2 w-full cursor-pointer opacity-0"
         />
         <div
-          className="absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border-2 border-primary bg-white shadow"
+          className="absolute top-1/2 h-4 w-4 -translate-y-1/2 rounded-full border-2 border-primary bg-card shadow"
           style={{ left: `calc(${pct}% - 8px)` }}
         />
       </div>

--- a/frontend/src/lib/chartColors.ts
+++ b/frontend/src/lib/chartColors.ts
@@ -1,0 +1,8 @@
+export const chartColors = {
+  danger:    "hsl(var(--chart-danger))",
+  warning:   "hsl(var(--chart-warning))",
+  success:   "hsl(var(--chart-success))",
+  primary:   "hsl(var(--chart-primary))",
+  secondary: "hsl(var(--chart-secondary))",
+  muted:     "hsl(var(--chart-muted))",
+} as const;

--- a/frontend/src/lib/chartColors.ts
+++ b/frontend/src/lib/chartColors.ts
@@ -5,4 +5,5 @@ export const chartColors = {
   primary:   "hsl(var(--chart-primary))",
   secondary: "hsl(var(--chart-secondary))",
   muted:     "hsl(var(--chart-muted))",
+  orange:    "hsl(var(--chart-orange))",
 } as const;


### PR DESCRIPTION
## 概要
`@variant dark` 宣言はあったが `.dark` クラス用のカラートークンが未定義で、Recharts の色もすべて hex ハードコードされていた。ダークテーマ用トークンを定義し、チャート色を CSS 変数経由に統一、ヘッダーにテーマ切替ボタンを追加する。

## 変更内容
- `frontend/src/app/globals.css` — `:root` にチャート用カラートークン（`--chart-*`）を追加、`.dark` ブロックを新設
- `frontend/src/lib/chartColors.ts` （新規）— CSS 変数を参照するチャート色定数
- `frontend/src/components/DeadCrossChart.tsx` — hex 色を `chartColors.*` に置換
- `frontend/src/components/CashFlowChart.tsx` — 同上
- `frontend/src/components/CostBreakdown.tsx` — 同上
- `frontend/src/components/ThemeToggle.tsx` （新規）— Sun/Moon アイコン・`localStorage` 永続化・`prefers-color-scheme` 検出
- `frontend/src/components/Dashboard.tsx` — ヘッダーに `<ThemeToggle />` を追加

## 関連Issue
Closes #210

## テスト
- [x] `tsc --noEmit` エラーなし
- [x] `npm test -- --run` 全パス（Dashboard テスト含む）
- [x] jsdom 環境での `localStorage` / `matchMedia` 未定義を try-catch でガード済み

## 確認事項
- [x] グラデーション不使用
- [x] `lucide-react` のみ使用
- [x] `aria-label` 付与（WCAG 1.4.1 準拠）