### PR TITLE
CI: govulncheck を Backend CI に追加

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -70,8 +70,14 @@ jobs:
           cat coverage.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+      - name: Cache govulncheck binary
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: ~/go/bin/govulncheck
+          key: govulncheck-v1.1.4
+
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: which govulncheck || go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
 
       - name: govulncheck
         run: govulncheck ./...

--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -70,6 +70,12 @@ jobs:
           cat coverage.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
 
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: govulncheck
+        run: govulncheck ./...
+
       - name: go build
         run: go build ./cmd/server
 


### PR DESCRIPTION
## 概要

Go 公式の脆弱性スキャナー `govulncheck` を Backend CI の `test` ジョブに追加する。

## 背景

現在の CI では Trivy で Docker イメージをスキャンしているが、守備範囲が異なる。

| | Trivy | govulncheck |
|---|---|---|
| 対象 | Docker イメージ全体（OS パッケージ含む） | Go モジュールのみ |
| 精度 | パッケージバージョンで判定 | 実際に呼び出している関数まで追跡して影響有無を判定 |

Trivy と govulncheck を組み合わせることで、Go 依存パッケージの CVE に対するカバレッジが向上する。

## 変更内容

- `.github/workflows/backend-ci.yml` の `test` ジョブに以下を追加
  - `go install golang.org/x/vuln/cmd/govulncheck@latest`
  - `govulncheck ./...`

## 確認事項

- [x] go test 通過
- [x] pre-push フック通過

## 関連

closes #721