### PR TITLE
feat(frontend): 「10年後の手残り」カードを結果上部に表示する

### DIFF
--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -225,6 +225,26 @@ export function ResultsSection({
                 yieldTarget={lastInput.yieldTarget}
                 holdingYears={lastInput.holdingYears}
               />
+              {(() => {
+                const row10 = result.multiExitComparison?.find((r) => r.year === 10);
+                if (!row10) return null;
+                const equityMan = Math.floor(row10.exitEquity / 10_000);
+                const isPositive = row10.exitEquity >= 0;
+                return (
+                  <div className="rounded-lg border bg-card p-3 shadow-sm">
+                    <p className="text-xs text-muted-foreground">10年後の手残り</p>
+                    <p
+                      className={`text-xl font-bold ${isPositive ? "text-green-600" : "text-red-600"}`}
+                    >
+                      {isPositive ? "+" : ""}
+                      {equityMan.toLocaleString()}万円
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {isPositive ? "出口時プラス" : "出口時マイナス"}
+                    </p>
+                  </div>
+                );
+              })()}
             </div>
           )}
           <HazardAlertBanner hazardRisks={hazardRisks} externalUrbanRisks={externalUrbanRisks} />


### PR DESCRIPTION
## 概要
出口戦略の核心情報である「10年後の手残り」を KpiStrip の直下に追加し、スクロールなしで確認できるようにする。

## 変更内容
- `ResultsSection.tsx`: KpiStrip の直下に 10年後の手残りカードを追加
  - 値: `result.multiExitComparison` の `year === 10` 行の `exitEquity`
  - プラスは緑、マイナスは赤で表示
  - `multiExitComparison` に 10年データが存在しない場合は非表示
  - `MultiExitCompareTable` 本体は finance タブにそのまま維持

## 関連Issue
Closes #676

## テスト
- [x] 既存テストが通ること（369 passed）
- [x] TypeScript 型チェック通過

## 確認事項
- [x] コードレビュー観点での自己レビュー済み