### PR TITLE
feat: Next.js standalone出力でDockerイメージを~200MBに軽量化 (#406)

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,10 +18,9 @@ WORKDIR /app
 ENV NODE_ENV=production
 # root実行を避けるために専用ユーザーを作成
 RUN addgroup -g 1001 appgroup && adduser -u 1001 -G appgroup -D appuser
-COPY --from=builder /app/.next ./.next
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/package.json ./package.json
-RUN chown -R appuser:appgroup .
+COPY --from=builder --chown=appuser:appgroup /app/.next/standalone ./
+COPY --from=builder --chown=appuser:appgroup /app/.next/static ./.next/static
+COPY --from=builder --chown=appuser:appgroup /app/public ./public
 USER appuser
 EXPOSE 3000
-CMD ["npm", "start"]
+CMD ["node", "server.js"]

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,6 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
+  output: "standalone",
   async rewrites() {
     const backendUrl = process.env.BACKEND_URL ?? "http://localhost:8080";
     return [

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'standalone',
   async rewrites() {
     const backendUrl = process.env.BACKEND_URL ?? "http://localhost:8080";
     return [


### PR DESCRIPTION
## 概要

 を有効化し、Dockerランナーステージから  全体（数百MB）のコピーを排除。イメージサイズを約1GBから約200MBに削減する。

## 変更内容

- :  を追加
- : ランナーステージを  ベースに書き換え
  -  と  のコピーを削除
  -  と  を別途コピー
  -  レイヤーを廃止し  に統一
  -  を  に変更

## 関連Issue

Closes #406

## テスト

- [ ]  が成功すること
- [ ] イメージサイズが~200MB程度であること
- [ ]  でアプリが起動し  がプロキシされること
- [ ] docker compose up --build で全体スタックが動作すること

## 確認事項

- [ ] コードレビュー観点での自己レビュー済み