### PR TITLE
fix(backend): PR #710で誤って削除されたハンドラーメソッドを復元する

### DIFF
--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/yield-guard/backend/internal/domain"
 	"github.com/yield-guard/backend/internal/mlit"
-	"github.com/yield-guard/backend/internal/service"
 )
 
 func init() {
@@ -279,16 +278,9 @@ func (m *mockMLITClient) FetchRentStats(ctx context.Context, q mlit.LandPriceQue
 	return domain.RentStatsResult{}, nil
 }
 
-// newTestRouter はモッククライアントを使ったテスト用ルーターを返す。
-// locationSvc が nil の場合は mlitClient を使った InvestmentScoreService を生成する。
-func newTestRouter(client MLITClient, geocodeClient GeocodeClient, locationSvc ...service.LocationService) *gin.Engine {
-	var svc service.LocationService
-	if len(locationSvc) > 0 && locationSvc[0] != nil {
-		svc = locationSvc[0]
-	} else {
-		svc = service.NewInvestmentScoreService(client)
-	}
-	h := NewHandler(client, geocodeClient, svc)
+// newTestRouter はモッククライアントを使ったテスト用ルーターを返す
+func newTestRouter(client MLITClient, geocodeClient GeocodeClient) *gin.Engine {
+	h := NewHandler(client, geocodeClient)
 	return NewRouter(h, os.Getenv("APP_INTERNAL_API_KEY"))
 }
 

--- a/backend/internal/api/location_handler.go
+++ b/backend/internal/api/location_handler.go
@@ -434,13 +434,14 @@ func (h *Handler) GetInvestmentScoreHeatmap(c *gin.Context) {
 		return
 	}
 
+	// parseZoom は z ∈ [11,15] を保証する
 	var maxTiles int
-	switch {
-	case z <= 12:
+	switch z {
+	case 11, 12:
 		maxTiles = 20
-	case z <= 14:
+	case 13, 14:
 		maxTiles = 30
-	default:
+	default: // z == 15
 		maxTiles = maxHeatmapTiles
 	}
 
@@ -465,11 +466,6 @@ func (h *Handler) GetInvestmentScoreHeatmap(c *gin.Context) {
 	for tx := xMin; tx <= xMax; tx++ {
 		for ty := yMin; ty <= yMax; ty++ {
 			go func(tx, ty int) {
-				defer func() {
-					if r := recover(); r != nil {
-						results <- tileResult{err: fmt.Errorf("panic in calcScoreForTile: %v", r)}
-					}
-				}()
 				select {
 				case <-ctx.Done():
 					results <- tileResult{err: ctx.Err()}
@@ -477,6 +473,11 @@ func (h *Handler) GetInvestmentScoreHeatmap(c *gin.Context) {
 				case sem <- struct{}{}:
 				}
 				defer func() { <-sem }()
+				defer func() {
+					if r := recover(); r != nil {
+						results <- tileResult{err: fmt.Errorf("panic in calcScoreForTile: %v", r)}
+					}
+				}()
 				score, err := h.calcScoreForTile(ctx, z, tx, ty)
 				if err != nil {
 					results <- tileResult{err: err}

--- a/backend/internal/api/location_handler.go
+++ b/backend/internal/api/location_handler.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
+	"strconv"
 
 	"github.com/gin-gonic/gin"
 	"github.com/yield-guard/backend/internal/domain"
@@ -91,4 +94,420 @@ func (h *Handler) GetPopulationForecast(c *gin.Context) {
 
 	result := domain.CalcPopulationForecast(items)
 	c.JSON(http.StatusOK, result)
+}
+
+// GetUrbanRisks は緯度経度から都市計画リスクを一括取得する
+// @Summary     都市計画リスク
+// @Tags        location
+// @Produce     json
+// @Param       lat  query  number  true  "緯度 (日本国内 20-46)"
+// @Param       lng  query  number  true  "経度 (日本国内 122-154)"
+// @Success     200  {array}   domain.UrbanRisk
+// @Failure     400  {object}  map[string]string
+// @Router      /api/urban-risks [get]
+func (h *Handler) GetUrbanRisks(c *gin.Context) {
+	lat, lng, ok := parseLatLng(c, coordsJapanOnly)
+	if !ok {
+		return
+	}
+
+	ctx := c.Request.Context()
+	z := 14
+	x, y := mlit.LatLngToTile(lat, lng, z)
+
+	type result struct {
+		location []domain.LocationOptimizationItem
+		embank   []domain.EmbankmentItem
+		road     []domain.UrbanRoadItem
+		disaster []domain.DisasterHistoryItem
+	}
+	var res result
+
+	locCh := fanOut(func() ([]domain.LocationOptimizationItem, error) { return h.mlitClient.FetchLocationOptimization(ctx, z, x, y) })
+	embCh := fanOut(func() ([]domain.EmbankmentItem, error) { return h.mlitClient.FetchEmbankment(ctx, z, x, y) })
+	rdCh := fanOut(func() ([]domain.UrbanRoadItem, error) { return h.mlitClient.FetchUrbanRoad(ctx, z, x, y) })
+	disCh := fanOut(func() ([]domain.DisasterHistoryItem, error) { return h.mlitClient.FetchDisasterHistory(ctx, z, x, y) })
+
+	if r := <-locCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchLocationOptimization failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		res.location = r.data
+	}
+	if r := <-embCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchEmbankment failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		res.embank = r.data
+	}
+	if r := <-rdCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchUrbanRoad failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		res.road = r.data
+	}
+	if r := <-disCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchDisasterHistory failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		res.disaster = r.data
+	}
+
+	risks := domain.BuildUrbanRisksFromAPIs(res.location, res.embank, res.road, res.disaster)
+	if risks == nil {
+		risks = []domain.UrbanRisk{}
+	}
+	c.JSON(http.StatusOK, risks)
+}
+
+// GetHazardInfo は物件の緯度経度から洪水・高潮・津波・土砂災害のハザード情報を返す
+// @Summary     ハザード情報
+// @Tags        location
+// @Produce     json
+// @Param       lat  query  number  true  "緯度 (日本国内 20-46)"
+// @Param       lng  query  number  true  "経度 (日本国内 122-154)"
+// @Success     200  {array}   domain.UrbanRisk
+// @Failure     400  {object}  map[string]string
+// @Router      /api/hazard [get]
+func (h *Handler) GetHazardInfo(c *gin.Context) {
+	lat, lng, ok := parseLatLng(c, coordsJapanOnly)
+	if !ok {
+		return
+	}
+
+	ctx := c.Request.Context()
+	z := 14
+	x, y := mlit.LatLngToTile(lat, lng, z)
+
+	floCh := fanOut(func() ([]domain.FloodHazardItem, error) { return h.mlitClient.FetchFloodHazard(ctx, z, x, y) })
+	stmCh := fanOut(func() ([]domain.StormHazardItem, error) { return h.mlitClient.FetchStormHazard(ctx, z, x, y) })
+	tsuCh := fanOut(func() ([]domain.TsunamiHazardItem, error) { return h.mlitClient.FetchTsunamiHazard(ctx, z, x, y) })
+	lsCh := fanOut(func() ([]domain.LandslideHazardItem, error) { return h.mlitClient.FetchLandslideHazard(ctx, z, x, y) })
+
+	var floods []domain.FloodHazardItem
+	var storms []domain.StormHazardItem
+	var tsunamis []domain.TsunamiHazardItem
+	var landslides []domain.LandslideHazardItem
+
+	if r := <-floCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchFloodHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		floods = r.data
+	}
+	if r := <-stmCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchStormHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		storms = r.data
+	}
+	if r := <-tsuCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchTsunamiHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		tsunamis = r.data
+	}
+	if r := <-lsCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchLandslideHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	} else {
+		landslides = r.data
+	}
+
+	risks := domain.BuildHazardRisks(floods, storms, tsunamis, landslides)
+	if risks == nil {
+		risks = []domain.UrbanRisk{}
+	}
+	c.JSON(http.StatusOK, risks)
+}
+
+// calcScoreForTile は指定タイル座標に対して複数 API を並列取得し投資適地スコアを返す。
+// 個別 API の失敗は警告ログのみでスキップする。コンテキストキャンセル時はエラーを返す。
+func (h *Handler) calcScoreForTile(ctx context.Context, z, x, y int) (domain.InvestmentScoreResult, error) {
+	if err := ctx.Err(); err != nil {
+		return domain.InvestmentScoreResult{}, err
+	}
+	popCh := fanOut(func() ([]domain.PopulationForecastItem, error) { return h.mlitClient.FetchPopulationForecast(ctx, z, x, y) })
+	ridCh := fanOut(func() ([]mlit.StationRidership, error) { return h.mlitClient.FetchStationRidership(ctx, z, x, y) })
+	locCh := fanOut(func() ([]domain.LocationOptimizationItem, error) { return h.mlitClient.FetchLocationOptimization(ctx, z, x, y) })
+	embCh := fanOut(func() ([]domain.EmbankmentItem, error) { return h.mlitClient.FetchEmbankment(ctx, z, x, y) })
+	disCh := fanOut(func() ([]domain.DisasterHistoryItem, error) { return h.mlitClient.FetchDisasterHistory(ctx, z, x, y) })
+	zonCh := fanOut(func() ([]domain.UrbanZoningItem, error) { return h.mlitClient.FetchUrbanZoning(ctx, z, x, y) })
+	liqCh := fanOut(func() ([]domain.LiquefactionRiskItem, error) { return h.mlitClient.FetchLiquefaction(ctx, z, x, y) })
+	floCh := fanOut(func() ([]domain.FloodHazardItem, error) { return h.mlitClient.FetchFloodHazard(ctx, z, x, y) })
+	stoCh := fanOut(func() ([]domain.StormHazardItem, error) { return h.mlitClient.FetchStormHazard(ctx, z, x, y) })
+	tsuCh := fanOut(func() ([]domain.TsunamiHazardItem, error) { return h.mlitClient.FetchTsunamiHazard(ctx, z, x, y) })
+	lanCh := fanOut(func() ([]domain.LandslideHazardItem, error) { return h.mlitClient.FetchLandslideHazard(ctx, z, x, y) })
+
+	centerLat, centerLng := mlit.TileToLatLng(x, y, z)
+	prefCode := domain.PrefCodeFromLatLng(centerLat, centerLng)
+	type landResult struct {
+		stats domain.LandPriceStats
+		err   error
+	}
+	recentLandCh := make(chan landResult, 1)
+	oldLandCh := make(chan landResult, 1)
+	if prefCode != "" {
+		go func() {
+			tx, e := h.mlitClient.FetchLandPrices(ctx, mlit.LandPriceQuery{Area: prefCode, Year: 2023, Quarter: 1, ToYear: 2024, ToQuarter: 4})
+			recentLandCh <- landResult{domain.CalcLandPriceStats(ctx, tx), e}
+		}()
+		go func() {
+			tx, e := h.mlitClient.FetchLandPrices(ctx, mlit.LandPriceQuery{Area: prefCode, Year: 2021, Quarter: 1, ToYear: 2022, ToQuarter: 4})
+			oldLandCh <- landResult{domain.CalcLandPriceStats(ctx, tx), e}
+		}()
+	} else {
+		recentLandCh <- landResult{}
+		oldLandCh <- landResult{}
+	}
+
+	input := domain.InvestmentScoreInput{}
+
+	if r := <-popCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchPopulationForecast failed", "error", r.err)
+	} else {
+		input.PopulationItems = r.data
+	}
+	if r := <-ridCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchStationRidership failed", "error", r.err)
+	} else {
+		input.StationRiderships = make([]domain.StationRidershipResult, 0, len(r.data))
+		for _, s := range r.data {
+			score := domain.CalcRidershipDemandScore(s.Passengers)
+			input.StationRiderships = append(input.StationRiderships, domain.StationRidershipResult{
+				StationName: s.StationName,
+				LineName:    s.LineName,
+				Passengers:  s.Passengers,
+				DemandScore: score,
+				Correction:  domain.RidershipCorrectionFactor(score),
+			})
+		}
+	}
+	if r := <-locCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchLocationOptimization failed", "error", r.err)
+	} else {
+		input.LocationItems = r.data
+	}
+	if r := <-embCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchEmbankment failed", "error", r.err)
+	} else {
+		input.EmbankmentItems = r.data
+	}
+	if r := <-disCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchDisasterHistory failed", "error", r.err)
+	} else {
+		input.DisasterItems = r.data
+	}
+	if r := <-zonCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchUrbanZoning failed", "error", r.err)
+	} else {
+		input.UrbanZoningItems = r.data
+	}
+	if r := <-liqCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchLiquefaction failed", "error", r.err)
+	} else {
+		input.LiquefactionItems = r.data
+	}
+	if r := <-floCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchFloodHazard failed", "error", r.err)
+	} else {
+		input.FloodItems = r.data
+	}
+	if r := <-stoCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchStormHazard failed", "error", r.err)
+	} else {
+		input.StormItems = r.data
+	}
+	if r := <-tsuCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchTsunamiHazard failed", "error", r.err)
+	} else {
+		input.TsunamiItems = r.data
+	}
+	if r := <-lanCh; r.err != nil {
+		slog.WarnContext(ctx, "FetchLandslideHazard failed", "error", r.err)
+	} else {
+		input.LandslideItems = r.data
+	}
+
+	recentLand := <-recentLandCh
+	oldLand := <-oldLandCh
+	if recentLand.err != nil || oldLand.err != nil {
+		if recentLand.err != nil {
+			slog.WarnContext(ctx, "FetchLandPrices (recent) failed", "error", recentLand.err)
+		}
+		if oldLand.err != nil {
+			slog.WarnContext(ctx, "FetchLandPrices (old) failed", "error", oldLand.err)
+		}
+	} else if recentLand.stats.MedianTsubo > 0 && oldLand.stats.MedianTsubo > 0 {
+		input.LandPriceChangeRate = (recentLand.stats.MedianTsubo - oldLand.stats.MedianTsubo) / oldLand.stats.MedianTsubo
+		input.HasLandPriceTrend = true
+	}
+
+	return domain.CalcInvestmentScore(input), nil
+}
+
+// GetInvestmentScore は物件の緯度経度から投資適地スコアを算出して返す
+// @Summary     投資適地スコア
+// @Tags        location
+// @Produce     json
+// @Param       lat  query  number  true  "緯度 (日本国内 20-46)"
+// @Param       lng  query  number  true  "経度 (日本国内 122-154)"
+// @Success     200  {object}  domain.InvestmentScoreResult
+// @Failure     400  {object}  map[string]string
+// @Failure     500  {object}  map[string]string
+// @Router      /api/investment-score [get]
+func (h *Handler) GetInvestmentScore(c *gin.Context) {
+	lat, lng, ok := parseLatLng(c, coordsJapanOnly)
+	if !ok {
+		return
+	}
+
+	ctx := c.Request.Context()
+	z := 14
+	x, y := mlit.LatLngToTile(lat, lng, z)
+
+	score, err := h.calcScoreForTile(ctx, z, x, y)
+	if err != nil {
+		slog.ErrorContext(ctx, "calcScoreForTile failed", "err", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "投資スコアの計算に失敗しました"})
+		return
+	}
+	c.JSON(http.StatusOK, score)
+}
+
+const maxHeatmapTiles = 50
+
+// GetInvestmentScoreHeatmap はバウンディングボックス内の全タイルに対して投資スコアを並列計算して返す
+// @Summary     投資スコアヒートマップ
+// @Tags        location
+// @Produce     json
+// @Param       minLat  query  number   true  "南端緯度"
+// @Param       maxLat  query  number   true  "北端緯度"
+// @Param       minLng  query  number   true  "西端経度"
+// @Param       maxLng  query  number   true  "東端経度"
+// @Param       z       query  integer  false "ズームレベル (11-15, デフォルト: 13)"
+// @Success     200  {object}  domain.HeatmapResponse
+// @Failure     400  {object}  map[string]string
+// @Failure     500  {object}  map[string]string
+// @Router      /api/investment-score-heatmap [get]
+func (h *Handler) GetInvestmentScoreHeatmap(c *gin.Context) {
+	minLatStr := c.Query("minLat")
+	maxLatStr := c.Query("maxLat")
+	minLngStr := c.Query("minLng")
+	maxLngStr := c.Query("maxLng")
+	if minLatStr == "" || maxLatStr == "" || minLngStr == "" || maxLngStr == "" {
+		badRequest(c, "minLat, maxLat, minLng, maxLng は必須パラメータです")
+		return
+	}
+	minLat, err := strconv.ParseFloat(minLatStr, 64)
+	if err != nil {
+		badRequest(c, "minLat の値が不正です")
+		return
+	}
+	maxLat, err := strconv.ParseFloat(maxLatStr, 64)
+	if err != nil {
+		badRequest(c, "maxLat の値が不正です")
+		return
+	}
+	minLng, err := strconv.ParseFloat(minLngStr, 64)
+	if err != nil {
+		badRequest(c, "minLng の値が不正です")
+		return
+	}
+	maxLng, err := strconv.ParseFloat(maxLngStr, 64)
+	if err != nil {
+		badRequest(c, "maxLng の値が不正です")
+		return
+	}
+
+	if minLat >= maxLat {
+		badRequest(c, "minLat は maxLat より小さい値を指定してください")
+		return
+	}
+	if minLng >= maxLng {
+		badRequest(c, "minLng は maxLng より小さい値を指定してください")
+		return
+	}
+	if minLat < 20 || maxLat > 46 {
+		badRequest(c, "緯度は日本国内（20〜46）の範囲で指定してください")
+		return
+	}
+	if minLng < 122 || maxLng > 154 {
+		badRequest(c, "経度は日本国内（122〜154）の範囲で指定してください")
+		return
+	}
+
+	z, ok := parseZoom(c, 13)
+	if !ok {
+		return
+	}
+
+	var maxTiles int
+	switch {
+	case z <= 12:
+		maxTiles = 20
+	case z <= 14:
+		maxTiles = 30
+	default:
+		maxTiles = maxHeatmapTiles
+	}
+
+	xMin, yMin := mlit.LatLngToTile(maxLat, minLng, z)
+	xMax, yMax := mlit.LatLngToTile(minLat, maxLng, z)
+
+	tileCount := (xMax - xMin + 1) * (yMax - yMin + 1)
+	if tileCount > maxTiles {
+		badRequest(c, fmt.Sprintf("too many tiles: max %d for zoom level %d", maxTiles, z))
+		return
+	}
+
+	ctx := c.Request.Context()
+
+	sem := make(chan struct{}, 5)
+	type tileResult struct {
+		tile domain.HeatmapTile
+		err  error
+	}
+	results := make(chan tileResult, tileCount)
+
+	for tx := xMin; tx <= xMax; tx++ {
+		for ty := yMin; ty <= yMax; ty++ {
+			go func(tx, ty int) {
+				defer func() {
+					if r := recover(); r != nil {
+						results <- tileResult{err: fmt.Errorf("panic in calcScoreForTile: %v", r)}
+					}
+				}()
+				select {
+				case <-ctx.Done():
+					results <- tileResult{err: ctx.Err()}
+					return
+				case sem <- struct{}{}:
+				}
+				defer func() { <-sem }()
+				score, err := h.calcScoreForTile(ctx, z, tx, ty)
+				if err != nil {
+					results <- tileResult{err: err}
+					return
+				}
+				lat, lng := mlit.TileToLatLng(tx, ty, z)
+				results <- tileResult{tile: domain.HeatmapTile{
+					X:          tx,
+					Y:          ty,
+					Z:          z,
+					CenterLat:  lat,
+					CenterLng:  lng,
+					TotalScore: score.TotalScore,
+					Grade:      score.Grade,
+				}}
+			}(tx, ty)
+		}
+	}
+
+	tiles := make([]domain.HeatmapTile, 0, tileCount)
+	for i := 0; i < tileCount; i++ {
+		r := <-results
+		if r.err != nil {
+			slog.WarnContext(ctx, "calcScoreForTile failed", "error", r.err)
+			continue
+		}
+		tiles = append(tiles, r.tile)
+	}
+
+	c.JSON(http.StatusOK, domain.HeatmapResponse{
+		Tiles:     tiles,
+		TileCount: len(tiles),
+	})
 }


### PR DESCRIPTION
## 概要

- PR #710 が \`location_handler.go\` から \`GetUrbanRisks\`・\`GetHazardInfo\`・\`calcScoreForTile\`・\`GetInvestmentScore\`・\`GetInvestmentScoreHeatmap\` を「重複」として削除したが、移動先の \`score_handler.go\` / \`risk_handler.go\` は実際には存在しなかった
- 同 PR が \`handler_test.go\` に存在しない \`internal/service\` パッケージのインポートを追加し、\`newTestRouter\` のシグネチャを壊した
- 結果として \`router.go\` が参照するハンドラーメソッドが未定義となり、swagger.json スキーマドリフト（CI fail）と、swagger チェックを通過した場合に露呈するコンパイルエラーの二重障害が発生

## 変更内容

- \`backend/internal/api/location_handler.go\`: 削除された5メソッドを swag アノテーションごと復元
- \`backend/internal/api/handler_test.go\`: 壊れた \`internal/service\` インポートを除去し、\`newTestRouter\` を元のシグネチャに戻す
- \`GetInvestmentScoreHeatmap\`: goroutine 内の defer 順序を修正（semaphore リーク対策）
- \`GetInvestmentScoreHeatmap\`: zoom レベルの switch を明示的な \`switch z\` 形式に変更

## 確認事項

- [x] \`go build ./...\` 通過
- [x] \`go test -race ./...\` 全通過
- [x] \`make swagger && git diff --exit-code docs/openapi/swagger.json\` ドリフトなし（swagger.json 変更なし）
- [x] pre-push hook（frontend vitest 376件 / backend go test 全件）通過