### PR TITLE
chore: lefthook セットアップ手順を整備し install-hooks を改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,9 +13,11 @@ Yield-Guard is a real estate investment decision-support tool that fetches land 
 ## Initial setup (clone後1回)
 
 ```bash
-make install          # frontend 依存関係をインストール
+make install          # frontend 依存関係をインストール（メインリポジトリのみ・worktree 不可）
 make install-hooks    # lefthook git フック (pre-commit: Prettier/lint, pre-push: test)
 ```
+
+> `lefthook install` が失敗する場合は `git config --unset-all --local core.hooksPath` を実行してから再試行する。
 
 ## Key commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,13 @@ Yield-Guard is a real estate investment decision-support tool that fetches land 
 - **Frontend**: Next.js 16 (App Router) / TypeScript / Tailwind CSS v4 / Shadcn/UI / Recharts → Vercel (`frontend/`)
 - **Data**: 国土交通省 不動産情報ライブラリ API (`reinfolib.mlit.go.jp`) — requires `MLIT_API_KEY`
 
+## Initial setup (clone後1回)
+
+```bash
+make install          # frontend 依存関係をインストール
+make install-hooks    # lefthook git フック (pre-commit: Prettier/lint, pre-push: test)
+```
+
 ## Key commands
 
 ```bash
@@ -237,5 +244,6 @@ These rules define the safety boundary for autonomous Claude Code operations.
   git worktree add ../<worktree-dir> -b branch-name
   ln -s "$(pwd)/frontend/node_modules" "../<worktree-dir>/frontend/node_modules"
   ```
+- **`make install-hooks` はメインリポジトリで1回だけ実行** — lefthook は `.git/hooks/` にフックを置くため、worktree は親リポジトリのフックを自動共有する。worktreeごとの再実行は不要
 - **Check main CI status before starting work** — know the baseline so pre-existing failures don't block the PR
 - **Rebase once, just before pushing** — rebase on the latest `origin/main` right before creating the PR, not repeatedly during development

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,10 @@ install:
 
 ## install-hooks: lefthook git フックをインストール
 install-hooks:
-	brew install lefthook || true
+	@if ! command -v lefthook >/dev/null 2>&1; then \
+	  echo "==> Installing lefthook via brew..."; \
+	  brew install lefthook; \
+	fi
 	lefthook install
 
 ## logs: Dockerコンテナのログを表示（未起動の場合は案内）


### PR DESCRIPTION
## 概要

- `lefthook.yml` は既にリポジトリに存在していたが、セットアップ手順が未整備で実質機能していなかった
- clone 後の初回セットアップ手順（`make install` + `make install-hooks`）を CLAUDE.md に追記
- worktree との相性を明記（`.git/hooks/` 共有により worktree ごとの再実行不要）
- `install-hooks` ターゲットを改善：lefthook が既にインストール済みの場合は brew をスキップ

## 変更内容

### `CLAUDE.md`
- `## Initial setup (clone後1回)` セクションを追加（Key commands の前）
- Worktree operations セクションに `make install-hooks` の worktree 共有説明を追記

### `Makefile`
- `install-hooks`: `brew install lefthook || true` → インストール済みチェック付きに変更

## lefthook の動作

```
pre-commit（ステージされたファイルのみ）
  ├── go-lint          backend/**/*.go → golangci-lint
  ├── frontend-format  frontend/src/**/*.{ts,tsx,css} → prettier --write + git add
  ├── frontend-lint    depends: frontend-format → eslint
  └── frontend-typecheck depends: frontend-format → tsc --noEmit

pre-push
  ├── go-test          go test -race ./...
  └── frontend-test    vitest run
```

## worktree との相性

lefthook は `.git/hooks/` にフックスクリプトを配置する。
git worktree はすべて親リポジトリの `.git/hooks/` を参照するため、
**メインリポジトリで `make install-hooks` を1回実行するだけで全 worktree に自動適用される。**

## テスト

- `make install-hooks` でフックが `.git/hooks/pre-commit`, `.git/hooks/pre-push` に生成されることを確認
- push 時に pre-push フックが起動し frontend/go テストがすべてパスすることを確認（このPR の push で動作済み）

## 注意事項

`core.hooksPath` がローカルに設定されている場合、`lefthook install` が失敗する。
その場合は以下を実行してから再試行：
```bash
git config --unset-all --local core.hooksPath
```