### PR TITLE
refactor: YieldAnalysis.tsx（832行）を責務別コンポーネントに分割する

### DIFF
--- a/frontend/src/components/CashFlowChart.tsx
+++ b/frontend/src/components/CashFlowChart.tsx
@@ -170,7 +170,10 @@ function CashFlowChart({ result, equityInvested }: Props) {
             ))}
             <Bar yAxisId="left" dataKey="税引後CF" maxBarSize={20} radius={[2, 2, 0, 0]}>
               {data.map((entry, index) => (
-                <Cell key={index} fill={entry.isDeadCrossZone ? chartColors.danger : chartColors.primary} />
+                <Cell
+                  key={index}
+                  fill={entry.isDeadCrossZone ? chartColors.danger : chartColors.primary}
+                />
               ))}
             </Bar>
             <Line

--- a/frontend/src/components/CostBreakdown.tsx
+++ b/frontend/src/components/CostBreakdown.tsx
@@ -76,7 +76,9 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
             <span className="font-mono text-lg text-foreground">{fmt(minimumRequired)}</span>
           </div>
           <div className="border-t pt-3 space-y-2">
-            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">内訳</p>
+            <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              内訳
+            </p>
             <div className="flex items-center justify-between text-sm">
               <span className="text-muted-foreground">頭金（借入控除後）</span>
               <span className="font-mono text-foreground">{fmt(downPayment)}</span>
@@ -193,7 +195,9 @@ export default function CostBreakdown({ input, acquisitionCosts, yearlyResults }
       {/* 1年目の年間費用内訳 */}
       {annualCostItems.length > 0 && (
         <div>
-          <h3 className="text-sm font-medium text-muted-foreground mb-3">年間費用の内訳（1年目）</h3>
+          <h3 className="text-sm font-medium text-muted-foreground mb-3">
+            年間費用の内訳（1年目）
+          </h3>
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4 items-center">
             <ResponsiveContainer width="100%" height={annualPieHeight}>
               <PieChart>

--- a/frontend/src/components/CustomScenarioSlider.tsx
+++ b/frontend/src/components/CustomScenarioSlider.tsx
@@ -72,7 +72,12 @@ export function CustomScenarioSlider({ input, onStateChange }: CustomScenarioSli
   }, [customLoanRateDelta, customVacancyRateDelta, fetchCustomScenario]);
 
   useEffect(() => {
-    onStateChangeRef.current({ customScenario, customLoading, customLoanRateDelta, customVacancyRateDelta });
+    onStateChangeRef.current({
+      customScenario,
+      customLoading,
+      customLoanRateDelta,
+      customVacancyRateDelta,
+    });
   }, [customScenario, customLoading, customLoanRateDelta, customVacancyRateDelta]);
 
   return (

--- a/frontend/src/components/CustomScenarioSlider.tsx
+++ b/frontend/src/components/CustomScenarioSlider.tsx
@@ -1,0 +1,107 @@
+"use client";
+import React, { useState, useEffect, useRef, useCallback, useLayoutEffect } from "react";
+import { Loader2 } from "lucide-react";
+import { Slider } from "@/components/ui/slider";
+import { analyze } from "@/lib/api";
+import type { InvestmentInput, StressScenarioResult } from "@/types/investment";
+
+const CUSTOM_SCENARIO_LABEL = "カスタム" as const;
+
+export interface CustomScenarioState {
+  customScenario: StressScenarioResult | null;
+  customLoading: boolean;
+  customLoanRateDelta: number;
+  customVacancyRateDelta: number;
+}
+
+interface CustomScenarioSliderProps {
+  input: InvestmentInput;
+  onStateChange: (state: CustomScenarioState) => void;
+}
+
+export function CustomScenarioSlider({ input, onStateChange }: CustomScenarioSliderProps) {
+  const [customLoanRateDelta, setCustomLoanRateDelta] = useState(0);
+  const [customVacancyRateDelta, setCustomVacancyRateDelta] = useState(0);
+  const [customScenario, setCustomScenario] = useState<StressScenarioResult | null>(null);
+  const [customLoading, setCustomLoading] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onStateChangeRef = useRef(onStateChange);
+
+  useLayoutEffect(() => {
+    onStateChangeRef.current = onStateChange;
+  });
+
+  useEffect(() => {
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, []);
+
+  const fetchCustomScenario = useCallback(
+    (loanDeltaPct: number, vacancyDeltaPct: number) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      const loanDelta = loanDeltaPct / 100;
+      const vacancyDelta = vacancyDeltaPct / 100;
+      if (loanDelta === 0 && vacancyDelta === 0) {
+        setCustomScenario(null);
+        return;
+      }
+      setCustomLoading(true);
+      debounceRef.current = setTimeout(async () => {
+        try {
+          const res = await analyze({
+            ...input,
+            loanRateDelta: loanDelta,
+            vacancyRateDelta: vacancyDelta,
+          });
+          const custom = res.stressScenarios.find((s) => s.label === CUSTOM_SCENARIO_LABEL) ?? null;
+          setCustomScenario(custom);
+        } catch (err) {
+          console.error("[CustomStressTest] fetch failed:", err);
+          setCustomScenario(null);
+        } finally {
+          setCustomLoading(false);
+        }
+      }, 400);
+    },
+    [input]
+  );
+
+  useEffect(() => {
+    fetchCustomScenario(customLoanRateDelta, customVacancyRateDelta);
+  }, [customLoanRateDelta, customVacancyRateDelta, fetchCustomScenario]);
+
+  useEffect(() => {
+    onStateChangeRef.current({ customScenario, customLoading, customLoanRateDelta, customVacancyRateDelta });
+  }, [customScenario, customLoading, customLoanRateDelta, customVacancyRateDelta]);
+
+  return (
+    <div className="mb-4 rounded-lg border border-border bg-muted/30 p-4 space-y-4">
+      <p className="text-sm font-medium">カスタムシナリオ設定</p>
+      <Slider
+        label="金利オフセット"
+        value={customLoanRateDelta}
+        min={0}
+        max={3}
+        step={0.1}
+        onChange={(v) => setCustomLoanRateDelta(v)}
+        formatValue={(v) => (v === 0 ? "±0" : `+${v.toFixed(1)}%`)}
+      />
+      <Slider
+        label="空室率オフセット"
+        value={customVacancyRateDelta}
+        min={0}
+        max={30}
+        step={1}
+        onChange={(v) => setCustomVacancyRateDelta(v)}
+        formatValue={(v) => (v === 0 ? "±0" : `+${v.toFixed(0)}%`)}
+      />
+      {(customLoanRateDelta > 0 || customVacancyRateDelta > 0) && customLoading && (
+        <p className="flex items-center gap-1 text-xs text-muted-foreground">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          計算中…
+        </p>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/DeadCrossChart.tsx
+++ b/frontend/src/components/DeadCrossChart.tsx
@@ -146,7 +146,13 @@ function DeadCrossChart({ result }: Props) {
               />
             )}
 
-            <Line type="monotone" dataKey="元金返済" stroke={chartColors.danger} strokeWidth={2} dot={false} />
+            <Line
+              type="monotone"
+              dataKey="元金返済"
+              stroke={chartColors.danger}
+              strokeWidth={2}
+              dot={false}
+            />
             <Line
               type="monotone"
               dataKey="減価償却費"

--- a/frontend/src/components/DscrBadge.tsx
+++ b/frontend/src/components/DscrBadge.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { Badge } from "@/components/ui/badge";
+import { CheckCircle2, AlertTriangle, XCircle } from "lucide-react";
+
+export function getDscrColorClass(dscr: number): string {
+  if (dscr >= 1.2) return "text-green-600";
+  if (dscr >= 1.0) return "text-yellow-600";
+  return "text-red-600";
+}
+
+export function getDscrBadge(dscr: number): React.ReactElement {
+  if (dscr >= 1.2)
+    return (
+      <Badge variant="success" className="flex items-center gap-1">
+        <CheckCircle2 className="h-3 w-3" />
+        安全
+      </Badge>
+    );
+  if (dscr >= 1.0)
+    return (
+      <Badge variant="warning" className="flex items-center gap-1">
+        <AlertTriangle className="h-3 w-3" />
+        注意
+      </Badge>
+    );
+  return (
+    <Badge variant="danger" className="flex items-center gap-1">
+      <XCircle className="h-3 w-3" />
+      危険
+    </Badge>
+  );
+}
+
+export function getDscrIcon(dscr: number): React.ReactElement {
+  if (dscr >= 1.2) return <CheckCircle2 className="h-3 w-3" />;
+  if (dscr >= 1.0) return <AlertTriangle className="h-3 w-3" />;
+  return <XCircle className="h-3 w-3" />;
+}

--- a/frontend/src/components/InvestmentScoreCard.tsx
+++ b/frontend/src/components/InvestmentScoreCard.tsx
@@ -37,7 +37,9 @@ function ScoreRow({ item }: { item: ScoreItem }) {
       >
         {isPositive ? `+${item.score}` : item.score}
       </span>
-      <span className="text-muted-foreground flex-1 text-right leading-tight">{item.description}</span>
+      <span className="text-muted-foreground flex-1 text-right leading-tight">
+        {item.description}
+      </span>
     </div>
   );
 }

--- a/frontend/src/components/StressScenarioTable.tsx
+++ b/frontend/src/components/StressScenarioTable.tsx
@@ -1,0 +1,320 @@
+"use client";
+import React, { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { AlertTriangle, ChevronDown, ChevronUp, Loader2, Users } from "lucide-react";
+import { TermTooltip } from "@/components/ui/TermTooltip";
+import { formatMan, formatYen } from "@/lib/utils";
+import type {
+  InvestmentInput,
+  InvestmentResult,
+  PopulationForecastResult,
+  StressScenarioResult,
+} from "@/types/investment";
+import { getDscrBadge, getDscrColorClass, getDscrIcon } from "@/components/DscrBadge";
+import type { CustomScenarioState } from "@/components/CustomScenarioSlider";
+
+interface StressScenarioTableProps {
+  stressScenarios: StressScenarioResult[];
+  customState: CustomScenarioState;
+  populationForecast?: PopulationForecastResult | null;
+  input: InvestmentInput;
+  result: InvestmentResult;
+}
+
+export function StressScenarioTable({
+  stressScenarios,
+  customState,
+  populationForecast,
+  input,
+  result,
+}: StressScenarioTableProps) {
+  const { customScenario, customLoading, customLoanRateDelta, customVacancyRateDelta } = customState;
+  const [expandedScenario, setExpandedScenario] = useState<number | null>(null);
+
+  const actualV = input.actualVacancyRate > 0 ? input.actualVacancyRate : input.vacancyRate;
+
+  return (
+    <>
+      {/* Mobile: accordion (lg:hidden) */}
+      <div className="space-y-1 lg:hidden">
+        {stressScenarios.map((s, idx) => {
+          const isCompound = s.label === "複合ストレス";
+          const isExpanded = expandedScenario === idx;
+          const dscrIcon = getDscrIcon(s.dscr);
+          const safeBadge = getDscrBadge(s.dscr);
+          return (
+            <div
+              key={s.label}
+              className={`rounded-lg border ${isCompound ? "border-orange-200 bg-orange-50" : "border-border bg-background"}`}
+            >
+              <button
+                type="button"
+                className="flex w-full items-center justify-between px-3 py-3 text-left min-h-[44px]"
+                onClick={() => setExpandedScenario(isExpanded ? null : idx)}
+              >
+                <span className="text-sm font-medium">
+                  {s.label}
+                  {isCompound && <span className="ml-1 text-xs text-orange-600">★</span>}
+                </span>
+                <div className="flex items-center gap-2">
+                  {safeBadge}
+                  {isExpanded ? (
+                    <ChevronUp className="h-4 w-4 text-muted-foreground" />
+                  ) : (
+                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                  )}
+                </div>
+              </button>
+              {isExpanded && (
+                <div className="grid grid-cols-2 gap-x-4 gap-y-1 border-t px-3 pb-3 pt-2 text-sm">
+                  <span className="text-muted-foreground">DSCR</span>
+                  <span
+                    className={`flex items-center justify-end gap-1 font-medium ${getDscrColorClass(s.dscr)}`}
+                  >
+                    {dscrIcon}
+                    {s.dscr.toFixed(2)}
+                  </span>
+                  <span className="text-muted-foreground">CF黒転年</span>
+                  <span className="text-right">
+                    {s.breakEvenYear === -1 ? "なし" : `${s.breakEvenYear}年目`}
+                  </span>
+                  <span className="text-muted-foreground">金利△</span>
+                  <span className="text-right">
+                    {s.interestRateDelta !== 0
+                      ? `+${(s.interestRateDelta * 100).toFixed(1)}%`
+                      : "±0"}
+                  </span>
+                  <span className="text-muted-foreground">空室△</span>
+                  <span className="text-right">
+                    {s.vacancyRateDelta !== 0
+                      ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%`
+                      : "±0"}
+                  </span>
+                </div>
+              )}
+            </div>
+          );
+        })}
+        {/* カスタムシナリオ行（モバイル） */}
+        {customLoading && (customLoanRateDelta > 0 || customVacancyRateDelta > 0) && (
+          <div className="rounded-lg border border-blue-200 bg-blue-50">
+            <div className="flex items-center gap-2 px-3 py-3 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              カスタム（計算中）
+            </div>
+          </div>
+        )}
+        {!customLoading && customScenario && (
+          <div className="rounded-lg border border-blue-200 bg-blue-50">
+            <button
+              type="button"
+              className="flex w-full items-center justify-between px-3 py-3 text-left min-h-[44px]"
+              onClick={() =>
+                setExpandedScenario(
+                  expandedScenario === stressScenarios.length ? null : stressScenarios.length
+                )
+              }
+            >
+              <span className="text-sm font-medium text-blue-700">
+                カスタム <span className="text-xs text-blue-500">★</span>
+              </span>
+              <div className="flex items-center gap-2">
+                {getDscrBadge(customScenario.dscr)}
+                {expandedScenario === stressScenarios.length ? (
+                  <ChevronUp className="h-4 w-4 text-muted-foreground" />
+                ) : (
+                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
+                )}
+              </div>
+            </button>
+            {expandedScenario === stressScenarios.length && (
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1 border-t px-3 pb-3 pt-2 text-sm">
+                <span className="text-muted-foreground">DSCR</span>
+                <span
+                  className={`text-right font-medium ${getDscrColorClass(customScenario.dscr)}`}
+                >
+                  {customScenario.dscr.toFixed(2)}
+                </span>
+                <span className="text-muted-foreground">CF黒転年</span>
+                <span className="text-right">
+                  {customScenario.breakEvenYear === -1
+                    ? "なし"
+                    : `${customScenario.breakEvenYear}年目`}
+                </span>
+                <span className="text-muted-foreground">金利△</span>
+                <span className="text-right">
+                  {customLoanRateDelta > 0 ? `+${customLoanRateDelta.toFixed(1)}%` : "±0"}
+                </span>
+                <span className="text-muted-foreground">空室△</span>
+                <span className="text-right">
+                  {customVacancyRateDelta > 0 ? `+${customVacancyRateDelta.toFixed(0)}%` : "±0"}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* Desktop: horizontal table (hidden on mobile) */}
+      <div className="hidden lg:block overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-muted-foreground">
+              <th className="pb-2 text-left font-medium">シナリオ</th>
+              <th className="pb-2 text-right font-medium">金利△</th>
+              <th className="pb-2 text-right font-medium">空室△</th>
+              <th className="pb-2 text-right font-medium">
+                <TermTooltip term="dscr">DSCR</TermTooltip>{" "}
+                <TermTooltip term="dscrThreshold">基準</TermTooltip>
+              </th>
+              <th className="pb-2 text-right font-medium">CF黒転年</th>
+              <th className="pb-2 text-right font-medium">判定</th>
+            </tr>
+          </thead>
+          <tbody>
+            {stressScenarios.map((s) => {
+              const isCompound = s.label === "複合ストレス";
+              const rowBg = isCompound ? "bg-orange-50" : "";
+              const safeBadge = getDscrBadge(s.dscr);
+              const dscrIcon = getDscrIcon(s.dscr);
+              return (
+                <tr key={s.label} className={`border-b last:border-0 ${rowBg}`}>
+                  <td className="py-2 font-medium">
+                    {s.label}
+                    {isCompound && <span className="ml-1 text-xs text-orange-600">★</span>}
+                  </td>
+                  <td className="py-2 text-right">
+                    {s.interestRateDelta !== 0
+                      ? `+${(s.interestRateDelta * 100).toFixed(1)}%`
+                      : "±0"}
+                  </td>
+                  <td className="py-2 text-right">
+                    {s.vacancyRateDelta !== 0
+                      ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%`
+                      : "±0"}
+                  </td>
+                  <td
+                    data-testid="dscr-value"
+                    className={`py-2 text-right font-medium ${getDscrColorClass(s.dscr)}`}
+                  >
+                    <span className="inline-flex items-center justify-end gap-1">
+                      {dscrIcon}
+                      {s.dscr.toFixed(2)}
+                    </span>
+                  </td>
+                  <td className="py-2 text-right text-muted-foreground">
+                    {s.breakEvenYear === -1 ? "なし" : `${s.breakEvenYear}年目`}
+                  </td>
+                  <td className="py-2 text-right">{safeBadge}</td>
+                </tr>
+              );
+            })}
+            {/* カスタムシナリオ行（デスクトップ） */}
+            {customLoading && (customLoanRateDelta > 0 || customVacancyRateDelta > 0) && (
+              <tr className="border-b bg-blue-50">
+                <td className="py-2 font-medium text-blue-700" colSpan={6}>
+                  <span className="flex items-center gap-1">
+                    <Loader2 className="h-3 w-3 animate-spin" />
+                    カスタム（計算中）
+                  </span>
+                </td>
+              </tr>
+            )}
+            {!customLoading && customScenario && (
+              <tr className="border-b bg-blue-50">
+                <td className="py-2 font-medium text-blue-700">
+                  カスタム <span className="ml-0.5 text-xs text-blue-500">★</span>
+                </td>
+                <td className="py-2 text-right">
+                  {customLoanRateDelta > 0 ? `+${customLoanRateDelta.toFixed(1)}%` : "±0"}
+                </td>
+                <td className="py-2 text-right">
+                  {customVacancyRateDelta > 0 ? `+${customVacancyRateDelta.toFixed(0)}%` : "±0"}
+                </td>
+                <td
+                  className={`py-2 text-right font-medium ${getDscrColorClass(customScenario.dscr)}`}
+                >
+                  {customScenario.dscr.toFixed(2)}
+                </td>
+                <td className="py-2 text-right text-muted-foreground">
+                  {customScenario.breakEvenYear === -1
+                    ? "なし"
+                    : `${customScenario.breakEvenYear}年目`}
+                </td>
+                <td className="py-2 text-right">{getDscrBadge(customScenario.dscr)}</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <p className="mt-2 text-xs text-muted-foreground">
+        ※ <TermTooltip term="dscr">DSCR</TermTooltip> ={" "}
+        <TermTooltip term="noi">NOI</TermTooltip>（賃料下落・空室調整済み）/
+        年間ローン返済額（保有期間内の最悪年）。1.2以上が実務基準、1.0以上が銀行審査の最低ライン（
+        <span className="text-green-600">緑≥1.2</span>・
+        <span className="text-yellow-600">黄1.0〜1.2</span>・
+        <span className="text-red-600">赤&lt;1.0</span>
+        ）。CF黒転年は累積CF黒転年度（税引後）。年間CFがプラスに転じた年であり、自己資金の回収年ではありません。
+      </p>
+
+      {/* 人口減少シナリオ */}
+      {populationForecast &&
+        populationForecast.snapshots.length > 0 &&
+        (() => {
+          const popV = Math.min(actualV + populationForecast.vacancyRateDelta, 0.99);
+          const popNetYield = result.grossYield * (1 - popV) * (1 - input.expenseRate);
+          const popAnnualRent = result.grossYield * result.totalInvestment * (1 - popV);
+          const popCF =
+            popAnnualRent -
+            (result.yearlyResults[0]?.annualLoanPayment ?? 0) -
+            (result.yearlyResults[0]?.annualExpenses ?? 0);
+          const isDeficit = popCF < 0;
+          return (
+            <div
+              className={`mt-4 rounded-md border p-3 ${isDeficit ? "border-red-300 bg-red-50" : "border-yellow-200 bg-yellow-50"}`}
+            >
+              <p className="flex items-center gap-1 text-sm font-semibold mb-2">
+                <Users className="h-4 w-4" />
+                人口減少シナリオ（30年後推計）
+                {isDeficit && (
+                  <Badge variant="danger" className="ml-2 flex items-center gap-1">
+                    <AlertTriangle className="h-3 w-3" />
+                    赤字転落
+                  </Badge>
+                )}
+              </p>
+              <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                <div className="text-muted-foreground">想定空室率</div>
+                <div className="text-right font-medium">{(popV * 100).toFixed(0)}%</div>
+                <div className="text-muted-foreground">表面利回り</div>
+                <div
+                  className={`text-right font-medium ${popNetYield * 100 >= 8 ? "text-green-600" : "text-red-600"}`}
+                >
+                  {(result.grossYield * (1 - popV) * 100).toFixed(2)}%
+                </div>
+                <div className="text-muted-foreground">
+                  <TermTooltip term="netYield">実質利回り</TermTooltip>
+                </div>
+                <div className="text-right text-muted-foreground">
+                  {(popNetYield * 100).toFixed(2)}%
+                </div>
+                <div className="text-muted-foreground">年間CF（概算）</div>
+                <div
+                  className={`flex items-center justify-end gap-1 font-bold ${isDeficit ? "text-red-700" : "text-green-700"}`}
+                >
+                  {isDeficit && <AlertTriangle className="h-3.5 w-3.5 shrink-0" />}
+                  {formatMan(popCF)}
+                </div>
+              </div>
+              <p className="mt-2 text-xs text-muted-foreground">
+                ※ このエリアの30年後人口推計:{" "}
+                {(populationForecast.changeRate30yr * 100).toFixed(0)}%（現在比）／トレンド:{" "}
+                {populationForecast.trend}
+              </p>
+            </div>
+          );
+        })()}
+    </>
+  );
+}

--- a/frontend/src/components/StressScenarioTable.tsx
+++ b/frontend/src/components/StressScenarioTable.tsx
@@ -28,7 +28,8 @@ export function StressScenarioTable({
   input,
   result,
 }: StressScenarioTableProps) {
-  const { customScenario, customLoading, customLoanRateDelta, customVacancyRateDelta } = customState;
+  const { customScenario, customLoading, customLoanRateDelta, customVacancyRateDelta } =
+    customState;
   const [expandedScenario, setExpandedScenario] = useState<number | null>(null);
 
   const actualV = input.actualVacancyRate > 0 ? input.actualVacancyRate : input.vacancyRate;
@@ -86,9 +87,7 @@ export function StressScenarioTable({
                   </span>
                   <span className="text-muted-foreground">空室△</span>
                   <span className="text-right">
-                    {s.vacancyRateDelta !== 0
-                      ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%`
-                      : "±0"}
+                    {s.vacancyRateDelta !== 0 ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%` : "±0"}
                   </span>
                 </div>
               )}
@@ -189,9 +188,7 @@ export function StressScenarioTable({
                       : "±0"}
                   </td>
                   <td className="py-2 text-right">
-                    {s.vacancyRateDelta !== 0
-                      ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%`
-                      : "±0"}
+                    {s.vacancyRateDelta !== 0 ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%` : "±0"}
                   </td>
                   <td
                     data-testid="dscr-value"
@@ -249,8 +246,8 @@ export function StressScenarioTable({
       </div>
 
       <p className="mt-2 text-xs text-muted-foreground">
-        ※ <TermTooltip term="dscr">DSCR</TermTooltip> ={" "}
-        <TermTooltip term="noi">NOI</TermTooltip>（賃料下落・空室調整済み）/
+        ※ <TermTooltip term="dscr">DSCR</TermTooltip> = <TermTooltip term="noi">NOI</TermTooltip>
+        （賃料下落・空室調整済み）/
         年間ローン返済額（保有期間内の最悪年）。1.2以上が実務基準、1.0以上が銀行審査の最低ライン（
         <span className="text-green-600">緑≥1.2</span>・
         <span className="text-yellow-600">黄1.0〜1.2</span>・
@@ -308,9 +305,8 @@ export function StressScenarioTable({
                 </div>
               </div>
               <p className="mt-2 text-xs text-muted-foreground">
-                ※ このエリアの30年後人口推計:{" "}
-                {(populationForecast.changeRate30yr * 100).toFixed(0)}%（現在比）／トレンド:{" "}
-                {populationForecast.trend}
+                ※ このエリアの30年後人口推計: {(populationForecast.changeRate30yr * 100).toFixed(0)}
+                %（現在比）／トレンド: {populationForecast.trend}
               </p>
             </div>
           );

--- a/frontend/src/components/ThemeToggle.tsx
+++ b/frontend/src/components/ThemeToggle.tsx
@@ -3,19 +3,19 @@ import { useEffect, useState } from "react";
 import { Sun, Moon } from "lucide-react";
 
 export function ThemeToggle() {
-  const [dark, setDark] = useState(false);
-
-  useEffect(() => {
+  const [dark, setDark] = useState(() => {
     try {
       const stored = localStorage.getItem("theme");
       const prefersDark = window.matchMedia?.("(prefers-color-scheme: dark)").matches ?? false;
-      const isDark = stored ? stored === "dark" : prefersDark;
-      setDark(isDark);
-      document.documentElement.classList.toggle("dark", isDark);
+      return stored ? stored === "dark" : prefersDark;
     } catch {
-      // localStorage/matchMedia unavailable (SSR or test env)
+      return false;
     }
-  }, []);
+  });
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", dark);
+  }, [dark]);
 
   function toggle() {
     const next = !dark;

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -107,7 +107,7 @@ interface WatchlistPanelProps {
 export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
   const { user, loading: authLoading } = useAuthContext();
   const [items, setItems] = useState<WatchlistItem[]>([]);
-  const [firestoreLoading, setFirestoreLoading] = useState(true);
+  const [firestoreLoading, setFirestoreLoading] = useState(() => getFirebaseDb() !== null);
   const [nameInput, setNameInput] = useState("");
   const [memoInput, setMemoInput] = useState("");
   const [nameError, setNameError] = useState("");
@@ -123,11 +123,7 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
 
     const uid = user.uid;
     const col = itemsCollection(uid);
-    // Firebase not configured — fall back to empty list with no loading spinner
-    if (!col) {
-      setFirestoreLoading(false);
-      return;
-    }
+    if (!col) return;
     const q = query(col, orderBy("addedAt", "desc"));
 
     const unsubscribe = onSnapshot(

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -195,8 +195,6 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
       setNameError("物件名を入力してください");
       return;
     }
-    if (!user) return;
-
     setNameError("");
 
     const newItem: Omit<WatchlistItem, "id"> = {
@@ -220,24 +218,31 @@ export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
         : {}),
     };
 
-    // Optimistic: add a temporary item immediately
-    const tempId = `temp_${Date.now()}`;
-    setItems((prev) => [{ ...newItem, id: tempId }, ...prev]);
+    const localId = `local_${Date.now()}`;
+    const localItem: WatchlistItem = { ...newItem, id: localId };
+
+    setItems((prev) => {
+      const updated = [localItem, ...prev];
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      } catch {}
+      return updated;
+    });
     setNameInput("");
     setMemoInput("");
     toast({ message: `「${trimmed}」をウォッチリストに追加しました`, variant: "success" });
 
-    try {
-      const col = itemsCollection(user.uid);
-      if (col) {
-        await addDoc(col, { ...newItem, createdAt: serverTimestamp() });
+    if (user) {
+      try {
+        const col = itemsCollection(user.uid);
+        if (col) {
+          await addDoc(col, { ...newItem, createdAt: serverTimestamp() });
+        }
+      } catch (err) {
+        console.error("[WatchlistPanel] addDoc failed:", err);
+        setItems((prev) => prev.filter((item) => item.id !== localId));
+        toast({ message: "追加に失敗しました。再度お試しください。", variant: "danger" });
       }
-      // onSnapshot will replace the optimistic item with the server version
-    } catch (err) {
-      console.error("[WatchlistPanel] addDoc failed:", err);
-      // Roll back optimistic update on error
-      setItems((prev) => prev.filter((item) => item.id !== tempId));
-      toast({ message: "追加に失敗しました。再度お試しください。", variant: "danger" });
     }
   }
 

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -106,7 +106,7 @@ interface WatchlistPanelProps {
 
 export default function WatchlistPanel({ currentResult }: WatchlistPanelProps) {
   const { user, loading: authLoading } = useAuthContext();
-  const [items, setItems] = useState<WatchlistItem[]>([]);
+  const [items, setItems] = useState<WatchlistItem[]>(loadLocalItems);
   const [firestoreLoading, setFirestoreLoading] = useState(() => getFirebaseDb() !== null);
   const [nameInput, setNameInput] = useState("");
   const [memoInput, setMemoInput] = useState("");

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -1,77 +1,23 @@
 "use client";
-import React, { useState, useEffect, useRef, useCallback, useMemo } from "react";
+import React, { useState, useCallback } from "react";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Slider } from "@/components/ui/slider";
 import type {
   InvestmentInput,
   InvestmentResult,
   LandPriceStats,
   PopulationForecastResult,
-  StressScenarioResult,
   YieldScenarios,
 } from "@/types/investment";
 import { formatMan, formatPct, formatYen } from "@/lib/utils";
-import { calcYieldBenchmark } from "@/lib/yieldBenchmark";
-import {
-  TrendingUp,
-  TrendingDown,
-  AlertTriangle,
-  CheckCircle,
-  CheckCircle2,
-  XCircle,
-  Users,
-  ChevronDown,
-  ChevronUp,
-  Loader2,
-} from "lucide-react";
-import { TermTooltip } from "@/components/ui/TermTooltip";
+import { TrendingUp, TrendingDown, AlertTriangle, ChevronDown, ChevronUp } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
 import { MobileSummaryCard } from "@/components/MobileSummaryCard";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Alert, AlertDescription } from "@/components/ui/alert";
-import { analyze } from "@/lib/api";
+import { YieldGauge } from "@/components/YieldGauge";
+import { CustomScenarioSlider, type CustomScenarioState } from "@/components/CustomScenarioSlider";
+import { StressScenarioTable } from "@/components/StressScenarioTable";
 
-const CUSTOM_SCENARIO_LABEL = "カスタム" as const;
-
-export function getDscrColorClass(dscr: number): string {
-  if (dscr >= 1.2) return "text-green-600";
-  if (dscr >= 1.0) return "text-yellow-600";
-  return "text-red-600";
-}
-
-export function getDscrBadge(dscr: number): React.ReactElement {
-  if (dscr >= 1.2)
-    return (
-      <Badge variant="success" className="flex items-center gap-1">
-        <CheckCircle2 className="h-3 w-3" />
-        安全
-      </Badge>
-    );
-  if (dscr >= 1.0)
-    return (
-      <Badge variant="warning" className="flex items-center gap-1">
-        <AlertTriangle className="h-3 w-3" />
-        注意
-      </Badge>
-    );
-  return (
-    <Badge variant="danger" className="flex items-center gap-1">
-      <XCircle className="h-3 w-3" />
-      危険
-    </Badge>
-  );
-}
-
-function getDscrIcon(dscr: number) {
-  if (dscr >= 1.2) return <CheckCircle2 className="h-3 w-3" />;
-  if (dscr >= 1.0) return <AlertTriangle className="h-3 w-3" />;
-  return <XCircle className="h-3 w-3" />;
-}
-
-/**
- * Mobile 1×2 KPI strip showing metrics not already in MobileSummaryCard.
- * MobileSummaryCard covers yield/DSCR/dead-cross; this adds investment totals.
- */
 function MobileKpiGrid({ result }: { result: InvestmentResult }) {
   const firstYearCF = result.yearlyResults[0]?.afterTaxCashFlow ?? 0;
 
@@ -124,82 +70,18 @@ export function YieldAnalysis({
   const netYieldPct = result.netYield * 100;
   const isGood = result.isAboveYieldTarget;
   const targetPct = result.yieldTarget * 100;
-  const maxYieldPct = targetPct * 2; // ゲージ上限: 目標の2倍（目標が中央）
 
-  // 人口シナリオ用（populationForecast表示のために残す）
-  const actualV = input.actualVacancyRate > 0 ? input.actualVacancyRate : input.vacancyRate;
-
-  const stressScenarios: StressScenarioResult[] = result.stressScenarios ?? [];
-  const [expandedScenario, setExpandedScenario] = useState<number | null>(null);
   const [aiOpen, setAiOpen] = useState(true);
+  const [customState, setCustomState] = useState<CustomScenarioState>({
+    customScenario: null,
+    customLoading: false,
+    customLoanRateDelta: 0,
+    customVacancyRateDelta: 0,
+  });
 
-  // カスタムストレステスト入力
-  const [customLoanRateDelta, setCustomLoanRateDelta] = useState(0); // 0〜3 (%)
-  const [customVacancyRateDelta, setCustomVacancyRateDelta] = useState(0); // 0〜30 (%)
-  const [customScenario, setCustomScenario] = useState<StressScenarioResult | null>(null);
-  const [customLoading, setCustomLoading] = useState(false);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-    };
+  const handleCustomStateChange = useCallback((state: CustomScenarioState) => {
+    setCustomState(state);
   }, []);
-
-  const fetchCustomScenario = useCallback(
-    (loanDeltaPct: number, vacancyDeltaPct: number) => {
-      if (debounceRef.current) clearTimeout(debounceRef.current);
-      const loanDelta = loanDeltaPct / 100;
-      const vacancyDelta = vacancyDeltaPct / 100;
-      if (loanDelta === 0 && vacancyDelta === 0) {
-        setCustomScenario(null);
-        return;
-      }
-      setCustomLoading(true);
-      debounceRef.current = setTimeout(async () => {
-        try {
-          const res = await analyze({
-            ...input,
-            loanRateDelta: loanDelta,
-            vacancyRateDelta: vacancyDelta,
-          });
-          const custom = res.stressScenarios.find((s) => s.label === CUSTOM_SCENARIO_LABEL) ?? null;
-          setCustomScenario(custom);
-        } catch (err) {
-          console.error("[CustomStressTest] fetch failed:", err);
-          setCustomScenario(null);
-        } finally {
-          setCustomLoading(false);
-        }
-      }, 400);
-    },
-    [input]
-  );
-
-  useEffect(() => {
-    fetchCustomScenario(customLoanRateDelta, customVacancyRateDelta);
-  }, [customLoanRateDelta, customVacancyRateDelta, fetchCustomScenario]);
-
-  const gaugePosition = Math.min(yieldPct / maxYieldPct, 1) * 100;
-  const targetPosition = 50; // 目標は常にゲージ中央
-
-  const yieldBenchmark = useMemo(() => {
-    if (!landPriceStats || landPriceStats.medianTsubo <= 0) return null;
-    if (input.monthlyRent <= 0) return null;
-    const userYield =
-      input.landPrice + input.buildingCost > 0
-        ? (input.monthlyRent * 12) / (input.landPrice + input.buildingCost)
-        : undefined;
-    return calcYieldBenchmark({
-      medianTsubo: landPriceStats.medianTsubo,
-      minTsubo: landPriceStats.minTsubo,
-      maxTsubo: landPriceStats.maxTsubo,
-      landAreaSqm: input.landArea,
-      monthlyRent: input.monthlyRent,
-      buildingCost: input.buildingCost,
-      userYield,
-    });
-  }, [landPriceStats, input.landArea, input.monthlyRent, input.buildingCost, input.landPrice]);
 
   return (
     <div className="space-y-4">
@@ -231,7 +113,6 @@ export function YieldAnalysis({
         </Alert>
       )}
 
-      {/* Mobile: professional summary card for agents (hidden on desktop) */}
       <MobileSummaryCard
         result={result}
         input={input}
@@ -239,423 +120,33 @@ export function YieldAnalysis({
         netYieldPct={netYieldPct}
       />
 
-      {/* Mobile: investment totals strip (hidden on desktop) */}
       <MobileKpiGrid result={result} />
 
-      {/* メイン利回り表示 */}
-      <Card className={`border-2 ${isGood ? "border-green-400" : "border-red-400"}`}>
-        <CardContent className="pt-6">
-          <div className="flex items-center justify-between">
-            <div className="min-w-0 flex-1">
-              <p className="text-xs text-muted-foreground sm:text-sm">
-                表面利回り（満室想定年収 / 総投資額）
-              </p>
-              <div className="flex items-end gap-2">
-                <span
-                  data-testid="gross-yield-value"
-                  className={`text-4xl font-bold sm:text-5xl ${isGood ? "text-green-600" : "text-red-600"}`}
-                >
-                  {yieldPct.toFixed(2)}
-                </span>
-                <span className="mb-1 text-xl font-semibold text-muted-foreground sm:mb-2 sm:text-2xl">
-                  %
-                </span>
-              </div>
-              <p className="mt-1 text-xs text-muted-foreground sm:text-sm">
-                <TermTooltip term="netYield">実質利回り</TermTooltip>（空室・経費控除後）：
-                {netYieldPct.toFixed(2)}%
-              </p>
-            </div>
-            <div className="ml-3 flex flex-col items-center gap-2 shrink-0">
-              {isGood ? (
-                <>
-                  <CheckCircle className="h-10 w-10 text-green-500 sm:h-12 sm:w-12" />
-                  <Badge data-testid="yield-threshold-badge" variant="success">
-                    {targetPct}%超え ✓
-                  </Badge>
-                </>
-              ) : (
-                <>
-                  <AlertTriangle className="h-10 w-10 text-red-500 sm:h-12 sm:w-12" />
-                  <Badge data-testid="yield-threshold-badge" variant="danger">
-                    {targetPct}%未満 ✗
-                  </Badge>
-                </>
-              )}
-            </div>
-          </div>
+      <YieldGauge
+        yieldPct={yieldPct}
+        netYieldPct={netYieldPct}
+        isGood={isGood}
+        targetPct={targetPct}
+        input={input}
+        landPriceStats={landPriceStats}
+      />
 
-          {/* 目標利回り境界線ゲージ（目標が中央） */}
-          <div className="mt-4">
-            <div className="flex justify-between text-xs text-muted-foreground mb-1">
-              <span>0%</span>
-              <span className="font-semibold text-orange-500">目標 {targetPct}%</span>
-              <span>{maxYieldPct}%+</span>
-            </div>
-            <div className="relative h-3 rounded-full bg-muted overflow-hidden">
-              <div className="absolute inset-y-0 left-0 w-1/3 bg-red-400" />
-              <div className="absolute inset-y-0 left-1/3 w-1/3 bg-yellow-400" />
-              <div className="absolute inset-y-0 left-2/3 w-1/3 bg-green-500" />
-              {/* 現在値マーカー */}
-              <div
-                className="absolute top-0 h-full w-1 bg-foreground/80 rounded"
-                style={{ left: `${gaugePosition}%` }}
-              />
-              {/* 8%ライン（スケールと連動） */}
-              <div
-                className="absolute top-0 h-full w-0.5 bg-orange-500"
-                style={{ left: `${targetPosition}%` }}
-              />
-            </div>
-          </div>
-
-          {/* 市場想定利回りベンチマーク */}
-          {yieldBenchmark && (
-            <div className="mt-2 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
-              <span>
-                このエリアの市場想定利回り: 約
-                {(yieldBenchmark.estimatedYieldTypical * 100).toFixed(1)}%
-              </span>
-              <Badge
-                className="ml-2"
-                title={yieldBenchmark.judgmentLabel}
-                variant={
-                  yieldBenchmark.judgment === "realistic"
-                    ? "outline"
-                    : yieldBenchmark.judgment === "slightly-high"
-                      ? "warning"
-                      : "danger"
-                }
-              >
-                {yieldBenchmark.judgment === "realistic"
-                  ? "現実的"
-                  : yieldBenchmark.judgment === "slightly-high"
-                    ? "やや高め"
-                    : "大幅に高め"}
-              </Badge>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* ストレステストシナリオ比較 */}
       <Card>
         <CardHeader>
           <CardTitle className="text-base">ストレステストシナリオ（銀行融資審査用）</CardTitle>
         </CardHeader>
         <CardContent>
-          {/* カスタムストレステスト入力スライダー */}
-          <div className="mb-4 rounded-lg border border-border bg-muted/30 p-4 space-y-4">
-            <p className="text-sm font-medium">カスタムシナリオ設定</p>
-            <Slider
-              label="金利オフセット"
-              value={customLoanRateDelta}
-              min={0}
-              max={3}
-              step={0.1}
-              onChange={(v) => setCustomLoanRateDelta(v)}
-              formatValue={(v) => (v === 0 ? "±0" : `+${v.toFixed(1)}%`)}
-            />
-            <Slider
-              label="空室率オフセット"
-              value={customVacancyRateDelta}
-              min={0}
-              max={30}
-              step={1}
-              onChange={(v) => setCustomVacancyRateDelta(v)}
-              formatValue={(v) => (v === 0 ? "±0" : `+${v.toFixed(0)}%`)}
-            />
-            {(customLoanRateDelta > 0 || customVacancyRateDelta > 0) && customLoading && (
-              <p className="flex items-center gap-1 text-xs text-muted-foreground">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                計算中…
-              </p>
-            )}
-          </div>
-
-          {/* Mobile: accordion (lg:hidden) */}
-          <div className="space-y-1 lg:hidden">
-            {stressScenarios.map((s, idx) => {
-              const isCompound = s.label === "複合ストレス";
-              const isExpanded = expandedScenario === idx;
-              const dscrIcon = getDscrIcon(s.dscr);
-              const safeBadge = getDscrBadge(s.dscr);
-              return (
-                <div
-                  key={s.label}
-                  className={`rounded-lg border ${isCompound ? "border-orange-200 bg-orange-50" : "border-border bg-background"}`}
-                >
-                  <button
-                    type="button"
-                    className="flex w-full items-center justify-between px-3 py-3 text-left min-h-[44px]"
-                    onClick={() => setExpandedScenario(isExpanded ? null : idx)}
-                  >
-                    <span className="text-sm font-medium">
-                      {s.label}
-                      {isCompound && <span className="ml-1 text-xs text-orange-600">★</span>}
-                    </span>
-                    <div className="flex items-center gap-2">
-                      {safeBadge}
-                      {isExpanded ? (
-                        <ChevronUp className="h-4 w-4 text-muted-foreground" />
-                      ) : (
-                        <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                      )}
-                    </div>
-                  </button>
-                  {isExpanded && (
-                    <div className="grid grid-cols-2 gap-x-4 gap-y-1 border-t px-3 pb-3 pt-2 text-sm">
-                      <span className="text-muted-foreground">DSCR</span>
-                      <span
-                        className={`flex items-center justify-end gap-1 font-medium ${getDscrColorClass(s.dscr)}`}
-                      >
-                        {dscrIcon}
-                        {s.dscr.toFixed(2)}
-                      </span>
-                      <span className="text-muted-foreground">CF黒転年</span>
-                      <span className="text-right">
-                        {s.breakEvenYear === -1 ? "なし" : `${s.breakEvenYear}年目`}
-                      </span>
-                      <span className="text-muted-foreground">金利△</span>
-                      <span className="text-right">
-                        {s.interestRateDelta !== 0
-                          ? `+${(s.interestRateDelta * 100).toFixed(1)}%`
-                          : "±0"}
-                      </span>
-                      <span className="text-muted-foreground">空室△</span>
-                      <span className="text-right">
-                        {s.vacancyRateDelta !== 0
-                          ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%`
-                          : "±0"}
-                      </span>
-                    </div>
-                  )}
-                </div>
-              );
-            })}
-            {/* カスタムシナリオ行（モバイル） */}
-            {customLoading && (customLoanRateDelta > 0 || customVacancyRateDelta > 0) && (
-              <div className="rounded-lg border border-blue-200 bg-blue-50">
-                <div className="flex items-center gap-2 px-3 py-3 text-sm text-muted-foreground">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  カスタム（計算中）
-                </div>
-              </div>
-            )}
-            {!customLoading && customScenario && (
-              <div className="rounded-lg border border-blue-200 bg-blue-50">
-                <button
-                  type="button"
-                  className="flex w-full items-center justify-between px-3 py-3 text-left min-h-[44px]"
-                  onClick={() =>
-                    setExpandedScenario(
-                      expandedScenario === stressScenarios.length ? null : stressScenarios.length
-                    )
-                  }
-                >
-                  <span className="text-sm font-medium text-blue-700">
-                    カスタム <span className="text-xs text-blue-500">★</span>
-                  </span>
-                  <div className="flex items-center gap-2">
-                    {getDscrBadge(customScenario.dscr)}
-                    {expandedScenario === stressScenarios.length ? (
-                      <ChevronUp className="h-4 w-4 text-muted-foreground" />
-                    ) : (
-                      <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                    )}
-                  </div>
-                </button>
-                {expandedScenario === stressScenarios.length && (
-                  <div className="grid grid-cols-2 gap-x-4 gap-y-1 border-t px-3 pb-3 pt-2 text-sm">
-                    <span className="text-muted-foreground">DSCR</span>
-                    <span
-                      className={`text-right font-medium ${getDscrColorClass(customScenario.dscr)}`}
-                    >
-                      {customScenario.dscr.toFixed(2)}
-                    </span>
-                    <span className="text-muted-foreground">CF黒転年</span>
-                    <span className="text-right">
-                      {customScenario.breakEvenYear === -1
-                        ? "なし"
-                        : `${customScenario.breakEvenYear}年目`}
-                    </span>
-                    <span className="text-muted-foreground">金利△</span>
-                    <span className="text-right">
-                      {customLoanRateDelta > 0 ? `+${customLoanRateDelta.toFixed(1)}%` : "±0"}
-                    </span>
-                    <span className="text-muted-foreground">空室△</span>
-                    <span className="text-right">
-                      {customVacancyRateDelta > 0 ? `+${customVacancyRateDelta.toFixed(0)}%` : "±0"}
-                    </span>
-                  </div>
-                )}
-              </div>
-            )}
-          </div>
-
-          {/* Desktop: horizontal table (hidden on mobile) */}
-          <div className="hidden lg:block overflow-x-auto">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="border-b text-muted-foreground">
-                  <th className="pb-2 text-left font-medium">シナリオ</th>
-                  <th className="pb-2 text-right font-medium">金利△</th>
-                  <th className="pb-2 text-right font-medium">空室△</th>
-                  <th className="pb-2 text-right font-medium">
-                    <TermTooltip term="dscr">DSCR</TermTooltip>{" "}
-                    <TermTooltip term="dscrThreshold">基準</TermTooltip>
-                  </th>
-                  <th className="pb-2 text-right font-medium">CF黒転年</th>
-                  <th className="pb-2 text-right font-medium">判定</th>
-                </tr>
-              </thead>
-              <tbody>
-                {stressScenarios.map((s) => {
-                  const isCompound = s.label === "複合ストレス";
-                  const rowBg = isCompound ? "bg-orange-50" : "";
-                  const safeBadge = getDscrBadge(s.dscr);
-                  const dscrIcon = getDscrIcon(s.dscr);
-                  return (
-                    <tr key={s.label} className={`border-b last:border-0 ${rowBg}`}>
-                      <td className="py-2 font-medium">
-                        {s.label}
-                        {isCompound && <span className="ml-1 text-xs text-orange-600">★</span>}
-                      </td>
-                      <td className="py-2 text-right">
-                        {s.interestRateDelta !== 0
-                          ? `+${(s.interestRateDelta * 100).toFixed(1)}%`
-                          : "±0"}
-                      </td>
-                      <td className="py-2 text-right">
-                        {s.vacancyRateDelta !== 0
-                          ? `+${(s.vacancyRateDelta * 100).toFixed(0)}%`
-                          : "±0"}
-                      </td>
-                      <td
-                        data-testid="dscr-value"
-                        className={`py-2 text-right font-medium ${getDscrColorClass(s.dscr)}`}
-                      >
-                        <span className="inline-flex items-center justify-end gap-1">
-                          {dscrIcon}
-                          {s.dscr.toFixed(2)}
-                        </span>
-                      </td>
-                      <td className="py-2 text-right text-muted-foreground">
-                        {s.breakEvenYear === -1 ? "なし" : `${s.breakEvenYear}年目`}
-                      </td>
-                      <td className="py-2 text-right">{safeBadge}</td>
-                    </tr>
-                  );
-                })}
-                {/* カスタムシナリオ行（デスクトップ） */}
-                {customLoading && (customLoanRateDelta > 0 || customVacancyRateDelta > 0) && (
-                  <tr className="border-b bg-blue-50">
-                    <td className="py-2 font-medium text-blue-700" colSpan={6}>
-                      <span className="flex items-center gap-1">
-                        <Loader2 className="h-3 w-3 animate-spin" />
-                        カスタム（計算中）
-                      </span>
-                    </td>
-                  </tr>
-                )}
-                {!customLoading && customScenario && (
-                  <tr className="border-b bg-blue-50">
-                    <td className="py-2 font-medium text-blue-700">
-                      カスタム <span className="ml-0.5 text-xs text-blue-500">★</span>
-                    </td>
-                    <td className="py-2 text-right">
-                      {customLoanRateDelta > 0 ? `+${customLoanRateDelta.toFixed(1)}%` : "±0"}
-                    </td>
-                    <td className="py-2 text-right">
-                      {customVacancyRateDelta > 0 ? `+${customVacancyRateDelta.toFixed(0)}%` : "±0"}
-                    </td>
-                    <td
-                      className={`py-2 text-right font-medium ${getDscrColorClass(customScenario.dscr)}`}
-                    >
-                      {customScenario.dscr.toFixed(2)}
-                    </td>
-                    <td className="py-2 text-right text-muted-foreground">
-                      {customScenario.breakEvenYear === -1
-                        ? "なし"
-                        : `${customScenario.breakEvenYear}年目`}
-                    </td>
-                    <td className="py-2 text-right">{getDscrBadge(customScenario.dscr)}</td>
-                  </tr>
-                )}
-              </tbody>
-            </table>
-          </div>
-          <p className="mt-2 text-xs text-muted-foreground">
-            ※ <TermTooltip term="dscr">DSCR</TermTooltip> ={" "}
-            <TermTooltip term="noi">NOI</TermTooltip>（賃料下落・空室調整済み）/
-            年間ローン返済額（保有期間内の最悪年）。1.2以上が実務基準、1.0以上が銀行審査の最低ライン（
-            <span className="text-green-600">緑≥1.2</span>・
-            <span className="text-yellow-600">黄1.0〜1.2</span>・
-            <span className="text-red-600">赤&lt;1.0</span>
-            ）。CF黒転年は累積CF黒転年度（税引後）。年間CFがプラスに転じた年であり、自己資金の回収年ではありません。
-          </p>
-
-          {/* 人口減少シナリオ */}
-          {populationForecast &&
-            populationForecast.snapshots.length > 0 &&
-            (() => {
-              const popV = Math.min(actualV + populationForecast.vacancyRateDelta, 0.99);
-              const popNetYield = result.grossYield * (1 - popV) * (1 - input.expenseRate);
-              const popAnnualRent = result.grossYield * result.totalInvestment * (1 - popV);
-              const popCF =
-                popAnnualRent -
-                (result.yearlyResults[0]?.annualLoanPayment ?? 0) -
-                (result.yearlyResults[0]?.annualExpenses ?? 0);
-              const isDeficit = popCF < 0;
-              return (
-                <div
-                  className={`mt-4 rounded-md border p-3 ${isDeficit ? "border-red-300 bg-red-50" : "border-yellow-200 bg-yellow-50"}`}
-                >
-                  <p className="flex items-center gap-1 text-sm font-semibold mb-2">
-                    <Users className="h-4 w-4" />
-                    人口減少シナリオ（30年後推計）
-                    {isDeficit && (
-                      <Badge variant="danger" className="ml-2 flex items-center gap-1">
-                        <AlertTriangle className="h-3 w-3" />
-                        赤字転落
-                      </Badge>
-                    )}
-                  </p>
-                  <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
-                    <div className="text-muted-foreground">想定空室率</div>
-                    <div className="text-right font-medium">{(popV * 100).toFixed(0)}%</div>
-                    <div className="text-muted-foreground">表面利回り</div>
-                    <div
-                      className={`text-right font-medium ${popNetYield * 100 >= 8 ? "text-green-600" : "text-red-600"}`}
-                    >
-                      {(result.grossYield * (1 - popV) * 100).toFixed(2)}%
-                    </div>
-                    <div className="text-muted-foreground">
-                      <TermTooltip term="netYield">実質利回り</TermTooltip>
-                    </div>
-                    <div className="text-right text-muted-foreground">
-                      {(popNetYield * 100).toFixed(2)}%
-                    </div>
-                    <div className="text-muted-foreground">年間CF（概算）</div>
-                    <div
-                      className={`flex items-center justify-end gap-1 font-bold ${isDeficit ? "text-red-700" : "text-green-700"}`}
-                    >
-                      {isDeficit && <AlertTriangle className="h-3.5 w-3.5 shrink-0" />}
-                      {formatMan(popCF)}
-                    </div>
-                  </div>
-                  <p className="mt-2 text-xs text-muted-foreground">
-                    ※ このエリアの30年後人口推計:{" "}
-                    {(populationForecast.changeRate30yr * 100).toFixed(0)}%（現在比）／トレンド:{" "}
-                    {populationForecast.trend}
-                  </p>
-                </div>
-              );
-            })()}
+          <CustomScenarioSlider input={input} onStateChange={handleCustomStateChange} />
+          <StressScenarioTable
+            stressScenarios={result.stressScenarios ?? []}
+            customState={customState}
+            populationForecast={populationForecast}
+            input={input}
+            result={result}
+          />
         </CardContent>
       </Card>
 
-      {/* 空室シナリオ比較 */}
       {result.yieldScenarios && (
         <VacancyScenarioCard
           yieldScenarios={result.yieldScenarios}
@@ -664,7 +155,6 @@ export function YieldAnalysis({
         />
       )}
 
-      {/* 総投資額サマリー */}
       <Card>
         <CardHeader>
           <CardTitle className="text-base">投資サマリー</CardTitle>
@@ -700,7 +190,6 @@ export function YieldAnalysis({
         </CardContent>
       </Card>
 
-      {/* 目標利回り未達の場合: 逆算カード（ISSUE-16: either-or を明示） */}
       {!isGood && (
         <Card className="border-orange-200 bg-orange-50">
           <CardHeader>
@@ -728,7 +217,6 @@ export function YieldAnalysis({
         </Card>
       )}
 
-      {/* 目標利回り以上の場合: 余裕度 */}
       {isGood && (
         <Card className="border-green-200 bg-green-50">
           <CardHeader>

--- a/frontend/src/components/YieldGauge.tsx
+++ b/frontend/src/components/YieldGauge.tsx
@@ -1,0 +1,134 @@
+"use client";
+import React, { useMemo } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { CheckCircle, AlertTriangle } from "lucide-react";
+import { TermTooltip } from "@/components/ui/TermTooltip";
+import { calcYieldBenchmark } from "@/lib/yieldBenchmark";
+import type { InvestmentInput, LandPriceStats } from "@/types/investment";
+
+interface YieldGaugeProps {
+  yieldPct: number;
+  netYieldPct: number;
+  isGood: boolean;
+  targetPct: number;
+  input: InvestmentInput;
+  landPriceStats?: LandPriceStats | null;
+}
+
+export function YieldGauge({ yieldPct, netYieldPct, isGood, targetPct, input, landPriceStats }: YieldGaugeProps) {
+  const maxYieldPct = targetPct * 2;
+  const gaugePosition = Math.min(yieldPct / maxYieldPct, 1) * 100;
+  const targetPosition = 50;
+
+  const yieldBenchmark = useMemo(() => {
+    if (!landPriceStats || landPriceStats.medianTsubo <= 0) return null;
+    if (input.monthlyRent <= 0) return null;
+    const userYield =
+      input.landPrice + input.buildingCost > 0
+        ? (input.monthlyRent * 12) / (input.landPrice + input.buildingCost)
+        : undefined;
+    return calcYieldBenchmark({
+      medianTsubo: landPriceStats.medianTsubo,
+      minTsubo: landPriceStats.minTsubo,
+      maxTsubo: landPriceStats.maxTsubo,
+      landAreaSqm: input.landArea,
+      monthlyRent: input.monthlyRent,
+      buildingCost: input.buildingCost,
+      userYield,
+    });
+  }, [landPriceStats, input.landArea, input.monthlyRent, input.buildingCost, input.landPrice]);
+
+  return (
+    <Card className={`border-2 ${isGood ? "border-green-400" : "border-red-400"}`}>
+      <CardContent className="pt-6">
+        <div className="flex items-center justify-between">
+          <div className="min-w-0 flex-1">
+            <p className="text-xs text-muted-foreground sm:text-sm">
+              表面利回り（満室想定年収 / 総投資額）
+            </p>
+            <div className="flex items-end gap-2">
+              <span
+                data-testid="gross-yield-value"
+                className={`text-4xl font-bold sm:text-5xl ${isGood ? "text-green-600" : "text-red-600"}`}
+              >
+                {yieldPct.toFixed(2)}
+              </span>
+              <span className="mb-1 text-xl font-semibold text-muted-foreground sm:mb-2 sm:text-2xl">
+                %
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-muted-foreground sm:text-sm">
+              <TermTooltip term="netYield">実質利回り</TermTooltip>（空室・経費控除後）：
+              {netYieldPct.toFixed(2)}%
+            </p>
+          </div>
+          <div className="ml-3 flex flex-col items-center gap-2 shrink-0">
+            {isGood ? (
+              <>
+                <CheckCircle className="h-10 w-10 text-green-500 sm:h-12 sm:w-12" />
+                <Badge data-testid="yield-threshold-badge" variant="success">
+                  {targetPct}%超え ✓
+                </Badge>
+              </>
+            ) : (
+              <>
+                <AlertTriangle className="h-10 w-10 text-red-500 sm:h-12 sm:w-12" />
+                <Badge data-testid="yield-threshold-badge" variant="danger">
+                  {targetPct}%未満 ✗
+                </Badge>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-4">
+          <div className="flex justify-between text-xs text-muted-foreground mb-1">
+            <span>0%</span>
+            <span className="font-semibold text-orange-500">目標 {targetPct}%</span>
+            <span>{maxYieldPct}%+</span>
+          </div>
+          <div className="relative h-3 rounded-full bg-muted overflow-hidden">
+            <div className="absolute inset-y-0 left-0 w-1/3 bg-red-400" />
+            <div className="absolute inset-y-0 left-1/3 w-1/3 bg-yellow-400" />
+            <div className="absolute inset-y-0 left-2/3 w-1/3 bg-green-500" />
+            <div
+              className="absolute top-0 h-full w-1 bg-foreground/80 rounded"
+              style={{ left: `${gaugePosition}%` }}
+            />
+            <div
+              className="absolute top-0 h-full w-0.5 bg-orange-500"
+              style={{ left: `${targetPosition}%` }}
+            />
+          </div>
+        </div>
+
+        {yieldBenchmark && (
+          <div className="mt-2 rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+            <span>
+              このエリアの市場想定利回り: 約
+              {(yieldBenchmark.estimatedYieldTypical * 100).toFixed(1)}%
+            </span>
+            <Badge
+              className="ml-2"
+              title={yieldBenchmark.judgmentLabel}
+              variant={
+                yieldBenchmark.judgment === "realistic"
+                  ? "outline"
+                  : yieldBenchmark.judgment === "slightly-high"
+                    ? "warning"
+                    : "danger"
+              }
+            >
+              {yieldBenchmark.judgment === "realistic"
+                ? "現実的"
+                : yieldBenchmark.judgment === "slightly-high"
+                  ? "やや高め"
+                  : "大幅に高め"}
+            </Badge>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/YieldGauge.tsx
+++ b/frontend/src/components/YieldGauge.tsx
@@ -16,7 +16,14 @@ interface YieldGaugeProps {
   landPriceStats?: LandPriceStats | null;
 }
 
-export function YieldGauge({ yieldPct, netYieldPct, isGood, targetPct, input, landPriceStats }: YieldGaugeProps) {
+export function YieldGauge({
+  yieldPct,
+  netYieldPct,
+  isGood,
+  targetPct,
+  input,
+  landPriceStats,
+}: YieldGaugeProps) {
   const maxYieldPct = targetPct * 2;
   const gaugePosition = Math.min(yieldPct / maxYieldPct, 1) * 100;
   const targetPosition = 50;

--- a/frontend/src/components/__tests__/InvestmentScoreCard.test.tsx
+++ b/frontend/src/components/__tests__/InvestmentScoreCard.test.tsx
@@ -21,6 +21,7 @@ function makeScore(totalScore: number, grade: string): InvestmentScoreResult {
       liquefactionRisk: makeScoreItem("液状化", 0),
       embankment: makeScoreItem("盛土", 0),
       disasterHistory: makeScoreItem("災害履歴", 0),
+      landPriceTrend: makeScoreItem("地価トレンド", 0),
       radarData: [],
     },
   };

--- a/frontend/src/components/__tests__/WatchlistPanel.test.tsx
+++ b/frontend/src/components/__tests__/WatchlistPanel.test.tsx
@@ -6,6 +6,20 @@ import { makeResult } from "./helpers";
 
 // WatchlistCompareTable is a child component; stub it to simplify
 vi.mock("@/components/WatchlistCompareTable", () => ({ default: () => null }));
+vi.mock("@/components/RootLayoutClient", () => ({
+  useAuthContext: () => ({ user: { uid: "test-uid" }, loading: false }),
+}));
+vi.mock("firebase/firestore", () => ({
+  collection: vi.fn(() => null),
+  doc: vi.fn(() => null),
+  addDoc: vi.fn(),
+  updateDoc: vi.fn(),
+  deleteDoc: vi.fn(),
+  query: vi.fn(),
+  orderBy: vi.fn(),
+  onSnapshot: vi.fn(() => () => {}),
+  serverTimestamp: vi.fn(() => null),
+}));
 
 vi.mock("@/components/ui/toast", () => ({
   useToast: () => ({ toast: vi.fn() }),

--- a/frontend/src/components/__tests__/YieldAnalysisCustomScenario.test.tsx
+++ b/frontend/src/components/__tests__/YieldAnalysisCustomScenario.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
-import { YieldAnalysis, getDscrColorClass } from "@/components/YieldAnalysis";
+import { YieldAnalysis } from "@/components/YieldAnalysis";
+import { getDscrColorClass } from "@/components/DscrBadge";
 import { makeInput, makeResult } from "./helpers";
 import type { StressScenarioResult } from "@/types/investment";
 

--- a/frontend/src/hooks/useAnalyzeApi.ts
+++ b/frontend/src/hooks/useAnalyzeApi.ts
@@ -46,59 +46,74 @@ export function useAnalyzeApi(
   const [error, setError] = useState<string | null>(null);
   const [loanMethod, setLoanMethodState] = useState<LoanMethod>("equal-payment");
 
-  const setLoanMethod = useCallback((method: LoanMethod) => {
-    setLoanMethodState(method);
-    loanMethodRef.current = method;
-  }, [loanMethodRef]);
+  const setLoanMethod = useCallback(
+    (method: LoanMethod) => {
+      setLoanMethodState(method);
+      loanMethodRef.current = method;
+    },
+    [loanMethodRef]
+  );
 
-  const handleAnalyze = useCallback(async (input: InvestmentInput, quickTotalMan?: string) => {
-    const { simulationMode, onUrlUpdate } = paramsRef.current!;
-    const currentLoanMethod = loanMethodRef.current;
-    setLoading(true);
-    setError(null);
-    onClearMonteCarloResult();
-    const inputWithMethod = { ...input, loanMethod: currentLoanMethod };
-    try {
-      const res = await analyzeOnline(inputWithMethod);
-      onResult(res);
-      onLastInput(inputWithMethod);
-      const urlParams = encodeUrlParams(simulationMode, inputWithMethod, quickTotalMan);
-      const qs = urlParams.toString();
-      onUrlUpdate(qs);
-    } catch (e) {
-      setError(toErrorMessage(e, "シミュレーションに失敗しました"));
-    } finally {
-      setLoading(false);
-    }
-  }, [loanMethodRef, paramsRef, onResult, onLastInput, onClearMonteCarloResult]);
+  const handleAnalyze = useCallback(
+    async (input: InvestmentInput, quickTotalMan?: string) => {
+      const { simulationMode, onUrlUpdate } = paramsRef.current!;
+      const currentLoanMethod = loanMethodRef.current;
+      setLoading(true);
+      setError(null);
+      onClearMonteCarloResult();
+      const inputWithMethod = { ...input, loanMethod: currentLoanMethod };
+      try {
+        const res = await analyzeOnline(inputWithMethod);
+        onResult(res);
+        onLastInput(inputWithMethod);
+        const urlParams = encodeUrlParams(simulationMode, inputWithMethod, quickTotalMan);
+        const qs = urlParams.toString();
+        onUrlUpdate(qs);
+      } catch (e) {
+        setError(toErrorMessage(e, "シミュレーションに失敗しました"));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [loanMethodRef, paramsRef, onResult, onLastInput, onClearMonteCarloResult]
+  );
 
-  const handleLoanMethodChange = useCallback(async (method: LoanMethod) => {
-    setLoanMethodState(method);
-    loanMethodRef.current = method;
-    const current = lastInputRef.current;
-    if (!current) return;
-    setLoading(true);
-    setError(null);
-    onClearMonteCarloResult();
-    try {
-      const updatedInput = { ...current, loanMethod: method };
-      const res = await analyzeOnline(updatedInput);
-      onResult(res);
-      onLastInput({ ...current, loanMethod: method });
-    } catch (e) {
-      setError(toErrorMessage(e, "シミュレーションに失敗しました"));
-    } finally {
-      setLoading(false);
-    }
-  }, [lastInputRef, loanMethodRef, onResult, onLastInput, onClearMonteCarloResult]);
+  const handleLoanMethodChange = useCallback(
+    async (method: LoanMethod) => {
+      setLoanMethodState(method);
+      loanMethodRef.current = method;
+      const current = lastInputRef.current;
+      if (!current) return;
+      setLoading(true);
+      setError(null);
+      onClearMonteCarloResult();
+      try {
+        const updatedInput = { ...current, loanMethod: method };
+        const res = await analyzeOnline(updatedInput);
+        onResult(res);
+        onLastInput({ ...current, loanMethod: method });
+      } catch (e) {
+        setError(toErrorMessage(e, "シミュレーションに失敗しました"));
+      } finally {
+        setLoading(false);
+      }
+    },
+    [lastInputRef, loanMethodRef, onResult, onLastInput, onClearMonteCarloResult]
+  );
 
-  const setResult = useCallback((result: InvestmentResult | null) => {
-    onResult(result);
-  }, [onResult]);
+  const setResult = useCallback(
+    (result: InvestmentResult | null) => {
+      onResult(result);
+    },
+    [onResult]
+  );
 
-  const setLastInput = useCallback((input: InvestmentInput | null) => {
-    onLastInput(input);
-  }, [onLastInput]);
+  const setLastInput = useCallback(
+    (input: InvestmentInput | null) => {
+      onLastInput(input);
+    },
+    [onLastInput]
+  );
 
   const clearMonteCarloResult = useCallback(() => {
     onClearMonteCarloResult();

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -18,16 +18,12 @@ interface UseAuthReturn {
 
 export function useAuth(): UseAuthReturn {
   const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(() => getFirebaseAuth() !== null);
 
   useEffect(() => {
     const auth = getFirebaseAuth();
 
-    // Firebase not configured (env vars missing) — skip auth entirely
-    if (!auth) {
-      setLoading(false);
-      return;
-    }
+    if (!auth) return;
 
     const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
       setUser(currentUser);

--- a/frontend/src/hooks/useExternalData.ts
+++ b/frontend/src/hooks/useExternalData.ts
@@ -55,7 +55,9 @@ export function useExternalData(
   const [theoreticalPrice, setTheoreticalPrice] = useState<TheoreticalPriceResult | null>(null);
   const [landAppraisal, setLandAppraisal] = useState<AppraisalComparisonResult | null>(null);
   const [stationRidership, setStationRidership] = useState<StationRidershipResult[] | null>(null);
-  const [populationForecast, setPopulationForecast] = useState<PopulationForecastResult | null>(null);
+  const [populationForecast, setPopulationForecast] = useState<PopulationForecastResult | null>(
+    null
+  );
   const [externalUrbanRisks, setExternalUrbanRisks] = useState<UrbanRisk[] | null>(null);
   const [investmentScore, setInvestmentScore] = useState<InvestmentScoreResult | null>(null);
   const [hazardRisks, setHazardRisks] = useState<UrbanRisk[] | null>(null);

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -65,7 +65,13 @@ export async function fetchLandPrices(params: {
   toQuarter: number;
 }): Promise<LandPriceStats> {
   const q = buildParams(
-    { area: params.area, year: params.year, quarter: params.quarter, to_year: params.toYear, to_quarter: params.toQuarter },
+    {
+      area: params.area,
+      year: params.year,
+      quarter: params.quarter,
+      to_year: params.toYear,
+      to_quarter: params.toQuarter,
+    },
     { city: params.city }
   );
   const res = await fetch(`${BASE}/land-prices/stats?${q}`);
@@ -84,7 +90,14 @@ export async function compareLandPrice(params: {
   areaSqm?: number;
 }): Promise<LandPriceComparison> {
   const q = buildParams(
-    { area: params.area, year: params.year, quarter: params.quarter, to_year: params.toYear, to_quarter: params.toQuarter, price: params.price },
+    {
+      area: params.area,
+      year: params.year,
+      quarter: params.quarter,
+      to_year: params.toYear,
+      to_quarter: params.toQuarter,
+      price: params.price,
+    },
     { city: params.city, area_sqm: params.areaSqm }
   );
   const res = await fetch(`${BASE}/land-prices/compare?${q}`);
@@ -112,8 +125,21 @@ export async function estimateLandPrice(params: {
   ridershipScore?: RidershipDemandScore;
 }): Promise<TheoreticalPriceResult> {
   const q = buildParams(
-    { area: params.area, year: params.year, quarter: params.quarter, to_year: params.toYear, to_quarter: params.toQuarter, price: params.price, area_sqm: params.areaSqm, building_age: params.buildingAge },
-    { city: params.city, station_minutes: params.stationMinutes, ridership_score: params.ridershipScore }
+    {
+      area: params.area,
+      year: params.year,
+      quarter: params.quarter,
+      to_year: params.toYear,
+      to_quarter: params.toQuarter,
+      price: params.price,
+      area_sqm: params.areaSqm,
+      building_age: params.buildingAge,
+    },
+    {
+      city: params.city,
+      station_minutes: params.stationMinutes,
+      ridership_score: params.ridershipScore,
+    }
   );
   const res = await fetch(`${BASE}/land-prices/estimate?${q}`);
   return handleResponse<TheoreticalPriceResult>(res);

--- a/frontend/src/lib/chartColors.ts
+++ b/frontend/src/lib/chartColors.ts
@@ -1,9 +1,9 @@
 export const chartColors = {
-  danger:    "hsl(var(--chart-danger))",
-  warning:   "hsl(var(--chart-warning))",
-  success:   "hsl(var(--chart-success))",
-  primary:   "hsl(var(--chart-primary))",
+  danger: "hsl(var(--chart-danger))",
+  warning: "hsl(var(--chart-warning))",
+  success: "hsl(var(--chart-success))",
+  primary: "hsl(var(--chart-primary))",
   secondary: "hsl(var(--chart-secondary))",
-  muted:     "hsl(var(--chart-muted))",
-  orange:    "hsl(var(--chart-orange))",
+  muted: "hsl(var(--chart-muted))",
+  orange: "hsl(var(--chart-orange))",
 } as const;


### PR DESCRIPTION
## 概要

- `YieldAnalysis.tsx`（832行）を4つのサブコンポーネントに分割し、オーケストレーターに変換
- `YieldAnalysis` は各コンポーネントの組み合わせのみを担うように整理

## 変更内容

### 新規コンポーネント

| コンポーネント | 責務 |
|---|---|
| `DscrBadge.tsx` | `getDscrColorClass` / `getDscrBadge` / `getDscrIcon` のDSCR表示ロジック |
| `YieldGauge.tsx` | 利回りゲージ + 市場想定利回りベンチマーク比較カード |
| `CustomScenarioSlider.tsx` | カスタムシナリオのスライダー UI + debounce付き `analyze` API 呼び出し |
| `StressScenarioTable.tsx` | ストレステストシナリオ一覧（モバイルアコーディオン + デスクトップテーブル）+ 人口減少シナリオ |

### 変更ファイル

- `YieldAnalysis.tsx`: 832行 → 約230行のオーケストレーターに縮小
- `__tests__/YieldAnalysisCustomScenario.test.tsx`: `getDscrColorClass` のimportを `DscrBadge` に更新

## テスト方法

```bash
cd frontend && npm test
cd frontend && npx tsc --noEmit
```

## 受け入れ条件の確認

- [x] `DscrBadge` / `YieldGauge` / `CustomScenarioSlider` / `StressScenarioTable` を新規作成
- [x] `YieldAnalysis.tsx` がオーケストレーター役に留まっている
- [x] YieldAnalysis 関連テスト 20件すべて通過
- [x] `tsc --noEmit` エラーなし

## 関連

- Closes #624