### PR TITLE
feat(infra): Terraform で staging 環境を構築し PR プレビューを本番から分離する

### DIFF
--- a/.github/workflows/deploy-backend-stg.yml
+++ b/.github/workflows/deploy-backend-stg.yml
@@ -1,0 +1,91 @@
+name: Deploy Backend to Cloud Run (stg)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build & Deploy (stg)
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+      security-events: write
+      actions: write
+
+    env:
+      IMAGE: asia-northeast1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/yield-guard/backend
+      DEPLOY_SHA: ${{ github.sha }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Authenticate to Google Cloud (OIDC)
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER_STG }}
+          service_account: ${{ secrets.SA_EMAIL_STG }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3.0.1
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker asia-northeast1-docker.pkg.dev --quiet
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+
+      - name: Build Docker image
+        run: |
+          docker buildx build \
+            --cache-from "type=gha,scope=${{ github.workflow }}" \
+            --cache-to   "type=gha,scope=${{ github.workflow }},mode=max" \
+            --tag "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}" \
+            --load \
+            ./backend
+
+      - name: Cache Trivy vulnerability database
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/.cache/trivy
+          key: trivy-db-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: trivy-db-${{ runner.os }}-
+
+      - name: Scan Docker image for vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}
+          format: sarif
+          output: trivy-results.sarif
+          exit-code: '1'
+          severity: CRITICAL
+          ignore-unfixed: true
+          scanners: vuln
+          cache-dir: ~/.cache/trivy
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@9e0d7b8d25671d64c341c19c0152d693099fb5ba  # v4.35.5
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif
+
+      - name: Push Docker image
+        run: |
+          docker tag "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}" "${{ env.IMAGE }}:latest"
+          docker push "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}"
+          docker push "${{ env.IMAGE }}:latest"
+
+      - name: Deploy to Cloud Run (stg)
+        uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d  # v3.0.1
+        with:
+          service: yield-guard-stg-backend
+          region: asia-northeast1
+          image: ${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}

--- a/.github/workflows/deploy-backend-stg.yml
+++ b/.github/workflows/deploy-backend-stg.yml
@@ -79,9 +79,9 @@ jobs:
 
       - name: Push Docker image
         run: |
-          docker tag "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}" "${{ env.IMAGE }}:latest"
+          docker tag "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}" "${{ env.IMAGE }}:latest-stg"
           docker push "${{ env.IMAGE }}:${{ env.DEPLOY_SHA }}"
-          docker push "${{ env.IMAGE }}:latest"
+          docker push "${{ env.IMAGE }}:latest-stg"
 
       - name: Deploy to Cloud Run (stg)
         uses: google-github-actions/deploy-cloudrun@2028e2d7d30a78c6910e0632e48dd561b064884d  # v3.0.1

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -13,6 +13,12 @@ on:
         type: boolean
         default: false
         required: true
+      environment:
+        description: "Target environment"
+        type: choice
+        options: [prod, stg]
+        default: prod
+        required: true
 
 permissions:
   contents: read
@@ -30,7 +36,7 @@ jobs:
 
     env:
       TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
-      TF_VAR_env: "prod"
+      TF_VAR_env: ${{ inputs.environment || 'prod' }}
       TF_VAR_region: "asia-northeast1"
       TF_VAR_mlit_api_key: ${{ secrets.MLIT_API_KEY }}
       TF_VAR_app_internal_api_key: ${{ secrets.APP_INTERNAL_API_KEY }}
@@ -55,11 +61,16 @@ jobs:
       - name: Authenticate to Google Cloud (OIDC)
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.SA_EMAIL }}
+          workload_identity_provider: ${{ inputs.environment == 'stg' && secrets.WIF_PROVIDER_STG || secrets.WIF_PROVIDER }}
+          service_account: ${{ inputs.environment == 'stg' && secrets.SA_EMAIL_STG || secrets.SA_EMAIL }}
 
       - name: Terraform Init
-        run: terraform init
+        run: |
+          if [ "${{ inputs.environment }}" = "stg" ]; then
+            terraform init -backend-config=backend-stg.hcl -reconfigure
+          else
+            terraform init
+          fi
         working-directory: terraform
 
       - name: Terraform Validate

--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -39,7 +39,7 @@ jobs:
       TF_VAR_env: ${{ inputs.environment || 'prod' }}
       TF_VAR_region: "asia-northeast1"
       TF_VAR_mlit_api_key: ${{ secrets.MLIT_API_KEY }}
-      TF_VAR_app_internal_api_key: ${{ secrets.APP_INTERNAL_API_KEY }}
+      TF_VAR_app_internal_api_key: ${{ inputs.environment == 'stg' && secrets.APP_INTERNAL_API_KEY_STG || secrets.APP_INTERNAL_API_KEY }}
       TF_VAR_vercel_frontend_url: ${{ vars.VERCEL_FRONTEND_URL }}
       TF_VAR_notification_email: ${{ vars.NOTIFICATION_EMAIL }}
       TF_VAR_billing_account_id: ${{ secrets.GCP_BILLING_ACCOUNT_ID }}

--- a/terraform/backend-stg.hcl
+++ b/terraform/backend-stg.hcl
@@ -1,0 +1,2 @@
+bucket = "yield-guard-tfstate"
+prefix = "yield-guard/stg"

--- a/terraform/billing.tf
+++ b/terraform/billing.tf
@@ -10,6 +10,7 @@
 # Firestore 3機能（AIサマリーキャッシュ・ジオコードキャッシュ・ウォッチリスト）導入に伴う
 # 月次コスト早期検知アラート: 1,000円 (80%/100%予測) で通知する。
 resource "google_billing_budget" "firestore_early_alert" {
+  count           = var.env == "prod" ? 1 : 0
   provider        = google.billing
   billing_account = var.billing_account_id
   display_name    = "Yield Guard Firestore 早期コストアラート"
@@ -38,7 +39,7 @@ resource "google_billing_budget" "firestore_early_alert" {
 
   all_updates_rule {
     monitoring_notification_channels = [
-      google_monitoring_notification_channel.email.id,
+      google_monitoring_notification_channel.email[0].id,
     ]
     disable_default_iam_recipients = true
   }
@@ -59,6 +60,7 @@ resource "google_billing_budget" "firestore_early_alert" {
 }
 
 resource "google_billing_budget" "monthly" {
+  count           = var.env == "prod" ? 1 : 0
   provider        = google.billing
   billing_account = var.billing_account_id
   display_name    = "Yield Guard 月次予算アラート"
@@ -83,7 +85,7 @@ resource "google_billing_budget" "monthly" {
 
   all_updates_rule {
     monitoring_notification_channels = [
-      google_monitoring_notification_channel.email.id,
+      google_monitoring_notification_channel.email[0].id,
     ]
     pubsub_topic                   = google_pubsub_topic.billing_alerts.id
     disable_default_iam_recipients = true

--- a/terraform/cloud_run.tf
+++ b/terraform/cloud_run.tf
@@ -2,7 +2,7 @@ resource "google_cloud_run_v2_service" "backend" {
   name                = local.service_name
   location            = var.region
   ingress             = "INGRESS_TRAFFIC_ALL"
-  deletion_protection = true
+  deletion_protection = var.env == "prod"
 
   template {
     service_account = google_service_account.backend.email

--- a/terraform/firestore.tf
+++ b/terraform/firestore.tf
@@ -1,4 +1,7 @@
+# Firestore の (default) データベースはプロジェクト単一リソースのため prod 専用。
+# stg 環境は既存の prod (default) DB を共用する（コレクション名でデータが分離される）。
 resource "google_firestore_database" "default" {
+  count       = var.env == "prod" ? 1 : 0
   project     = var.project_id
   name        = "(default)"
   location_id = "asia-northeast1"
@@ -7,16 +10,18 @@ resource "google_firestore_database" "default" {
 }
 
 resource "google_firestore_field" "mlit_cache_ttl" {
+  count      = var.env == "prod" ? 1 : 0
   project    = var.project_id
-  database   = google_firestore_database.default.name
+  database   = google_firestore_database.default[0].name
   collection = "mlit_cache"
   field      = "expiresAt"
   ttl_config {}
 }
 
 resource "google_firestore_field" "geocode_cache_ttl" {
+  count      = var.env == "prod" ? 1 : 0
   project    = var.project_id
-  database   = google_firestore_database.default.name
+  database   = google_firestore_database.default[0].name
   collection = "geocode_cache"
   field      = "expiresAt"
   ttl_config {}

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -265,7 +265,8 @@ resource "google_monitoring_alert_policy" "cache_hit_rate" {
 # Cloud Scheduler はジョブ実行結果を Cloud Logging に書き込む（severity=ERROR で失敗）。
 # メトリクスと異なりジョブ初回実行前でも Terraform リソースとして作成できる。
 resource "google_logging_metric" "warmup_job_failure" {
-  name = "warmup-job-failure-${var.env}"
+  count = var.env == "prod" ? 1 : 0
+  name  = "warmup-job-failure-${var.env}"
   filter = join(" AND ", [
     "resource.type=\"cloud_scheduler_job\"",
     "resource.labels.job_id=~\"warmup-.*-${var.env}\"",
@@ -310,7 +311,7 @@ resource "google_monitoring_alert_policy" "warmup_job_failure" {
     auto_close = "86400s"
   }
 
-  depends_on = [google_logging_metric.warmup_job_failure]
+  depends_on = [google_logging_metric.warmup_job_failure[0]]
 }
 
 # 5. Cloud Run インスタンス数が上限 (max_instance_count=2) に到達し 5 分継続

--- a/terraform/monitoring.tf
+++ b/terraform/monitoring.tf
@@ -1,7 +1,9 @@
 # ─────────────────────────────────────────────────────
 # 通知チャンネル
 # ─────────────────────────────────────────────────────
+# 通知チャンネルはプロジェクト単位のリソースのため prod 専用。
 resource "google_monitoring_notification_channel" "email" {
+  count        = var.env == "prod" ? 1 : 0
   display_name = "Yield Guard アラート通知"
   type         = "email"
   labels = {
@@ -15,6 +17,7 @@ resource "google_monitoring_notification_channel" "email" {
 # Cloud Run 標準メトリクス: run.googleapis.com/<name>
 # ─────────────────────────────────────────────────────
 resource "google_monitoring_dashboard" "yield_guard" {
+  count = var.env == "prod" ? 1 : 0
   dashboard_json = jsonencode({
     displayName = "Yield Guard"
     mosaicLayout = {
@@ -156,8 +159,10 @@ resource "google_monitoring_dashboard" "yield_guard" {
 # アラートポリシー (#253)
 # ─────────────────────────────────────────────────────
 
+# アラートポリシーは prod 専用（stg では通知不要）。
 # 1. MLIT API P99 応答時間 > 15s が 5 分継続
 resource "google_monitoring_alert_policy" "mlit_latency" {
+  count        = var.env == "prod" ? 1 : 0
   display_name = "[Yield Guard] MLIT API P99 応答時間 > 15s"
   combiner     = "OR"
 
@@ -176,7 +181,7 @@ resource "google_monitoring_alert_policy" "mlit_latency" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.email.id]
+  notification_channels = [google_monitoring_notification_channel.email[0].id]
   alert_strategy {
     auto_close = "3600s"
   }
@@ -185,6 +190,7 @@ resource "google_monitoring_alert_policy" "mlit_latency" {
 # 2. Cloud Run 5xx エラー率 > 5% が 5 分継続
 # ratio = 5xx_count / total_count
 resource "google_monitoring_alert_policy" "cloudrun_error_rate" {
+  count        = var.env == "prod" ? 1 : 0
   display_name = "[Yield Guard] Cloud Run 5xx エラー率 > 5%"
   combiner     = "OR"
 
@@ -210,7 +216,7 @@ resource "google_monitoring_alert_policy" "cloudrun_error_rate" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.email.id]
+  notification_channels = [google_monitoring_notification_channel.email[0].id]
   alert_strategy {
     auto_close = "3600s"
   }
@@ -219,6 +225,7 @@ resource "google_monitoring_alert_policy" "cloudrun_error_rate" {
 # 3. キャッシュヒット率 < 50% が 10 分継続
 # ratio = misses / (misses + hits) → alert when > 0.5 (= hit rate < 50%)
 resource "google_monitoring_alert_policy" "cache_hit_rate" {
+  count        = var.env == "prod" ? 1 : 0
   display_name = "[Yield Guard] キャッシュヒット率 < 50%"
   combiner     = "OR"
 
@@ -248,7 +255,7 @@ resource "google_monitoring_alert_policy" "cache_hit_rate" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.email.id]
+  notification_channels = [google_monitoring_notification_channel.email[0].id]
   alert_strategy {
     auto_close = "3600s"
   }
@@ -278,6 +285,7 @@ resource "google_logging_metric" "warmup_job_failure" {
 }
 
 resource "google_monitoring_alert_policy" "warmup_job_failure" {
+  count        = var.env == "prod" ? 1 : 0
   display_name = "[Yield Guard] ウォームアップジョブが失敗"
   combiner     = "OR"
 
@@ -297,7 +305,7 @@ resource "google_monitoring_alert_policy" "warmup_job_failure" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.email.id]
+  notification_channels = [google_monitoring_notification_channel.email[0].id]
   alert_strategy {
     auto_close = "86400s"
   }
@@ -307,6 +315,7 @@ resource "google_monitoring_alert_policy" "warmup_job_failure" {
 
 # 5. Cloud Run インスタンス数が上限 (max_instance_count=2) に到達し 5 分継続
 resource "google_monitoring_alert_policy" "cloudrun_max_instances" {
+  count        = var.env == "prod" ? 1 : 0
   display_name = "[Yield Guard] Cloud Run インスタンス数が上限に到達"
   combiner     = "OR"
 
@@ -325,7 +334,7 @@ resource "google_monitoring_alert_policy" "cloudrun_max_instances" {
     }
   }
 
-  notification_channels = [google_monitoring_notification_channel.email.id]
+  notification_channels = [google_monitoring_notification_channel.email[0].id]
   alert_strategy {
     auto_close = "3600s"
   }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,5 +1,5 @@
 output "cloud_run_url" {
-  description = "Public URL of the Cloud Run service"
+  description = "Public URL of the Cloud Run service. For stg: set as BACKEND_URL in Vercel project settings → Environment Variables → Preview."
   value       = google_cloud_run_v2_service.backend.uri
 }
 

--- a/terraform/terraform.stg.tfvars.example
+++ b/terraform/terraform.stg.tfvars.example
@@ -1,0 +1,27 @@
+# stg 環境用 tfvars テンプレート。
+# このファイルを terraform.stg.tfvars にコピーして値を埋めること。
+# terraform.stg.tfvars は .gitignore 済み（シークレットを含むため）。
+#
+# 使い方:
+#   terraform init -backend-config=backend-stg.hcl -reconfigure
+#   terraform apply -var-file=terraform.stg.tfvars
+#
+# apply 後に GitHub へ登録する値:
+#
+# GitHub Secrets（Settings → Secrets and variables → Actions → Secrets）:
+#   WIF_PROVIDER_STG          = terraform output -raw wif_provider
+#   SA_EMAIL_STG              = terraform output -raw deployer_sa_email
+#   APP_INTERNAL_API_KEY_STG  = var.app_internal_api_key  ← prod とは別の値を生成すること
+#
+# Vercel プロジェクト設定（Preview 環境のみ）:
+#   BACKEND_URL               = terraform output -raw cloud_run_url
+
+project_id           = "your-gcp-project-id"
+region               = "asia-northeast1"
+env                  = "stg"
+mlit_api_key         = "your-mlit-api-key"  # prod と同じ値でも可
+app_internal_api_key = "generate with: openssl rand -hex 32"  # prod とは別の値を使うこと
+gemini_api_key       = ""  # 任意。空文字のままでも動作（AI サマリーが無効になるだけ）
+vercel_frontend_url  = "https://your-stg-preview.vercel.app"
+notification_email   = "your@email.com"
+billing_account_id   = "XXXXXX-XXXXXX-XXXXXX"  # gcloud billing accounts list で確認

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,7 +1,16 @@
 # Copy this file to terraform.tfvars and fill in real values.
 # terraform.tfvars is excluded from git (see .gitignore).
 #
-# After terraform apply, register the following in GitHub:
+# --- Staging environment ---
+# For stg, use a separate backend config:
+#   terraform init -backend-config=backend-stg.hcl -reconfigure
+#   terraform apply -var-file=terraform.stg.tfvars
+#
+# After stg terraform apply, register in GitHub:
+#   Secrets: WIF_PROVIDER_STG, SA_EMAIL_STG
+#   Vercel project → Environment Variables → Preview: BACKEND_URL = <stg Cloud Run URL>
+#
+# --- After terraform apply, register the following in GitHub (prod):
 #
 # GitHub Secrets（Settings → Secrets and variables → Actions → Secrets）:
 #   WIF_PROVIDER              = terraform output -raw wif_provider


### PR DESCRIPTION
## 概要

- `terraform/backend-stg.hcl` を追加（stg 用 TF state パス `yield-guard/stg`）
- Firestore DB・billing budgets・monitoring リソースに `count = var.env == "prod" ? 1 : 0` ガードを追加
- Cloud Run の `deletion_protection = var.env == "prod"` に変更（stg は削除可能）
- `.github/workflows/deploy-backend-stg.yml` を新規作成（`workflow_dispatch` のみ）
- `terraform-ci.yml` に `environment` 入力（prod/stg）を追加

## 変更の背景・目的

現在 Vercel プレビューが本番 API を使用しており、PR テスト中の意図しないデータ送信リスクがある。CI コメントにも "⚠️ このプレビューは本番 API を使用しています" と警告が出ていた。staging Cloud Run を分離し、Vercel Preview Environment から参照させることで本番を保護する。

## ⚠️ 手動作業（マージ後に別途実施）

- [ ] `terraform init -backend-config=terraform/backend-stg.hcl -reconfigure && terraform apply -var env=stg -var-file=terraform.stg.tfvars` を実行
- [ ] GitHub Secrets に `WIF_PROVIDER_STG`, `SA_EMAIL_STG` を登録（`terraform output` の値）
- [ ] Vercel プロジェクト → Environment Variables → **Preview** に `BACKEND_URL = <stg Cloud Run URL>` を設定

## テスト計画

- [x] `terraform fmt -check -recursive` パス
- [ ] CI (terraform-ci) の format/validate が通ること
- [ ] `workflow_dispatch` で `environment=stg` を指定して plan が成功すること

Closes #673