### PR TITLE
feat(frontend): 相場取得の重複 API 呼び出しを防ぐ一時キャッシュを追加する

### DIFF
--- a/frontend/src/lib/__tests__/apiCache.test.ts
+++ b/frontend/src/lib/__tests__/apiCache.test.ts
@@ -51,10 +51,7 @@ describe("cachedFetch", () => {
   });
 
   it("does not cache errors and retries on next call", async () => {
-    const fetcher = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("network"))
-      .mockResolvedValueOnce("ok");
+    const fetcher = vi.fn().mockRejectedValueOnce(new Error("network")).mockResolvedValueOnce("ok");
 
     await expect(cachedFetch("key4", 60_000, fetcher)).rejects.toThrow("network");
     const result = await cachedFetch("key4", 60_000, fetcher);

--- a/frontend/src/lib/__tests__/apiCache.test.ts
+++ b/frontend/src/lib/__tests__/apiCache.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cachedFetch, invalidateCache } from "../apiCache";
+
+beforeEach(() => {
+  invalidateCache();
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  invalidateCache();
+  vi.useRealTimers();
+});
+
+describe("cachedFetch", () => {
+  it("returns cached value without calling fetcher again", async () => {
+    const fetcher = vi.fn().mockResolvedValue({ value: 42 });
+
+    const r1 = await cachedFetch("key1", 60_000, fetcher);
+    const r2 = await cachedFetch("key1", 60_000, fetcher);
+
+    expect(r1).toEqual({ value: 42 });
+    expect(r2).toEqual({ value: 42 });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls fetcher again after TTL expires", async () => {
+    const fetcher = vi.fn().mockResolvedValue("data");
+    const TTL = 5_000;
+
+    await cachedFetch("key2", TTL, fetcher);
+    vi.advanceTimersByTime(TTL + 1);
+    await cachedFetch("key2", TTL, fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates concurrent in-flight requests", async () => {
+    let resolveFirst!: (v: string) => void;
+    const inflight = new Promise<string>((r) => (resolveFirst = r));
+    const fetcher = vi.fn().mockReturnValue(inflight);
+
+    const p1 = cachedFetch("key3", 60_000, fetcher);
+    const p2 = cachedFetch("key3", 60_000, fetcher);
+
+    resolveFirst("shared");
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toBe("shared");
+    expect(r2).toBe("shared");
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not cache errors and retries on next call", async () => {
+    const fetcher = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("network"))
+      .mockResolvedValueOnce("ok");
+
+    await expect(cachedFetch("key4", 60_000, fetcher)).rejects.toThrow("network");
+    const result = await cachedFetch("key4", 60_000, fetcher);
+
+    expect(result).toBe("ok");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches null values", async () => {
+    const fetcher = vi.fn().mockResolvedValue(null);
+
+    const r1 = await cachedFetch("key5", 60_000, fetcher);
+    const r2 = await cachedFetch("key5", 60_000, fetcher);
+
+    expect(r1).toBeNull();
+    expect(r2).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats different keys independently", async () => {
+    const fetcherA = vi.fn().mockResolvedValue("a");
+    const fetcherB = vi.fn().mockResolvedValue("b");
+
+    const a = await cachedFetch("keyA", 60_000, fetcherA);
+    const b = await cachedFetch("keyB", 60_000, fetcherB);
+
+    expect(a).toBe("a");
+    expect(b).toBe("b");
+    expect(fetcherA).toHaveBeenCalledTimes(1);
+    expect(fetcherB).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("invalidateCache", () => {
+  it("clears all entries when called without prefix", async () => {
+    const fetcher = vi.fn().mockResolvedValue("x");
+
+    await cachedFetch("a:1", 60_000, fetcher);
+    await cachedFetch("b:1", 60_000, fetcher);
+    invalidateCache();
+    await cachedFetch("a:1", 60_000, fetcher);
+    await cachedFetch("b:1", 60_000, fetcher);
+
+    expect(fetcher).toHaveBeenCalledTimes(4);
+  });
+
+  it("clears only prefix-matching entries", async () => {
+    const fetcherA = vi.fn().mockResolvedValue("a");
+    const fetcherB = vi.fn().mockResolvedValue("b");
+
+    await cachedFetch("municipalities:13", 60_000, fetcherA);
+    await cachedFetch("rentStats:13::", 60_000, fetcherB);
+
+    invalidateCache("municipalities");
+
+    await cachedFetch("municipalities:13", 60_000, fetcherA);
+    await cachedFetch("rentStats:13::", 60_000, fetcherB);
+
+    expect(fetcherA).toHaveBeenCalledTimes(2);
+    expect(fetcherB).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/lib/__tests__/apiCache.test.ts
+++ b/frontend/src/lib/__tests__/apiCache.test.ts
@@ -116,4 +116,30 @@ describe("invalidateCache", () => {
     expect(fetcherA).toHaveBeenCalledTimes(2);
     expect(fetcherB).toHaveBeenCalledTimes(1);
   });
+
+  it("clears in-flight entries matching prefix", async () => {
+    let resolveA!: (v: string) => void;
+    const inflightA = new Promise<string>((r) => (resolveA = r));
+    const fetcherA = vi.fn().mockReturnValueOnce(inflightA).mockResolvedValue("a2");
+    const fetcherB = vi.fn().mockResolvedValue("b");
+
+    // fetcherA は in-flight 状態（まだ未解決）
+    const p1 = cachedFetch("municipalities:13", 60_000, fetcherA);
+
+    // in-flight 中に prefix 無効化
+    invalidateCache("municipalities");
+
+    // 無効化後の呼び出しは fetcher を再実行する（in-flight が削除されているため）
+    const p2 = cachedFetch("municipalities:13", 60_000, fetcherA);
+
+    resolveA("a1");
+    const [r1, r2] = await Promise.all([p1, p2]);
+
+    expect(r1).toBe("a1");
+    expect(r2).toBe("a2");
+    expect(fetcherA).toHaveBeenCalledTimes(2);
+    // b はキャッシュ・in-flight ともに影響なし
+    await cachedFetch("rentStats:13::", 60_000, fetcherB);
+    expect(fetcherB).toHaveBeenCalledTimes(1);
+  });
 });

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -359,18 +359,14 @@ export function fetchRentStats(params: {
 }): Promise<RentStatsResult | null> {
   const municipality = params.municipality ?? "";
   const areaSqm = params.areaSqm ?? "";
-  return cachedFetch(
-    `rentStats:${params.area}:${municipality}:${areaSqm}`,
-    TTL_RENT,
-    async () => {
-      const q = new URLSearchParams({ area: params.area });
-      if (params.municipality) q.set("municipality", params.municipality);
-      if (params.areaSqm && params.areaSqm > 0) q.set("area_sqm", String(params.areaSqm));
-      const res = await fetch(`${BASE}/rent-stats?${q}`);
-      if (!res.ok) return null;
-      const data = await res.json();
-      if (!data || data.count === 0) return null;
-      return data as RentStatsResult;
-    }
-  );
+  return cachedFetch(`rentStats:${params.area}:${municipality}:${areaSqm}`, TTL_RENT, async () => {
+    const q = new URLSearchParams({ area: params.area });
+    if (params.municipality) q.set("municipality", params.municipality);
+    if (params.areaSqm && params.areaSqm > 0) q.set("area_sqm", String(params.areaSqm));
+    const res = await fetch(`${BASE}/rent-stats?${q}`);
+    if (!res.ok) return null;
+    const data = await res.json();
+    if (!data || data.count === 0) return null;
+    return data as RentStatsResult;
+  });
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -19,10 +19,14 @@ import type {
   GeocodeResult,
   Municipality,
 } from "@/types/investment";
+import { cachedFetch } from "./apiCache";
 
 export type { Municipality };
 
 const BASE = "/api";
+
+const TTL_MARKET = 10 * 60 * 1000;
+const TTL_RENT = 5 * 60 * 1000;
 
 async function handleResponse<T>(res: Response): Promise<T> {
   if (!res.ok) {
@@ -56,7 +60,7 @@ function buildParams(
 }
 
 /** 土地取引価格の統計を取得 */
-export async function fetchLandPrices(params: {
+export function fetchLandPrices(params: {
   area: string;
   city?: string;
   year: number;
@@ -74,12 +78,14 @@ export async function fetchLandPrices(params: {
     },
     { city: params.city }
   );
-  const res = await fetch(`${BASE}/land-prices/stats?${q}`);
-  return handleResponse<LandPriceStats>(res);
+  return cachedFetch(`landPrices:${q}`, TTL_MARKET, async () => {
+    const res = await fetch(`${BASE}/land-prices/stats?${q}`);
+    return handleResponse<LandPriceStats>(res);
+  });
 }
 
 /** 検討中の土地価格と相場を比較 */
-export async function compareLandPrice(params: {
+export function compareLandPrice(params: {
   area: string;
   city?: string;
   year: number;
@@ -100,18 +106,22 @@ export async function compareLandPrice(params: {
     },
     { city: params.city, area_sqm: params.areaSqm }
   );
-  const res = await fetch(`${BASE}/land-prices/compare?${q}`);
-  return handleResponse<LandPriceComparison>(res);
+  return cachedFetch(`compareLandPrice:${q}`, TTL_RENT, async () => {
+    const res = await fetch(`${BASE}/land-prices/compare?${q}`);
+    return handleResponse<LandPriceComparison>(res);
+  });
 }
 
 /** 都道府県コードから市区町村一覧を取得（XIT002） */
-export async function fetchMunicipalities(area: string): Promise<Municipality[]> {
-  const res = await fetch(`${BASE}/municipalities?area=${encodeURIComponent(area)}`);
-  return handleResponse<Municipality[]>(res);
+export function fetchMunicipalities(area: string): Promise<Municipality[]> {
+  return cachedFetch(`municipalities:${area}`, TTL_MARKET, async () => {
+    const res = await fetch(`${BASE}/municipalities?area=${encodeURIComponent(area)}`);
+    return handleResponse<Municipality[]>(res);
+  });
 }
 
 /** 築年数・駅距離・乗降客数補正による理論価格推定 */
-export async function estimateLandPrice(params: {
+export function estimateLandPrice(params: {
   area: string;
   city?: string;
   year: number;
@@ -141,80 +151,103 @@ export async function estimateLandPrice(params: {
       ridership_score: params.ridershipScore,
     }
   );
-  const res = await fetch(`${BASE}/land-prices/estimate?${q}`);
-  return handleResponse<TheoreticalPriceResult>(res);
+  return cachedFetch(`estimateLandPrice:${q}`, TTL_RENT, async () => {
+    const res = await fetch(`${BASE}/land-prices/estimate?${q}`);
+    return handleResponse<TheoreticalPriceResult>(res);
+  });
 }
 
 /** 物件の緯度経度から周辺駅の乗降客数と需要スコアを取得（XKT015） */
-export async function fetchStationRidership(params: {
+export function fetchStationRidership(params: {
   lat: number;
   lng: number;
   z?: number;
 }): Promise<StationRidershipResult[]> {
-  const q = new URLSearchParams({
-    lat: String(params.lat),
-    lng: String(params.lng),
+  const z = params.z ?? "";
+  return cachedFetch(`ridership:${params.lat}:${params.lng}:${z}`, TTL_MARKET, async () => {
+    const q = new URLSearchParams({
+      lat: String(params.lat),
+      lng: String(params.lng),
+    });
+    if (params.z !== undefined) q.set("z", String(params.z));
+    const res = await fetch(`${BASE}/station-ridership?${q}`);
+    return handleResponse<StationRidershipResult[]>(res);
   });
-  if (params.z !== undefined) q.set("z", String(params.z));
-  const res = await fetch(`${BASE}/station-ridership?${q}`);
-  return handleResponse<StationRidershipResult[]>(res);
 }
 
 /** 物件の緯度経度から将来推計人口と人口減少シナリオを取得（XKT013） */
-export async function fetchPopulationForecast(params: {
+export function fetchPopulationForecast(params: {
   lat: number;
   lng: number;
   z?: number;
 }): Promise<PopulationForecastResult> {
-  const q = new URLSearchParams({
-    lat: String(params.lat),
-    lng: String(params.lng),
+  const z = params.z ?? "";
+  return cachedFetch(`population:${params.lat}:${params.lng}:${z}`, TTL_MARKET, async () => {
+    const q = new URLSearchParams({
+      lat: String(params.lat),
+      lng: String(params.lng),
+    });
+    if (params.z !== undefined) q.set("z", String(params.z));
+    const res = await fetch(`${BASE}/population-forecast?${q}`);
+    return handleResponse<PopulationForecastResult>(res);
   });
-  if (params.z !== undefined) q.set("z", String(params.z));
-  const res = await fetch(`${BASE}/population-forecast?${q}`);
-  return handleResponse<PopulationForecastResult>(res);
 }
 
 /** 地価公示情報を取得して取引価格との2軸比較統計を返す（XCT001） */
-export async function fetchLandAppraisals(params: {
+export function fetchLandAppraisals(params: {
   area: string;
   year: number;
   city?: string;
   division?: string;
 }): Promise<AppraisalComparisonResult> {
-  const q = new URLSearchParams({
-    area: params.area,
-    year: String(params.year),
-    division: params.division ?? "00",
-  });
-  if (params.city) q.set("city", params.city);
-  const res = await fetch(`${BASE}/land-appraisals?${q}`);
-  return handleResponse<AppraisalComparisonResult>(res);
+  const city = params.city ?? "";
+  const division = params.division ?? "00";
+  return cachedFetch(
+    `appraisals:${params.area}:${params.year}:${city}:${division}`,
+    TTL_MARKET,
+    async () => {
+      const q = new URLSearchParams({
+        area: params.area,
+        year: String(params.year),
+        division,
+      });
+      if (params.city) q.set("city", params.city);
+      const res = await fetch(`${BASE}/land-appraisals?${q}`);
+      return handleResponse<AppraisalComparisonResult>(res);
+    }
+  );
 }
 
 /** 地価公示データから賃料下落率参考値を取得 */
-export async function fetchRentDeclineHint(params: {
+export function fetchRentDeclineHint(params: {
   area: string;
   municipality?: string;
 }): Promise<RentDeclineHint> {
-  const q = new URLSearchParams({ area: params.area });
-  if (params.municipality) q.set("municipality", params.municipality);
-  const res = await fetch(`${BASE}/investment/rent-decline-hint?${q}`);
-  return handleResponse<RentDeclineHint>(res);
+  const municipality = params.municipality ?? "";
+  return cachedFetch(`rentDecline:${params.area}:${municipality}`, TTL_MARKET, async () => {
+    const q = new URLSearchParams({ area: params.area });
+    if (params.municipality) q.set("municipality", params.municipality);
+    const res = await fetch(`${BASE}/investment/rent-decline-hint?${q}`);
+    return handleResponse<RentDeclineHint>(res);
+  });
 }
 
 /** 緯度経度から都市計画リスクを一括取得 */
-export async function fetchUrbanRisks(lat: number, lng: number): Promise<UrbanRisk[]> {
-  const q = new URLSearchParams({ lat: String(lat), lng: String(lng) });
-  const res = await fetch(`${BASE}/urban-risks?${q}`);
-  return handleResponse<UrbanRisk[]>(res);
+export function fetchUrbanRisks(lat: number, lng: number): Promise<UrbanRisk[]> {
+  return cachedFetch(`urbanRisks:${lat}:${lng}`, TTL_MARKET, async () => {
+    const q = new URLSearchParams({ lat: String(lat), lng: String(lng) });
+    const res = await fetch(`${BASE}/urban-risks?${q}`);
+    return handleResponse<UrbanRisk[]>(res);
+  });
 }
 
 /** 緯度経度からハザード情報（洪水・高潮・津波・土砂災害）を取得 */
-export async function fetchHazardInfo(lat: number, lng: number): Promise<UrbanRisk[]> {
-  const q = new URLSearchParams({ lat: String(lat), lng: String(lng) });
-  const res = await fetch(`${BASE}/hazard?${q}`);
-  return handleResponse<UrbanRisk[]>(res);
+export function fetchHazardInfo(lat: number, lng: number): Promise<UrbanRisk[]> {
+  return cachedFetch(`hazard:${lat}:${lng}`, TTL_MARKET, async () => {
+    const q = new URLSearchParams({ lat: String(lat), lng: String(lng) });
+    const res = await fetch(`${BASE}/hazard?${q}`);
+    return handleResponse<UrbanRisk[]>(res);
+  });
 }
 
 /** 投資シミュレーションを実行 */
@@ -228,16 +261,18 @@ export async function analyzeRenovation(input: RenovationInput): Promise<Renovat
 }
 
 /** 投資適地スコアを取得 */
-export async function fetchInvestmentScore(params: {
+export function fetchInvestmentScore(params: {
   lat: number;
   lng: number;
 }): Promise<InvestmentScoreResult> {
-  const p = new URLSearchParams({
-    lat: String(params.lat),
-    lng: String(params.lng),
+  return cachedFetch(`score:${params.lat}:${params.lng}`, TTL_RENT, async () => {
+    const p = new URLSearchParams({
+      lat: String(params.lat),
+      lng: String(params.lng),
+    });
+    const res = await fetch(`${BASE}/investment-score?${p}`);
+    return handleResponse(res);
   });
-  const res = await fetch(`${BASE}/investment-score?${p}`);
-  return handleResponse(res);
 }
 
 /** エリア内全タイルの投資スコアをまとめて取得 */
@@ -276,16 +311,24 @@ export interface AreaDiscoveryResponse {
 }
 
 /** エリア発見モード — 予算・目標利回りから候補エリアをランキング取得 */
-export async function fetchAreaDiscovery(params: {
+export function fetchAreaDiscovery(params: {
   prefecture: string;
   budget?: number;
   yield?: number;
 }): Promise<AreaDiscoveryResponse> {
-  const q = new URLSearchParams({ prefecture: params.prefecture });
-  if (params.budget) q.set("budget", String(params.budget));
-  if (params.yield) q.set("yield", String(params.yield));
-  const res = await fetch(`${BASE}/area-discovery?${q}`);
-  return handleResponse<AreaDiscoveryResponse>(res);
+  const budget = params.budget ?? "";
+  const yieldRate = params.yield ?? "";
+  return cachedFetch(
+    `areaDiscovery:${params.prefecture}:${budget}:${yieldRate}`,
+    TTL_MARKET,
+    async () => {
+      const q = new URLSearchParams({ prefecture: params.prefecture });
+      if (params.budget) q.set("budget", String(params.budget));
+      if (params.yield) q.set("yield", String(params.yield));
+      const res = await fetch(`${BASE}/area-discovery?${q}`);
+      return handleResponse<AreaDiscoveryResponse>(res);
+    }
+  );
 }
 
 /** モンテカルロシミュレーションを実行 */
@@ -294,10 +337,12 @@ export async function simulate(input: MonteCarloInput): Promise<MonteCarloResult
 }
 
 /** 住所文字列から緯度・経度を取得（バックエンド経由でGoogle Maps Geocoding API を呼び出す） */
-export async function fetchGeocode(address: string): Promise<GeocodeResult> {
-  const q = new URLSearchParams({ address });
-  const res = await fetch(`${BASE}/geocode?${q}`);
-  return handleResponse<GeocodeResult>(res);
+export function fetchGeocode(address: string): Promise<GeocodeResult> {
+  return cachedFetch(`geocode:${address}`, TTL_MARKET, async () => {
+    const q = new URLSearchParams({ address });
+    const res = await fetch(`${BASE}/geocode?${q}`);
+    return handleResponse<GeocodeResult>(res);
+  });
 }
 
 export interface RentStatsResult {
@@ -307,17 +352,25 @@ export interface RentStatsResult {
 }
 
 /** エリア賃料相場（中央値・平均値・件数）を取得（XIT001 賃貸） */
-export async function fetchRentStats(params: {
+export function fetchRentStats(params: {
   area: string;
   municipality?: string;
   areaSqm?: number;
 }): Promise<RentStatsResult | null> {
-  const q = new URLSearchParams({ area: params.area });
-  if (params.municipality) q.set("municipality", params.municipality);
-  if (params.areaSqm && params.areaSqm > 0) q.set("area_sqm", String(params.areaSqm));
-  const res = await fetch(`${BASE}/rent-stats?${q}`);
-  if (!res.ok) return null;
-  const data = await res.json();
-  if (!data || data.count === 0) return null;
-  return data as RentStatsResult;
+  const municipality = params.municipality ?? "";
+  const areaSqm = params.areaSqm ?? "";
+  return cachedFetch(
+    `rentStats:${params.area}:${municipality}:${areaSqm}`,
+    TTL_RENT,
+    async () => {
+      const q = new URLSearchParams({ area: params.area });
+      if (params.municipality) q.set("municipality", params.municipality);
+      if (params.areaSqm && params.areaSqm > 0) q.set("area_sqm", String(params.areaSqm));
+      const res = await fetch(`${BASE}/rent-stats?${q}`);
+      if (!res.ok) return null;
+      const data = await res.json();
+      if (!data || data.count === 0) return null;
+      return data as RentStatsResult;
+    }
+  );
 }

--- a/frontend/src/lib/apiCache.ts
+++ b/frontend/src/lib/apiCache.ts
@@ -42,4 +42,7 @@ export function invalidateCache(prefix?: string): void {
   for (const k of store.keys()) {
     if (k.startsWith(prefix)) store.delete(k);
   }
+  for (const k of inflight.keys()) {
+    if (k.startsWith(prefix)) inflight.delete(k);
+  }
 }

--- a/frontend/src/lib/apiCache.ts
+++ b/frontend/src/lib/apiCache.ts
@@ -6,11 +6,7 @@ interface CacheEntry<T> {
 const store = new Map<string, CacheEntry<unknown>>();
 const inflight = new Map<string, Promise<unknown>>();
 
-export function cachedFetch<T>(
-  key: string,
-  ttlMs: number,
-  fetcher: () => Promise<T>
-): Promise<T> {
+export function cachedFetch<T>(key: string, ttlMs: number, fetcher: () => Promise<T>): Promise<T> {
   const now = Date.now();
   const hit = store.get(key) as CacheEntry<T> | undefined;
   if (hit && hit.expiresAt > now) return Promise.resolve(hit.value);

--- a/frontend/src/lib/apiCache.ts
+++ b/frontend/src/lib/apiCache.ts
@@ -1,0 +1,45 @@
+interface CacheEntry<T> {
+  value: T;
+  expiresAt: number;
+}
+
+const store = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+export function cachedFetch<T>(
+  key: string,
+  ttlMs: number,
+  fetcher: () => Promise<T>
+): Promise<T> {
+  const now = Date.now();
+  const hit = store.get(key) as CacheEntry<T> | undefined;
+  if (hit && hit.expiresAt > now) return Promise.resolve(hit.value);
+
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+
+  const promise = fetcher().then(
+    (value) => {
+      store.set(key, { value, expiresAt: Date.now() + ttlMs });
+      inflight.delete(key);
+      return value;
+    },
+    (err: unknown) => {
+      inflight.delete(key);
+      throw err;
+    }
+  );
+  inflight.set(key, promise as Promise<unknown>);
+  return promise;
+}
+
+export function invalidateCache(prefix?: string): void {
+  if (!prefix) {
+    store.clear();
+    inflight.clear();
+    return;
+  }
+  for (const k of store.keys()) {
+    if (k.startsWith(prefix)) store.delete(k);
+  }
+}


### PR DESCRIPTION
## 概要

- `frontend/src/lib/apiCache.ts` を新規作成（TTL キャッシュ + in-flight 重複排除の2層実装）
- `frontend/src/lib/api.ts` の全 GET 関数を `cachedFetch` でラップ（POST エンドポイントは対象外）
- `frontend/src/lib/__tests__/apiCache.test.ts` でユニットテスト8件を追加

## 変更の背景・目的

`useRentValidation.ts`（デバウンス後に毎回 `fetchRentStats` を呼び出す）や `useExternalData.ts`（`Promise.allSettled` で8本の API を並列送信）で、同一パラメータの重複リクエストが発生していた。React Query / SWR を導入せず、セッションレベルのキャッシュモジュール1つで解消する。

## キャッシュ戦略

| 種別 | TTL | 対象 |
|------|-----|------|
| 相場・スコア系 | 5 min | `rentStats`, `compareLandPrice`, `estimateLandPrice`, `investmentScore` |
| 静的・地理系 | 10 min | `municipalities`, `ridership`, `population`, `appraisals`, `urbanRisks`, `hazard`, `rentDecline`, `areaDiscovery`, `geocode` |

## テスト計画

- [x] `npm test` 8件全パス（TTL 満了、in-flight dedup、エラー非キャッシュ、prefix invalidation）
- [x] `tsc --noEmit` 型エラーなし
- [ ] CI (frontend-ci) が通ること

Closes #671