### PR TITLE
fix(backend/frontend): ヒートマップのタイル取得失敗をユーザーに伝える (#680)

### DIFF
--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -2179,6 +2179,37 @@ func TestGetInvestmentScoreHeatmap_Success(t *testing.T) {
 	if resp.TileCount != len(resp.Tiles) {
 		t.Errorf("tileCount=%d does not match len(tiles)=%d", resp.TileCount, len(resp.Tiles))
 	}
+	if resp.FailedTiles != 0 {
+		t.Errorf("expected FailedTiles=0 on success, got %d", resp.FailedTiles)
+	}
+}
+
+func TestGetInvestmentScoreHeatmap_PartialFailure(t *testing.T) {
+	locSvc := &mockLocationService{
+		calcScoreFunc: func(_ context.Context, _, _, _ int) (domain.InvestmentScoreResult, error) {
+			return domain.InvestmentScoreResult{}, errors.New("MLIT API error")
+		},
+	}
+	r := newTestRouter(&mockMLITClient{}, nil, locSvc)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/investment-score-heatmap?minLat=35.60&maxLat=35.70&minLng=139.60&maxLng=139.70&z=11",
+		nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 even when tiles fail, got %d", w.Code)
+	}
+	var resp domain.HeatmapResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.FailedTiles == 0 {
+		t.Error("expected FailedTiles > 0 when all tile calculations fail")
+	}
+	if len(resp.Tiles) != 0 {
+		t.Errorf("expected empty tiles on full failure, got %d", len(resp.Tiles))
+	}
 }
 
 func TestGetInvestmentScoreHeatmap_TooManyTiles(t *testing.T) {

--- a/backend/internal/api/score_handler.go
+++ b/backend/internal/api/score_handler.go
@@ -175,17 +175,20 @@ func (h *Handler) GetInvestmentScoreHeatmap(c *gin.Context) {
 	}
 
 	tiles := make([]domain.HeatmapTile, 0, tileCount)
+	failedTiles := 0
 	for i := 0; i < tileCount; i++ {
 		r := <-results
 		if r.err != nil {
 			slog.WarnContext(ctx, "CalcScoreForTile failed", "error", r.err)
+			failedTiles++
 			continue
 		}
 		tiles = append(tiles, r.tile)
 	}
 
 	c.JSON(http.StatusOK, domain.HeatmapResponse{
-		Tiles:     tiles,
-		TileCount: len(tiles),
+		Tiles:       tiles,
+		TileCount:   len(tiles),
+		FailedTiles: failedTiles,
 	})
 }

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -678,8 +678,9 @@ type HeatmapTile struct {
 
 // HeatmapResponse はヒートマップエンドポイントのレスポンス
 type HeatmapResponse struct {
-	Tiles     []HeatmapTile `json:"tiles"`
-	TileCount int           `json:"tileCount"`
+	Tiles       []HeatmapTile `json:"tiles"`
+	TileCount   int           `json:"tileCount"`
+	FailedTiles int           `json:"failedTiles"`
 }
 
 // AreaDiscoveryItem は市区町村ごとの投資適性サマリー

--- a/docs/openapi/swagger.json
+++ b/docs/openapi/swagger.json
@@ -1340,6 +1340,9 @@
         "domain.HeatmapResponse": {
             "type": "object",
             "properties": {
+                "failedTiles": {
+                    "type": "integer"
+                },
                 "tileCount": {
                     "type": "integer"
                 },

--- a/frontend/src/components/InvestmentScoreHeatmap.tsx
+++ b/frontend/src/components/InvestmentScoreHeatmap.tsx
@@ -2,7 +2,9 @@
 
 import { useCallback, useState } from "react";
 import { MapContainer, TileLayer, Rectangle, Tooltip, useMapEvents } from "react-leaflet";
+import { AlertTriangle } from "lucide-react";
 import { fetchInvestmentScoreHeatmap } from "@/lib/api";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import type { HeatmapTile } from "@/types/investment";
 
 function scoreToColor(score: number): string {
@@ -81,13 +83,16 @@ export default function InvestmentScoreHeatmap({
   const [tiles, setTiles] = useState<HeatmapTile[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [failedTiles, setFailedTiles] = useState(0);
 
   const handleAnalyze = useCallback(async (bounds: AnalyzeBounds) => {
     setLoading(true);
     setError(null);
+    setFailedTiles(0);
     try {
       const data = await fetchInvestmentScoreHeatmap(bounds);
       setTiles(data.tiles);
+      setFailedTiles(data.failedTiles ?? 0);
     } catch (e) {
       setError(e instanceof Error ? e.message : "取得失敗");
     } finally {
@@ -102,6 +107,17 @@ export default function InvestmentScoreHeatmap({
         スコアは需要・安全性の評価です。表面利回りとは別軸の指標です。
       </p>
       {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
+      {failedTiles > 0 &&
+        tiles.length + failedTiles > 0 &&
+        failedTiles / (tiles.length + failedTiles) > 0.5 && (
+          <Alert className="mb-3">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription className="text-xs">
+              一部のエリアデータを取得できませんでした（{failedTiles} タイル失敗）。
+              表示されているスコアは部分的な結果です。
+            </AlertDescription>
+          </Alert>
+        )}
       <div style={{ height: 480 }}>
         <MapContainer
           center={[centerLat, centerLng]}

--- a/frontend/src/components/InvestmentScoreHeatmap.tsx
+++ b/frontend/src/components/InvestmentScoreHeatmap.tsx
@@ -107,17 +107,15 @@ export default function InvestmentScoreHeatmap({
         スコアは需要・安全性の評価です。表面利回りとは別軸の指標です。
       </p>
       {error && <p className="text-red-500 text-sm mb-2">{error}</p>}
-      {failedTiles > 0 &&
-        tiles.length + failedTiles > 0 &&
-        failedTiles / (tiles.length + failedTiles) > 0.5 && (
-          <Alert className="mb-3">
-            <AlertTriangle className="h-4 w-4" />
-            <AlertDescription className="text-xs">
-              一部のエリアデータを取得できませんでした（{failedTiles} タイル失敗）。
-              表示されているスコアは部分的な結果です。
-            </AlertDescription>
-          </Alert>
-        )}
+      {failedTiles > 0 && failedTiles / (tiles.length + failedTiles) > 0.5 && (
+        <Alert className="mb-3">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription className="text-xs">
+            一部のエリアデータを取得できませんでした（{failedTiles} タイル失敗）。
+            表示されているスコアは部分的な結果です。
+          </AlertDescription>
+        </Alert>
+      )}
       <div style={{ height: 480 }}>
         <MapContainer
           center={[centerLat, centerLng]}

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -495,6 +495,7 @@ export interface HeatmapTile {
 export interface HeatmapResponse {
   tiles: HeatmapTile[];
   tileCount: number;
+  failedTiles?: number;
 }
 
 export type WatchlistStatus = "検討中" | "見送り" | "購入済み";


### PR DESCRIPTION
## 概要

ヒートマップでタイル取得が失敗しても `slog.Warn` のみで HTTP 200 を返しており、ユーザーには地図が欠けている理由が分からない問題を修正する。

## 変更内容

### Backend

- `domain.HeatmapResponse` に `FailedTiles int` フィールドを追加
- `GetInvestmentScoreHeatmap` でタイル失敗数をカウントし、レスポンスに含める
- `docs/openapi/swagger.json` を再生成（`failedTiles` フィールド追加）

### Frontend

- `HeatmapResponse` 型に `failedTiles?: number` を追加（`types/investment.ts`）
- 失敗率が 50% 超の場合に `<Alert>` 警告バナーを表示（`InvestmentScoreHeatmap.tsx`）
  - アイコン (`AlertTriangle`) + テキストで WCAG 1.4.1 準拠

## 完了の定義確認

- [x] `go test -race ./...` PASS
- [x] `npm test` PASS（33 suites / 376 tests）
- [x] pre-commit フック（Prettier・lint・tsc・go-lint）PASS
- [x] pre-push フック（vitest + go test）PASS

Closes #680
Parent: #667