### PR TITLE
perf: dynamic importの対象を重量コンポーネントに拡張してバンドルサイズを削減する

### DIFF
--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -8,16 +8,13 @@ import DeadCrossChart from "@/components/DeadCrossChart";
 import { LandPriceAnalysis } from "@/components/LandPriceAnalysis";
 import CostBreakdown from "@/components/CostBreakdown";
 import { LoanOptimizationPanel } from "@/components/LoanOptimizationPanel";
-import { LoanComparePanel } from "@/components/LoanComparePanel";
 import RenovationPanel from "@/components/RenovationPanel";
 import MultiExitCompareTable from "@/components/MultiExitCompareTable";
 import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 import { HazardAlertBanner } from "@/components/HazardAlertBanner";
-import { MonteCarloChart } from "@/components/MonteCarloChart";
 import NegotiationPanel from "@/components/NegotiationPanel";
 import WatchlistPanel from "@/components/WatchlistPanel";
-import DueDiligenceChecklist from "@/components/DueDiligenceChecklist";
 import { AreaDiscovery } from "@/components/AreaDiscovery";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
@@ -41,6 +38,15 @@ import type {
 } from "@/types/investment";
 
 const InvestmentScoreHeatmap = dynamic(() => import("./InvestmentScoreHeatmap"), { ssr: false });
+const MonteCarloChart = dynamic(() => import("@/components/MonteCarloChart").then((m) => ({ default: m.MonteCarloChart })), {
+  loading: () => <Skeleton className="h-64 w-full rounded-xl" />,
+});
+const LoanComparePanel = dynamic(() => import("@/components/LoanComparePanel").then((m) => ({ default: m.LoanComparePanel })), {
+  loading: () => <Skeleton className="h-64 w-full rounded-xl" />,
+});
+const DueDiligenceChecklist = dynamic(() => import("@/components/DueDiligenceChecklist"), {
+  loading: () => <Skeleton className="h-96 w-full rounded-xl" />,
+});
 
 type ResultsTab = "finance" | "loan";
 const DEFAULT_RESULTS_TAB: ResultsTab = "finance";

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -38,12 +38,18 @@ import type {
 } from "@/types/investment";
 
 const InvestmentScoreHeatmap = dynamic(() => import("./InvestmentScoreHeatmap"), { ssr: false });
-const MonteCarloChart = dynamic(() => import("@/components/MonteCarloChart").then((m) => ({ default: m.MonteCarloChart })), {
-  loading: () => <Skeleton className="h-64 w-full rounded-xl" />,
-});
-const LoanComparePanel = dynamic(() => import("@/components/LoanComparePanel").then((m) => ({ default: m.LoanComparePanel })), {
-  loading: () => <Skeleton className="h-64 w-full rounded-xl" />,
-});
+const MonteCarloChart = dynamic(
+  () => import("@/components/MonteCarloChart").then((m) => ({ default: m.MonteCarloChart })),
+  {
+    loading: () => <Skeleton className="h-64 w-full rounded-xl" />,
+  }
+);
+const LoanComparePanel = dynamic(
+  () => import("@/components/LoanComparePanel").then((m) => ({ default: m.LoanComparePanel })),
+  {
+    loading: () => <Skeleton className="h-64 w-full rounded-xl" />,
+  }
+);
 const DueDiligenceChecklist = dynamic(() => import("@/components/DueDiligenceChecklist"), {
   loading: () => <Skeleton className="h-96 w-full rounded-xl" />,
 });

--- a/frontend/src/components/WatchlistPanel.tsx
+++ b/frontend/src/components/WatchlistPanel.tsx
@@ -30,10 +30,14 @@ import {
   Home,
 } from "lucide-react";
 import type { WatchlistItem, WatchlistStatus, InvestmentResult } from "@/types/investment";
-import WatchlistCompareTable from "@/components/WatchlistCompareTable";
+import dynamic from "next/dynamic";
 import AuthStatusBadge from "@/components/AuthStatusBadge";
 import { useAuthContext } from "@/components/RootLayoutClient";
 import { getFirebaseDb } from "@/lib/firebase";
+
+const WatchlistCompareTable = dynamic(() => import("@/components/WatchlistCompareTable"), {
+  loading: () => <Skeleton className="h-64 w-full rounded-xl" />,
+});
 
 // localStorage keys
 const STORAGE_KEY = "yg_watchlist";


### PR DESCRIPTION
## 概要

- `next/dynamic` による遅延読み込みを4コンポーネントに拡張
- 初回ロード時の JS バンドルサイズを削減し、各コンポーネントは必要になったタイミングで初めて読み込まれる

## 変更内容

| コンポーネント | 変更ファイル | 理由 |
|---|---|---|
| `MonteCarloChart` | `ResultsSection.tsx` | ボタン押下後にしか表示されない大型Rechartsチャート |
| `LoanComparePanel` | `ResultsSection.tsx` | デフォルト折りたたみ済み、展開時のみ必要 |
| `DueDiligenceChecklist` | `ResultsSection.tsx` | 「詳細・アクション」タブにしか表示されない |
| `WatchlistCompareTable` | `WatchlistPanel.tsx` | ウォッチリスト比較モード時のみ表示 |

すべて `loading: () => <Skeleton className="h-64 w-full rounded-xl" />` を指定し、CLAUDE.mdの「ローディング中はSkeleton UIを使用する」ルールに準拠。

## テスト方法

```bash
cd frontend && npm test
cd frontend && npx tsc --noEmit
```

## 受け入れ条件の確認

- [x] 対象4コンポーネントがすべて `next/dynamic` 化
- [x] `loading` に Skeleton を指定
- [x] テスト 343件通過（既存失敗11件はmainブランチと同一）
- [x] `tsc --noEmit` エラーなし

## 関連

- Closes #601