### PR TITLE
feat(frontend/backend): Phase 1 — 初めて使うユーザーが結果をすぐに理解できるよう結果画面を改善する

### DIFF
--- a/backend/internal/ai/gemini.go
+++ b/backend/internal/ai/gemini.go
@@ -25,16 +25,25 @@ const (
 )
 
 const systemPrompt = `あなたは日本の不動産投資専門アドバイザーです。
-以下の判断基準で分析してください：
-- DSCR 1.2未満: 危険域（ローン返済に余裕がない）
-- DSCR 1.2〜1.5: 要注意
-- DSCR 1.5以上: 安全域
-- デッドクロス10年以内: 税引後CFが悪化するため短期出口戦略が必須
-- 表面利回りはエリア・建物種別・築年数で判断が変わる
-- 木造（耐用年数22年）は減価償却が早くデッドクロスが来やすい
+投資経験のない初心者にも分かるよう、専門用語を使わず平易な日本語で回答してください。
+
+【用語の言い換えルール（回答中で必ず使用）】
+- DSCR → 返済の余裕度
+- デッドクロス → 税負担急増リスク
+- NPV → 将来収益の現在価値
+- IRR → 実質利回り
+
+【判断基準（参考情報）】
+- 返済の余裕度が1.2未満: ローン返済に余裕がない状態
+- 返済の余裕度が1.5以上: 安全域
+- 税負担急増リスクが10年以内に発生: 短期での売却戦略が重要
+- 木造（耐用年数22年）は税負担急増が早く来やすい
 - RC造・SRC造（耐用年数47年）は長期保有向き
-- 軽量鉄骨・重量鉄骨は耐用年数19〜34年で木造とRC造の中間的特性
-回答は3〜4文の日本語のみで返すこと。`
+
+【回答フォーマット（厳守）】
+結論1文・理由2文・アクション1文の計4文で回答すること。
+必ず「月々の返済額」と「10年後の手残り」の数値に言及すること。
+回答は日本語のみ。`
 
 func envOrDefault(key, fallback string) string {
 	if v := os.Getenv(key); v != "" {
@@ -229,8 +238,21 @@ func buildPrompt(input domain.InvestmentInput, r domain.InvestmentResult) string
 		buildingAge = fmt.Sprintf("%d年", input.BuildingAge)
 	}
 
+	monthlyPaymentMan := 0.0
+	if len(r.YearlyResults) > 0 {
+		monthlyPaymentMan = r.YearlyResults[0].AnnualLoanPayment / 12 / 10000
+	}
+
+	equity10Man := 0.0
+	for _, row := range r.MultiExitComparison {
+		if row.Year == 10 {
+			equity10Man = row.ExitEquity / 10000
+			break
+		}
+	}
+
 	return fmt.Sprintf(
-		`以下の不動産投資シミュレーション結果を分析し、強み・リスク・推奨アクションを専門家が初心者に説明するスタイルで、数値を引用しながらまとめてください。
+		`以下の不動産投資シミュレーション結果を分析し、強み・リスク・推奨アクションを初心者向けに数値を引用しながらまとめてください。
 
 【物件・ローン条件】
 - 建物種別: %s（築%s）
@@ -239,12 +261,14 @@ func buildPrompt(input domain.InvestmentInput, r domain.InvestmentResult) string
 - 空室率: %.1f%%
 
 【シミュレーション結果】
+- 月々の返済額: %.1f万円（1年目）
 - 表面利回り: %.1f%%
 - 実質利回り: %.1f%%
-- デッドクロス発生: %s
-- DSCR（借入金償還余裕率）: %.2f
+- 税負担急増リスク発生: %s
+- 返済の余裕度: %.2f
+- 10年後の手残り: %.0f万円
 - 保有期間最終手残り: %.0f万円
-- NPV（正味現在価値）: %.0f万円`,
+- 将来収益の現在価値: %.0f万円`,
 		input.BuildingType,
 		buildingAge,
 		input.LoanAmount/10000,
@@ -253,10 +277,12 @@ func buildPrompt(input domain.InvestmentInput, r domain.InvestmentResult) string
 		loanMethod,
 		input.HoldingYears,
 		input.VacancyRate*100,
+		monthlyPaymentMan,
 		r.GrossYield*100,
 		r.NetYield*100,
 		deadCross,
 		r.DSCR,
+		equity10Man,
 		r.ExitTotalEquity/10000,
 		r.NPV/10000,
 	)

--- a/backend/internal/ai/gemini.go
+++ b/backend/internal/ai/gemini.go
@@ -243,12 +243,17 @@ func buildPrompt(input domain.InvestmentInput, r domain.InvestmentResult) string
 		monthlyPaymentMan = r.YearlyResults[0].AnnualLoanPayment / 12 / 10000
 	}
 
-	equity10Man := 0.0
+	equity10Man := -1.0
 	for _, row := range r.MultiExitComparison {
 		if row.Year == 10 {
 			equity10Man = row.ExitEquity / 10000
 			break
 		}
+	}
+
+	equity10Line := ""
+	if equity10Man != -1.0 {
+		equity10Line = fmt.Sprintf("\n- 10年後の手残り: %.0f万円", equity10Man)
 	}
 
 	return fmt.Sprintf(
@@ -265,8 +270,7 @@ func buildPrompt(input domain.InvestmentInput, r domain.InvestmentResult) string
 - 表面利回り: %.1f%%
 - 実質利回り: %.1f%%
 - 税負担急増リスク発生: %s
-- 返済の余裕度: %.2f
-- 10年後の手残り: %.0f万円
+- 返済の余裕度: %.2f%s
 - 保有期間最終手残り: %.0f万円
 - 将来収益の現在価値: %.0f万円`,
 		input.BuildingType,
@@ -282,7 +286,7 @@ func buildPrompt(input domain.InvestmentInput, r domain.InvestmentResult) string
 		r.NetYield*100,
 		deadCross,
 		r.DSCR,
-		equity10Man,
+		equity10Line,
 		r.ExitTotalEquity/10000,
 		r.NPV/10000,
 	)

--- a/frontend/e2e/error-handling.spec.ts
+++ b/frontend/e2e/error-handling.spec.ts
@@ -60,7 +60,7 @@ test("@p3 ハザードアラートバナー：洪水リスクが表示される"
   });
   await page.goto("/");
 
-  await page.getByRole("radio", { name: "詳細" }).click();
+  await page.getByRole("radio", { name: "くわしく分析" }).click();
   await page.getByLabel("土地取得価格").fill("1200");
   await page.getByLabel("建物価格").fill("800");
   await page.getByLabel("築年数").fill("20");

--- a/frontend/e2e/land-price-fetch.spec.ts
+++ b/frontend/e2e/land-price-fetch.spec.ts
@@ -6,7 +6,7 @@ test.beforeEach(async ({ page }) => {
   await setupApiMocks(page);
   await page.addInitScript((key) => localStorage.setItem(key, "1"), ONBOARDING_KEY);
   await page.goto("/");
-  await page.getByRole("radio", { name: "詳細" }).click();
+  await page.getByRole("radio", { name: "くわしく分析" }).click();
 });
 
 test("@p2 地価データ取得：市区町村を選択して相場取得ボタンを押すと比較結果が表示される", async ({

--- a/frontend/e2e/mode-switch.spec.ts
+++ b/frontend/e2e/mode-switch.spec.ts
@@ -14,7 +14,7 @@ test("@p2 モード切替：Quick分析後に詳細へ切り替えると結果�
   await expect(sim.grossYield()).toHaveText("9.89");
 
   // 詳細モードに切り替え
-  await page.getByRole("radio", { name: "詳細" }).click();
+  await page.getByRole("radio", { name: "くわしく分析" }).click();
 
   await expect(
     page.getByText(

--- a/frontend/e2e/pages/simulation.page.ts
+++ b/frontend/e2e/pages/simulation.page.ts
@@ -40,7 +40,7 @@ export class SimulationPage {
     monthlyRent: string;
     loanAmount?: string;
   }) {
-    await this.page.getByRole("radio", { name: "詳細" }).click();
+    await this.page.getByRole("radio", { name: "くわしく分析" }).click();
     await this.page.getByLabel("土地取得価格").fill(params.landPrice);
     await this.page.getByLabel("建物価格").fill(params.buildingCost);
     await this.page.getByLabel("築年数").fill(params.buildingAge);

--- a/frontend/src/components/InvestmentForm.tsx
+++ b/frontend/src/components/InvestmentForm.tsx
@@ -523,7 +523,14 @@ export function InvestmentForm({
 
   return (
     <div className="space-y-4">
-      {showModeToggle && <SimulationModeToggle mode={simulationMode} onChange={onModeChange} />}
+      {showModeToggle && (
+        <div className="space-y-1.5">
+          <SimulationModeToggle mode={simulationMode} onChange={onModeChange} />
+          <p className="text-xs text-muted-foreground px-1">
+            かんたん判定: 2項目入力→即判定 / くわしく分析: 17項目で精密分析
+          </p>
+        </div>
+      )}
 
       {!isQuick && pendingDraft && (
         <div className="flex items-center justify-between rounded-lg border border-yellow-200 bg-yellow-50 px-4 py-2 text-sm">

--- a/frontend/src/components/KpiStrip.tsx
+++ b/frontend/src/components/KpiStrip.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TrendingUp, ShieldCheck, AlertCircle, Banknote } from "lucide-react";
+import { TrendingUp, ShieldCheck, AlertCircle, Banknote, CreditCard } from "lucide-react";
 import type { InvestmentResult } from "@/types/investment";
 
 interface KpiStripProps {
@@ -40,6 +40,10 @@ function KpiCell({ icon, label, value, sub, subPositive }: KpiCellProps) {
 }
 
 export function KpiStrip({ result, yieldTarget = 0.08, holdingYears = 30 }: KpiStripProps) {
+  const monthlyPaymentMan = Math.floor(
+    (result.yearlyResults[0]?.annualLoanPayment ?? 0) / 12 / 10_000
+  );
+
   const grossYieldPct = result.grossYield * 100;
   const yieldDiff = grossYieldPct - yieldTarget * 100;
   const yieldDiffStr = (yieldDiff >= 0 ? "+" : "") + yieldDiff.toFixed(2) + "pp vs 目標";
@@ -66,7 +70,13 @@ export function KpiStrip({ result, yieldTarget = 0.08, holdingYears = 30 }: KpiS
   const equitySub = equityPositive ? "出口時プラス" : "出口時マイナス";
 
   return (
-    <div aria-label="KPIサマリ" className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+    <div aria-label="KPIサマリ" className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5">
+      <KpiCell
+        icon={<CreditCard className="h-3.5 w-3.5" aria-hidden />}
+        label="月々の返済額"
+        value={`${monthlyPaymentMan.toLocaleString()}万円`}
+        sub="元利合計（1年目）"
+      />
       <KpiCell
         icon={<TrendingUp className="h-3.5 w-3.5" aria-hidden />}
         label="表面利回り"

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -20,7 +20,14 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import dynamic from "next/dynamic";
-import { AlertTriangle, BarChart3, ChevronDown, ChevronUp, ShieldAlert } from "lucide-react";
+import {
+  AlertTriangle,
+  BarChart3,
+  ChevronDown,
+  ChevronUp,
+  ShieldAlert,
+  TrendingUp,
+} from "lucide-react";
 import { PREFECTURE_CENTERS } from "@/lib/prefectureCenters";
 import type {
   InvestmentInput,
@@ -219,12 +226,33 @@ export function ResultsSection({
           {result && lastInput && (
             <div className="space-y-3">
               <CriticalErrorBanner errors={result.criticalErrors} />
-              <StatusSummary result={result} />
+              <StatusSummary result={result} input={lastInput} />
               <KpiStrip
                 result={result}
                 yieldTarget={lastInput.yieldTarget}
                 holdingYears={lastInput.holdingYears}
               />
+              {(() => {
+                const row10 = result.multiExitComparison?.find((r) => r.year === 10);
+                if (!row10) return null;
+                const equityMan = Math.round(row10.exitEquity / 10_000);
+                const equityStr =
+                  Math.abs(equityMan) >= 10_000
+                    ? `${(equityMan / 10_000).toFixed(1)}億円`
+                    : `${equityMan.toLocaleString()}万円`;
+                const isPositive = row10.exitEquity >= 0;
+                return (
+                  <div className="flex items-center gap-3 rounded-lg border bg-card px-4 py-3 shadow-sm">
+                    <TrendingUp className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden />
+                    <span className="text-sm text-muted-foreground">10年後の手残り</span>
+                    <span
+                      className={`ml-auto text-xl font-bold ${isPositive ? "text-green-600" : "text-red-600"}`}
+                    >
+                      {equityStr}
+                    </span>
+                  </div>
+                );
+              })()}
             </div>
           )}
           <HazardAlertBanner hazardRisks={hazardRisks} externalUrbanRisks={externalUrbanRisks} />

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -233,6 +233,7 @@ export function ResultsSection({
                 holdingYears={lastInput.holdingYears}
               />
               {(() => {
+                if (lastInput.holdingYears < 10) return null;
                 const row10 = result.multiExitComparison?.find((r) => r.year === 10);
                 if (!row10) return null;
                 const equityMan = Math.round(row10.exitEquity / 10_000);

--- a/frontend/src/components/SimulationModeToggle.tsx
+++ b/frontend/src/components/SimulationModeToggle.tsx
@@ -28,9 +28,9 @@ export function SimulationModeToggle({ mode, onChange, className }: Props) {
       >
         <span className="flex items-center gap-1.5">
           <Zap className="h-3.5 w-3.5" />
-          クイック
+          かんたん判定
         </span>
-        <span className="text-xs font-normal opacity-75">内覧でサッと試す</span>
+        <span className="text-xs font-normal opacity-75">2項目で即判定</span>
       </button>
       <button
         type="button"
@@ -45,9 +45,9 @@ export function SimulationModeToggle({ mode, onChange, className }: Props) {
       >
         <span className="flex items-center gap-1.5">
           <SlidersHorizontal className="h-3.5 w-3.5" />
-          詳細
+          くわしく分析
         </span>
-        <span className="text-xs font-normal opacity-75">じっくり分析する</span>
+        <span className="text-xs font-normal opacity-75">17項目で精密分析</span>
       </button>
     </div>
   );

--- a/frontend/src/components/StatusSummary.tsx
+++ b/frontend/src/components/StatusSummary.tsx
@@ -46,7 +46,7 @@ export function StatusSummary({ result, input }: StatusSummaryProps) {
       <span className="font-semibold">[{label}]</span>
       <span className="hidden sm:inline text-muted-foreground">|</span>
       <span>
-        利回り {grossYieldPct}% / DSCR {dscrVal} / デッドクロス {dcYear}
+        利回り {grossYieldPct}% / 返済の余裕度 {dscrVal} / 税負担急増リスク {dcYear}
       </span>
     </div>
   );

--- a/frontend/src/components/StatusSummary.tsx
+++ b/frontend/src/components/StatusSummary.tsx
@@ -1,43 +1,35 @@
 import React from "react";
 import { CheckCircle2, AlertTriangle, XOctagon } from "lucide-react";
-import type { InvestmentResult } from "@/types/investment";
+import type { InvestmentInput, InvestmentResult } from "@/types/investment";
+import { calcVerdict } from "@/lib/pdf/verdict";
 
 interface StatusSummaryProps {
   result: InvestmentResult;
+  input: InvestmentInput;
 }
 
-type StatusLevel = "OK" | "CAUTION" | "RISK";
-
-function getStatus(result: InvestmentResult): StatusLevel {
-  if (result.criticalErrors.some((e) => e.status === "REJECT")) return "RISK";
-  if (result.criticalErrors.some((e) => e.status === "WARNING")) return "CAUTION";
-  return "OK";
-}
-
-const STATUS_CONFIG: Record<
-  StatusLevel,
-  { label: string; icon: React.ReactNode; className: string }
-> = {
-  OK: {
-    label: "OK",
+const LEVEL_CONFIG = {
+  PASS: {
+    label: "投資適格",
     icon: <CheckCircle2 className="h-4 w-4 shrink-0 text-green-600" aria-hidden />,
     className: "border-green-300 bg-green-50 text-green-900",
   },
   CAUTION: {
-    label: "注意",
+    label: "要交渉",
     icon: <AlertTriangle className="h-4 w-4 shrink-0 text-yellow-600" aria-hidden />,
     className: "border-yellow-300 bg-yellow-50 text-yellow-900",
   },
-  RISK: {
-    label: "リスク",
+  REJECT: {
+    label: "見送り推奨",
     icon: <XOctagon className="h-4 w-4 shrink-0 text-red-600" aria-hidden />,
     className: "border-red-300 bg-red-50 text-red-900",
   },
-};
+} as const;
 
-export function StatusSummary({ result }: StatusSummaryProps) {
-  const status = getStatus(result);
-  const { label, icon, className } = STATUS_CONFIG[status];
+export function StatusSummary({ result, input }: StatusSummaryProps) {
+  const dscrStress = result.stressScenarios.find((sc) => sc.label === "複合ストレス")?.dscr ?? 0;
+  const verdict = calcVerdict(input, result, result.dscr, dscrStress);
+  const { label, icon, className } = LEVEL_CONFIG[verdict.level];
 
   const grossYieldPct = (result.grossYield * 100).toFixed(2);
   const dscrVal = result.dscr.toFixed(2);

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -84,7 +84,7 @@ describe("Dashboard", () => {
     render(<Dashboard />);
 
     // 詳細モードに切り替え（Dashboard は複数箇所にトグルを持つため最初の要素を使う）
-    await userEvent.click(screen.getAllByRole("radio", { name: /詳細/ })[0]);
+    await userEvent.click(screen.getAllByRole("radio", { name: /くわしく分析/ })[0]);
 
     await userEvent.click(screen.getByRole("button", { name: /シミュレーション実行/ }));
 
@@ -174,7 +174,7 @@ describe("Dashboard", () => {
     const params = new URLSearchParams("mode=quick&totalPrice=2000&rent=12");
     render(<Dashboard initialParams={params} />);
     // クイックモードのラジオが選択されていること
-    expect(screen.getAllByRole("radio", { name: /クイック/ })[0]).toHaveAttribute(
+    expect(screen.getAllByRole("radio", { name: /かんたん判定/ })[0]).toHaveAttribute(
       "aria-checked",
       "true"
     );
@@ -186,7 +186,7 @@ describe("Dashboard", () => {
     const params = new URLSearchParams("mode=full&landPrice=1000&buildingCost=500");
     render(<Dashboard initialParams={params} />);
     // フルモードのラジオが選択されていること
-    expect(screen.getAllByRole("radio", { name: /詳細/ })[0]).toHaveAttribute(
+    expect(screen.getAllByRole("radio", { name: /くわしく分析/ })[0]).toHaveAttribute(
       "aria-checked",
       "true"
     );

--- a/frontend/src/components/__tests__/InvestmentForm.test.tsx
+++ b/frontend/src/components/__tests__/InvestmentForm.test.tsx
@@ -223,13 +223,13 @@ describe("InvestmentForm", () => {
 
     it("詳細ボタンをクリックすると onModeChange('full') が呼ばれる", async () => {
       const { onModeChange } = await renderForm("quick");
-      await userEvent.click(screen.getByRole("radio", { name: /詳細/ }));
+      await userEvent.click(screen.getByRole("radio", { name: /くわしく分析/ }));
       expect(onModeChange).toHaveBeenCalledWith("full");
     });
 
     it("クイックモードのラジオボタンは aria-checked=true", async () => {
       await renderForm("quick");
-      const quickBtn = screen.getByRole("radio", { name: /クイック/ });
+      const quickBtn = screen.getByRole("radio", { name: /かんたん判定/ });
       expect(quickBtn).toHaveAttribute("aria-checked", "true");
     });
 

--- a/frontend/src/components/__tests__/SimulationModeToggle.test.tsx
+++ b/frontend/src/components/__tests__/SimulationModeToggle.test.tsx
@@ -4,38 +4,47 @@ import userEvent from "@testing-library/user-event";
 import { SimulationModeToggle } from "@/components/SimulationModeToggle";
 
 describe("SimulationModeToggle", () => {
-  it("クイックと詳細のラジオボタンが表示される", () => {
+  it("かんたん判定とくわしく分析のラジオボタンが表示される", () => {
     render(<SimulationModeToggle mode="quick" onChange={vi.fn()} />);
-    expect(screen.getByRole("radio", { name: /クイック/ })).toBeInTheDocument();
-    expect(screen.getByRole("radio", { name: /詳細/ })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /かんたん判定/ })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /くわしく分析/ })).toBeInTheDocument();
   });
 
-  it("mode='quick' のときクイックが選択状態になる", () => {
+  it("mode='quick' のときかんたん判定が選択状態になる", () => {
     render(<SimulationModeToggle mode="quick" onChange={vi.fn()} />);
-    expect(screen.getByRole("radio", { name: /クイック/ })).toHaveAttribute("aria-checked", "true");
-    expect(screen.getByRole("radio", { name: /詳細/ })).toHaveAttribute("aria-checked", "false");
-  });
-
-  it("mode='full' のとき詳細が選択状態になる", () => {
-    render(<SimulationModeToggle mode="full" onChange={vi.fn()} />);
-    expect(screen.getByRole("radio", { name: /詳細/ })).toHaveAttribute("aria-checked", "true");
-    expect(screen.getByRole("radio", { name: /クイック/ })).toHaveAttribute(
+    expect(screen.getByRole("radio", { name: /かんたん判定/ })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect(screen.getByRole("radio", { name: /くわしく分析/ })).toHaveAttribute(
       "aria-checked",
       "false"
     );
   });
 
-  it("クイックボタンをクリックすると onChange('quick') が呼ばれる", async () => {
+  it("mode='full' のときくわしく分析が選択状態になる", () => {
+    render(<SimulationModeToggle mode="full" onChange={vi.fn()} />);
+    expect(screen.getByRole("radio", { name: /くわしく分析/ })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect(screen.getByRole("radio", { name: /かんたん判定/ })).toHaveAttribute(
+      "aria-checked",
+      "false"
+    );
+  });
+
+  it("かんたん判定ボタンをクリックすると onChange('quick') が呼ばれる", async () => {
     const onChange = vi.fn();
     render(<SimulationModeToggle mode="full" onChange={onChange} />);
-    await userEvent.click(screen.getByRole("radio", { name: /クイック/ }));
+    await userEvent.click(screen.getByRole("radio", { name: /かんたん判定/ }));
     expect(onChange).toHaveBeenCalledWith("quick");
   });
 
-  it("詳細ボタンをクリックすると onChange('full') が呼ばれる", async () => {
+  it("くわしく分析ボタンをクリックすると onChange('full') が呼ばれる", async () => {
     const onChange = vi.fn();
     render(<SimulationModeToggle mode="quick" onChange={onChange} />);
-    await userEvent.click(screen.getByRole("radio", { name: /詳細/ }));
+    await userEvent.click(screen.getByRole("radio", { name: /くわしく分析/ }));
     expect(onChange).toHaveBeenCalledWith("full");
   });
 
@@ -44,14 +53,14 @@ describe("SimulationModeToggle", () => {
     expect(screen.getByRole("group", { name: "シミュレーションモード" })).toBeInTheDocument();
   });
 
-  it("「内覧でサッと試す」サブラベルが表示される", () => {
+  it("「2項目で即判定」サブラベルが表示される", () => {
     render(<SimulationModeToggle mode="quick" onChange={vi.fn()} />);
-    expect(screen.getByText("内覧でサッと試す")).toBeInTheDocument();
+    expect(screen.getByText("2項目で即判定")).toBeInTheDocument();
   });
 
-  it("「じっくり分析する」サブラベルが表示される", () => {
+  it("「17項目で精密分析」サブラベルが表示される", () => {
     render(<SimulationModeToggle mode="quick" onChange={vi.fn()} />);
-    expect(screen.getByText("じっくり分析する")).toBeInTheDocument();
+    expect(screen.getByText("17項目で精密分析")).toBeInTheDocument();
   });
 
   it("className prop が渡されると div に反映される", () => {


### PR DESCRIPTION
## 概要

[Epic #666] Phase 1 の全サブissueを実装。既存の計算ロジックを組み替えるだけで、初めて使うユーザーでも 30 秒以内に判断できる画面に改善する。

## 変更内容

### #675 投資判定ロジックを calcVerdict に一本化
- `StatusSummary.tsx` の独自 `getStatus()` を削除し、`lib/pdf/verdict.ts` の `calcVerdict()` を使うよう統一
- 画面表示と PDF で判定結果が食い違うリスクを解消

### #674 KpiStrip に「月々の返済額」を追加
- KpiStrip の先頭カードに月々の返済額（元利合計・1年目）を追加
- `yearlyResults[0].annualLoanPayment / 12` を万円表示（既存フィールド流用）
- 4列 → 5列グリッドに変更（`sm:grid-cols-3 lg:grid-cols-5`）

### #676 「10年後の手残り」カードを結果上部に表示
- KpiStrip 直下に10年保有時の手残り額を常時表示
- `multiExitComparison` の `year === 10` 行の `exitEquity` を流用（データがない場合は非表示）

### #677 かんたん入力 / くわしく入力の違いをフォーム入口に説明
- モードラベルを「クイック」→「かんたん判定」、「詳細」→「くわしく分析」に変更
- サブラベルを「2項目で即判定」「17項目で精密分析」に更新
- フォームのモードトグル直下に説明テキスト1行を追加

### #678 AI 投資レポートのプロンプトを平易な表現に改訂
- systemPrompt に用語言い換えルールを追加（DSCR→返済の余裕度、デッドクロス→税負担急増リスク等）
- 出力フォーマットを「結論1文・理由2文・アクション1文」に統一
- buildPrompt に月々の返済額・10年後の手残りを含めるよう拡張

## 関連Issue

Closes #674
Closes #675
Closes #676
Closes #677
Closes #678
Closes #666

## テスト

- [x] `vitest run` 369件全PASSを確認
- [x] `go test -race ./...` 全PASSを確認
- [x] `tsc --noEmit` 型エラーなし
- [x] `golangci-lint` 0 issues
- [x] `SimulationModeToggle.test.tsx` のラベルテキスト参照をすべて新ラベルに更新
- [x] `Dashboard.test.tsx` / `InvestmentForm.test.tsx` の旧ラベル参照を更新

## 確認事項

- [x] 新しい計算ロジックは追加していない（既存フィールドの流用のみ）
- [x] グラデーション背景・Lucide 以外のアイコン不使用
- [x] `Co-Authored-By` 行なし