### PR TITLE
fix(backend): Firestoreジオコードキャッシュから住所（PII）フィールドを削除

### DIFF
--- a/backend/internal/api/geocode_firestore_cache.go
+++ b/backend/internal/api/geocode_firestore_cache.go
@@ -17,9 +17,34 @@ const (
 	geocodeCacheKeyLen     = 32
 )
 
+// geocodeDocStore は firestoreGeocodeCache が必要とする最小限のドキュメント読み書き操作を表す。
+// テストでは fakeGeocodeDocStore で差し替えられる。
+type geocodeDocStore interface {
+	get(ctx context.Context, docID string) (map[string]any, bool)
+	set(ctx context.Context, docID string, data map[string]any) error
+}
+
+// firestoreGeocodeDocStore は実際の Firestore クライアントを geocodeDocStore に適合させるアダプタ。
+type firestoreGeocodeDocStore struct {
+	client *firestore.Client
+}
+
+func (s *firestoreGeocodeDocStore) get(ctx context.Context, docID string) (map[string]any, bool) {
+	doc, err := s.client.Collection(geocodeCacheCollection).Doc(docID).Get(ctx)
+	if err != nil {
+		return nil, false
+	}
+	return doc.Data(), true
+}
+
+func (s *firestoreGeocodeDocStore) set(ctx context.Context, docID string, data map[string]any) error {
+	_, err := s.client.Collection(geocodeCacheCollection).Doc(docID).Set(ctx, data)
+	return err
+}
+
 // firestoreGeocodeCache は Firestore を使ったジオコードキャッシュ実装
 type firestoreGeocodeCache struct {
-	client *firestore.Client
+	store geocodeDocStore
 }
 
 // NewFirestoreGeocodeCache は Firestore クライアントからキャッシュを返す。
@@ -28,7 +53,7 @@ func NewFirestoreGeocodeCache(client *firestore.Client) GeocodeCache {
 	if client == nil {
 		return &noopGeocodeCache{}
 	}
-	return &firestoreGeocodeCache{client: client}
+	return &firestoreGeocodeCache{store: &firestoreGeocodeDocStore{client: client}}
 }
 
 func (f *firestoreGeocodeCache) cacheKey(address string) string {
@@ -38,12 +63,11 @@ func (f *firestoreGeocodeCache) cacheKey(address string) string {
 
 func (f *firestoreGeocodeCache) Get(ctx context.Context, address string) (*GeocodeResult, bool) {
 	key := f.cacheKey(address)
-	doc, err := f.client.Collection(geocodeCacheCollection).Doc(key).Get(ctx)
-	if err != nil {
+	data, ok := f.store.get(ctx, key)
+	if !ok {
 		return nil, false
 	}
 
-	data := doc.Data()
 	expiresAt, ok := data["expiresAt"].(time.Time)
 	if !ok || time.Now().After(expiresAt) {
 		return nil, false
@@ -72,7 +96,7 @@ func (f *firestoreGeocodeCache) Set(ctx context.Context, address string, result 
 	if err != nil {
 		return
 	}
-	if _, err := f.client.Collection(geocodeCacheCollection).Doc(key).Set(ctx, map[string]any{
+	if err := f.store.set(ctx, key, map[string]any{
 		"data":      string(raw),
 		"expiresAt": time.Now().Add(geocodeCacheTTL),
 	}); err != nil {

--- a/backend/internal/api/geocode_firestore_cache.go
+++ b/backend/internal/api/geocode_firestore_cache.go
@@ -75,7 +75,6 @@ func (f *firestoreGeocodeCache) Set(ctx context.Context, address string, result 
 	if _, err := f.client.Collection(geocodeCacheCollection).Doc(key).Set(ctx, map[string]any{
 		"data":      string(raw),
 		"expiresAt": time.Now().Add(geocodeCacheTTL),
-		"address":   address,
 	}); err != nil {
 		slog.WarnContext(ctx, "geocode_cache: failed to write to Firestore", "error", err)
 	}

--- a/backend/internal/api/geocode_firestore_cache_test.go
+++ b/backend/internal/api/geocode_firestore_cache_test.go
@@ -1,0 +1,124 @@
+package api
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeGeocodeDocStore はテスト用のインメモリ geocodeDocStore 実装。
+type fakeGeocodeDocStore struct {
+	mu   sync.RWMutex
+	docs map[string]map[string]any
+}
+
+func newFakeGeocodeDocStore() *fakeGeocodeDocStore {
+	return &fakeGeocodeDocStore{docs: make(map[string]map[string]any)}
+}
+
+func (f *fakeGeocodeDocStore) get(_ context.Context, docID string) (map[string]any, bool) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	d, ok := f.docs[docID]
+	return d, ok
+}
+
+func (f *fakeGeocodeDocStore) set(_ context.Context, docID string, data map[string]any) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.docs[docID] = data
+	return nil
+}
+
+func newTestGeocodeCache(store geocodeDocStore) *firestoreGeocodeCache {
+	return &firestoreGeocodeCache{store: store}
+}
+
+func TestGeocodeCache_SetDoesNotStoreAddress(t *testing.T) {
+	store := newFakeGeocodeDocStore()
+	c := newTestGeocodeCache(store)
+	result := &GeocodeResult{Lat: 35.6895, Lng: 139.6917}
+
+	c.Set(context.Background(), "東京都千代田区丸の内1-1-1", result)
+
+	key := c.cacheKey("東京都千代田区丸の内1-1-1")
+	doc, ok := store.get(context.Background(), key)
+	if !ok {
+		t.Fatal("expected doc in store after Set")
+	}
+	if _, found := doc["address"]; found {
+		t.Error("address field must not be stored in cache document (PII)")
+	}
+}
+
+func TestGeocodeCache_SetThenGet(t *testing.T) {
+	store := newFakeGeocodeDocStore()
+	c := newTestGeocodeCache(store)
+	want := &GeocodeResult{Lat: 35.6895, Lng: 139.6917}
+
+	c.Set(context.Background(), "東京都千代田区", want)
+	got, ok := c.Get(context.Background(), "東京都千代田区")
+
+	if !ok {
+		t.Fatal("expected cache hit after Set")
+	}
+	if got.Lat != want.Lat || got.Lng != want.Lng {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestGeocodeCache_GetMissOnEmpty(t *testing.T) {
+	c := newTestGeocodeCache(newFakeGeocodeDocStore())
+	_, ok := c.Get(context.Background(), "存在しない住所")
+	if ok {
+		t.Fatal("expected miss on empty store")
+	}
+}
+
+func TestGeocodeCache_GetMissOnExpiredTTL(t *testing.T) {
+	store := newFakeGeocodeDocStore()
+	c := newTestGeocodeCache(store)
+	result := &GeocodeResult{Lat: 35.0, Lng: 135.0}
+
+	c.Set(context.Background(), "address", result)
+
+	key := c.cacheKey("address")
+	doc, _ := store.get(context.Background(), key)
+	doc["expiresAt"] = time.Now().Add(-1 * time.Second)
+	store.set(context.Background(), key, doc) //nolint:errcheck
+
+	_, ok := c.Get(context.Background(), "address")
+	if ok {
+		t.Fatal("expected miss for expired entry")
+	}
+}
+
+func TestGeocodeCache_TTLIs30Days(t *testing.T) {
+	store := newFakeGeocodeDocStore()
+	c := newTestGeocodeCache(store)
+
+	before := time.Now()
+	c.Set(context.Background(), "address", &GeocodeResult{Lat: 35.0, Lng: 135.0})
+	after := time.Now()
+
+	key := c.cacheKey("address")
+	doc, _ := store.get(context.Background(), key)
+	expiresAt, ok := doc["expiresAt"].(time.Time)
+	if !ok {
+		t.Fatalf("expiresAt type = %T, want time.Time", doc["expiresAt"])
+	}
+
+	expectedMin := before.Add(30 * 24 * time.Hour)
+	expectedMax := after.Add(30 * 24 * time.Hour)
+	if expiresAt.Before(expectedMin) || expiresAt.After(expectedMax) {
+		t.Errorf("TTL is not ~30 days: expiresAt=%v", expiresAt)
+	}
+}
+
+func TestNewFirestoreGeocodeCache_NilClientReturnsNoop(t *testing.T) {
+	cache := NewFirestoreGeocodeCache(nil)
+	if _, isNoop := cache.(*noopGeocodeCache); !isNoop {
+		t.Errorf("expected *noopGeocodeCache, got %T", cache)
+	}
+}


### PR DESCRIPTION
## 変更内容

`geocode_cache` コレクションのドキュメントから、不要な `address` フィールドを削除する。

### 背景

`firestoreGeocodeCache.Set` は `data`（JSON化された緯度経度）と `expiresAt` に加えて、生の住所文字列を `address` フィールドとして30日間 Firestore に保存していた。

しかしキャッシュキーはすでに住所の SHA-256 ハッシュから生成されており（`cacheKey` 関数）、`address` フィールドはキャッシュの読み書きに一切使われていない。

### 問題点

- 機能上まったく不要なフィールドに個人情報（住所）を30日間保持していた
- バックエンドの侵害・サービスアカウントキー漏洩・GCP IAM 設定ミスが発生した場合、直近30日分のユーザー住所が一覧取得可能になるリスクがあった
- ログでは住所を10文字に切り詰めてマスクしているにもかかわらず、Firestore には無加工で保存されており一貫性がなかった

### 修正

`Set` メソッドの `map[string]any` から `"address": address` の1行を削除。

```go
// 修正前
map[string]any{
    "data":      string(raw),
    "expiresAt": time.Now().Add(geocodeCacheTTL),
    "address":   address,   // ← 削除
}

// 修正後
map[string]any{
    "data":      string(raw),
    "expiresAt": time.Now().Add(geocodeCacheTTL),
}
```

既存ドキュメント（`address` フィールドあり）との後方互換性は問題なし。`Get` は `address` フィールドを一切参照していないため、既存キャッシュはそのまま有効。

## テスト

- `go test ./internal/api/...` — pass
- `vitest run` (frontend) — 376 tests pass

## チェックリスト

- [x] 動作への影響なし（`address` フィールドは読み取り側で参照されていない）
- [x] 既存キャッシュとの後方互換性あり
- [x] テスト通過