### PR TITLE
fix(backend): stg Vercel プレビュー URL の CORS を許可する（ワイルドカードサフィックス対応）

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -40,7 +40,7 @@ jobs:
       TF_VAR_region: "asia-northeast1"
       TF_VAR_mlit_api_key: ${{ secrets.MLIT_API_KEY }}
       TF_VAR_app_internal_api_key: ${{ inputs.environment == 'stg' && secrets.APP_INTERNAL_API_KEY_STG || secrets.APP_INTERNAL_API_KEY }}
-      TF_VAR_vercel_frontend_url: ${{ vars.VERCEL_FRONTEND_URL }}
+      TF_VAR_vercel_frontend_url: ${{ inputs.environment == 'stg' && vars.VERCEL_FRONTEND_URL_STG || vars.VERCEL_FRONTEND_URL }}
       TF_VAR_notification_email: ${{ vars.NOTIFICATION_EMAIL }}
       TF_VAR_billing_account_id: ${{ secrets.GCP_BILLING_ACCOUNT_ID }}
       TF_VAR_gemini_api_key: ${{ secrets.GEMINI_API_KEY }}

--- a/backend/internal/api/router.go
+++ b/backend/internal/api/router.go
@@ -93,12 +93,25 @@ func NewRouter(h *Handler, appInternalAPIKey string) *gin.Engine {
 
 	// CORS: 許可オリジンを環境変数 ALLOW_ORIGINS（カンマ区切り）から取得
 	// 未設定の場合は localhost:3000 のみ許可
+	// "*.example.com" 形式のエントリはサフィックス一致として扱う（stg の Vercel プレビュー URL 対応）
 	allowOrigins := os.Getenv("ALLOW_ORIGINS")
 	if allowOrigins == "" {
 		allowOrigins = "http://localhost:3000"
 	}
+	origins := strings.Split(allowOrigins, ",")
 	r.Use(cors.New(cors.Config{
-		AllowOrigins:     strings.Split(allowOrigins, ","),
+		AllowOriginFunc: func(origin string) bool {
+			for _, o := range origins {
+				if strings.HasPrefix(o, "*.") {
+					if strings.HasSuffix(origin, o[1:]) {
+						return true
+					}
+				} else if o == origin {
+					return true
+				}
+			}
+			return false
+		},
 		AllowMethods:     []string{"GET", "POST", "OPTIONS"},
 		AllowHeaders:     []string{"Content-Type", "Accept"},
 		AllowCredentials: false,

--- a/backend/internal/api/router_test.go
+++ b/backend/internal/api/router_test.go
@@ -96,6 +96,47 @@ func TestRouter_CORS_MultipleOrigins(t *testing.T) {
 	}
 }
 
+func TestRouter_CORS_WildcardSuffix(t *testing.T) {
+	// *.vercel.app 形式はサフィックス一致で許可される
+	t.Setenv("ALLOW_ORIGINS", "https://prod.example.com,*.vercel.app")
+
+	r := newTestRouter(&mockMLITClient{}, &mockGeocodeClient{})
+
+	allowed := []string{
+		"https://prod.example.com",
+		"https://frontend-git-feat-xxx-team.vercel.app",
+		"https://myapp.vercel.app",
+	}
+	for _, origin := range allowed {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Header.Set("Origin", origin)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		got := w.Header().Get("Access-Control-Allow-Origin")
+		if got != origin {
+			t.Errorf("origin %q should be allowed, got Access-Control-Allow-Origin = %q", origin, got)
+		}
+	}
+
+	denied := []string{
+		"https://evil.com",
+		"https://notvercel.app",
+		"https://evil.vercel.app.evil.com",
+	}
+	for _, origin := range denied {
+		req := httptest.NewRequest(http.MethodGet, "/health", nil)
+		req.Header.Set("Origin", origin)
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+
+		got := w.Header().Get("Access-Control-Allow-Origin")
+		if got == origin {
+			t.Errorf("origin %q should be denied, but was allowed", origin)
+		}
+	}
+}
+
 // --- ルート登録 ---
 
 func TestRouter_HealthEndpoint(t *testing.T) {


### PR DESCRIPTION
## 概要

- `router.go`: `AllowOrigins`（完全一致）を `AllowOriginFunc` に置き換え。`*.example.com` 形式のエントリをサフィックス一致として扱う
- `terraform-ci.yml`: stg apply 時に `VERCEL_FRONTEND_URL_STG` GitHub Variable を使用するよう修正
- GitHub Variable `VERCEL_FRONTEND_URL_STG` = `https://yield-guard-alpha.vercel.app,*.vercel.app` を登録済み

## 変更の背景・目的

stg Cloud Run の `ALLOW_ORIGINS` に Vercel プレビュー URL を設定しても、PR ごとに URL が変わるため完全一致では CORS が通らない（#699）。

`*.vercel.app` をサフィックス一致として扱うことで、全プレビューデプロイが stg バックエンドを呼び出せるようになる。

## 動作

```
ALLOW_ORIGINS = "https://yield-guard-alpha.vercel.app,*.vercel.app"

→ https://yield-guard-alpha.vercel.app          ✅ 完全一致
→ https://frontend-git-feat-xxx-glkt3912s-projects.vercel.app  ✅ *.vercel.app にサフィックス一致
→ https://evil.com                              ❌ 拒否
```

## テスト計画

- [x] `go build ./...` パス
- [x] `go test ./internal/api/...` パス（`-race` あり）
- [x] `golangci-lint` 0 issues
- [x] pre-push フック全パス
- [ ] CI が通ること
- [ ] マージ後に `terraform apply -var env=stg` で stg Cloud Run の `ALLOW_ORIGINS` を更新すること

## 関連

- #699 CORS フォローアップ issue