### PR TITLE
fix(infra): stg terraform apply のブロッカーを解消する（シングルトンリソースの prod 専用化）

### DIFF
--- a/terraform/artifact_registry.tf
+++ b/terraform/artifact_registry.tf
@@ -1,4 +1,7 @@
+# Artifact Registry は prod 専用。stg は prod の同一リポジトリを共用する。
+# repository_id に env suffix がないため stg で作ろうとすると既存リソースと競合する。
 resource "google_artifact_registry_repository" "backend" {
+  count         = var.env == "prod" ? 1 : 0
   repository_id = "yield-guard"
   location      = var.region
   format        = "DOCKER"

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -1,5 +1,8 @@
-# Cloud Function のソースコードをバケットにアップロード
+# Cloud Function のソースコードをバケットにアップロード。
+# バケット名はグローバルユニークのため prod 専用。stg は prod バケットを共用しない
+#（stg に billing stop Function 自体が不要なため）。
 resource "google_storage_bucket" "functions_source" {
+  count                       = var.env == "prod" ? 1 : 0
   name                        = "${var.project_id}-functions-source"
   location                    = var.region
   uniform_bucket_level_access = true
@@ -9,18 +12,21 @@ resource "google_storage_bucket" "functions_source" {
 }
 
 data "archive_file" "billing_stop" {
+  count       = var.env == "prod" ? 1 : 0
   type        = "zip"
   source_dir  = "${path.module}/functions/billing_stop"
   output_path = "${path.module}/functions/billing_stop.zip"
 }
 
 resource "google_storage_bucket_object" "billing_stop" {
-  name   = "billing_stop_${data.archive_file.billing_stop.output_md5}.zip"
-  bucket = google_storage_bucket.functions_source.name
-  source = data.archive_file.billing_stop.output_path
+  count  = var.env == "prod" ? 1 : 0
+  name   = "billing_stop_${data.archive_file.billing_stop[0].output_md5}.zip"
+  bucket = google_storage_bucket.functions_source[0].name
+  source = data.archive_file.billing_stop[0].output_path
 }
 
 resource "google_cloudfunctions2_function" "billing_stop" {
+  count    = var.env == "prod" ? 1 : 0
   name     = "billing-stop-${var.env}"
   location = var.region
   project  = var.project_id
@@ -30,8 +36,8 @@ resource "google_cloudfunctions2_function" "billing_stop" {
     entry_point = "stop_cloud_run"
     source {
       storage_source {
-        bucket = google_storage_bucket.functions_source.name
-        object = google_storage_bucket_object.billing_stop.name
+        bucket = google_storage_bucket.functions_source[0].name
+        object = google_storage_bucket_object.billing_stop[0].name
       }
     }
   }

--- a/terraform/functions.tf
+++ b/terraform/functions.tf
@@ -43,7 +43,7 @@ resource "google_cloudfunctions2_function" "billing_stop" {
   }
 
   service_config {
-    service_account_email = google_service_account.billing_stop.email
+    service_account_email = google_service_account.billing_stop[0].email
     environment_variables = {
       PROJECT_ID   = var.project_id
       REGION       = var.region

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -81,7 +81,10 @@ resource "google_project_iam_member" "deployer_run_developer" {
 }
 
 resource "google_artifact_registry_repository_iam_member" "deployer_push" {
-  repository = google_artifact_registry_repository.backend.name
+  # リポジトリは prod TF が作成するが、stg deployer も同リポジトリにプッシュする。
+  # google_artifact_registry_repository.backend は prod 専用 (count=0 for stg) なので
+  # リソース参照ではなくリポジトリ ID を直接指定する。
+  repository = "yield-guard"
   location   = var.region
   role       = "roles/artifactregistry.writer"
   member     = "serviceAccount:${google_service_account.deployer.email}"
@@ -95,13 +98,15 @@ resource "google_service_account_iam_member" "deployer_act_as_backend" {
 }
 
 resource "google_service_account_iam_member" "deployer_act_as_billing_stop" {
+  count = var.env == "prod" ? 1 : 0
   # deployer SA impersonates billing_stop SA when deploying Cloud Function.
-  service_account_id = google_service_account.billing_stop.name
+  service_account_id = google_service_account.billing_stop[0].name
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${google_service_account.deployer.email}"
 }
 
 resource "google_service_account_iam_member" "deployer_act_as_default_compute" {
+  count = var.env == "prod" ? 1 : 0
   # Cloud Functions Gen2 build (Cloud Build) runs as the default Compute SA.
   # deployer SA must be able to act as it to submit the build job.
   service_account_id = "projects/${var.project_id}/serviceAccounts/${data.google_project.project.number}-compute@developer.gserviceaccount.com"
@@ -175,6 +180,7 @@ resource "google_project_iam_member" "deployer_cloudscheduler_admin" {
 }
 
 resource "google_billing_account_iam_member" "deployer_billing_admin" {
+  count    = var.env == "prod" ? 1 : 0
   provider = google.billing
   # Required to create and update Billing Budgets via terraform apply.
   # billing.admin is needed; billing.costsManager does not include budgets.update in practice.
@@ -223,20 +229,23 @@ resource "google_project_iam_member" "backend_firestore_user" {
   member  = "serviceAccount:${google_service_account.backend.email}"
 }
 
-# ─── Billing Stop Cloud Function SA ───────────────────────────────────────────
+# ─── Billing Stop Cloud Function SA (prod 専用) ────────────────────────────────
 resource "google_service_account" "billing_stop" {
+  count        = var.env == "prod" ? 1 : 0
   account_id   = "sa-billing-stop-${var.env}"
   display_name = "yield-guard ${var.env} billing stop (Cloud Function)"
 }
 
 resource "google_project_iam_member" "billing_stop_run_developer" {
+  count   = var.env == "prod" ? 1 : 0
   project = var.project_id
   role    = "roles/run.developer"
-  member  = "serviceAccount:${google_service_account.billing_stop.email}"
+  member  = "serviceAccount:${google_service_account.billing_stop[0].email}"
 }
 
 resource "google_storage_bucket_iam_member" "billing_stop_storage_viewer" {
-  bucket = google_storage_bucket.functions_source.name
+  count  = var.env == "prod" ? 1 : 0
+  bucket = google_storage_bucket.functions_source[0].name
   role   = "roles/storage.objectViewer"
-  member = "serviceAccount:${google_service_account.billing_stop.email}"
+  member = "serviceAccount:${google_service_account.billing_stop[0].email}"
 }

--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -84,6 +84,9 @@ resource "google_artifact_registry_repository_iam_member" "deployer_push" {
   # リポジトリは prod TF が作成するが、stg deployer も同リポジトリにプッシュする。
   # google_artifact_registry_repository.backend は prod 専用 (count=0 for stg) なので
   # リソース参照ではなくリポジトリ ID を直接指定する。
+  # depends_on でリポジトリ作成後に IAM を付与することを保証する（prod 初回 apply 時の競合防止）。
+  # stg では backend が count=0 のため depends_on は空依存となり副作用なし。
+  depends_on = [google_artifact_registry_repository.backend]
   repository = "yield-guard"
   location   = var.region
   role       = "roles/artifactregistry.writer"


### PR DESCRIPTION
## 概要

#696 で staging 環境を追加した際、GCP プロジェクト内でシングルトンとなるリソース（env suffix なし）に `count` ガードが不足していた。このまま `terraform apply -var env=stg` を実行すると既存の prod リソースと競合してエラーになる。

## 変更内容

### `terraform/functions.tf`

- `google_storage_bucket.functions_source` — バケット名 `{project_id}-functions-source` は env suffix なし。GCS バケット名はグローバルユニークのため prod 専用に
- `data.archive_file.billing_stop` / `google_storage_bucket_object.billing_stop` / `google_cloudfunctions2_function.billing_stop` — 上記バケットに依存するリソースをまとめて prod 専用化

### `terraform/artifact_registry.tf`

- `google_artifact_registry_repository.backend` — `repository_id = "yield-guard"` は env suffix なし。stg は prod が作成した同一リポジトリを共用するため prod 専用化

### `terraform/iam.tf`

- `deployer_push` — AR リポジトリリソース参照（`backend.name`）をリポジトリ ID 文字列（`"yield-guard"`）に変更。stg deployer も同一リポジトリにプッシュするが、リソースが prod 専用のため直接参照できないため
- `deployer_act_as_billing_stop` / `deployer_act_as_default_compute` — Cloud Functions 関連の SA act-as 権限を prod 専用化
- `deployer_billing_admin` — billing account レベルの IAM を prod 専用化（stg は Billing Budget を作成しないため不要）
- `billing_stop` SA 群 — SA 本体と関連 IAM バインディングをすべて prod 専用化

## テスト計画

- [x] `terraform fmt -check` パス
- [x] pre-push フック（frontend: 369件・go-test: 全パス）
- [ ] CI (terraform-ci) が通ること
- [ ] `terraform plan -var env=stg` でエラーなし（手動確認）

## 関連

- #696 staging 環境構築 PR
- #699 CORS フォローアップ issue