### PR TITLE
refactor(frontend): api.ts ヘルパー抽出・Municipality 型移動・テスト追加

### DIFF
--- a/frontend/src/components/__tests__/InvestmentScoreCard.test.tsx
+++ b/frontend/src/components/__tests__/InvestmentScoreCard.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
+import type { InvestmentScoreResult, ScoreItem } from "@/types/investment";
+
+function makeScoreItem(label: string, score: number): ScoreItem {
+  return { label, score, description: `${label}の説明` };
+}
+
+function makeScore(totalScore: number, grade: string): InvestmentScoreResult {
+  return {
+    totalScore,
+    grade,
+    breakdown: {
+      population: makeScoreItem("人口動態", 5),
+      ridership: makeScoreItem("乗降客数", 10),
+      urbanArea: makeScoreItem("市街化区域", 3),
+      locationOptimization: makeScoreItem("立地最適化", 2),
+      hazardRisk: makeScoreItem("ハザード", -5),
+      liquefactionRisk: makeScoreItem("液状化", 0),
+      embankment: makeScoreItem("盛土", 0),
+      disasterHistory: makeScoreItem("災害履歴", 0),
+      radarData: [],
+    },
+  };
+}
+
+describe("InvestmentScoreCard", () => {
+  it("totalScore と grade が表示される", () => {
+    render(<InvestmentScoreCard score={makeScore(78, "良好")} />);
+    expect(screen.getByText("78")).toBeTruthy();
+    expect(screen.getByText("良好")).toBeTruthy();
+  });
+
+  it("優良グレードで Badge が表示される", () => {
+    render(<InvestmentScoreCard score={makeScore(90, "優良")} />);
+    expect(screen.getByText("優良")).toBeTruthy();
+  });
+
+  it("要注意グレードで Badge が表示される", () => {
+    render(<InvestmentScoreCard score={makeScore(30, "要注意")} />);
+    expect(screen.getByText("要注意")).toBeTruthy();
+  });
+
+  it("各スコア項目のラベルが表示される", () => {
+    render(<InvestmentScoreCard score={makeScore(60, "普通")} />);
+    expect(screen.getByText("人口動態")).toBeTruthy();
+    expect(screen.getByText("乗降客数")).toBeTruthy();
+    expect(screen.getByText("ハザード")).toBeTruthy();
+  });
+
+  it("onApplyRecommend が渡された場合、推奨値適用ボタンが表示される", async () => {
+    const onApply = vi.fn();
+    render(<InvestmentScoreCard score={makeScore(70, "良好")} onApplyRecommend={onApply} />);
+    const btn = screen.getByRole("button", { name: /推奨空室率/ });
+    expect(btn).toBeTruthy();
+    await userEvent.click(btn);
+    expect(onApply).toHaveBeenCalledOnce();
+  });
+
+  it("onApplyRecommend が渡されない場合、推奨値適用ボタンは表示されない", () => {
+    render(<InvestmentScoreCard score={makeScore(60, "普通")} />);
+    expect(screen.queryByRole("button", { name: /推奨空室率/ })).toBeNull();
+  });
+});

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -17,7 +17,10 @@ import type {
   RentDeclineHint,
   HeatmapResponse,
   GeocodeResult,
+  Municipality,
 } from "@/types/investment";
+
+export type { Municipality };
 
 const BASE = "/api";
 
@@ -29,6 +32,29 @@ async function handleResponse<T>(res: Response): Promise<T> {
   return res.json() as Promise<T>;
 }
 
+async function postJson<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  return handleResponse<T>(res);
+}
+
+function buildParams(
+  required: Record<string, string | number>,
+  optional?: Record<string, string | number | undefined>
+): URLSearchParams {
+  const q = new URLSearchParams();
+  for (const [k, v] of Object.entries(required)) q.set(k, String(v));
+  if (optional) {
+    for (const [k, v] of Object.entries(optional)) {
+      if (v !== undefined) q.set(k, String(v));
+    }
+  }
+  return q;
+}
+
 /** 土地取引価格の統計を取得 */
 export async function fetchLandPrices(params: {
   area: string;
@@ -38,14 +64,10 @@ export async function fetchLandPrices(params: {
   toYear: number;
   toQuarter: number;
 }): Promise<LandPriceStats> {
-  const q = new URLSearchParams({
-    area: params.area,
-    year: String(params.year),
-    quarter: String(params.quarter),
-    to_year: String(params.toYear),
-    to_quarter: String(params.toQuarter),
-  });
-  if (params.city) q.set("city", params.city);
+  const q = buildParams(
+    { area: params.area, year: params.year, quarter: params.quarter, to_year: params.toYear, to_quarter: params.toQuarter },
+    { city: params.city }
+  );
   const res = await fetch(`${BASE}/land-prices/stats?${q}`);
   return handleResponse<LandPriceStats>(res);
 }
@@ -61,23 +83,12 @@ export async function compareLandPrice(params: {
   price: number;
   areaSqm?: number;
 }): Promise<LandPriceComparison> {
-  const q = new URLSearchParams({
-    area: params.area,
-    year: String(params.year),
-    quarter: String(params.quarter),
-    to_year: String(params.toYear),
-    to_quarter: String(params.toQuarter),
-    price: String(params.price),
-  });
-  if (params.city) q.set("city", params.city);
-  if (params.areaSqm) q.set("area_sqm", String(params.areaSqm));
+  const q = buildParams(
+    { area: params.area, year: params.year, quarter: params.quarter, to_year: params.toYear, to_quarter: params.toQuarter, price: params.price },
+    { city: params.city, area_sqm: params.areaSqm }
+  );
   const res = await fetch(`${BASE}/land-prices/compare?${q}`);
   return handleResponse<LandPriceComparison>(res);
-}
-
-export interface Municipality {
-  id: string;
-  name: string;
 }
 
 /** 都道府県コードから市区町村一覧を取得（XIT002） */
@@ -100,19 +111,10 @@ export async function estimateLandPrice(params: {
   stationMinutes?: number;
   ridershipScore?: RidershipDemandScore;
 }): Promise<TheoreticalPriceResult> {
-  const q = new URLSearchParams({
-    area: params.area,
-    year: String(params.year),
-    quarter: String(params.quarter),
-    to_year: String(params.toYear),
-    to_quarter: String(params.toQuarter),
-    price: String(params.price),
-    area_sqm: String(params.areaSqm),
-    building_age: String(params.buildingAge),
-  });
-  if (params.city) q.set("city", params.city);
-  if (params.stationMinutes) q.set("station_minutes", String(params.stationMinutes));
-  if (params.ridershipScore) q.set("ridership_score", params.ridershipScore);
+  const q = buildParams(
+    { area: params.area, year: params.year, quarter: params.quarter, to_year: params.toYear, to_quarter: params.toQuarter, price: params.price, area_sqm: params.areaSqm, building_age: params.buildingAge },
+    { city: params.city, station_minutes: params.stationMinutes, ridership_score: params.ridershipScore }
+  );
   const res = await fetch(`${BASE}/land-prices/estimate?${q}`);
   return handleResponse<TheoreticalPriceResult>(res);
 }
@@ -191,22 +193,12 @@ export async function fetchHazardInfo(lat: number, lng: number): Promise<UrbanRi
 
 /** 投資シミュレーションを実行 */
 export async function analyze(input: InvestmentInput): Promise<InvestmentResult> {
-  const res = await fetch(`${BASE}/investment/analyze`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  return handleResponse<InvestmentResult>(res);
+  return postJson<InvestmentResult>("/investment/analyze", input);
 }
 
 /** リフォームROIシミュレーションを実行 */
 export async function analyzeRenovation(input: RenovationInput): Promise<RenovationResult> {
-  const res = await fetch(`${BASE}/renovation/analyze`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  return handleResponse<RenovationResult>(res);
+  return postJson<RenovationResult>("/renovation/analyze", input);
 }
 
 /** 投資適地スコアを取得 */
@@ -272,12 +264,7 @@ export async function fetchAreaDiscovery(params: {
 
 /** モンテカルロシミュレーションを実行 */
 export async function simulate(input: MonteCarloInput): Promise<MonteCarloResult> {
-  const res = await fetch(`${BASE}/investment/simulate`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
-  });
-  return handleResponse<MonteCarloResult>(res);
+  return postJson<MonteCarloResult>("/investment/simulate", input);
 }
 
 /** 住所文字列から緯度・経度を取得（バックエンド経由でGoogle Maps Geocoding API を呼び出す） */

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -1,3 +1,8 @@
+export interface Municipality {
+  id: string;
+  name: string;
+}
+
 export interface CriticalError {
   code: string;
   status: "REJECT" | "WARNING";


### PR DESCRIPTION
## 概要
`api.ts` に POST フェッチと `URLSearchParams` 構築のボイラープレートが散在していた。共通ヘルパーを抽出してコードを簡潔にし、`Municipality` 型を適切な場所へ移動する。また `InvestmentScoreCard` の単体テストが存在しなかったため追加した。

## 変更内容
- `frontend/src/lib/api.ts`
  - `postJson<T>(path, body)` ヘルパーを追加（`analyze` / `analyzeRenovation` / `simulate` の3箇所に適用）
  - `buildParams(required, optional)` ヘルパーを追加（`fetchLandPrices` / `compareLandPrice` / `estimateLandPrice` の3箇所に適用）
  - `Municipality` インターフェースを削除し `types/investment.ts` から re-export に変更
- `frontend/src/types/investment.ts` — `Municipality` インターフェースを追加
- `frontend/src/components/__tests__/InvestmentScoreCard.test.tsx` （新規）— スコア表示・グレード別バッジ・推奨値適用ボタンの6ケース

## 関連Issue
Closes #329

## テスト
- [x] `tsc --noEmit` エラーなし
- [x] `npm test -- --run` 全パス（InvestmentScoreCard 6ケース含む）
- [x] 既存の `Municipality` インポートサイトは `@/lib/api` 経由の re-export で無変更のまま動作

## 確認事項
- [x] `Municipality` を直接 import していた他コンポーネントは変更不要（re-export で互換維持）