### PR TITLE
chore(ci): 旧プレビューデプロイ手動削除用ワークフローを追加（使い捨て）

### DIFF
--- a/.github/workflows/delete-preview.yml
+++ b/.github/workflows/delete-preview.yml
@@ -1,0 +1,31 @@
+name: Delete Vercel preview deployments (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      urls:
+        description: "削除するVercelプレビューURL（スペース区切りで複数指定可）"
+        required: true
+
+jobs:
+  delete:
+    name: Delete preview deployments
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - name: Install Vercel CLI
+        run: npm install -g vercel@51.8.0
+
+      - name: Delete deployments
+        run: |
+          for url in ${{ github.event.inputs.urls }}; do
+            echo "Deleting: $url"
+            vercel rm "$url" --yes || echo "Skip: $url not found or already deleted"
+          done
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          NO_COLOR: "1"


### PR DESCRIPTION
## 概要

PR #691 マージ前にクローズされた PR のプレビューデプロイが残存しているため、手動削除用の `workflow_dispatch` ワークフローを一時的に追加する。

## 対象のプレビュー URL

| PR | URL |
|---|---|
| #663 Docker standalone | `https://yield-guard-3bkoswgsm-glkt3912s-projects.vercel.app` |
| #664 Dark mode tokens | `https://yield-guard-qea7f74r8-glkt3912s-projects.vercel.app` |

## 使い方

マージ後、GitHub Actions の「Delete Vercel preview deployments (manual)」ワークフローを手動実行する。

`urls` に以下を入力：
```
https://yield-guard-3bkoswgsm-glkt3912s-projects.vercel.app https://yield-guard-qea7f74r8-glkt3912s-projects.vercel.app
```

## 注意

このワークフローファイルは削除後に別 PR で除去する（使い捨て）。
