### PR TITLE
feat(backend/frontend): 給与所得との損益通算・個人/法人税負担比較シミュレーションを追加

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -81,6 +81,7 @@ func Analyze(ctx context.Context, input InvestmentInput) InvestmentResult {
 		exitSalePrice, sim.accumulatedDepreciation)
 
 	multiExit := calcMultiExitComparison(input, sim.yearlyResults, yp.miscExpenses)
+	taxSim := CalcTaxSimulation(input, sim.yearlyResults, exitCapGain)
 
 	return InvestmentResult{
 		TotalInvestment:       yp.totalInvestment,
@@ -108,6 +109,7 @@ func Analyze(ctx context.Context, input InvestmentInput) InvestmentResult {
 		NPV:                   irrNPV.npv,
 		TotalInterest:         sim.totalInterest,
 		MultiExitComparison:   multiExit,
+		TaxSimulation:         taxSim,
 	}
 }
 

--- a/backend/internal/domain/tax.go
+++ b/backend/internal/domain/tax.go
@@ -119,7 +119,6 @@ func CalcTaxSimulation(input InvestmentInput, yearly []YearlyResult, exitCapital
 			RETaxableIncome: yr.TaxableIncome,
 			CombinedIncome:  combinedTaxable,
 			CombinedTax:     combinedTax,
-			BaselineTax:     baselineTax,
 			TaxDifference:   diff,
 		}
 	}
@@ -144,12 +143,16 @@ func CalcTaxSimulation(input InvestmentInput, yearly []YearlyResult, exitCapital
 		}
 	}
 
-	// 売却時の譲渡税
-	indivTransferTax := exitCapitalGain * longTermTransferTaxRate
-	if holdingYears <= 5 {
-		indivTransferTax = exitCapitalGain * shortTermTransferTaxRate
+	// 売却時の譲渡税（譲渡損の場合は課税なし）
+	var indivTransferTax, corpTransferTax float64
+	if exitCapitalGain > 0 {
+		if holdingYears <= 5 {
+			indivTransferTax = exitCapitalGain * shortTermTransferTaxRate
+		} else {
+			indivTransferTax = exitCapitalGain * longTermTransferTaxRate
+		}
+		corpTransferTax = exitCapitalGain * corporateEffectiveRate
 	}
-	corpTransferTax := exitCapitalGain * corporateEffectiveRate
 
 	indivCumul := makeCumulative(indivAnnual, indivTransferTax)
 	corpCumul := makeCumulative(corpAnnual, corpTransferTax)

--- a/backend/internal/domain/tax.go
+++ b/backend/internal/domain/tax.go
@@ -1,0 +1,215 @@
+package domain
+
+import "math"
+
+// 所得税累進ブラケット（所得税法89条、2023年以降）
+// rate: 国税所得税率, deduction: 控除額（円）
+var incomeTaxBrackets = []struct {
+	limit     float64
+	rate      float64
+	deduction float64
+}{
+	{1_950_000, 0.05, 0},
+	{3_300_000, 0.10, 97_500},
+	{6_950_000, 0.20, 427_500},
+	{9_000_000, 0.23, 636_000},
+	{18_000_000, 0.33, 1_536_000},
+	{40_000_000, 0.40, 2_796_000},
+	{math.MaxFloat64, 0.45, 4_796_000},
+}
+
+// corporateEffectiveRate は小規模法人（資本金1億円未満）の概算実効税率。
+// 内訳: 法人税15%/23.2% + 地方法人税10.3% + 住民税7% + 事業税3.5% の合算概算。
+const corporateEffectiveRate = 0.334
+
+// calcIncomeTax は課税所得に対する国税所得税額を返す（住民税10%・復興特別税2.1%は含まない）。
+// 課税所得が0以下のときは0を返す。
+func calcIncomeTax(taxableIncome float64) float64 {
+	if taxableIncome <= 0 {
+		return 0
+	}
+	for _, b := range incomeTaxBrackets {
+		if taxableIncome <= b.limit {
+			return taxableIncome*b.rate - b.deduction
+		}
+	}
+	return taxableIncome*0.45 - 4_796_000
+}
+
+// calcTotalTax は課税所得に対する合算税額（所得税＋住民税10%＋復興特別税2.1%）を返す。
+// 損益通算で課税所得が負になった場合は0を返す（還付は行政手続きを経るが概算では0扱い）。
+func calcTotalTax(taxableIncome float64) float64 {
+	if taxableIncome <= 0 {
+		return 0
+	}
+	incomeTax := calcIncomeTax(taxableIncome)
+	// 復興特別所得税: 所得税 × 2.1%
+	reconstructionTax := incomeTax * 0.021
+	// 住民税: 課税所得 × 10%
+	residentTax := taxableIncome * 0.10
+	return incomeTax + reconstructionTax + residentTax
+}
+
+// calcSalaryDeduction は給与所得控除額を返す（所得税法28条、2020年以降）。
+func calcSalaryDeduction(salary float64) float64 {
+	switch {
+	case salary <= 1_625_000:
+		return 550_000
+	case salary <= 1_800_000:
+		return salary*0.40 - 100_000
+	case salary <= 3_600_000:
+		return salary*0.30 + 80_000
+	case salary <= 6_600_000:
+		return salary*0.20 + 440_000
+	case salary <= 8_500_000:
+		return salary*0.10 + 1_100_000
+	default:
+		return 1_950_000
+	}
+}
+
+// calcSalaryTaxableIncome は給与年収から給与所得控除・基礎控除を差し引いた課税所得を返す。
+// 基礎控除は48万円（所得税法86条、2020年以降・所得2,400万円以下の場合）。
+func calcSalaryTaxableIncome(salary float64) float64 {
+	deduction := calcSalaryDeduction(salary)
+	const basicDeduction = 480_000
+	taxable := salary - deduction - basicDeduction
+	if taxable < 0 {
+		return 0
+	}
+	return taxable
+}
+
+// CalcTaxSimulation は給与年収を元に損益通算と個人/法人比較を算出する。
+// input.SalaryIncome == 0 のときは nil を返す。
+// exitCapitalGain は売却時の譲渡所得（exit.go の calcExit から取得）。
+func CalcTaxSimulation(input InvestmentInput, yearly []YearlyResult, exitCapitalGain float64) *TaxSimulationResult {
+	if input.SalaryIncome <= 0 {
+		return nil
+	}
+
+	holdingYears := input.HoldingYears
+	if holdingYears <= 0 {
+		holdingYears = 10
+	}
+	if holdingYears > len(yearly) {
+		holdingYears = len(yearly)
+	}
+
+	salaryTaxable := calcSalaryTaxableIncome(input.SalaryIncome)
+	baselineTax := calcTotalTax(salaryTaxable)
+
+	// --- 損益通算シミュレーション (#399) ---
+	rows := make([]TaxSimRow, holdingYears)
+	var totalTaxSaving float64
+
+	for i := 0; i < holdingYears; i++ {
+		yr := yearly[i]
+		// 合算課税所得: 給与課税所得 + 不動産課税所得（負なら損益通算で圧縮）
+		combinedTaxable := salaryTaxable + yr.TaxableIncome
+		if combinedTaxable < 0 {
+			combinedTaxable = 0
+		}
+		combinedTax := calcTotalTax(combinedTaxable)
+		diff := baselineTax - combinedTax // 正=節税、負=増税
+		totalTaxSaving += diff
+
+		rows[i] = TaxSimRow{
+			Year:            yr.Year,
+			RETaxableIncome: yr.TaxableIncome,
+			CombinedIncome:  combinedTaxable,
+			CombinedTax:     combinedTax,
+			BaselineTax:     baselineTax,
+			TaxDifference:   diff,
+		}
+	}
+
+	// --- 個人 vs 法人比較 (#392) ---
+	indivAnnual := make([]float64, holdingYears)
+	corpAnnual := make([]float64, holdingYears)
+
+	for i := 0; i < holdingYears; i++ {
+		reTaxable := yearly[i].TaxableIncome
+
+		// 個人: 給与+不動産の合算から「給与のみ」を引いた差分を不動産帰属税とみなす
+		combinedTaxable := salaryTaxable + reTaxable
+		if combinedTaxable < 0 {
+			combinedTaxable = 0
+		}
+		indivAnnual[i] = calcTotalTax(combinedTaxable) - baselineTax
+
+		// 法人: 不動産課税所得に法人実効税率（負なら0、繰越控除の簡易近似）
+		if reTaxable > 0 {
+			corpAnnual[i] = reTaxable * corporateEffectiveRate
+		}
+	}
+
+	// 売却時の譲渡税
+	indivTransferTax := exitCapitalGain * longTermTransferTaxRate
+	if holdingYears <= 5 {
+		indivTransferTax = exitCapitalGain * shortTermTransferTaxRate
+	}
+	corpTransferTax := exitCapitalGain * corporateEffectiveRate
+
+	indivCumul := makeCumulative(indivAnnual, indivTransferTax)
+	corpCumul := makeCumulative(corpAnnual, corpTransferTax)
+
+	breakevenYear := -1
+	for i := 0; i < holdingYears; i++ {
+		if corpCumul[i] < indivCumul[i] {
+			breakevenYear = i + 1
+			break
+		}
+	}
+
+	indivTotal := sum(indivAnnual) + indivTransferTax
+	corpTotal := sum(corpAnnual) + corpTransferTax
+
+	return &TaxSimulationResult{
+		SalaryLossCarryover: SalaryLossCarryoverResult{
+			SalaryIncomeYen:   input.SalaryIncome,
+			BaselineSalaryTax: baselineTax,
+			YearlyRows:        rows,
+			TotalTaxSaving:    totalTaxSaving,
+		},
+		OwnershipComparison: OwnershipComparisonResult{
+			Individual: OwnershipScenario{
+				Label:            "個人",
+				AnnualTax:        indivAnnual,
+				TransferTax:      indivTransferTax,
+				TotalTaxBurden:   indivTotal,
+				CumulativeBurden: indivCumul,
+			},
+			Corporate: OwnershipScenario{
+				Label:            "法人",
+				AnnualTax:        corpAnnual,
+				TransferTax:      corpTransferTax,
+				TotalTaxBurden:   corpTotal,
+				CumulativeBurden: corpCumul,
+			},
+			BreakevenYear: breakevenYear,
+		},
+	}
+}
+
+func makeCumulative(annual []float64, transferTax float64) []float64 {
+	cumul := make([]float64, len(annual))
+	running := 0.0
+	for i, v := range annual {
+		running += v
+		cumul[i] = running
+	}
+	// 最終年に譲渡税を加算
+	if len(cumul) > 0 {
+		cumul[len(cumul)-1] += transferTax
+	}
+	return cumul
+}
+
+func sum(vals []float64) float64 {
+	total := 0.0
+	for _, v := range vals {
+		total += v
+	}
+	return total
+}

--- a/backend/internal/domain/tax_test.go
+++ b/backend/internal/domain/tax_test.go
@@ -1,15 +1,10 @@
 package domain
 
 import (
-	"math"
 	"testing"
 )
 
 const taxEpsilon = 1.0 // 1円単位の誤差を許容
-
-func approxEqualTax(a, b, eps float64) bool {
-	return math.Abs(a-b) <= eps
-}
 
 func TestCalcIncomeTax(t *testing.T) {
 	tests := []struct {
@@ -31,7 +26,7 @@ func TestCalcIncomeTax(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := calcIncomeTax(tt.taxable)
-			if !approxEqualTax(got, tt.wantApprox, taxEpsilon) {
+			if !approxEqual(got, tt.wantApprox, taxEpsilon) {
 				t.Errorf("calcIncomeTax(%.0f) = %.0f, want %.0f", tt.taxable, got, tt.wantApprox)
 			}
 		})
@@ -55,7 +50,7 @@ func TestCalcSalaryDeduction(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := calcSalaryDeduction(tt.salary)
-			if !approxEqualTax(got, tt.wantApprox, taxEpsilon) {
+			if !approxEqual(got, tt.wantApprox, taxEpsilon) {
 				t.Errorf("calcSalaryDeduction(%.0f) = %.0f, want %.0f", tt.salary, got, tt.wantApprox)
 			}
 		})
@@ -164,5 +159,37 @@ func TestCalcTaxSimulation_LowIncomeNeverBreakeven(t *testing.T) {
 	// 低所得者は法人税率(33.4%) > 個人実効税率(15%程度)なので法人不利
 	if cmp.BreakevenYear != -1 {
 		t.Errorf("低年収(300万)では法人有利年は -1 であるべき、got %d", cmp.BreakevenYear)
+	}
+}
+
+func TestCalcTaxSimulation_NegativeExitCapitalGain(t *testing.T) {
+	// 譲渡損（exitCapitalGain < 0）のとき TransferTax が 0 になること
+	yearly := []YearlyResult{
+		{Year: 1, TaxableIncome: 100_000},
+	}
+	input := InvestmentInput{
+		SalaryIncome: 6_000_000,
+		HoldingYears: 1,
+	}
+
+	result := CalcTaxSimulation(input, yearly, -500_000)
+	if result == nil {
+		t.Fatal("結果が nil")
+	}
+
+	indiv := result.OwnershipComparison.Individual
+	corp := result.OwnershipComparison.Corporate
+
+	if indiv.TransferTax != 0 {
+		t.Errorf("譲渡損のとき個人 TransferTax = 0 を期待、got %.0f", indiv.TransferTax)
+	}
+	if corp.TransferTax != 0 {
+		t.Errorf("譲渡損のとき法人 TransferTax = 0 を期待、got %.0f", corp.TransferTax)
+	}
+	if indiv.TotalTaxBurden < 0 {
+		t.Errorf("個人 TotalTaxBurden が負になってはいけない、got %.0f", indiv.TotalTaxBurden)
+	}
+	if corp.TotalTaxBurden < 0 {
+		t.Errorf("法人 TotalTaxBurden が負になってはいけない、got %.0f", corp.TotalTaxBurden)
 	}
 }

--- a/backend/internal/domain/tax_test.go
+++ b/backend/internal/domain/tax_test.go
@@ -1,0 +1,168 @@
+package domain
+
+import (
+	"math"
+	"testing"
+)
+
+const taxEpsilon = 1.0 // 1円単位の誤差を許容
+
+func approxEqualTax(a, b, eps float64) bool {
+	return math.Abs(a-b) <= eps
+}
+
+func TestCalcIncomeTax(t *testing.T) {
+	tests := []struct {
+		name        string
+		taxable     float64
+		wantApprox  float64
+	}{
+		{"ゼロ", 0, 0},
+		{"負の課税所得", -500_000, 0},
+		{"195万以下(5%)", 1_000_000, 50_000},
+		{"330万以下(10%)", 2_000_000, 102_500},
+		{"695万以下(20%)", 5_000_000, 572_500},
+		{"900万以下(23%)", 8_000_000, 1_204_000},
+		{"1800万以下(33%)", 12_000_000, 2_424_000},
+		{"4000万以下(40%)", 20_000_000, 5_204_000},
+		{"4000万超(45%)", 50_000_000, 17_704_000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calcIncomeTax(tt.taxable)
+			if !approxEqualTax(got, tt.wantApprox, taxEpsilon) {
+				t.Errorf("calcIncomeTax(%.0f) = %.0f, want %.0f", tt.taxable, got, tt.wantApprox)
+			}
+		})
+	}
+}
+
+func TestCalcSalaryDeduction(t *testing.T) {
+	tests := []struct {
+		name       string
+		salary     float64
+		wantApprox float64
+	}{
+		{"162.5万以下", 1_500_000, 550_000},
+		{"180万以下", 1_700_000, 580_000},       // 1700000*0.4-100000
+		{"360万以下", 3_000_000, 980_000},       // 3000000*0.3+80000
+		{"660万以下", 6_000_000, 1_640_000},     // 6000000*0.2+440000
+		{"850万以下", 8_000_000, 1_900_000},     // 8000000*0.1+1100000
+		{"850万超", 10_000_000, 1_950_000},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calcSalaryDeduction(tt.salary)
+			if !approxEqualTax(got, tt.wantApprox, taxEpsilon) {
+				t.Errorf("calcSalaryDeduction(%.0f) = %.0f, want %.0f", tt.salary, got, tt.wantApprox)
+			}
+		})
+	}
+}
+
+func TestCalcTaxSimulation_NilWhenNoSalary(t *testing.T) {
+	input := InvestmentInput{SalaryIncome: 0, HoldingYears: 10}
+	result := CalcTaxSimulation(input, []YearlyResult{}, 0)
+	if result != nil {
+		t.Error("SalaryIncome=0のとき nil を返すべき")
+	}
+}
+
+func TestCalcTaxSimulation_LossCarryover(t *testing.T) {
+	// 年収600万円の投資家が減価償却で不動産所得が赤字の年に節税が発生すること
+	salary := 6_000_000.0
+	// 課税所得: 6000000 - 1640000(控除) - 480000(基礎) = 3880000
+	// 税額(概算): 3880000*0.20 - 427500 + 3880000*0.021 + 3880000*0.10
+
+	yearly := []YearlyResult{
+		{Year: 1, TaxableIncome: -500_000}, // 赤字(節税)
+		{Year: 2, TaxableIncome: 200_000},  // 黒字(増税)
+		{Year: 3, TaxableIncome: -300_000}, // 赤字(節税)
+	}
+
+	input := InvestmentInput{
+		SalaryIncome: salary,
+		HoldingYears: 3,
+	}
+
+	result := CalcTaxSimulation(input, yearly, 1_000_000)
+	if result == nil {
+		t.Fatal("SalaryIncome>0のとき non-nil を返すべき")
+	}
+
+	rows := result.SalaryLossCarryover.YearlyRows
+	if len(rows) != 3 {
+		t.Fatalf("yearlyRows の長さが 3 であるべき、got %d", len(rows))
+	}
+
+	// 赤字年は節税（TaxDifference > 0）
+	if rows[0].TaxDifference <= 0 {
+		t.Errorf("1年目(赤字): 節税額 > 0 を期待、got %.0f", rows[0].TaxDifference)
+	}
+	// 黒字年は増税（TaxDifference < 0）
+	if rows[1].TaxDifference >= 0 {
+		t.Errorf("2年目(黒字): 増税額 < 0 を期待、got %.0f", rows[1].TaxDifference)
+	}
+	// 3年目も赤字なので節税
+	if rows[2].TaxDifference <= 0 {
+		t.Errorf("3年目(赤字): 節税額 > 0 を期待、got %.0f", rows[2].TaxDifference)
+	}
+}
+
+func TestCalcTaxSimulation_OwnershipBreakeven(t *testing.T) {
+	// 高年収（2000万）で不動産黒字が続く場合、法人が有利になる年が存在すること
+	salary := 20_000_000.0 // 課税後は高い累進税率ゾーン
+
+	yearly := make([]YearlyResult, 15)
+	for i := range yearly {
+		yearly[i] = YearlyResult{Year: i + 1, TaxableIncome: 3_000_000} // 毎年黒字
+	}
+
+	input := InvestmentInput{
+		SalaryIncome: salary,
+		HoldingYears: 15,
+	}
+
+	result := CalcTaxSimulation(input, yearly, 5_000_000)
+	if result == nil {
+		t.Fatal("結果が nil")
+	}
+
+	cmp := result.OwnershipComparison
+	// 高所得者は法人税率(33.4%) < 個人実効税率(40%超)なので早期に法人が有利
+	if cmp.BreakevenYear == -1 {
+		t.Error("高年収(2000万)で法人が有利になる年が存在するはず")
+	}
+	if cmp.Corporate.TotalTaxBurden >= cmp.Individual.TotalTaxBurden {
+		t.Errorf("法人合計税負担(%.0f) < 個人(%.0f) であるべき",
+			cmp.Corporate.TotalTaxBurden, cmp.Individual.TotalTaxBurden)
+	}
+}
+
+func TestCalcTaxSimulation_LowIncomeNeverBreakeven(t *testing.T) {
+	// 低年収（300万）では個人累進税率が低く、法人化のメリットが保有期間内に出ないこと
+	salary := 3_000_000.0
+
+	yearly := make([]YearlyResult, 10)
+	for i := range yearly {
+		yearly[i] = YearlyResult{Year: i + 1, TaxableIncome: 500_000}
+	}
+
+	input := InvestmentInput{
+		SalaryIncome: salary,
+		HoldingYears: 10,
+	}
+
+	result := CalcTaxSimulation(input, yearly, 1_000_000)
+	if result == nil {
+		t.Fatal("結果が nil")
+	}
+
+	cmp := result.OwnershipComparison
+	// 低所得者は法人税率(33.4%) > 個人実効税率(15%程度)なので法人不利
+	if cmp.BreakevenYear != -1 {
+		t.Errorf("低年収(300万)では法人有利年は -1 であるべき、got %d", cmp.BreakevenYear)
+	}
+}

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -410,7 +410,6 @@ type TaxSimRow struct {
 	RETaxableIncome float64 `json:"reTaxableIncome"` // 不動産課税所得（YearlyResult.TaxableIncome）
 	CombinedIncome  float64 `json:"combinedIncome"`  // 給与+不動産 合算課税所得
 	CombinedTax     float64 `json:"combinedTax"`     // 合算後所得税
-	BaselineTax     float64 `json:"baselineTax"`     // 給与のみの所得税
 	TaxDifference   float64 `json:"taxDifference"`   // 正=節税 / 負=増税
 }
 

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -151,6 +151,9 @@ type InvestmentInput struct {
 	RestorationCost float64 `json:"restorationCost,omitempty"` // 原状回復費（円/回）例: 150000
 	AdFee           float64 `json:"adFee,omitempty"`           // 入居者募集 AD（円/回）例: 家賃1ヶ月分
 	RentFreePeriod  float64 `json:"rentFreePeriod,omitempty"`  // フリーレント（ヶ月）例: 0.5
+
+	// 税務シミュレーション用（任意）。0 の場合は損益通算・法人比較を計算しない。
+	SalaryIncome float64 `json:"salaryIncome,omitempty"` // 給与年収（円）
 }
 
 // CapexEvent は大規模修繕費の発生スケジュール1件
@@ -383,6 +386,48 @@ type InvestmentResult struct {
 	AISummary string `json:"aiSummary"` // Gemini 生成の投資サマリー（空文字 = 未生成）
 
 	MultiExitComparison []MultiExitRow `json:"multiExitComparison,omitempty"` // 複数保有年数の出口比較
+
+	TaxSimulation *TaxSimulationResult `json:"taxSimulation,omitempty"` // 損益通算・個人/法人比較（SalaryIncome>0時のみ）
+}
+
+// TaxSimulationResult は損益通算・個人/法人比較の結果
+type TaxSimulationResult struct {
+	SalaryLossCarryover SalaryLossCarryoverResult `json:"salaryLossCarryover"`
+	OwnershipComparison OwnershipComparisonResult `json:"ownershipComparison"`
+}
+
+// SalaryLossCarryoverResult は給与所得との損益通算シミュレーション（#399）
+type SalaryLossCarryoverResult struct {
+	SalaryIncomeYen   float64      `json:"salaryIncomeYen"`   // 入力給与年収（円）
+	BaselineSalaryTax float64      `json:"baselineSalaryTax"` // 不動産なし時の所得税（年額）
+	YearlyRows        []TaxSimRow  `json:"yearlyRows"`
+	TotalTaxSaving    float64      `json:"totalTaxSaving"` // 保有期間合計節税額
+}
+
+// TaxSimRow は各年の損益通算詳細
+type TaxSimRow struct {
+	Year            int     `json:"year"`
+	RETaxableIncome float64 `json:"reTaxableIncome"` // 不動産課税所得（YearlyResult.TaxableIncome）
+	CombinedIncome  float64 `json:"combinedIncome"`  // 給与+不動産 合算課税所得
+	CombinedTax     float64 `json:"combinedTax"`     // 合算後所得税
+	BaselineTax     float64 `json:"baselineTax"`     // 給与のみの所得税
+	TaxDifference   float64 `json:"taxDifference"`   // 正=節税 / 負=増税
+}
+
+// OwnershipComparisonResult は個人 vs 法人の税負担比較（#392）
+type OwnershipComparisonResult struct {
+	Individual    OwnershipScenario `json:"individual"`
+	Corporate     OwnershipScenario `json:"corporate"`
+	BreakevenYear int               `json:"breakevenYear"` // 法人が有利になる年 (-1=保有期間内に逆転なし)
+}
+
+// OwnershipScenario は保有形態別の年次税負担
+type OwnershipScenario struct {
+	Label            string    `json:"label"`
+	AnnualTax        []float64 `json:"annualTax"`        // 各年の所得税負担（保有年数分）
+	TransferTax      float64   `json:"transferTax"`      // 売却時譲渡税
+	TotalTaxBurden   float64   `json:"totalTaxBurden"`   // 保有期間合計（所得税+譲渡税）
+	CumulativeBurden []float64 `json:"cumulativeBurden"` // 累積税負担（グラフ用）
 }
 
 // AcquisitionCostBreakdown は物件取得時の諸経費内訳

--- a/docs/openapi/swagger.json
+++ b/docs/openapi/swagger.json
@@ -117,179 +117,6 @@
                 }
             }
         },
-        "/api/hazard": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "location"
-                ],
-                "summary": "ハザード情報",
-                "parameters": [
-                    {
-                        "type": "number",
-                        "description": "緯度 (日本国内 20-46)",
-                        "name": "lat",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "number",
-                        "description": "経度 (日本国内 122-154)",
-                        "name": "lng",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/domain.UrbanRisk"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/investment-score": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "location"
-                ],
-                "summary": "投資適地スコア",
-                "parameters": [
-                    {
-                        "type": "number",
-                        "description": "緯度 (日本国内 20-46)",
-                        "name": "lat",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "number",
-                        "description": "経度 (日本国内 122-154)",
-                        "name": "lng",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/domain.InvestmentScoreResult"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/api/investment-score-heatmap": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "location"
-                ],
-                "summary": "投資スコアヒートマップ",
-                "parameters": [
-                    {
-                        "type": "number",
-                        "description": "南端緯度",
-                        "name": "minLat",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "number",
-                        "description": "北端緯度",
-                        "name": "maxLat",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "number",
-                        "description": "西端経度",
-                        "name": "minLng",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "number",
-                        "description": "東端経度",
-                        "name": "maxLng",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "integer",
-                        "description": "ズームレベル (11-15, デフォルト: 13)",
-                        "name": "z",
-                        "in": "query"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "$ref": "#/definitions/domain.HeatmapResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/api/investment/analyze": {
             "post": {
                 "consumes": [
@@ -1055,53 +882,6 @@
                 }
             }
         },
-        "/api/urban-risks": {
-            "get": {
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "location"
-                ],
-                "summary": "都市計画リスク",
-                "parameters": [
-                    {
-                        "type": "number",
-                        "description": "緯度 (日本国内 20-46)",
-                        "name": "lat",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "number",
-                        "description": "経度 (日本国内 122-154)",
-                        "name": "lng",
-                        "in": "query",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "OK",
-                        "schema": {
-                            "type": "array",
-                            "items": {
-                                "$ref": "#/definitions/domain.UrbanRisk"
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
-                        }
-                    }
-                }
-            }
-        },
         "/health": {
             "get": {
                 "produces": [
@@ -1337,46 +1117,6 @@
                 "CriticalStatusWarning"
             ]
         },
-        "domain.HeatmapResponse": {
-            "type": "object",
-            "properties": {
-                "tileCount": {
-                    "type": "integer"
-                },
-                "tiles": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/domain.HeatmapTile"
-                    }
-                }
-            }
-        },
-        "domain.HeatmapTile": {
-            "type": "object",
-            "properties": {
-                "centerLat": {
-                    "type": "number"
-                },
-                "centerLng": {
-                    "type": "number"
-                },
-                "grade": {
-                    "type": "string"
-                },
-                "totalScore": {
-                    "type": "integer"
-                },
-                "x": {
-                    "type": "integer"
-                },
-                "y": {
-                    "type": "integer"
-                },
-                "z": {
-                    "type": "integer"
-                }
-            }
-        },
         "domain.HistogramBin": {
             "type": "object",
             "properties": {
@@ -1555,6 +1295,10 @@
                     "description": "原状回復費（円/回）例: 150000",
                     "type": "number"
                 },
+                "salaryIncome": {
+                    "description": "税務シミュレーション用（任意）。0 の場合は損益通算・法人比較を計算しない。",
+                    "type": "number"
+                },
                 "vacancyRate": {
                     "description": "空室率 (例: 0.05)",
                     "type": "number"
@@ -1663,6 +1407,14 @@
                         "$ref": "#/definitions/domain.StressScenarioResult"
                     }
                 },
+                "taxSimulation": {
+                    "description": "損益通算・個人/法人比較（SalaryIncome\u003e0時のみ）",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/domain.TaxSimulationResult"
+                        }
+                    ]
+                },
                 "totalInterest": {
                     "description": "保有期間の総支払利息",
                     "type": "number"
@@ -1683,21 +1435,6 @@
                 "yieldTarget": {
                     "description": "目標表面利回り（例: 0.08）",
                     "type": "number"
-                }
-            }
-        },
-        "domain.InvestmentScoreResult": {
-            "type": "object",
-            "properties": {
-                "breakdown": {
-                    "$ref": "#/definitions/domain.ScoreBreakdown"
-                },
-                "grade": {
-                    "description": "優良/良好/普通/注意/要注意",
-                    "type": "string"
-                },
-                "totalScore": {
-                    "type": "integer"
                 }
             }
         },
@@ -1931,6 +1668,51 @@
                 }
             }
         },
+        "domain.OwnershipComparisonResult": {
+            "type": "object",
+            "properties": {
+                "breakevenYear": {
+                    "description": "法人が有利になる年 (-1=保有期間内に逆転なし)",
+                    "type": "integer"
+                },
+                "corporate": {
+                    "$ref": "#/definitions/domain.OwnershipScenario"
+                },
+                "individual": {
+                    "$ref": "#/definitions/domain.OwnershipScenario"
+                }
+            }
+        },
+        "domain.OwnershipScenario": {
+            "type": "object",
+            "properties": {
+                "annualTax": {
+                    "description": "各年の所得税負担（保有年数分）",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "cumulativeBurden": {
+                    "description": "累積税負担（グラフ用）",
+                    "type": "array",
+                    "items": {
+                        "type": "number"
+                    }
+                },
+                "label": {
+                    "type": "string"
+                },
+                "totalTaxBurden": {
+                    "description": "保有期間合計（所得税+譲渡税）",
+                    "type": "number"
+                },
+                "transferTax": {
+                    "description": "売却時譲渡税",
+                    "type": "number"
+                }
+            }
+        },
         "domain.Percentiles": {
             "type": "object",
             "properties": {
@@ -1998,17 +1780,6 @@
                 "PopulationTrendSlowDecline",
                 "PopulationTrendSteepDecline"
             ]
-        },
-        "domain.RadarPoint": {
-            "type": "object",
-            "properties": {
-                "category": {
-                    "type": "string"
-                },
-                "score": {
-                    "type": "number"
-                }
-            }
         },
         "domain.RateAdjustment": {
             "type": "object",
@@ -2183,55 +1954,26 @@
                 "RidershipScoreE"
             ]
         },
-        "domain.ScoreBreakdown": {
+        "domain.SalaryLossCarryoverResult": {
             "type": "object",
             "properties": {
-                "disasterHistory": {
-                    "$ref": "#/definitions/domain.ScoreItem"
+                "baselineSalaryTax": {
+                    "description": "不動産なし時の所得税（年額）",
+                    "type": "number"
                 },
-                "embankment": {
-                    "$ref": "#/definitions/domain.ScoreItem"
+                "salaryIncomeYen": {
+                    "description": "入力給与年収（円）",
+                    "type": "number"
                 },
-                "hazardRisk": {
-                    "$ref": "#/definitions/domain.ScoreItem"
+                "totalTaxSaving": {
+                    "description": "保有期間合計節税額",
+                    "type": "number"
                 },
-                "landPriceTrend": {
-                    "$ref": "#/definitions/domain.ScoreItem"
-                },
-                "liquefactionRisk": {
-                    "$ref": "#/definitions/domain.ScoreItem"
-                },
-                "locationOptimization": {
-                    "$ref": "#/definitions/domain.ScoreItem"
-                },
-                "population": {
-                    "$ref": "#/definitions/domain.ScoreItem"
-                },
-                "radarData": {
+                "yearlyRows": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/domain.RadarPoint"
+                        "$ref": "#/definitions/domain.TaxSimRow"
                     }
-                },
-                "ridership": {
-                    "$ref": "#/definitions/domain.ScoreItem"
-                },
-                "urbanArea": {
-                    "$ref": "#/definitions/domain.ScoreItem"
-                }
-            }
-        },
-        "domain.ScoreItem": {
-            "type": "object",
-            "properties": {
-                "description": {
-                    "type": "string"
-                },
-                "label": {
-                    "type": "string"
-                },
-                "score": {
-                    "type": "integer"
                 }
             }
         },
@@ -2287,6 +2029,45 @@
                 },
                 "vacancyRateDelta": {
                     "type": "number"
+                }
+            }
+        },
+        "domain.TaxSimRow": {
+            "type": "object",
+            "properties": {
+                "baselineTax": {
+                    "description": "給与のみの所得税",
+                    "type": "number"
+                },
+                "combinedIncome": {
+                    "description": "給与+不動産 合算課税所得",
+                    "type": "number"
+                },
+                "combinedTax": {
+                    "description": "合算後所得税",
+                    "type": "number"
+                },
+                "reTaxableIncome": {
+                    "description": "不動産課税所得（YearlyResult.TaxableIncome）",
+                    "type": "number"
+                },
+                "taxDifference": {
+                    "description": "正=節税 / 負=増税",
+                    "type": "number"
+                },
+                "year": {
+                    "type": "integer"
+                }
+            }
+        },
+        "domain.TaxSimulationResult": {
+            "type": "object",
+            "properties": {
+                "ownershipComparison": {
+                    "$ref": "#/definitions/domain.OwnershipComparisonResult"
+                },
+                "salaryLossCarryover": {
+                    "$ref": "#/definitions/domain.SalaryLossCarryoverResult"
                 }
             }
         },

--- a/docs/openapi/swagger.json
+++ b/docs/openapi/swagger.json
@@ -117,6 +117,179 @@
                 }
             }
         },
+        "/api/hazard": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "location"
+                ],
+                "summary": "ハザード情報",
+                "parameters": [
+                    {
+                        "type": "number",
+                        "description": "緯度 (日本国内 20-46)",
+                        "name": "lat",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "number",
+                        "description": "経度 (日本国内 122-154)",
+                        "name": "lng",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.UrbanRisk"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/investment-score": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "location"
+                ],
+                "summary": "投資適地スコア",
+                "parameters": [
+                    {
+                        "type": "number",
+                        "description": "緯度 (日本国内 20-46)",
+                        "name": "lat",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "number",
+                        "description": "経度 (日本国内 122-154)",
+                        "name": "lng",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.InvestmentScoreResult"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/investment-score-heatmap": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "location"
+                ],
+                "summary": "投資スコアヒートマップ",
+                "parameters": [
+                    {
+                        "type": "number",
+                        "description": "南端緯度",
+                        "name": "minLat",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "number",
+                        "description": "北端緯度",
+                        "name": "maxLat",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "number",
+                        "description": "西端経度",
+                        "name": "minLng",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "number",
+                        "description": "東端経度",
+                        "name": "maxLng",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "ズームレベル (11-15, デフォルト: 13)",
+                        "name": "z",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/domain.HeatmapResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/api/investment/analyze": {
             "post": {
                 "consumes": [
@@ -882,6 +1055,53 @@
                 }
             }
         },
+        "/api/urban-risks": {
+            "get": {
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "location"
+                ],
+                "summary": "都市計画リスク",
+                "parameters": [
+                    {
+                        "type": "number",
+                        "description": "緯度 (日本国内 20-46)",
+                        "name": "lat",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "number",
+                        "description": "経度 (日本国内 122-154)",
+                        "name": "lng",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/domain.UrbanRisk"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/health": {
             "get": {
                 "produces": [
@@ -1116,6 +1336,46 @@
                 "CriticalStatusReject",
                 "CriticalStatusWarning"
             ]
+        },
+        "domain.HeatmapResponse": {
+            "type": "object",
+            "properties": {
+                "tileCount": {
+                    "type": "integer"
+                },
+                "tiles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.HeatmapTile"
+                    }
+                }
+            }
+        },
+        "domain.HeatmapTile": {
+            "type": "object",
+            "properties": {
+                "centerLat": {
+                    "type": "number"
+                },
+                "centerLng": {
+                    "type": "number"
+                },
+                "grade": {
+                    "type": "string"
+                },
+                "totalScore": {
+                    "type": "integer"
+                },
+                "x": {
+                    "type": "integer"
+                },
+                "y": {
+                    "type": "integer"
+                },
+                "z": {
+                    "type": "integer"
+                }
+            }
         },
         "domain.HistogramBin": {
             "type": "object",
@@ -1435,6 +1695,21 @@
                 "yieldTarget": {
                     "description": "目標表面利回り（例: 0.08）",
                     "type": "number"
+                }
+            }
+        },
+        "domain.InvestmentScoreResult": {
+            "type": "object",
+            "properties": {
+                "breakdown": {
+                    "$ref": "#/definitions/domain.ScoreBreakdown"
+                },
+                "grade": {
+                    "description": "優良/良好/普通/注意/要注意",
+                    "type": "string"
+                },
+                "totalScore": {
+                    "type": "integer"
                 }
             }
         },
@@ -1781,6 +2056,17 @@
                 "PopulationTrendSteepDecline"
             ]
         },
+        "domain.RadarPoint": {
+            "type": "object",
+            "properties": {
+                "category": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "number"
+                }
+            }
+        },
         "domain.RateAdjustment": {
             "type": "object",
             "properties": {
@@ -1977,6 +2263,58 @@
                 }
             }
         },
+        "domain.ScoreBreakdown": {
+            "type": "object",
+            "properties": {
+                "disasterHistory": {
+                    "$ref": "#/definitions/domain.ScoreItem"
+                },
+                "embankment": {
+                    "$ref": "#/definitions/domain.ScoreItem"
+                },
+                "hazardRisk": {
+                    "$ref": "#/definitions/domain.ScoreItem"
+                },
+                "landPriceTrend": {
+                    "$ref": "#/definitions/domain.ScoreItem"
+                },
+                "liquefactionRisk": {
+                    "$ref": "#/definitions/domain.ScoreItem"
+                },
+                "locationOptimization": {
+                    "$ref": "#/definitions/domain.ScoreItem"
+                },
+                "population": {
+                    "$ref": "#/definitions/domain.ScoreItem"
+                },
+                "radarData": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/domain.RadarPoint"
+                    }
+                },
+                "ridership": {
+                    "$ref": "#/definitions/domain.ScoreItem"
+                },
+                "urbanArea": {
+                    "$ref": "#/definitions/domain.ScoreItem"
+                }
+            }
+        },
+        "domain.ScoreItem": {
+            "type": "object",
+            "properties": {
+                "description": {
+                    "type": "string"
+                },
+                "label": {
+                    "type": "string"
+                },
+                "score": {
+                    "type": "integer"
+                }
+            }
+        },
         "domain.StationRidershipResult": {
             "type": "object",
             "properties": {
@@ -2035,10 +2373,6 @@
         "domain.TaxSimRow": {
             "type": "object",
             "properties": {
-                "baselineTax": {
-                    "description": "給与のみの所得税",
-                    "type": "number"
-                },
                 "combinedIncome": {
                     "description": "給与+不動産 合算課税所得",
                     "type": "number"

--- a/frontend/src/components/ResultsSection.tsx
+++ b/frontend/src/components/ResultsSection.tsx
@@ -10,6 +10,7 @@ import CostBreakdown from "@/components/CostBreakdown";
 import { LoanOptimizationPanel } from "@/components/LoanOptimizationPanel";
 import RenovationPanel from "@/components/RenovationPanel";
 import MultiExitCompareTable from "@/components/MultiExitCompareTable";
+import { TaxSimulationPanel } from "@/components/TaxSimulationPanel";
 import { InvestmentScoreCard } from "@/components/InvestmentScoreCard";
 import { CriticalErrorBanner } from "@/components/CriticalErrorBanner";
 import { HazardAlertBanner } from "@/components/HazardAlertBanner";
@@ -327,6 +328,7 @@ export function ResultsSection({
               {result.multiExitComparison && result.multiExitComparison.length > 0 && (
                 <MultiExitCompareTable rows={result.multiExitComparison} />
               )}
+              {result.taxSimulation && <TaxSimulationPanel result={result} input={lastInput} />}
               {simulationMode === "full" && (
                 <>
                   {result.acquisitionCosts && (

--- a/frontend/src/components/TaxSimulationPanel.tsx
+++ b/frontend/src/components/TaxSimulationPanel.tsx
@@ -45,7 +45,12 @@ export function TaxSimulationPanel({ result, input }: Props) {
 
   const { individual, corporate, breakevenYear } = ownershipComparison;
   const holdingYears = input.holdingYears || 10;
-  const ownershipChartData = Array.from({ length: holdingYears }, (_, i) => ({
+  const safeLen = Math.min(
+    holdingYears,
+    individual.cumulativeBurden.length,
+    corporate.cumulativeBurden.length
+  );
+  const ownershipChartData = Array.from({ length: safeLen }, (_, i) => ({
     year: `${i + 1}年`,
     個人: Math.round(individual.cumulativeBurden[i] / 10_000),
     法人: Math.round(corporate.cumulativeBurden[i] / 10_000),

--- a/frontend/src/components/TaxSimulationPanel.tsx
+++ b/frontend/src/components/TaxSimulationPanel.tsx
@@ -1,0 +1,280 @@
+"use client";
+import React, { useState } from "react";
+import {
+  BarChart,
+  Bar,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+  ReferenceLine,
+} from "recharts";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import type { InvestmentResult, InvestmentInput, TaxSimRow } from "@/types/investment";
+import { formatMan } from "@/lib/utils";
+import { chartColors } from "@/lib/chartColors";
+import { TrendingDown, TrendingUp, Building2, User } from "lucide-react";
+
+interface Props {
+  result: InvestmentResult;
+  input: InvestmentInput;
+}
+
+type PanelTab = "carryover" | "ownership";
+
+export function TaxSimulationPanel({ result, input }: Props) {
+  const [tab, setTab] = useState<PanelTab>("carryover");
+
+  if (!result.taxSimulation) return null;
+  const { salaryLossCarryover, ownershipComparison } = result.taxSimulation;
+
+  const totalSaving = salaryLossCarryover.totalTaxSaving;
+  const isSaving = totalSaving > 0;
+
+  const carryoverChartData = salaryLossCarryover.yearlyRows.map((row: TaxSimRow) => ({
+    year: `${row.year}年`,
+    節税額: row.taxDifference > 0 ? Math.round(row.taxDifference / 10_000) : 0,
+    増税額: row.taxDifference < 0 ? Math.round(-row.taxDifference / 10_000) : 0,
+  }));
+
+  const { individual, corporate, breakevenYear } = ownershipComparison;
+  const holdingYears = input.holdingYears || 10;
+  const ownershipChartData = Array.from({ length: holdingYears }, (_, i) => ({
+    year: `${i + 1}年`,
+    個人: Math.round(individual.cumulativeBurden[i] / 10_000),
+    法人: Math.round(corporate.cumulativeBurden[i] / 10_000),
+  }));
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base flex items-center gap-2">
+          税務シミュレーション
+          <Badge variant="outline" className="text-xs font-normal">
+            給与年収 {formatMan(salaryLossCarryover.salaryIncomeYen)}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* タブ切り替え */}
+        <div className="flex gap-1 border rounded-lg p-1 bg-muted/30">
+          <button
+            className={`flex-1 text-xs py-1.5 px-2 rounded transition-colors ${
+              tab === "carryover"
+                ? "bg-background shadow-sm font-medium"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            onClick={() => setTab("carryover")}
+          >
+            損益通算（節税効果）
+          </button>
+          <button
+            className={`flex-1 text-xs py-1.5 px-2 rounded transition-colors ${
+              tab === "ownership"
+                ? "bg-background shadow-sm font-medium"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            onClick={() => setTab("ownership")}
+          >
+            個人 vs 法人
+          </button>
+        </div>
+
+        {tab === "carryover" && (
+          <div className="space-y-4">
+            {/* サマリー */}
+            <div className="flex items-center gap-3 p-3 rounded-lg bg-muted/30">
+              {isSaving ? (
+                <TrendingDown className="h-5 w-5 text-chart-success shrink-0" />
+              ) : (
+                <TrendingUp className="h-5 w-5 text-destructive shrink-0" />
+              )}
+              <div>
+                <p className="text-xs text-muted-foreground">
+                  {holdingYears}年間の損益通算
+                  {isSaving ? "節税" : "増税"}合計
+                </p>
+                <p
+                  className={`text-lg font-bold ${isSaving ? "text-chart-success" : "text-destructive"}`}
+                >
+                  {isSaving ? "▼" : "▲"} {formatMan(Math.abs(totalSaving))}
+                </p>
+              </div>
+              <div className="ml-auto text-right">
+                <p className="text-xs text-muted-foreground">給与のみの税額（年）</p>
+                <p className="text-sm font-medium">
+                  {formatMan(salaryLossCarryover.baselineSalaryTax)}
+                </p>
+              </div>
+            </div>
+
+            {/* 棒グラフ */}
+            <div>
+              <p className="text-xs text-muted-foreground mb-2">年別の節税額／増税額（万円）</p>
+              <ResponsiveContainer width="100%" height={180}>
+                <BarChart
+                  data={carryoverChartData}
+                  margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="year" tick={{ fontSize: 10 }} />
+                  <YAxis tick={{ fontSize: 10 }} unit="万" />
+                  <Tooltip formatter={(v, name) => [`${v}万円`, name]} />
+                  <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+                  <ReferenceLine y={0} stroke="hsl(var(--border))" />
+                  <Bar dataKey="節税額" fill={chartColors.success} radius={[2, 2, 0, 0]} />
+                  <Bar dataKey="増税額" fill={chartColors.danger} radius={[2, 2, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+
+            {/* 年別テーブル（折りたたみ） */}
+            <details className="text-xs">
+              <summary className="cursor-pointer text-muted-foreground hover:text-foreground py-1">
+                年別明細を表示
+              </summary>
+              <div className="mt-2 overflow-x-auto">
+                <table className="w-full text-xs border-collapse">
+                  <thead>
+                    <tr className="border-b text-muted-foreground">
+                      <th className="text-left py-1 pr-3">年</th>
+                      <th className="text-right py-1 pr-3">不動産課税所得</th>
+                      <th className="text-right py-1 pr-3">合算課税所得</th>
+                      <th className="text-right py-1">節税/増税額</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {salaryLossCarryover.yearlyRows.map((row: TaxSimRow) => (
+                      <tr key={row.year} className="border-b border-border/40">
+                        <td className="py-1 pr-3">{row.year}年目</td>
+                        <td
+                          className={`text-right py-1 pr-3 ${row.reTaxableIncome < 0 ? "text-chart-success" : ""}`}
+                        >
+                          {formatMan(row.reTaxableIncome)}
+                        </td>
+                        <td className="text-right py-1 pr-3">{formatMan(row.combinedIncome)}</td>
+                        <td
+                          className={`text-right py-1 font-medium ${
+                            row.taxDifference > 0
+                              ? "text-chart-success"
+                              : row.taxDifference < 0
+                                ? "text-destructive"
+                                : ""
+                          }`}
+                        >
+                          {row.taxDifference > 0 ? "▼" : row.taxDifference < 0 ? "▲" : "―"}
+                          {formatMan(Math.abs(row.taxDifference))}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </details>
+          </div>
+        )}
+
+        {tab === "ownership" && (
+          <div className="space-y-4">
+            {/* ブレークイーヤーバッジ */}
+            <div className="flex items-center gap-3 p-3 rounded-lg bg-muted/30">
+              <Building2 className="h-5 w-5 text-primary shrink-0" />
+              <div>
+                <p className="text-xs text-muted-foreground">法人保有が有利になる年</p>
+                {breakevenYear === -1 ? (
+                  <div className="flex items-center gap-2">
+                    <Badge variant="outline">保有期間内に逆転なし</Badge>
+                    <span className="text-xs text-muted-foreground">個人保有が有利</span>
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <Badge className="bg-primary text-primary-foreground">
+                      {breakevenYear}年目〜
+                    </Badge>
+                    <span className="text-xs text-muted-foreground">以降は法人が有利</span>
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* 累積税負担グラフ */}
+            <div>
+              <p className="text-xs text-muted-foreground mb-2">
+                累積税負担の推移（万円・譲渡税含む）
+              </p>
+              <ResponsiveContainer width="100%" height={200}>
+                <LineChart
+                  data={ownershipChartData}
+                  margin={{ top: 4, right: 8, left: 0, bottom: 0 }}
+                >
+                  <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                  <XAxis dataKey="year" tick={{ fontSize: 10 }} />
+                  <YAxis tick={{ fontSize: 10 }} unit="万" />
+                  <Tooltip formatter={(v, name) => [`${v}万円`, name]} />
+                  <Legend iconSize={10} wrapperStyle={{ fontSize: 11 }} />
+                  <Line
+                    type="monotone"
+                    dataKey="個人"
+                    stroke={chartColors.primary}
+                    strokeWidth={2}
+                    dot={false}
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="法人"
+                    stroke={chartColors.secondary}
+                    strokeWidth={2}
+                    dot={false}
+                    strokeDasharray="5 5"
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+
+            {/* サマリー表 */}
+            <div className="grid grid-cols-2 gap-3">
+              {[
+                { scenario: individual, icon: <User className="h-4 w-4" /> },
+                { scenario: corporate, icon: <Building2 className="h-4 w-4" /> },
+              ].map(({ scenario, icon }) => (
+                <div key={scenario.label} className="rounded-lg border p-3 space-y-1.5">
+                  <div className="flex items-center gap-1.5 text-sm font-medium">
+                    {icon}
+                    {scenario.label}
+                  </div>
+                  <div className="text-xs space-y-0.5">
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">保有中の税合計</span>
+                      <span>{formatMan(scenario.totalTaxBurden - scenario.transferTax)}</span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-muted-foreground">売却時の税</span>
+                      <span>{formatMan(scenario.transferTax)}</span>
+                    </div>
+                    <div className="flex justify-between font-medium border-t pt-1 mt-1">
+                      <span>合計税負担</span>
+                      <span>{formatMan(scenario.totalTaxBurden)}</span>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <Alert>
+          <AlertDescription className="text-xs text-muted-foreground">
+            概算値です。個人事業・法人設立コスト・青色申告・消費税は含みません。
+            実際の申告・意思決定は税理士にご相談ください。
+          </AlertDescription>
+        </Alert>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/components/sections/ScenarioSection.tsx
+++ b/frontend/src/components/sections/ScenarioSection.tsx
@@ -247,6 +247,33 @@ export function ScenarioSection({
           </div>
         )}
       </div>
+      {/* 税務シミュレーション（任意） */}
+      <div className="border-t pt-4 space-y-3">
+        <p className="text-sm font-semibold text-foreground">税務シミュレーション（任意）</p>
+        <Input
+          label="給与年収"
+          type="number"
+          inputMode="numeric"
+          suffix="万円"
+          min="0"
+          max="100000"
+          step="100"
+          placeholder="例: 600（0なら計算しない）"
+          value={
+            input.salaryIncome != null && input.salaryIncome > 0
+              ? String(Math.round(input.salaryIncome / 10_000))
+              : ""
+          }
+          onChange={(e) => {
+            const v = parseFloat(e.target.value);
+            setNum("salaryIncome", isNaN(v) ? 0 : v * 10_000);
+          }}
+        />
+        <p className="text-xs text-muted-foreground">
+          入力すると損益通算の節税効果と個人/法人の税負担比較が表示されます。
+        </p>
+      </div>
+
       {/* 入退去コスト（任意） */}
       <div className="border-t pt-4">
         <button

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -114,6 +114,9 @@ export interface InvestmentInput {
   restorationCost?: number; // 原状回復費（円/回）例: 150000
   adFee?: number; // 入居者募集 AD（円/回）例: 家賃1ヶ月分
   rentFreePeriod?: number; // フリーレント（ヶ月）例: 0.5
+
+  // 税務シミュレーション用（任意）。0 の場合は損益通算・法人比較を計算しない。
+  salaryIncome?: number; // 給与年収（円）
 }
 
 export interface CapexEvent {
@@ -198,6 +201,42 @@ export interface InvestmentResult {
   totalInterest: number; // 保有期間の総支払利息
   aiSummary?: string;
   multiExitComparison?: MultiExitRow[]; // 複数保有年数の出口比較
+  taxSimulation?: TaxSimulationResult; // 損益通算・個人/法人比較（salaryIncome>0時のみ）
+}
+
+export interface TaxSimRow {
+  year: number;
+  reTaxableIncome: number;
+  combinedIncome: number;
+  combinedTax: number;
+  baselineTax: number;
+  taxDifference: number; // 正=節税 / 負=増税
+}
+
+export interface SalaryLossCarryoverResult {
+  salaryIncomeYen: number;
+  baselineSalaryTax: number;
+  yearlyRows: TaxSimRow[];
+  totalTaxSaving: number;
+}
+
+export interface OwnershipScenario {
+  label: string;
+  annualTax: number[];
+  transferTax: number;
+  totalTaxBurden: number;
+  cumulativeBurden: number[];
+}
+
+export interface OwnershipComparisonResult {
+  individual: OwnershipScenario;
+  corporate: OwnershipScenario;
+  breakevenYear: number; // -1 = 保有期間内に法人有利年なし
+}
+
+export interface TaxSimulationResult {
+  salaryLossCarryover: SalaryLossCarryoverResult;
+  ownershipComparison: OwnershipComparisonResult;
 }
 
 export interface LandTransaction {

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -209,7 +209,6 @@ export interface TaxSimRow {
   reTaxableIncome: number;
   combinedIncome: number;
   combinedTax: number;
-  baselineTax: number;
   taxDifference: number; // 正=節税 / 負=増税
 }
 


### PR DESCRIPTION
## 概要

- **#399** 給与所得との損益通算・節税額シミュレーション
- **#392** 個人 vs 法人保有の税負担比較（簡易版：税率差のみ）

`salaryIncome`（給与年収）を入力することで、累進税率ベースの損益通算効果と個人/法人の保有期間合計税負担比較を算出する。`salaryIncome=0`（未入力）の場合は計算をスキップするため、既存ユーザーへの影響はない。

## 変更内容

### バックエンド
- `domain/tax.go`（新規）: 日本の累進所得税計算・給与所得控除・`CalcTaxSimulation()`
- `domain/tax_test.go`（新規）: テーブル駆動テスト 14 ケース
- `domain/types.go`: `SalaryIncome` フィールド追加、`TaxSimulationResult` 等の新規型
- `domain/investment.go`: `Analyze()` から `CalcTaxSimulation` を呼び出し
- `location_handler.go`: PR #710 で誤って削除されたハンドラーメソッドを復元（cherry-pick #7759aa2）

### フロントエンド
- `TaxSimulationPanel.tsx`（新規）: 2 タブ構成（損益通算 / 個人 vs 法人）
- `ScenarioSection.tsx`: 給与年収入力フィールド追加（フルモードのみ）
- `ResultsSection.tsx`: `taxSimulation` があるときパネルを表示
- `types/investment.ts`: 対応 TypeScript 型定義追加

## 動作確認

- [ ] 給与年収 600 万円を入力してシミュレーション → 税務シミュレーションパネルが表示される
- [ ] 損益通算タブ: 初期年（減価償却大）に節税が発生する
- [ ] 個人/法人タブ: 高年収（2000 万円）では法人有利年が表示される
- [ ] 給与年収を 0 にするとパネルが非表示になる
- [ ] `go test -race ./internal/domain/...` が全通過
- [ ] `vitest run` が全通過
- [ ] `tsc --noEmit` がエラーなし

## 注意事項

- 簡易計算のため法人設立コスト・青色申告・消費税は含まない（免責 Alert をパネルに表示済み）
- 累進税率ブラケットは 2023 年以降の所得税法 89 条に準拠
- 法人実効税率は概算 33.4%（資本金 1 億円未満の小規模法人を想定）

Closes #399
Related to #392