### PR TITLE
fix(infra): stg deployer SA から不要な 6 権限を除去して最小権限化する

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -67,8 +67,10 @@ resource "google_project_iam_member" "deployer_sa_admin" {
 }
 
 resource "google_project_iam_member" "deployer_ar_repo_admin" {
+  count = var.env == "prod" ? 1 : 0
   # artifactregistry.admin is required to update repository metadata (cleanup_policies etc.)
   # via terraform apply. repoAdmin does not include artifactregistry.repositories.update.
+  # stg does not manage the AR repository (prod-only); writer is already granted via deployer_push.
   project = var.project_id
   role    = "roles/artifactregistry.admin"
   member  = "serviceAccount:${google_service_account.deployer.email}"
@@ -125,8 +127,10 @@ resource "google_storage_bucket_iam_member" "deployer_tfstate_admin" {
 }
 
 resource "google_project_iam_member" "deployer_monitoring_editor" {
+  count = var.env == "prod" ? 1 : 0
   # Required to manage Cloud Monitoring dashboards, alert policies, and notification channels via terraform apply.
   # monitoring.editor covers CRUD for dashboards/alerts/channels without IAM management (unlike monitoring.admin).
+  # stg has no monitoring resources (all guarded with count = prod ? 1 : 0).
   project = var.project_id
   role    = "roles/monitoring.editor"
   member  = "serviceAccount:${google_service_account.deployer.email}"
@@ -140,7 +144,9 @@ resource "google_project_iam_member" "deployer_secret_manager_admin" {
 }
 
 resource "google_project_iam_member" "deployer_storage_admin" {
+  count = var.env == "prod" ? 1 : 0
   # Required to create GCS buckets (e.g. Cloud Function source bucket) via terraform apply.
+  # stg has no GCS buckets to manage. tfstate access is granted separately via deployer_tfstate_admin.
   project = var.project_id
   role    = "roles/storage.admin"
   member  = "serviceAccount:${google_service_account.deployer.email}"
@@ -155,21 +161,27 @@ resource "google_project_iam_member" "deployer_pubsub_editor" {
 }
 
 resource "google_project_iam_member" "deployer_cloudfunctions_admin" {
+  count = var.env == "prod" ? 1 : 0
   # Required to deploy Cloud Functions Gen2 via terraform apply.
+  # stg has no Cloud Functions.
   project = var.project_id
   role    = "roles/cloudfunctions.admin"
   member  = "serviceAccount:${google_service_account.deployer.email}"
 }
 
 resource "google_project_iam_member" "deployer_logging_config_writer" {
+  count = var.env == "prod" ? 1 : 0
   # Required to create and manage log-based metrics via terraform apply.
+  # stg has no log-based metrics (warmup_job_failure metric is prod-only).
   project = var.project_id
   role    = "roles/logging.configWriter"
   member  = "serviceAccount:${google_service_account.deployer.email}"
 }
 
 resource "google_project_iam_member" "deployer_firestore_owner" {
+  count = var.env == "prod" ? 1 : 0
   # Required to create Firestore databases and TTL policies via terraform apply.
+  # stg does not manage Firestore; it reuses the prod (default) database.
   project = var.project_id
   role    = "roles/datastore.owner"
   member  = "serviceAccount:${google_service_account.deployer.email}"


### PR DESCRIPTION
## 概要

stg deployer SA が prod と同一の広権限を持っていた。stg では不要なリソース（AR リポジトリ・モニタリング・Cloud Functions・GCS バケット・ログメトリクス・Firestore）に対応する IAM ロールを prod 専用化する。

## セキュリティ上の動機

stg の WIF プール/プロバイダが侵害された場合、広権限 stg deployer SA を通じて prod リソースへの IAM 変更や機密データへのアクセスが可能になる。本 PR でそのリスクを削減する。

## 変更内容（`terraform/iam.tf`）

| リソース | 権限 | prod-only 化した理由 |
|---------|------|---------------------|
| `deployer_ar_repo_admin` | `roles/artifactregistry.admin` | stg は AR リポジトリを管理しない（prod-only）。イメージプッシュは `deployer_push` の writer で十分 |
| `deployer_monitoring_editor` | `roles/monitoring.editor` | モニタリングリソースはすべて prod-only |
| `deployer_storage_admin` | `roles/storage.admin`（プロジェクト全体） | Functions 用 GCS バケットは prod-only。tfstate アクセスはバケット単位の `deployer_tfstate_admin` で維持 |
| `deployer_cloudfunctions_admin` | `roles/cloudfunctions.admin` | Cloud Functions は prod-only |
| `deployer_logging_config_writer` | `roles/logging.configWriter` | ログベースメトリクスは prod-only |
| `deployer_firestore_owner` | `roles/datastore.owner` | stg は Firestore を管理しない（prod の (default) DB を共用） |

## stg deployer に残す権限

`roles/resourcemanager.projectIamAdmin`・`roles/iam.serviceAccountAdmin` は stg の `terraform apply` でも必要（stg SA の WIF バインディングやプロジェクト IAM メンバーを作成するため）。

## テスト計画

- [x] `terraform fmt -check` パス
- [x] pre-push フック（frontend 369件・go-test 全パス）
- [ ] CI (terraform-ci) が通ること
- [ ] `terraform plan -var env=stg` で permission error がないこと（手動確認）

## 関連

- #701 stg terraform apply ブロッカー解消 PR（本 PR と同時マージ推奨）