### PR TITLE
feat: シミュレーション結果の URL 共有時に動的 OGP メタデータを生成する

### DIFF
--- a/frontend/src/app/_dashboard-client.tsx
+++ b/frontend/src/app/_dashboard-client.tsx
@@ -1,0 +1,8 @@
+"use client";
+import { useSearchParams } from "next/navigation";
+import { Dashboard } from "@/components/Dashboard";
+
+export function DashboardWithParams() {
+  const searchParams = useSearchParams();
+  return <Dashboard initialParams={searchParams} />;
+}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -16,9 +16,7 @@ export async function generateMetadata({
       ? `物件価格 ${priceNum.toLocaleString()}万円`
       : null;
   const rent =
-    params.rent && !isNaN(rentNum) && rentNum > 0
-      ? `月額賃料 ${rentNum.toLocaleString()}円`
-      : null;
+    params.rent && !isNaN(rentNum) && rentNum > 0 ? `月額賃料 ${rentNum.toLocaleString()}円` : null;
 
   if (!price) return {};
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,12 +9,16 @@ export async function generateMetadata({
   searchParams: Promise<Record<string, string>>;
 }): Promise<Metadata> {
   const params = await searchParams;
-  const price = params.price
-    ? `物件価格 ${Number(params.price).toLocaleString()}万円`
-    : null;
-  const rent = params.rent
-    ? `月額賃料 ${Number(params.rent).toLocaleString()}円`
-    : null;
+  const priceNum = Number(params.price);
+  const rentNum = Number(params.rent);
+  const price =
+    params.price && !isNaN(priceNum) && priceNum > 0
+      ? `物件価格 ${priceNum.toLocaleString()}万円`
+      : null;
+  const rent =
+    params.rent && !isNaN(rentNum) && rentNum > 0
+      ? `月額賃料 ${rentNum.toLocaleString()}円`
+      : null;
 
   if (!price) return {};
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,11 +1,32 @@
-"use client";
 import { Suspense } from "react";
-import { useSearchParams } from "next/navigation";
+import type { Metadata } from "next";
 import { Dashboard } from "@/components/Dashboard";
+import { DashboardWithParams } from "./_dashboard-client";
 
-function DashboardWithParams() {
-  const searchParams = useSearchParams();
-  return <Dashboard initialParams={searchParams} />;
+export async function generateMetadata({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string>>;
+}): Promise<Metadata> {
+  const params = await searchParams;
+  const price = params.price
+    ? `物件価格 ${Number(params.price).toLocaleString()}万円`
+    : null;
+  const rent = params.rent
+    ? `月額賃料 ${Number(params.rent).toLocaleString()}円`
+    : null;
+
+  if (!price) return {};
+
+  const description = [price, rent].filter(Boolean).join(" / ");
+  return {
+    title: `${description} — Yield-Guard シミュレーション結果`,
+    description: `${description} のシミュレーション結果を確認する`,
+    openGraph: {
+      title: `${description} — Yield-Guard`,
+      description: `利回り・デッドクロス・出口戦略を分析した結果です`,
+    },
+  };
 }
 
 export default function Home() {

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -9,12 +9,14 @@ export async function generateMetadata({
   searchParams: Promise<Record<string, string>>;
 }): Promise<Metadata> {
   const params = await searchParams;
-  const priceNum = Number(params.price);
+
+  // クイックモード: totalPrice、フルモード: landPrice + buildingCost を合算
+  const quickPrice = Number(params.totalPrice);
+  const fullPrice = (Number(params.landPrice) || 0) + (Number(params.buildingCost) || 0);
+  const resolvedPrice = quickPrice > 0 ? quickPrice : fullPrice;
+
   const rentNum = Number(params.rent);
-  const price =
-    params.price && !isNaN(priceNum) && priceNum > 0
-      ? `物件価格 ${priceNum.toLocaleString()}万円`
-      : null;
+  const price = resolvedPrice > 0 ? `物件価格 ${resolvedPrice.toLocaleString()}万円` : null;
   const rent =
     params.rent && !isNaN(rentNum) && rentNum > 0 ? `月額賃料 ${rentNum.toLocaleString()}円` : null;
 


### PR DESCRIPTION
## 概要

SNS シェア時のプレビューカードに物件条件を表示する。

- `page.tsx` をサーバーコンポーネント化し `generateMetadata` をエクスポート
- `useSearchParams` を使うクライアントロジックを `_dashboard-client.tsx` に分離
- `?price=3000&rent=150000` のような URL をシェアすると「物件価格 3,000万円 / 月額賃料 150,000円 — Yield-Guard シミュレーション結果」がタイトル・OGP に反映される
- パラメータなしのアクセスは `layout.tsx` の静的メタデータにフォールバック

## 変更ファイル

- `frontend/src/app/page.tsx` — `"use client"` 除去 + `generateMetadata` 追加
- `frontend/src/app/_dashboard-client.tsx` — 新規作成（クライアント境界）

## 確認項目

- [x] `tsc --noEmit` がエラーなし
- [ ] `/?price=5000&rent=200000` で OGP タイトルに物件条件が含まれる
- [ ] パラメータなしでも通常通り表示される

Closes #602