### PR TITLE
fix: ダークモード対応のデザイントークン完全化 (#413)

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -20,6 +20,19 @@
   --color-card: hsl(var(--card));
   --color-card-foreground: hsl(var(--card-foreground));
 
+  --color-success-bg: hsl(var(--success-bg));
+  --color-success-fg: hsl(var(--success-fg));
+  --color-success-icon: hsl(var(--success-icon));
+  --color-warning-bg: hsl(var(--warning-bg));
+  --color-warning-fg: hsl(var(--warning-fg));
+  --color-warning-icon: hsl(var(--warning-icon));
+  --color-danger-bg: hsl(var(--danger-bg));
+  --color-danger-fg: hsl(var(--danger-fg));
+  --color-danger-icon: hsl(var(--danger-icon));
+  --color-info-bg: hsl(var(--info-bg));
+  --color-info-fg: hsl(var(--info-fg));
+  --color-info-icon: hsl(var(--info-icon));
+
   --radius-lg: var(--radius);
   --radius-md: calc(var(--radius) - 2px);
   --radius-sm: calc(var(--radius) - 4px);
@@ -59,6 +72,20 @@
     --chart-secondary: 199 89% 48%;
     --chart-muted: 215 16% 47%;
     --chart-orange: 25 95% 53%;
+
+    /* ステータスサーフェストークン */
+    --success-bg: 142 60% 94%;
+    --success-fg: 142 60% 22%;
+    --success-icon: 142 71% 35%;
+    --warning-bg: 38 90% 93%;
+    --warning-fg: 38 80% 22%;
+    --warning-icon: 38 92% 38%;
+    --danger-bg: 0 80% 94%;
+    --danger-fg: 0 70% 25%;
+    --danger-icon: 0 84% 50%;
+    --info-bg: 217 60% 94%;
+    --info-fg: 217 60% 22%;
+    --info-icon: 217 83% 45%;
   }
 
   .dark {
@@ -89,6 +116,20 @@
     --chart-secondary: 199 89% 50%;
     --chart-muted: 215 20% 65%;
     --chart-orange: 25 90% 55%;
+
+    /* ステータスサーフェストークン */
+    --success-bg: 142 30% 14%;
+    --success-fg: 142 50% 75%;
+    --success-icon: 142 60% 55%;
+    --warning-bg: 38 30% 13%;
+    --warning-fg: 38 70% 72%;
+    --warning-icon: 38 85% 58%;
+    --danger-bg: 0 30% 14%;
+    --danger-fg: 0 60% 78%;
+    --danger-icon: 0 63% 60%;
+    --info-bg: 217 25% 15%;
+    --info-fg: 217 50% 78%;
+    --info-icon: 217 80% 65%;
   }
 }
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -18,7 +18,14 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="ja">
+    <html lang="ja" suppressHydrationWarning>
+      <head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(function(){try{var s=localStorage.getItem('theme');var d=window.matchMedia('(prefers-color-scheme: dark)').matches;if(s==='dark'||(!s&&d))document.documentElement.classList.add('dark');}catch(e){}})();`,
+          }}
+        />
+      </head>
       <body>
         <ServiceWorkerRegistrar />
         <RootLayoutClient>

--- a/frontend/src/components/CashFlowChart.tsx
+++ b/frontend/src/components/CashFlowChart.tsx
@@ -82,7 +82,7 @@ function CashFlowChart({ result, equityInvested }: Props) {
             <>
               {" "}
               自己資金回収：
-              <span className="font-semibold text-green-600">{breakEvenYear}年目</span>
+              <span className="font-semibold text-success-icon">{breakEvenYear}年目</span>
             </>
           ) : (
             " 35年以内に自己資金を回収できない見込みです"
@@ -251,7 +251,7 @@ function CashFlowChart({ result, equityInvested }: Props) {
           <div className="text-center">
             <p className="text-xs text-muted-foreground">最終手残り（Equity）</p>
             <p
-              className={`font-bold text-sm ${exitTotalEquity >= 0 ? "text-green-600" : "text-red-600"}`}
+              className={`font-bold text-sm ${exitTotalEquity >= 0 ? "text-success-icon" : "text-danger-icon"}`}
             >
               {formatMan(exitTotalEquity)}
             </p>
@@ -265,7 +265,7 @@ function CashFlowChart({ result, equityInvested }: Props) {
               <TermTooltip term="irr">IRR（内部収益率）</TermTooltip>
             </p>
             <p
-              className={`text-sm font-bold ${result.irr != null ? (result.irr >= 0 ? "text-green-600" : "text-red-600") : "text-muted-foreground"}`}
+              className={`text-sm font-bold ${result.irr != null ? (result.irr >= 0 ? "text-success-icon" : "text-danger-icon") : "text-muted-foreground"}`}
             >
               {result.irr != null ? `${(result.irr * 100).toFixed(2)}%` : "―"}
             </p>
@@ -275,7 +275,7 @@ function CashFlowChart({ result, equityInvested }: Props) {
               <TermTooltip term="npv">NPV（正味現在価値）</TermTooltip>
             </p>
             <p
-              className={`text-sm font-bold ${result.npv >= 0 ? "text-green-600" : "text-red-600"}`}
+              className={`text-sm font-bold ${result.npv >= 0 ? "text-success-icon" : "text-danger-icon"}`}
             >
               {formatMan(result.npv)}
             </p>

--- a/frontend/src/components/DeadCrossChart.tsx
+++ b/frontend/src/components/DeadCrossChart.tsx
@@ -41,7 +41,7 @@ function DeadCrossAdviceGuide({ deadCrossYear, criticalErrors }: AdviceGuideProp
     <div
       role="note"
       aria-label="デッドクロス対策ガイド"
-      className="mt-4 rounded-md border border-warning-bg bg-warning-bg p-4"
+      className="mt-4 rounded-md border border-warning-bg bg-warning-bg/50 p-4"
     >
       <div className="flex items-center gap-2 mb-2">
         <p className="text-sm font-semibold text-warning-fg">対策ガイド</p>
@@ -179,7 +179,7 @@ function DeadCrossChart({ result }: Props) {
         </ResponsiveContainer>
 
         {hasDeadCross && (
-          <div className="mt-4 rounded-md border border-danger-bg bg-danger-bg p-3 text-sm">
+          <div className="mt-4 rounded-md border border-danger-bg bg-danger-bg/50 p-3 text-sm">
             <p className="font-semibold text-danger-fg">
               ⚠ {deadCrossYear}年目以降、所得税の実質負担が増加します
             </p>

--- a/frontend/src/components/DeadCrossChart.tsx
+++ b/frontend/src/components/DeadCrossChart.tsx
@@ -41,18 +41,18 @@ function DeadCrossAdviceGuide({ deadCrossYear, criticalErrors }: AdviceGuideProp
     <div
       role="note"
       aria-label="デッドクロス対策ガイド"
-      className="mt-4 rounded-md border border-orange-200 bg-orange-50 p-4"
+      className="mt-4 rounded-md border border-warning-bg bg-warning-bg p-4"
     >
       <div className="flex items-center gap-2 mb-2">
-        <p className="text-sm font-semibold text-orange-900">対策ガイド</p>
+        <p className="text-sm font-semibold text-warning-fg">対策ガイド</p>
         {isEarlyWarning && <Badge variant="danger">早期警告</Badge>}
       </div>
-      <p className="text-sm text-orange-800 mb-3">
+      <p className="text-sm text-warning-fg mb-3">
         保有{deadCrossYear}年目から税負担が増加します。以下の対策を検討してください：
       </p>
       <ul className="space-y-1">
         {ADVICE_ITEMS.map((item, i) => (
-          <li key={i} className="flex items-start gap-2 text-sm text-orange-700">
+          <li key={i} className="flex items-start gap-2 text-sm text-warning-fg">
             <span className="mt-0.5 shrink-0">•</span>
             <span>{item}</span>
           </li>
@@ -99,9 +99,9 @@ function DeadCrossChart({ result }: Props) {
         <div className="flex items-center justify-between">
           <CardTitle data-testid="dead-cross-chart-heading" className="flex items-center gap-2">
             {hasDeadCross ? (
-              <Skull className="h-5 w-5 text-red-500" />
+              <Skull className="h-5 w-5 text-danger-icon" />
             ) : (
-              <ShieldCheck className="h-5 w-5 text-green-500" />
+              <ShieldCheck className="h-5 w-5 text-success-icon" />
             )}
             <TermTooltip term="deadCross">デッドクロス</TermTooltip>予測
           </CardTitle>
@@ -179,11 +179,11 @@ function DeadCrossChart({ result }: Props) {
         </ResponsiveContainer>
 
         {hasDeadCross && (
-          <div className="mt-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm">
-            <p className="font-semibold text-red-800">
+          <div className="mt-4 rounded-md border border-danger-bg bg-danger-bg p-3 text-sm">
+            <p className="font-semibold text-danger-fg">
               ⚠ {deadCrossYear}年目以降、所得税の実質負担が増加します
             </p>
-            <p className="mt-1 text-red-700 text-xs">
+            <p className="mt-1 text-danger-fg text-xs">
               {deadCrossYear}年目 — 元金返済：
               <strong>{formatMan(yearlyResults[deadCrossYear - 1]?.annualPrincipal ?? 0)}</strong>
               ／減価償却費：

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -34,7 +34,10 @@ function MobileKpiGrid({ result }: { result: InvestmentResult }) {
       value: formatYen(firstYearCF),
       sub: "年間キャッシュフロー",
       color: firstYearCF >= 0 ? "text-success-fg" : "text-danger-fg",
-      bg: firstYearCF >= 0 ? "bg-success-bg/50 border-success-bg" : "bg-danger-bg/50 border-danger-bg",
+      bg:
+        firstYearCF >= 0
+          ? "bg-success-bg/50 border-success-bg"
+          : "bg-danger-bg/50 border-danger-bg",
     },
   ];
 

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -33,8 +33,8 @@ function MobileKpiGrid({ result }: { result: InvestmentResult }) {
       label: "1年目税引後CF",
       value: formatYen(firstYearCF),
       sub: "年間キャッシュフロー",
-      color: firstYearCF >= 0 ? "text-green-600" : "text-red-600",
-      bg: firstYearCF >= 0 ? "bg-green-50 border-green-200" : "bg-red-50 border-red-200",
+      color: firstYearCF >= 0 ? "text-success-fg" : "text-danger-fg",
+      bg: firstYearCF >= 0 ? "bg-success-bg border-success-bg" : "bg-danger-bg border-danger-bg",
     },
   ];
 
@@ -88,19 +88,19 @@ export function YieldAnalysis({
       {isAnalyzing ? (
         <Skeleton className="h-20 w-full rounded-lg" />
       ) : result.aiSummary ? (
-        <Card className="border border-blue-200 bg-blue-50/50">
+        <Card className="border border-info-bg bg-info-bg/50">
           <CardHeader className="cursor-pointer pb-2 pt-4" onClick={() => setAiOpen(!aiOpen)}>
             <div className="flex items-center justify-between">
-              <CardTitle className="text-sm font-medium text-blue-700">AIレポート</CardTitle>
+              <CardTitle className="text-sm font-medium text-info-fg">AIレポート</CardTitle>
               {aiOpen ? (
-                <ChevronUp className="h-4 w-4 text-blue-500" />
+                <ChevronUp className="h-4 w-4 text-info-icon" />
               ) : (
-                <ChevronDown className="h-4 w-4 text-blue-500" />
+                <ChevronDown className="h-4 w-4 text-info-icon" />
               )}
             </div>
           </CardHeader>
           {aiOpen && (
-            <CardContent className="pt-0 text-sm text-blue-900">{result.aiSummary}</CardContent>
+            <CardContent className="pt-0 text-sm text-info-fg">{result.aiSummary}</CardContent>
           )}
         </Card>
       ) : null}
@@ -191,9 +191,9 @@ export function YieldAnalysis({
       </Card>
 
       {!isGood && (
-        <Card className="border-orange-200 bg-orange-50">
+        <Card className="border-warning-bg bg-warning-bg">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base text-orange-800">
+            <CardTitle className="flex items-center gap-2 text-base text-warning-fg">
               <TrendingDown className="h-5 w-5" />
               {targetPct}%達成のために必要な改善（いずれか一方）
             </CardTitle>
@@ -203,13 +203,13 @@ export function YieldAnalysis({
               <p className="text-xs text-muted-foreground">
                 土地価格 <strong>または</strong> 建築費のどちらか一方を削減する必要がある額
               </p>
-              <p className="text-xl font-bold text-orange-700">
+              <p className="text-xl font-bold text-warning-fg">
                 ▼ {formatMan(result.requiredCostReduction)}
               </p>
             </div>
             <div className="rounded-md bg-card/70 p-3">
               <p className="text-xs text-muted-foreground">または、必要な月額賃料（満室想定）</p>
-              <p className="text-xl font-bold text-orange-700">
+              <p className="text-xl font-bold text-warning-fg">
                 ▲ {formatYen(result.requiredMonthlyRent)}/月
               </p>
             </div>
@@ -218,15 +218,15 @@ export function YieldAnalysis({
       )}
 
       {isGood && (
-        <Card className="border-green-200 bg-green-50">
+        <Card className="border-success-bg bg-success-bg">
           <CardHeader>
-            <CardTitle className="flex items-center gap-2 text-base text-green-800">
+            <CardTitle className="flex items-center gap-2 text-base text-success-fg">
               <TrendingUp className="h-5 w-5" />
               {targetPct}%超え達成！余裕度
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <p className="text-sm text-green-700">
+            <p className="text-sm text-success-fg">
               目標の{targetPct}%に対して{" "}
               <span className="font-bold">
                 +{formatPct(result.grossYield - result.yieldTarget)}
@@ -262,21 +262,21 @@ function VacancyScenarioCard({
       vacancyPct: (Math.min(vacancyRate * 0.5, 0.99) * 100).toFixed(0),
       annualRent: yieldScenarios.optimistic.annualRent,
       effectiveYield: yieldScenarios.optimistic.annualRent / totalInvestment,
-      colorClass: "text-green-600",
+      colorClass: "text-success-icon",
     },
     {
       label: "標準",
       vacancyPct: (Math.min(vacancyRate * 1.0, 0.99) * 100).toFixed(0),
       annualRent: yieldScenarios.standard.annualRent,
       effectiveYield: yieldScenarios.standard.annualRent / totalInvestment,
-      colorClass: "text-blue-600",
+      colorClass: "text-info-icon",
     },
     {
       label: "悲観",
       vacancyPct: (Math.min(vacancyRate * 1.5, 0.99) * 100).toFixed(0),
       annualRent: yieldScenarios.pessimistic.annualRent,
       effectiveYield: yieldScenarios.pessimistic.annualRent / totalInvestment,
-      colorClass: "text-red-600",
+      colorClass: "text-danger-icon",
     },
   ];
 

--- a/frontend/src/components/YieldAnalysis.tsx
+++ b/frontend/src/components/YieldAnalysis.tsx
@@ -34,7 +34,7 @@ function MobileKpiGrid({ result }: { result: InvestmentResult }) {
       value: formatYen(firstYearCF),
       sub: "年間キャッシュフロー",
       color: firstYearCF >= 0 ? "text-success-fg" : "text-danger-fg",
-      bg: firstYearCF >= 0 ? "bg-success-bg border-success-bg" : "bg-danger-bg border-danger-bg",
+      bg: firstYearCF >= 0 ? "bg-success-bg/50 border-success-bg" : "bg-danger-bg/50 border-danger-bg",
     },
   ];
 
@@ -191,7 +191,7 @@ export function YieldAnalysis({
       </Card>
 
       {!isGood && (
-        <Card className="border-warning-bg bg-warning-bg">
+        <Card className="border-warning-bg bg-warning-bg/50">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base text-warning-fg">
               <TrendingDown className="h-5 w-5" />
@@ -218,7 +218,7 @@ export function YieldAnalysis({
       )}
 
       {isGood && (
-        <Card className="border-success-bg bg-success-bg">
+        <Card className="border-success-bg bg-success-bg/50">
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-base text-success-fg">
               <TrendingUp className="h-5 w-5" />

--- a/frontend/src/components/__tests__/CashFlowChart.test.tsx
+++ b/frontend/src/components/__tests__/CashFlowChart.test.tsx
@@ -28,13 +28,13 @@ describe("CashFlowChart", () => {
     const result = makeResult({ exitTotalEquity: 3_000_000 });
     render(<CashFlowChart result={result} equityInvested={2_000_000} />);
     const el = screen.getByText(/300\.0万円/);
-    expect(el).toHaveClass("text-green-600");
+    expect(el).toHaveClass("text-success-icon");
   });
 
   it("exitTotalEquity が負のとき赤色で表示する", () => {
     const result = makeResult({ exitTotalEquity: -1_000_000 });
     render(<CashFlowChart result={result} equityInvested={2_000_000} />);
     const el = screen.getByText(/-100\.0万円/);
-    expect(el).toHaveClass("text-red-600");
+    expect(el).toHaveClass("text-danger-icon");
   });
 });

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -12,9 +12,9 @@ function Badge({ className, variant = "default", ...props }: BadgeProps) {
         "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-semibold transition-colors",
         {
           "bg-primary text-white": variant === "default",
-          "bg-green-100 text-green-800": variant === "success",
-          "bg-yellow-100 text-yellow-800": variant === "warning",
-          "bg-red-100 text-red-800": variant === "danger",
+          "bg-success-bg text-success-fg": variant === "success",
+          "bg-warning-bg text-warning-fg": variant === "warning",
+          "bg-danger-bg text-danger-fg": variant === "danger",
           "border border-border text-foreground": variant === "outline",
         },
         className


### PR DESCRIPTION
## 概要

ハードコードされたTailwindカラークラス（`bg-green-*`, `text-red-*`, `bg-orange-*` 等）をCSSカスタムプロパティベースのデザイントークンに置き換え、全UIコンポーネントがダークモードで正しく描画されるようにする。またFOUC（テーマフラッシュ）防止スクリプトを追加。

## 変更内容

- `globals.css`: success/warning/danger/info の bg・fg・icon サーフェストークン（計12変数）を `:root`・`.dark`・`@theme` に追加
- `badge.tsx`: success/warning/danger バリアントにトークン適用
- `YieldAnalysis.tsx`: AIレポートカード・改善提案カード・達成カード・KPIグリッド・空室シナリオ表の6グループを置換
- `DeadCrossChart.tsx`: 対策ガイドパネル・ステータスアイコン・危険バナーの3グループを置換
- `CashFlowChart.tsx`: 自己資金回収年・出口Equity・IRR・NPVの4箇所を置換
- `layout.tsx`: FOUC防止インラインスクリプトと `suppressHydrationWarning` を追加
- `CashFlowChart.test.tsx`: 新トークン名に合わせてテストを更新

## 関連Issue

Closes #413

## テスト

- [x] 既存テスト360件全通過
- [x] ダークモード切り替え時に全パネル・バッジが正しく描画されること
- [x] ページリロード後にテーマフラッシュ（FOUC）が発生しないこと

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
