### PR TITLE
chore(ci): PRクローズ時にVercelプレビューを自動削除する

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -29,6 +29,7 @@ jobs:
   ci:
     name: Format, Lint, Type Check & Build
     runs-on: ubuntu-24.04
+    if: github.event.action != 'closed'
 
     defaults:
       run:
@@ -247,6 +248,7 @@ jobs:
 
       - name: Delete preview deployment
         if: steps.get-url.outputs.url != ''
+        continue-on-error: true
         run: vercel rm "${{ steps.get-url.outputs.url }}" --yes
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -10,6 +10,7 @@ on:
       - "Makefile"
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, closed]
     paths:
       - "frontend/**"
       - "docs/openapi/**"
@@ -132,6 +133,7 @@ jobs:
     if: |
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'pull_request' &&
+       github.event.action != 'closed' &&
        github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
@@ -210,3 +212,44 @@ jobs:
             }
         env:
           PREVIEW_URL: ${{ steps.preview.outputs.url }}
+
+  cleanup:
+    name: Delete Vercel preview on PR close
+    runs-on: ubuntu-24.04
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      pull-requests: read
+
+    steps:
+      - name: Get preview URL from PR comment
+        id: get-url
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- vercel-preview -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const comment = comments.find(c => c.body.includes(marker));
+            if (!comment) { core.setOutput('url', ''); return; }
+            const match = comment.body.match(/https:\/\/[a-zA-Z0-9._-]+\.vercel\.app/);
+            core.setOutput('url', match ? match[0] : '');
+
+      - name: Install Vercel CLI
+        if: steps.get-url.outputs.url != ''
+        run: npm install -g vercel@51.8.0
+
+      - name: Delete preview deployment
+        if: steps.get-url.outputs.url != ''
+        run: vercel rm "${{ steps.get-url.outputs.url }}" --yes
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          NO_COLOR: "1"


### PR DESCRIPTION
## 概要

PR クローズ時に Vercel プレビューデプロイを自動削除する CI ジョブを追加する。マージ後もプレビュー URL が公開アクセス可能な状態で残り続ける問題を解消する。

## 背景

現状、Vercel プレビュー URL は PR コメントに投稿されるが、PR マージ後も URL が有効なまま残る。プレビューは本番バックエンド（Cloud Run）に接続しているため、以下のリスクがある：

- MLIT API クォータの不正消費
- 認証なしで誰でもアプリにアクセス可能

## 変更内容

- `pull_request` トリガーに `closed` タイプを追加
- `deploy` ジョブに `event.action != 'closed'` 条件を追加（PR クローズ時に再デプロイしない）
- `cleanup` ジョブを新規追加：PR クローズ時に `<!-- vercel-preview -->` コメントから URL を読み出し `vercel rm` で削除

## 動作フロー

```
PR open/push  → deploy ジョブ → プレビュー URL をコメントに投稿
PR close/merge → cleanup ジョブ → コメントから URL を取得 → vercel rm で削除
```

## 関連

Vercel Deployment Protection（Pro プラン）が利用可能になった場合はそちらへの移行を検討する。

## テスト

- [ ] CI ワークフローの構文エラーがないこと（GitHub Actions の lint）
- [ ] 次回 PR マージ時に cleanup ジョブが実行されプレビューが削除されること
