### PR TITLE
ci(backend): 国交省API統合テストを週次スケジュールでCIに追加 (#681)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -11,6 +11,8 @@ on:
     paths:
       - "backend/**"
       - ".github/workflows/backend-ci.yml"
+  schedule:
+    - cron: "0 1 * * 1"  # 毎週月曜 01:00 UTC
   workflow_dispatch:
 
 permissions:
@@ -74,3 +76,25 @@ jobs:
       - name: docker build (smoke test)
         working-directory: .
         run: docker build --progress=plain ./backend
+
+  integration-test:
+    name: Integration Test (MLIT API)
+    runs-on: ubuntu-24.04
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6.4.0
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Run integration tests
+        env:
+          MLIT_API_KEY: ${{ secrets.MLIT_API_KEY }}
+        run: go test -tags=integration -v ./internal/mlit/... -timeout 120s


### PR DESCRIPTION
## 概要

`backend/internal/mlit/integration_test.go` に `//go:build integration` タグで書かれた統合テストが存在するが、通常の `go test ./...` では実行されない。国交省 API のスペック変更や障害を定期的に検知する仕組みがなかった。

## 変更内容

`.github/workflows/backend-ci.yml` に `integration-test` ジョブを追加：

- **トリガー**: `schedule: cron: '0 1 * * 1'`（毎週月曜 01:00 UTC）および `workflow_dispatch`（手動実行）
- **通常 CI では実行しない**: `if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'` で制限し、push/PR のたびに API を呼ばない
- **実行コマンド**: `go test -tags=integration -v ./internal/mlit/... -timeout 120s`
- **認証**: `MLIT_API_KEY` を GitHub Secrets から注入（本番 deploy workflow で使用中）

## 検証方法

```bash
gh workflow run backend-ci.yml --ref ci/mlit-integration-test-weekly
```

で手動トリガーして `integration-test` ジョブが成功することを確認する。

## 完了の定義確認

- [x] `schedule: '0 1 * * 1'` と手動トリガーのみで実行される
- [x] 通常の push/PR CI には影響しない
- [ ] **手動実行で実際の国交省 API リクエストが成功することを確認**（マージ後に実施）

Closes #681
Parent: #667