### PR TITLE
docs: worktreeとPRマージのルールをCLAUDE.mdに追記する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,15 +227,15 @@ These rules define the safety boundary for autonomous Claude Code operations.
 
 - **Never merge a PR without explicit instruction** — even if CI passes
 - **Never post comments to Issues or PRs without explicit instruction** — unintended external communication must be avoided
-- **Never use `--squash` when merging** — always use `--merge`; add `--delete-branch` to clean up
+- **Never use `--squash` when merging** — always use `--merge`; add `--delete-branch` to remove the remote branch (local branch / worktree must be removed manually afterward)
 
 ### Worktree operations
 
-- **Never run `npm install` in a worktree** — it regenerates `package-lock.json` with the local npm version, causing CI drift and exposing pre-existing lint/format issues
-- **Share `node_modules` via symlink instead:**
+- **Never run `npm install` in a worktree** — it regenerates `package-lock.json` with the local npm version, causing CI drift and exposing pre-existing lint/format issues (frontend only; Go backend is unaffected due to shared module cache)
+- **Share frontend `node_modules` via symlink instead** — run from the main repo root:
   ```bash
-  git worktree add ../yield-guard-xxx -b branch-name
-  ln -s $(pwd)/frontend/node_modules ../yield-guard-xxx/frontend/node_modules
+  git worktree add ../<worktree-dir> -b branch-name
+  ln -s "$(pwd)/frontend/node_modules" "../<worktree-dir>/frontend/node_modules"
   ```
 - **Check main CI status before starting work** — know the baseline so pre-existing failures don't block the PR
 - **Rebase once, just before pushing** — rebase on the latest `origin/main` right before creating the PR, not repeatedly during development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,3 +227,15 @@ These rules define the safety boundary for autonomous Claude Code operations.
 
 - **Never merge a PR without explicit instruction** — even if CI passes
 - **Never post comments to Issues or PRs without explicit instruction** — unintended external communication must be avoided
+- **Never use `--squash` when merging** — always use `--merge`; add `--delete-branch` to clean up
+
+### Worktree operations
+
+- **Never run `npm install` in a worktree** — it regenerates `package-lock.json` with the local npm version, causing CI drift and exposing pre-existing lint/format issues
+- **Share `node_modules` via symlink instead:**
+  ```bash
+  git worktree add ../yield-guard-xxx -b branch-name
+  ln -s $(pwd)/frontend/node_modules ../yield-guard-xxx/frontend/node_modules
+  ```
+- **Check main CI status before starting work** — know the baseline so pre-existing failures don't block the PR
+- **Rebase once, just before pushing** — rebase on the latest `origin/main` right before creating the PR, not repeatedly during development


### PR DESCRIPTION
## 概要

今回の issue #624/#601 対応で時間がかかった原因を分析し、再発防止のルールを CLAUDE.md に追記。

## 追記内容

### PR and external actions
- `--squash` 禁止、`--merge` + `--delete-branch` を使う

### Worktree operations（新規セクション）
- worktree で `npm install` を禁止 — lock file 汚染・CI ドリフトの原因
- `node_modules` を symlink で共有する手順を明記
- 作業前に main CI ステータスを確認する
- リベースは PR 直前に一度だけ行う

## 背景

worktree で `npm install` を走らせたことで `package-lock.json` が再生成され、CI の eslint-plugin-react-compiler バージョンが上がり、既存コードの潜在バグが大量に検出された。これが複数回の修正→プッシュ→CI 確認サイクルの原因となった。

## 関連

- issue #624 / #601 対応（PR #654, #655）での教訓