### PR TITLE
feat: 賃料統計 API でサンプル数不足時に low_confidence フラグを返す

### DIFF
--- a/backend/internal/api/rent_handler.go
+++ b/backend/internal/api/rent_handler.go
@@ -72,5 +72,6 @@ func (h *Handler) GetRentStats(c *gin.Context) {
 		return
 	}
 
+	result.LowConfidence = result.Count < 3
 	c.JSON(http.StatusOK, result)
 }

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -615,9 +615,10 @@ type RenovationResult struct {
 
 // RentStatsResult は賃貸取引価格の統計情報
 type RentStatsResult struct {
-	Median  float64 `json:"median"`  // 月額賃料 中央値（円）
-	Average float64 `json:"average"` // 月額賃料 平均値（円）
-	Count   int     `json:"count"`   // サンプル数
+	Median        float64 `json:"median"`         // 月額賃料 中央値（円）
+	Average       float64 `json:"average"`        // 月額賃料 平均値（円）
+	Count         int     `json:"count"`          // サンプル数
+	LowConfidence bool    `json:"low_confidence"` // サンプル数が3件未満で信頼性低
 }
 
 // HeatmapTile はヒートマップの1タイル分の投資スコア情報

--- a/docs/openapi/swagger.json
+++ b/docs/openapi/swagger.json
@@ -2142,6 +2142,10 @@
                     "description": "サンプル数",
                     "type": "integer"
                 },
+                "low_confidence": {
+                    "description": "サンプル数が3件未満で信頼性低",
+                    "type": "boolean"
+                },
                 "median": {
                     "description": "月額賃料 中央値（円）",
                     "type": "number"

--- a/frontend/src/components/RentValidationHint.tsx
+++ b/frontend/src/components/RentValidationHint.tsx
@@ -46,7 +46,7 @@ function badge(
 }
 
 export function RentValidationHint({ monthlyRent, area, city, landArea }: RentValidationHintProps) {
-  const { stats, deviationPct, level, loading, lowSample } = useRentValidation(
+  const { stats, deviationPct, level, loading, lowSample, lowConfidence } = useRentValidation(
     monthlyRent,
     area,
     city,
@@ -65,7 +65,12 @@ export function RentValidationHint({ monthlyRent, area, city, landArea }: RentVa
   return (
     <div className="mt-1">
       <p className={`text-xs ${info.className}`}>{info.message}</p>
-      {lowSample && stats && (
+      {lowConfidence && stats && (
+        <p className="text-xs text-destructive mt-0.5">
+          ※ データが少なく参考程度です（{stats.count}件）
+        </p>
+      )}
+      {!lowConfidence && lowSample && stats && (
         <p className="text-xs text-muted-foreground mt-0.5">
           ※ サンプル数が少ないため参考値です（{stats.count}件）
         </p>

--- a/frontend/src/hooks/useRentValidation.ts
+++ b/frontend/src/hooks/useRentValidation.ts
@@ -70,7 +70,14 @@ export function useRentValidation(
   }, [monthlyRent, area, city, areaSqm]);
 
   if (!stats || !stats.median || monthlyRent <= 0) {
-    return { stats, deviationPct: null, level: null, loading, lowSample: false, lowConfidence: false };
+    return {
+      stats,
+      deviationPct: null,
+      level: null,
+      loading,
+      lowSample: false,
+      lowConfidence: false,
+    };
   }
 
   const deviationPct = ((monthlyRent - stats.median) / stats.median) * 100;

--- a/frontend/src/hooks/useRentValidation.ts
+++ b/frontend/src/hooks/useRentValidation.ts
@@ -10,6 +10,7 @@ export interface RentValidationState {
   level: RentDeviationLevel;
   loading: boolean;
   lowSample: boolean;
+  lowConfidence: boolean;
 }
 
 const DEBOUNCE_MS = 600;
@@ -69,11 +70,12 @@ export function useRentValidation(
   }, [monthlyRent, area, city, areaSqm]);
 
   if (!stats || !stats.median || monthlyRent <= 0) {
-    return { stats, deviationPct: null, level: null, loading, lowSample: false };
+    return { stats, deviationPct: null, level: null, loading, lowSample: false, lowConfidence: false };
   }
 
   const deviationPct = ((monthlyRent - stats.median) / stats.median) * 100;
   const lowSample = stats.count < 10;
+  const lowConfidence = !!stats.low_confidence;
 
   let level: RentDeviationLevel = "normal";
   if (deviationPct >= 30) {
@@ -84,5 +86,5 @@ export function useRentValidation(
     level = "low-note";
   }
 
-  return { stats, deviationPct, level, loading, lowSample };
+  return { stats, deviationPct, level, loading, lowSample, lowConfidence };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -304,6 +304,7 @@ export interface RentStatsResult {
   median: number;
   average: number;
   count: number;
+  low_confidence?: boolean;
 }
 
 /** エリア賃料相場（中央値・平均値・件数）を取得（XIT001 賃貸） */


### PR DESCRIPTION
## 概要

- `RentStatsResult` に `LowConfidence bool` フィールドを追加し、`Count < 3` のとき `true` をセット
- フロントエンドは `low_confidence` フラグを優先し、危険色（`text-destructive`）で「データが少なく参考程度です」と案内
- サンプル 3〜9 件の緩い警告（`lowSample`）は従来通り残す

## 変更ファイル

- `backend/internal/domain/types.go` — `LowConfidence` フィールド追加
- `backend/internal/api/rent_handler.go` — フラグセット
- `docs/openapi/swagger.json` — 自動生成（`make swagger`）
- `frontend/src/lib/api.ts` — `low_confidence?: boolean` を型に追加
- `frontend/src/hooks/useRentValidation.ts` — `lowConfidence` を state に公開
- `frontend/src/components/RentValidationHint.tsx` — フラグ別表示分岐

## 確認項目

- [ ] `Count = 1` のレスポンスに `"low_confidence": true` が含まれる
- [ ] フロントエンドで危険色の注記が表示される
- [ ] `Count = 5` のとき `low_confidence` は `false`、`lowSample` 警告が表示される

Closes #592