### PR TITLE
test(backend): Firestore L2 キャッシュのユニットテストを追加する

### DIFF
--- a/backend/internal/mlit/firestore_cache.go
+++ b/backend/internal/mlit/firestore_cache.go
@@ -11,9 +11,34 @@ import (
 )
 
 const (
-	mlitCacheCollection = "mlit_cache"    //nolint:unused
-	mlitCacheTTL        = 24 * time.Hour  //nolint:unused
+	mlitCacheCollection = "mlit_cache"
+	mlitCacheTTL        = 24 * time.Hour
 )
+
+// docStore は firestoreL2 が必要とする最小限のドキュメント読み書き操作を表す。
+// テストでは fakeDocStore で差し替えられる。
+type docStore interface {
+	get(ctx context.Context, docID string) (map[string]any, bool)
+	set(ctx context.Context, docID string, data map[string]any)
+}
+
+// firestoreDocStore は実際の Firestore クライアントを docStore に適合させるアダプタ。
+type firestoreDocStore struct {
+	client     *firestore.Client
+	collection string
+}
+
+func (s *firestoreDocStore) get(ctx context.Context, docID string) (map[string]any, bool) {
+	doc, err := s.client.Collection(s.collection).Doc(docID).Get(ctx)
+	if err != nil {
+		return nil, false
+	}
+	return doc.Data(), true
+}
+
+func (s *firestoreDocStore) set(ctx context.Context, docID string, data map[string]any) {
+	_, _ = s.client.Collection(s.collection).Doc(docID).Set(ctx, data)
+}
 
 // l2Cache はFirestore L2キャッシュの汎用インターフェース。
 type l2Cache[E any] interface {
@@ -23,40 +48,44 @@ type l2Cache[E any] interface {
 
 // firestoreL2 はFirestoreをL2キャッシュとして使用する汎用実装。
 type firestoreL2[E any] struct {
-	client   *firestore.Client
+	store    docStore
 	endpoint string
 }
 
 // noopL2 はFirestore未設定時のダミー実装。
 type noopL2[E any] struct{}
 
-func (n *noopL2[E]) get(_ context.Context, _ string) ([]E, bool) { return nil, false } //nolint:unused
-func (n *noopL2[E]) set(_ context.Context, _ string, _ []E)      {}                    //nolint:unused
+func (n *noopL2[E]) get(_ context.Context, _ string) ([]E, bool) { return nil, false }
+func (n *noopL2[E]) set(_ context.Context, _ string, _ []E)      {}
 
 // newFirestoreL2 は client が nil の場合 noopL2 を、それ以外は firestoreL2 を返す。
 func newFirestoreL2[E any](client *firestore.Client, endpoint string) l2Cache[E] {
 	if client == nil {
 		return &noopL2[E]{}
 	}
-	return &firestoreL2[E]{client: client, endpoint: endpoint}
+	return &firestoreL2[E]{
+		store:    &firestoreDocStore{client: client, collection: mlitCacheCollection},
+		endpoint: endpoint,
+	}
 }
 
-func (f *firestoreL2[E]) docID(key string) string { //nolint:unused
+func (f *firestoreL2[E]) docID(key string) string {
 	return f.endpoint + ":" + key
 }
 
-func (f *firestoreL2[E]) get(ctx context.Context, key string) ([]E, bool) { //nolint:unused
-	doc, err := f.client.Collection(mlitCacheCollection).Doc(f.docID(key)).Get(ctx)
-	if err != nil {
+func (f *firestoreL2[E]) get(ctx context.Context, key string) ([]E, bool) {
+	data, ok := f.store.get(ctx, f.docID(key))
+	if !ok {
 		return nil, false
 	}
-	expiresAt, ok := doc.Data()["expiresAt"].(time.Time)
+
+	expiresAt, ok := data["expiresAt"].(time.Time)
 	if !ok || time.Now().After(expiresAt) {
 		return nil, false
 	}
 
 	var raw []byte
-	switch v := doc.Data()["data"].(type) {
+	switch v := data["data"].(type) {
 	case []byte:
 		raw = v
 	case string:
@@ -72,12 +101,12 @@ func (f *firestoreL2[E]) get(ctx context.Context, key string) ([]E, bool) { //no
 	return result, true
 }
 
-func (f *firestoreL2[E]) set(ctx context.Context, key string, data []E) { //nolint:unused
+func (f *firestoreL2[E]) set(ctx context.Context, key string, data []E) {
 	raw, err := json.Marshal(data)
 	if err != nil {
 		return
 	}
-	_, _ = f.client.Collection(mlitCacheCollection).Doc(f.docID(key)).Set(ctx, map[string]any{
+	f.store.set(ctx, f.docID(key), map[string]any{
 		"data":      string(raw),
 		"expiresAt": time.Now().Add(mlitCacheTTL),
 		"endpoint":  f.endpoint,

--- a/backend/internal/mlit/firestore_cache_test.go
+++ b/backend/internal/mlit/firestore_cache_test.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/yield-guard/backend/internal/domain"
 )
 
 // fakeDocStore は docStore インターフェースのインメモリ実装。
@@ -220,13 +222,14 @@ func TestNewFirestoreL2_NilClientReturnsNoop(t *testing.T) {
 	}
 }
 
-func TestNewFirestoreL2_NonNilClientReturnsFirestoreL2(t *testing.T) {
-	// newFirestoreL2 の nil チェックは client ポインタの nil チェックのみ。
-	// 非 nil のダミーポインタで型を確認する（実際の接続は不要）。
-	// *firestore.Client のゼロ値ポインタは使えないため、
-	// 代わりに newFirestoreL2CacheGroup の戻り値型から確認する。
+func TestNewFirestoreL2CacheGroup_NilClientProducesNoop(t *testing.T) {
+	// newFirestoreL2CacheGroup に nil を渡すと全フィールドが noopL2 になることを確認。
+	// 実際の *firestore.Client 生成はネットワーク接続を要するためここでは行わない。
 	group := newFirestoreL2CacheGroup(nil)
 	if _, isNoop := group.municipalities.(*noopL2[Municipality]); !isNoop {
 		t.Errorf("nil client should produce noopL2, got %T", group.municipalities)
+	}
+	if _, isNoop := group.landPrices.(*noopL2[domain.LandTransaction]); !isNoop {
+		t.Errorf("nil client should produce noopL2 for landPrices, got %T", group.landPrices)
 	}
 }

--- a/backend/internal/mlit/firestore_cache_test.go
+++ b/backend/internal/mlit/firestore_cache_test.go
@@ -1,0 +1,232 @@
+package mlit
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeDocStore は docStore インターフェースのインメモリ実装。
+type fakeDocStore struct {
+	mu   sync.RWMutex
+	docs map[string]map[string]any
+}
+
+func newFakeDocStore() *fakeDocStore {
+	return &fakeDocStore{docs: make(map[string]map[string]any)}
+}
+
+func (f *fakeDocStore) get(_ context.Context, docID string) (map[string]any, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	d, ok := f.docs[docID]
+	return d, ok
+}
+
+func (f *fakeDocStore) set(_ context.Context, docID string, data map[string]any) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.docs[docID] = data
+}
+
+// newTestL2 はテスト用の firestoreL2[Municipality] を返す。
+func newTestL2(store docStore) *firestoreL2[Municipality] {
+	return &firestoreL2[Municipality]{store: store, endpoint: "TEST"}
+}
+
+// marshaledMunis は []Municipality を JSON 文字列にして返すヘルパー。
+func marshaledMunis(munis []Municipality) string {
+	b, _ := json.Marshal(munis)
+	return string(b)
+}
+
+// --- firestoreL2 ---
+
+func TestFirestoreL2_Miss(t *testing.T) {
+	c := newTestL2(newFakeDocStore())
+	got, ok := c.get(context.Background(), "key1")
+	if ok {
+		t.Fatalf("expected miss on empty store, got %v", got)
+	}
+}
+
+func TestFirestoreL2_SetThenGet(t *testing.T) {
+	c := newTestL2(newFakeDocStore())
+	munis := []Municipality{{ID: "13101", Name: "千代田区"}}
+
+	c.set(context.Background(), "key1", munis)
+	got, ok := c.get(context.Background(), "key1")
+
+	if !ok {
+		t.Fatal("expected hit after set")
+	}
+	if len(got) != 1 || got[0].ID != "13101" || got[0].Name != "千代田区" {
+		t.Errorf("unexpected data: %+v", got)
+	}
+}
+
+func TestFirestoreL2_TTLExpiry(t *testing.T) {
+	store := newFakeDocStore()
+	c := newTestL2(store)
+	munis := []Municipality{{ID: "13101", Name: "千代田区"}}
+
+	store.set(context.Background(), c.docID("key1"), map[string]any{
+		"data":      marshaledMunis(munis),
+		"expiresAt": time.Now().Add(-1 * time.Second), // 期限切れ
+		"endpoint":  "TEST",
+	})
+
+	got, ok := c.get(context.Background(), "key1")
+	if ok {
+		t.Fatalf("expected miss for expired entry, got %v", got)
+	}
+}
+
+func TestFirestoreL2_TTLValid(t *testing.T) {
+	store := newFakeDocStore()
+	c := newTestL2(store)
+	munis := []Municipality{{ID: "13101", Name: "千代田区"}}
+
+	store.set(context.Background(), c.docID("key1"), map[string]any{
+		"data":      marshaledMunis(munis),
+		"expiresAt": time.Now().Add(1 * time.Hour),
+		"endpoint":  "TEST",
+	})
+
+	got, ok := c.get(context.Background(), "key1")
+	if !ok {
+		t.Fatal("expected hit for valid TTL entry")
+	}
+	if len(got) != 1 || got[0].ID != "13101" {
+		t.Errorf("unexpected data: %+v", got)
+	}
+}
+
+func TestFirestoreL2_MalformedData_MissingField(t *testing.T) {
+	store := newFakeDocStore()
+	c := newTestL2(store)
+
+	// "data" フィールドなし
+	store.set(context.Background(), c.docID("key1"), map[string]any{
+		"expiresAt": time.Now().Add(1 * time.Hour),
+		"endpoint":  "TEST",
+	})
+
+	_, ok := c.get(context.Background(), "key1")
+	if ok {
+		t.Fatal("expected miss when data field is missing")
+	}
+}
+
+func TestFirestoreL2_BadJSON(t *testing.T) {
+	store := newFakeDocStore()
+	c := newTestL2(store)
+
+	store.set(context.Background(), c.docID("key1"), map[string]any{
+		"data":      `not valid json [[[`,
+		"expiresAt": time.Now().Add(1 * time.Hour),
+		"endpoint":  "TEST",
+	})
+
+	_, ok := c.get(context.Background(), "key1")
+	if ok {
+		t.Fatal("expected miss for invalid JSON")
+	}
+}
+
+func TestFirestoreL2_DocIDFormat(t *testing.T) {
+	c := newTestL2(newFakeDocStore())
+	got := c.docID("somekey")
+	want := "TEST:somekey"
+	if got != want {
+		t.Errorf("docID = %q, want %q", got, want)
+	}
+}
+
+func TestFirestoreL2_SetWritesCorrectFields(t *testing.T) {
+	store := newFakeDocStore()
+	c := newTestL2(store)
+	munis := []Municipality{{ID: "13101", Name: "千代田区"}}
+
+	before := time.Now()
+	c.set(context.Background(), "key1", munis)
+	after := time.Now()
+
+	doc, ok := store.get(context.Background(), c.docID("key1"))
+	if !ok {
+		t.Fatal("expected doc in store after set")
+	}
+
+	if doc["endpoint"] != "TEST" {
+		t.Errorf("endpoint = %v, want TEST", doc["endpoint"])
+	}
+	if doc["data"] == nil {
+		t.Error("data field should not be nil")
+	}
+	expiresAt, ok := doc["expiresAt"].(time.Time)
+	if !ok {
+		t.Fatalf("expiresAt type = %T, want time.Time", doc["expiresAt"])
+	}
+	expectedMin := before.Add(mlitCacheTTL)
+	expectedMax := after.Add(mlitCacheTTL)
+	if expiresAt.Before(expectedMin) || expiresAt.After(expectedMax) {
+		t.Errorf("expiresAt %v not in [%v, %v]", expiresAt, expectedMin, expectedMax)
+	}
+}
+
+func TestFirestoreL2_TTLIs24Hours(t *testing.T) {
+	store := newFakeDocStore()
+	c := newTestL2(store)
+
+	before := time.Now()
+	c.set(context.Background(), "key1", []Municipality{{ID: "13101", Name: "千代田区"}})
+	after := time.Now()
+
+	doc, _ := store.get(context.Background(), c.docID("key1"))
+	expiresAt := doc["expiresAt"].(time.Time)
+
+	if expiresAt.Before(before.Add(24*time.Hour)) || expiresAt.After(after.Add(24*time.Hour)) {
+		t.Errorf("TTL is not ~24h: expiresAt=%v", expiresAt)
+	}
+}
+
+// --- noopL2 ---
+
+func TestNoopL2_AlwaysMisses(t *testing.T) {
+	n := &noopL2[Municipality]{}
+	got, ok := n.get(context.Background(), "any")
+	if ok || got != nil {
+		t.Errorf("noopL2.get should always return (nil, false), got (%v, %v)", got, ok)
+	}
+}
+
+func TestNoopL2_SetIsNoop(t *testing.T) {
+	n := &noopL2[Municipality]{}
+	n.set(context.Background(), "any", []Municipality{{ID: "13101"}})
+	got, ok := n.get(context.Background(), "any")
+	if ok || got != nil {
+		t.Errorf("noopL2 should not store data, got (%v, %v)", got, ok)
+	}
+}
+
+// --- newFirestoreL2 constructor ---
+
+func TestNewFirestoreL2_NilClientReturnsNoop(t *testing.T) {
+	cache := newFirestoreL2[Municipality](nil, "TEST")
+	if _, isNoop := cache.(*noopL2[Municipality]); !isNoop {
+		t.Errorf("expected *noopL2, got %T", cache)
+	}
+}
+
+func TestNewFirestoreL2_NonNilClientReturnsFirestoreL2(t *testing.T) {
+	// newFirestoreL2 の nil チェックは client ポインタの nil チェックのみ。
+	// 非 nil のダミーポインタで型を確認する（実際の接続は不要）。
+	// *firestore.Client のゼロ値ポインタは使えないため、
+	// 代わりに newFirestoreL2CacheGroup の戻り値型から確認する。
+	group := newFirestoreL2CacheGroup(nil)
+	if _, isNoop := group.municipalities.(*noopL2[Municipality]); !isNoop {
+		t.Errorf("nil client should produce noopL2, got %T", group.municipalities)
+	}
+}


### PR DESCRIPTION
## 概要

- `backend/internal/mlit/firestore_cache.go` に `docStore` インターフェースと `firestoreDocStore` アダプタを追加（約15行の変更）
- `backend/internal/mlit/firestore_cache_test.go` を新規作成（13件のユニットテスト）

## 変更の背景・目的

`firestoreL2` は Firestore SDK の `*firestore.Client` を直接使用しており、エミュレータなしではテスト不能だった。狭い `docStore` インターフェースを抽出して `fakeDocStore` によるインメモリテストを可能にする。既存の TTL 判定・JSON 処理ロジックは変更しない。

## テストカバレッジ

| テスト | 確認内容 |
|--------|---------|
| `TestFirestoreL2_Miss` | 空ストア → miss |
| `TestFirestoreL2_SetThenGet` | set → get でデータ一致 |
| `TestFirestoreL2_TTLExpiry` | 期限切れエントリ → miss |
| `TestFirestoreL2_TTLValid` | 有効エントリ → hit |
| `TestFirestoreL2_MalformedData_MissingField` | data フィールドなし → miss |
| `TestFirestoreL2_BadJSON` | 不正 JSON → miss |
| `TestFirestoreL2_DocIDFormat` | `"endpoint:key"` 形式確認 |
| `TestFirestoreL2_SetWritesFields` | data/expiresAt/endpoint が書き込まれる |
| `TestFirestoreL2_TTLIs24Hours` | expiresAt が約 24h 後 |
| `TestNoopL2_AlwaysMisses` | 常に miss |
| `TestNoopL2_SetIsNoop` | set 後も miss |
| `TestNewFirestoreL2_NilClient` | nil → `*noopL2` |
| `TestNewFirestoreL2_NonNilClient` | nil client group → noop |

## テスト計画

- [x] `go test -race ./internal/mlit/...` 全パス（既存テスト含む）
- [ ] CI (backend-ci) が通ること

Closes #672