### PR TITLE
docs: LLM Wiki アーキテクチャの導入によるトークン消費最適化

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,6 @@ frontend/public/swe-worker-*.js.map
 # 環境変数（APIキー等を含むためgit管理外）
 .env
 
-# docs-mcp-server 設定（絶対パスがマシン依存のため）
-.mcp.json
 
 # Claude Code 内部ファイル
 .claude/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "docs": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "./docs"]
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,250 +2,64 @@
 
 ## Project overview
 
-Yield-Guard is a real estate investment decision-support tool that fetches land transaction data from Japan's MLIT (国土交通省) API and visualizes gross yield, dead-cross timing, and exit strategy equity in real time.
-
-## Stack
+Yield-Guard: Japan real estate investment tool. Fetches MLIT land transaction data; visualizes gross yield, dead-cross, exit equity.
 
 - **Backend**: Go 1.25 / Gin / Clean Architecture → Cloud Run (`backend/`)
-- **Frontend**: Next.js 16 (App Router) / TypeScript / Tailwind CSS v4 / Shadcn/UI / Recharts → Vercel (`frontend/`)
+- **Frontend**: Next.js 16 (App Router) / TypeScript / Tailwind CSS v4 / Shadcn/UI → Vercel (`frontend/`)
 - **Data**: 国土交通省 不動産情報ライブラリ API (`reinfolib.mlit.go.jp`) — requires `MLIT_API_KEY`
-
-## Initial setup (clone後1回)
-
-```bash
-make install          # frontend 依存関係をインストール（メインリポジトリのみ・worktree 不可）
-make install-hooks    # lefthook git フック (pre-commit: Prettier/lint, pre-push: test)
-```
-
-> `lefthook install` が失敗する場合は `git config --unset-all --local core.hooksPath` を実行してから再試行する。
 
 ## Key commands
 
 ```bash
-make dev          # backend :8080 + frontend :3000 (local, no Docker)
-make docker-up    # Docker Compose build & start
-make docker-down  # stop containers
-make test         # go test -race ./... + vitest run
-make lint         # golangci-lint + eslint + tsc --noEmit
-make build        # go build + next build
-make integration  # integration tests against real MLIT API (needs MLIT_API_KEY)
-make swagger        # OpenAPI スキーマ生成 (docs/openapi/swagger.json)
-make swagger-check  # スキーマドリフトをローカルで確認 (PR 前チェック用)
-```
-
-**Backend only:**
-```bash
-cd backend && go run ./cmd/server          # :8080
-cd backend && go test -race ./... -timeout 120s
-```
-
-**Frontend only:**
-```bash
-cd frontend && npm run dev                 # :3000
-cd frontend && npm test
-cd frontend && npm run generate:types      # TypeScript 型を再生成 (要: make swagger 実行済み)
-```
-
-**MLIT API debug:**
-```bash
-make mlit-land-prices area=13 year=2024 quarter=1 to_year=2024 to_quarter=4
-make mlit-municipalities area=13
+make dev            # backend :8080 + frontend :3000
+make test           # go test -race ./... + vitest run
+make lint           # golangci-lint + eslint + tsc --noEmit
+make swagger        # regenerate docs/openapi/swagger.json (run after any Go type change)
+make swagger-check  # verify no schema drift
+make integration    # real MLIT API tests (needs MLIT_API_KEY)
 ```
 
 ## Environment variables
 
-Copy `.env.example` → `.env` (project root).
-- `MLIT_API_KEY` — required for all MLIT data endpoints
-- `APP_INTERNAL_API_KEY` — Vercel→Cloud Run auth (omit for local dev)
-- `ALLOW_ORIGINS` — comma-separated CORS origins (default: `http://localhost:3000`)
-
-## API endpoints
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/health` | Health check |
-| `GET` | `/api/land-prices/stats` | Land transaction stats |
-| `GET` | `/api/land-prices/compare` | Compare vs. market price |
-| `GET` | `/api/land-prices/estimate` | Theoretical price estimate |
-| `POST` | `/api/investment/analyze` | Investment simulation |
-| `GET` | `/api/investment/rent-decline-hint` | Rent decline rate hint from land appraisals (area, municipality) |
-| `GET` | `/api/municipalities` | Municipality list |
-| `GET` | `/api/station-ridership` | Station ridership (tile coords) |
-| `GET` | `/api/population-forecast` | Population forecast (tile coords) |
-| `GET` | `/api/land-appraisals` | Official land appraisals |
-| `GET` | `/api/urban-risks` | Urban planning risks (tile coords) |
-| `GET` | `/api/hazard` | Hazard info: flood/storm/tsunami/landslide (tile coords) |
-| `GET` | `/api/investment-score` | Investment suitability score (tile coords) |
-| `GET` | `/api/investment-score-heatmap` | Batch investment scores for viewport bbox (minLat, maxLat, minLng, maxLng, z=11-15) |
-| `GET` | `/api/rent-stats` | Area rent market stats: median/average/count from MLIT rental data (area, municipality, area_sqm) |
-| `POST` | `/api/renovation/analyze` | Renovation cost & yield impact analysis |
-| `POST` | `/api/investment/simulate` | Monte Carlo cash-flow simulation |
-| `GET` | `/api/area-discovery` | Discover investment areas by tile coords |
-| `GET` | `/api/geocode` | Geocoding: address → lat/lng |
-
-## Directory structure
-
-```
-yield-guard/
-├── backend/
-│   ├── cmd/server/main.go          # entry point
-│   └── internal/
-│       ├── domain/
-│       │   ├── types.go            # domain models
-│       │   ├── investment.go       # yield / dead-cross / exit calc logic
-│       │   └── investment_test.go
-│       ├── mlit/
-│       │   ├── client.go           # MLIT API client (retry + cache)
-│       │   ├── cache.go            # in-memory TTL cache (24h)
-│       │   └── types.go            # API response types
-│       └── api/
-│           ├── handler.go          # HTTP handlers
-│           ├── rent_handler.go     # GET /api/rent-stats handler
-│           └── router.go           # Gin router + CORS + auth middleware
-├── frontend/src/
-│   ├── app/                        # Next.js App Router pages
-│   ├── components/                 # UI components (see below)
-│   ├── lib/                        # API client, calc utilities
-│   └── types/
-│       ├── investment.ts           # 手動定義の TypeScript 型（フロントエンド用）
-│       └── api.generated.ts        # 自動生成型 ※git管理外・編集禁止 (npm run generate:types で生成)
-├── docs/
-│   ├── openapi/
-│   │   ├── swagger.json            # 自動生成: make swagger (Swagger 2.0) ※コミット対象・編集禁止
-│   │   └── openapi.json            # 自動生成: npm run generate:types (OpenAPI 3.0) ※git管理外
-│   └── *.md                        # 設計ドキュメント (read via docs MCP)
-├── terraform/                      # Cloud Run / infra
-├── docker-compose.yml
-├── Makefile
-└── .env.example
-```
-
-**Key frontend components:**
-- `Dashboard.tsx` — top-level layout
-- `InvestmentForm.tsx` — input form
-- `LandPriceAnalysis.tsx` — market comparison
-- `YieldAnalysis.tsx` — gross yield + 8% threshold
-- `DeadCrossChart.tsx` — dead-cross visualization
-- `CashFlowChart.tsx` — stress-test cash flow
-- `CostBreakdown.tsx` — cost breakdown
-- `WatchlistPanel.tsx` — property watchlist (localStorage persistence)
-
-## OpenAPI 型自動生成パイプライン
-
-Go の型定義を Single Source of Truth として、TypeScript 型を自動生成する。
-
-```
-backend/internal/domain/*.go  (Go struct + swag アノテーション)
-    ↓ make swagger
-docs/openapi/swagger.json     (コミット対象 — 編集禁止)
-    ↓ npm run generate:types  (swagger2openapi で変換 → openapi-typescript v7)
-docs/openapi/openapi.json     (git 管理外 — Node.js バージョン差で内容が変わるため)
-frontend/src/types/api.generated.ts  (git 管理外 — CI で毎回生成)
-```
-
-### ルール
-
-- `swagger.json` は **コミット対象**。Go 型を変更したら必ず `make swagger` を実行してコミットする
-- `openapi.json` と `api.generated.ts` は **git 管理外**（`.gitignore` 済み）。Node.js バージョンによって出力が変わるため
-- ローカルで型を使う場合は `npm run generate:types` を実行する（`npm test` / `npm run build` 時にファイルが無ければ自動生成される）
-- CI は `npm run generate:types` で型を生成してから `tsc --noEmit` で型チェックを行う
-- e2e fixtures は `satisfies components["schemas"]["domain.XxxType"]` で自動生成型を参照する
-
-### swag アノテーション記法
-
-```go
-// HandlerFunc はエンドポイントの説明
-// @Summary     概要（日本語可）
-// @Tags        タグ名
-// @Produce     json
-// @Param       name  query  string  true  "説明"
-// @Success     200  {object}  domain.ResponseType
-// @Failure     400  {object}  map[string]string
-// @Router      /api/path [get]
-func (h *Handler) HandlerFunc(c *gin.Context) {
-```
-
-> **注意**: `@title` 等のメタ情報アノテーションは `cmd/server/main.go` の `func main()` 直前に記述する（`doc.go` 単独では swag に読み取られない）。
+Copy `.env.example` → `.env`. Key vars: `MLIT_API_KEY`, `APP_INTERNAL_API_KEY`, `ALLOW_ORIGINS`.
 
 ## Conventions
 
-- **Branch**: prefix by type, no issue numbers
-  - `feature/<content>` — new features
-  - `fix/<content>` — bug fixes
-  - `chore/<content>` — dependency updates, config changes
-  - `docs/<content>` — documentation only
-  - `refactor/<content>` — refactoring without behavior change
-  - `test/<content>` — test additions or fixes
-- **Commits**: English, small logical units (types / logic / API / frontend / tests)
-- **PR body**: Japanese, follow `.github/pull_request_template.md`
-- **PR title**: Japanese
-- **No `Co-Authored-By`** lines in commits
-
-### UI デザインルール
-
-**Don't**
-- グラデーション（`bg-gradient-*`）を背景色に使用しない — ブランドカラーのみ使用する
-- Lucide 以外のアイコンライブラリを混在させない（`lucide-react` 統一）
-- 色のみで状態（エラー・警告・成功）を表現しない — Badge やアイコンを必ず併記する（WCAG 1.4.1）
-- ネストされた可変幅コンテナを3段以上重ねない — レイアウト崩れの原因になる
-- ラベルなしのアイコンボタンを使用しない — `aria-label` か `Tooltip` を必ず付ける
-
-**Must**
-- 投資シミュレーション結果には必ず免責事項ブロック（`<Alert>`）を表示する（`YieldAnalysis.tsx` 参照）
-- ステータス表示は `<Badge>` + アイコンを併記する（`WatchlistPanel.tsx` 参照）
-- `Recharts` の `<ResponsiveContainer>` で必ずチャートをラップする（`DeadCrossChart.tsx` 参照）
-- 削除・リセット系操作は `AlertDialog` で確認ステップを挟む
-- ローディング中は Skeleton UI を使用する（`<Spinner>` は使わない）
-
-## CI (GitHub Actions)
-
-| Workflow | Trigger paths | Checks |
-|----------|--------------|--------|
-| `backend-ci.yml` | `backend/**` | golangci-lint, go test -race, go build |
-| `frontend-ci.yml` | `frontend/**` | lint, tsc, vitest, next build |
+- **Branch**: `feature/*` | `fix/*` | `chore/*` | `docs/*` | `refactor/*` | `test/*`
+- **Commits**: English, small logical units
+- **PR title/body**: Japanese; follow `.github/pull_request_template.md`
+- **No `Co-Authored-By`** in commits
 
 ## MCP servers
 
-`docs` server is configured in `.mcp.json` — use `mcp__docs__*` tools to read `docs/` design documents (overview, API reference, domain specs, etc.).
+`docs` server reads `docs/` via `.mcp.json` — use `mcp__docs__*` tools for design documents.
+
+## Task-specific entry points
+
+Before starting work, read the relevant entry doc in `docs/llm/`:
+
+| Task | Entry doc |
+|------|-----------|
+| Backend / API / Go | `docs/llm/backend.md` |
+| Frontend / UI / TSX | `docs/llm/frontend.md` |
+| Investment calc / domain logic | `docs/llm/domain.md` |
+| Branch / worktree / PR | `docs/llm/worktree.md` |
 
 ## Claude Code operating rules
 
-These rules define the safety boundary for autonomous Claude Code operations.
+### Git
+- **Never push to `main` directly** — use a typed branch + PR
+- **Never force-push** or skip hooks (`--no-verify`)
+- **`git reset --hard` only on explicit instruction**
 
-### Git operations
-
-- **Never push directly to `main`** — always work on a typed branch (`feature/*`, `fix/*`, `chore/*`, `docs/*`, `refactor/*`, `test/*`) and open a PR
-- **Never force-push** (`git push --force`) — prevents overwriting remote history
-- **Never skip hooks** (`git commit --no-verify`) — pre-commit hooks must always run
-- **`git reset --hard` only on explicit instruction** — prevents loss of uncommitted work
-
-### Secrets and environment variables
-
-- **Never read, display, or log the contents of `.env`** — `MLIT_API_KEY`, `APP_INTERNAL_API_KEY`, and other secrets must not appear in output
-- **Never stage or commit `.env`** — it is gitignored; do not force-add it
-- **Never include secret values in API responses, test output, or error messages**
+### Secrets
+- **Never read, display, or commit `.env`** — secrets must not appear in output or responses
 
 ### Infrastructure
-
-- **`terraform destroy` only on explicit instruction** — prevents accidental deletion of Cloud Run services or IAM resources
-- **`terraform apply` requires confirmation** — always review the plan output before applying
-- **Never modify GCS bucket contents or Secret Manager secrets directly** — these are managed by Terraform
-- **Destructive local operations** (`docker volume rm`, `rm -rf`, etc.) require confirmation before execution
+- **`terraform destroy` / `terraform apply`** — always confirm before running
+- **Destructive local ops** (`docker volume rm`, `rm -rf`) — confirm before running
 
 ### PR and external actions
-
-- **Never merge a PR without explicit instruction** — even if CI passes
-- **Never post comments to Issues or PRs without explicit instruction** — unintended external communication must be avoided
-- **Never use `--squash` when merging** — always use `--merge`; add `--delete-branch` to remove the remote branch (local branch / worktree must be removed manually afterward)
-
-### Worktree operations
-
-- **Never run `npm install` in a worktree** — it regenerates `package-lock.json` with the local npm version, causing CI drift and exposing pre-existing lint/format issues (frontend only; Go backend is unaffected due to shared module cache)
-- **Share frontend `node_modules` via symlink instead** — run from the main repo root:
-  ```bash
-  git worktree add ../<worktree-dir> -b branch-name
-  ln -s "$(pwd)/frontend/node_modules" "../<worktree-dir>/frontend/node_modules"
-  ```
-- **`make install-hooks` はメインリポジトリで1回だけ実行** — lefthook は `.git/hooks/` にフックを置くため、worktree は親リポジトリのフックを自動共有する。worktreeごとの再実行は不要
-- **Check main CI status before starting work** — know the baseline so pre-existing failures don't block the PR
-- **Rebase once, just before pushing** — rebase on the latest `origin/main` right before creating the PR, not repeatedly during development
+- **Never merge a PR** without explicit instruction
+- **Never post to Issues/PRs** without explicit instruction
+- **Never use `--squash`** when merging — use `--merge --delete-branch`

--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ cp .env.example .env
 # .env を編集して MLIT_API_KEY を設定する
 # APIキー申請: https://www.reinfolib.mlit.go.jp/api/request/（審査5営業日）
 # APP_INTERNAL_API_KEY は本番環境（Vercel→Cloud Run 間認証）用。ローカルでは未設定でよい
+
+# 依存関係のインストールとフックの設定（初回のみ）
+make install          # frontend の npm install
+make install-hooks    # lefthook の pre-commit / pre-push フック登録
 ```
+
+> `make install-hooks` が失敗する場合は `git config --unset-all --local core.hooksPath` を実行してから再試行する。
 
 ### Docker（推奨）
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,19 @@ cd frontend && npm install && npm run dev
 
 ## ドキュメント体系
 
+### Claude Code 向けエントリードキュメント（`docs/llm/`）
+
+作業開始前に対応するファイルを参照することでトークン消費を最小化できる。
+
+| 作業内容 | エントリードキュメント |
+|---------|-------------------|
+| バックエンド / API / Go | [docs/llm/backend.md](docs/llm/backend.md) |
+| フロントエンド / UI / TSX | [docs/llm/frontend.md](docs/llm/frontend.md) |
+| 投資計算 / ドメインロジック | [docs/llm/domain.md](docs/llm/domain.md) |
+| ブランチ / worktree / PR | [docs/llm/worktree.md](docs/llm/worktree.md) |
+
+### 詳細設計ドキュメント（`docs/`）
+
 | 対象層 | ドキュメント |
 |--------|-------------|
 | 全体設計・デプロイフロー | [docs/overview.md](docs/overview.md) |

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,3 +1,11 @@
+---
+purpose: 全 HTTP エンドポイントの詳細仕様（リクエスト/レスポンス/認証）
+triggers: [api, endpoint, handler, request, response, auth]
+audience: backend-dev, frontend-dev
+token_weight: heavy
+reads_next: [docs/llm/backend.md]
+---
+
 # APIリファレンス
 
 バックエンド: `backend/internal/api/handler.go` / `router.go`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,3 +1,10 @@
+---
+purpose: 技術選定の背景・設計原則の説明
+triggers: [architecture, design, why, clean architecture, gin, next.js]
+audience: all
+token_weight: medium
+---
+
 # アーキテクチャ詳細
 
 ## 技術選定の背景（Why）

--- a/docs/domain-depreciation-dead-cross.md
+++ b/docs/domain-depreciation-dead-cross.md
@@ -1,3 +1,11 @@
+---
+purpose: 減価償却計算・デッドクロス判定の詳細仕様（法定耐用年数含む）
+triggers: [depreciation, dead cross, 減価償却, デッドクロス, BuildingType, UsefulLife]
+audience: backend-dev
+token_weight: medium
+reads_next: [docs/llm/domain.md]
+---
+
 # 減価償却・デッドクロス詳細仕様
 
 `backend/internal/domain/types.go` に `BuildingType` / `UsefulLife` / `CalcResidualUsefulLife` がある。

--- a/docs/domain-exit-strategy.md
+++ b/docs/domain-exit-strategy.md
@@ -1,3 +1,11 @@
+---
+purpose: 売却価格算出・譲渡所得税計算の仕様
+triggers: [exit strategy, 出口戦略, 譲渡所得, 売却, calcExit, capital gains]
+audience: backend-dev
+token_weight: medium
+reads_next: [docs/llm/domain.md]
+---
+
 # 出口戦略・譲渡所得税計算仕様
 
 `backend/internal/domain/investment.go` の `calcExit` 関数（非公開）が担当。

--- a/docs/domain-glossary.md
+++ b/docs/domain-glossary.md
@@ -1,3 +1,10 @@
+---
+purpose: 不動産投資ドメイン用語・概念・指標の解説
+triggers: [glossary, 用語, NOI, cap rate, LTV, 表面利回り, 実質利回り, キャッシュフロー]
+audience: all
+token_weight: heavy
+---
+
 # 不動産投資 概念・指標 解説
 
 このドキュメントは Yield-Guard が扱う不動産投資の概念・指標を「**なぜ重要か・何を意味するか・どう使うか**」の観点で解説する。  

--- a/docs/domain-investment-calculation.md
+++ b/docs/domain-investment-calculation.md
@@ -1,3 +1,11 @@
+---
+purpose: InvestmentInput 全フィールド定義・計算手順の詳細仕様
+triggers: [investment calculation, InvestmentInput, Analyze, 計算ロジック, 収益計算]
+audience: backend-dev
+token_weight: heavy
+reads_next: [docs/llm/domain.md]
+---
+
 # 投資計算ロジック詳細仕様
 
 `backend/internal/domain/investment.go` の `Analyze` 関数が中心。

--- a/docs/domain-zoning.md
+++ b/docs/domain-zoning.md
@@ -1,3 +1,11 @@
+---
+purpose: 用途地域・都市計画区域のドメイン型仕様
+triggers: [zoning, 用途地域, urban planning, ZoningType, 都市計画]
+audience: backend-dev
+token_weight: light
+reads_next: [docs/llm/domain.md]
+---
+
 # 用途地域・都市計画区域 ドメイン型仕様
 
 実装: `backend/internal/domain/zoning.go`

--- a/docs/e2e-selector-guide.md
+++ b/docs/e2e-selector-guide.md
@@ -1,3 +1,11 @@
+---
+purpose: Playwright E2E テストのセレクタ優先順位ガイド
+triggers: [e2e, playwright, selector, test, data-testid]
+audience: frontend-dev
+token_weight: medium
+reads_next: [docs/llm/frontend.md]
+---
+
 # E2E セレクタ ガイドライン
 
 Playwright を使った E2E テストを追加・変更する際の指針。

--- a/docs/frontend-components.md
+++ b/docs/frontend-components.md
@@ -1,3 +1,11 @@
+---
+purpose: フロントエンドコンポーネントの詳細仕様・状態フロー
+triggers: [component, dashboard, form, chart, watchlist, state, props]
+audience: frontend-dev
+token_weight: heavy
+reads_next: [docs/llm/frontend.md]
+---
+
 # フロントエンドコンポーネント仕様
 
 `frontend/src/components/` 配下。フレームワーク: Next.js 16 (App Router)

--- a/docs/llm/backend.md
+++ b/docs/llm/backend.md
@@ -1,0 +1,60 @@
+---
+purpose: バックエンド開発（Go / API / swagger）の出発点
+triggers: [go, handler, router, swagger, api endpoint, mlit client, domain type]
+reads_next: [docs/api-reference.md, docs/mlit-api-integration.md]
+last_updated: 2026-05-21
+---
+
+## 重要ファイル
+
+| ファイル | 役割 |
+|---------|-----|
+| `backend/cmd/server/main.go` | エントリーポイント・swag メタアノテーション置き場 |
+| `backend/internal/api/handler.go` | HTTP ハンドラ（大半のエンドポイント） |
+| `backend/internal/api/rent_handler.go` | `/api/rent-stats` ハンドラ |
+| `backend/internal/api/router.go` | Gin ルーター・CORS・認証ミドルウェア |
+| `backend/internal/domain/types.go` | ドメイン型（Go struct = TypeScript 型の Single Source of Truth） |
+| `backend/internal/domain/investment.go` | 利回り / デッドクロス / 出口計算ロジック |
+| `backend/internal/mlit/client.go` | MLIT API クライアント（リトライ・キャッシュ） |
+
+## 新規エンドポイント追加の手順
+
+1. `domain/types.go` にリクエスト/レスポンス型を追加
+2. `handler.go`（または新ファイル）にハンドラを実装
+3. `router.go` にルートを登録
+4. `make swagger` を実行 → `docs/openapi/swagger.json` を更新
+5. swagger.json を**コミットに含める**（CI が型チェックに使う）
+
+## swag アノテーション記法
+
+```go
+// @Summary     概要（日本語可）
+// @Tags        タグ名
+// @Produce     json
+// @Param       name  query  string  true  "説明"
+// @Success     200  {object}  domain.ResponseType
+// @Failure     400  {object}  map[string]string
+// @Router      /api/path [get]
+func (h *Handler) HandlerFunc(c *gin.Context) {
+```
+
+> `@title` 等のメタ情報は `cmd/server/main.go` の `func main()` 直前に書く（`doc.go` では読まれない）。
+
+## OpenAPI 型生成パイプライン
+
+```
+backend/internal/domain/*.go  (Go struct + swag アノテーション)
+    ↓ make swagger
+docs/openapi/swagger.json     (コミット対象 — 編集禁止)
+    ↓ npm run generate:types
+frontend/src/types/api.generated.ts  (git 管理外 — CI で毎回生成)
+```
+
+- `swagger.json` は git 管理対象。変更したら必ずコミットに含める
+- `api.generated.ts` は git 管理外。ローカルで使う場合は `npm run generate:types` を実行
+
+## テスト実行
+
+```bash
+cd backend && go test -race ./... -timeout 120s
+```

--- a/docs/llm/domain.md
+++ b/docs/llm/domain.md
@@ -1,0 +1,43 @@
+---
+purpose: 投資計算・ドメインロジック変更の出発点
+triggers: [yield, 利回り, dead cross, デッドクロス, exit, 出口戦略, depreciation, 減価償却, investment calc]
+reads_next: [docs/domain-investment-calculation.md, docs/domain-depreciation-dead-cross.md, docs/domain-exit-strategy.md]
+last_updated: 2026-05-21
+---
+
+## 重要ファイル
+
+| ファイル | 役割 |
+|---------|-----|
+| `backend/internal/domain/types.go` | 全ドメイン型定義（`InvestmentInput`, `InvestmentResult` 等） |
+| `backend/internal/domain/investment.go` | 粗利回り・デッドクロス・出口戦略の計算実装 |
+| `backend/internal/domain/investment_test.go` | 計算ロジックのユニットテスト |
+
+## 計算ロジックの所在
+
+| 計算内容 | 関数 / ファイル |
+|---------|--------------|
+| 粗利回り（表面・実質） | `investment.go` — `CalcGrossYield` |
+| デッドクロス判定 | `investment.go` — `CalcDeadCross` |
+| 出口戦略・譲渡所得税 | `investment.go` — `CalcExitStrategy` |
+| 減価償却（法定耐用年数） | `investment.go` — 詳細は `docs/domain-depreciation-dead-cross.md` |
+
+## 型変更時の注意
+
+ドメイン型（`types.go`）を変更したら必ず:
+
+1. `make swagger` を実行
+2. `docs/openapi/swagger.json` を変更に含めてコミット
+3. フロントエンド側で `npm run generate:types` を実行して型ズレを確認
+
+## テスト追加パターン
+
+```go
+func TestCalcXxx(t *testing.T) {
+    input := domain.InvestmentInput{ /* フィールド */ }
+    result := CalcXxx(input)
+    assert.Equal(t, expected, result.Field)
+}
+```
+
+詳細な計算仕様: `docs/domain-investment-calculation.md`（フィールド定義・計算手順）

--- a/docs/llm/domain.md
+++ b/docs/llm/domain.md
@@ -15,12 +15,16 @@ last_updated: 2026-05-21
 
 ## 計算ロジックの所在
 
-| 計算内容 | 関数 / ファイル |
-|---------|--------------|
-| 粗利回り（表面・実質） | `investment.go` — `CalcGrossYield` |
-| デッドクロス判定 | `investment.go` — `CalcDeadCross` |
-| 出口戦略・譲渡所得税 | `investment.go` — `CalcExitStrategy` |
-| 減価償却（法定耐用年数） | `investment.go` — 詳細は `docs/domain-depreciation-dead-cross.md` |
+すべての計算は `Analyze` 関数（公開）がエントリーポイント。個別ロジックは内部で分岐する。
+
+| 計算内容 | 関数 / フィールド |
+|---------|----------------|
+| 投資シミュレーション全体 | `investment.go` — `Analyze(ctx, InvestmentInput) InvestmentResult` |
+| 粗利回り（結果フィールド） | `InvestmentResult.GrossYield` |
+| デッドクロス発生年（結果フィールド） | `InvestmentResult.DeadCrossYear` |
+| 出口戦略・譲渡所得税（非公開） | `investment.go` — `calcExit(...)` |
+| DSCR 計算（公開ユーティリティ） | `investment.go` — `CalcDSCR(noi, annualDebtService)` |
+| 減価償却（法定耐用年数） | `investment.go` 内部 — 詳細は `docs/domain-depreciation-dead-cross.md` |
 
 ## 型変更時の注意
 
@@ -33,10 +37,10 @@ last_updated: 2026-05-21
 ## テスト追加パターン
 
 ```go
-func TestCalcXxx(t *testing.T) {
+func TestAnalyze_Xxx(t *testing.T) {
     input := domain.InvestmentInput{ /* フィールド */ }
-    result := CalcXxx(input)
-    assert.Equal(t, expected, result.Field)
+    result := domain.Analyze(context.Background(), input)
+    assert.Equal(t, expected, result.GrossYield)
 }
 ```
 

--- a/docs/llm/frontend.md
+++ b/docs/llm/frontend.md
@@ -1,0 +1,49 @@
+---
+purpose: フロントエンド開発（Next.js / TSX / UI）の出発点
+triggers: [tsx, react, component, tailwind, shadcn, recharts, frontend, ui]
+reads_next: [docs/frontend-components.md, docs/usecases.md]
+last_updated: 2026-05-21
+---
+
+## 重要ファイル
+
+| ファイル | 役割 |
+|---------|-----|
+| `frontend/src/app/` | Next.js App Router ページ |
+| `frontend/src/components/Dashboard.tsx` | トップレベルレイアウト |
+| `frontend/src/components/InvestmentForm.tsx` | 入力フォーム |
+| `frontend/src/components/YieldAnalysis.tsx` | 粗利回り + 8%閾値（免責事項 Alert の参照実装） |
+| `frontend/src/components/DeadCrossChart.tsx` | デッドクロス可視化（ResponsiveContainer の参照実装） |
+| `frontend/src/components/WatchlistPanel.tsx` | ウォッチリスト（Badge + アイコンの参照実装） |
+| `frontend/src/lib/` | API クライアント・計算ユーティリティ |
+| `frontend/src/types/investment.ts` | 手動定義 TypeScript 型 |
+| `frontend/src/types/api.generated.ts` | 自動生成型（編集禁止・git 管理外） |
+
+## TypeScript 型の再生成
+
+```bash
+# make swagger が実行済みであること（swagger.json が最新であること）が前提
+cd frontend && npm run generate:types
+```
+
+## UI デザインルール
+
+**禁止**
+- グラデーション背景（`bg-gradient-*`）— ブランドカラーのみ
+- Lucide 以外のアイコンライブラリ
+- 色だけで状態（エラー/警告/成功）を表現 — Badge + アイコンを必ず併記（WCAG 1.4.1）
+- ネスト3段以上の可変幅コンテナ
+- ラベルなしアイコンボタン（`aria-label` か `Tooltip` を必ず付ける）
+
+**必須**
+- 投資シミュレーション結果には `<Alert>` で免責事項を表示（`YieldAnalysis.tsx` 参照）
+- ステータス表示は `<Badge>` + アイコン（`WatchlistPanel.tsx` 参照）
+- チャートは `<ResponsiveContainer>` でラップ（`DeadCrossChart.tsx` 参照）
+- 削除・リセット操作は `AlertDialog` で確認
+- ローディングは Skeleton UI（`<Spinner>` 不使用）
+
+## テスト実行
+
+```bash
+cd frontend && npm test
+```

--- a/docs/llm/worktree.md
+++ b/docs/llm/worktree.md
@@ -1,0 +1,51 @@
+---
+purpose: ブランチ作成・worktree・PR 作業の手順
+triggers: [worktree, branch, pr, pull request, rebase, merge]
+reads_next: []
+last_updated: 2026-05-21
+---
+
+## Worktree 作成手順
+
+```bash
+# メインリポジトリのルートで実行
+git worktree add ../<worktree-dir> -b <branch-name>
+ln -s "$(pwd)/frontend/node_modules" "../<worktree-dir>/frontend/node_modules"
+```
+
+- `npm install` は worktree 内で**絶対に実行しない**（`package-lock.json` が壊れる）
+- `make install-hooks` も不要（メインリポジトリの `.git/hooks/` を自動共有）
+
+## ブランチ命名
+
+```
+feature/<content>   新機能
+fix/<content>       バグ修正
+chore/<content>     依存更新・設定変更
+docs/<content>      ドキュメントのみ
+refactor/<content>  動作変更なしのリファクタ
+test/<content>      テスト追加・修正
+```
+
+## PR 作成前チェックリスト
+
+- [ ] `make lint` が通る
+- [ ] `make test` が通る
+- [ ] Go 型変更がある場合 → `make swagger` 実行 + `swagger.json` をコミットに含める
+- [ ] `git rebase origin/main` を**プッシュ直前に1回だけ**実行
+- [ ] PR title: 日本語、PR body: `.github/pull_request_template.md` に従う
+
+## マージ方法
+
+```bash
+# squash は禁止。必ず --merge を使う
+gh pr merge <PR番号> --merge --delete-branch
+# ローカル worktree は手動で削除
+git worktree remove ../<worktree-dir>
+```
+
+## PR 作業時の注意
+
+- `main` への直接プッシュ禁止
+- `--force` プッシュ禁止
+- コミットに `Co-Authored-By:` 行を追加しない

--- a/docs/llm/worktree.md
+++ b/docs/llm/worktree.md
@@ -5,6 +5,15 @@ reads_next: []
 last_updated: 2026-05-21
 ---
 
+## 初回セットアップ（clone 後1回）
+
+```bash
+make install          # frontend npm install（メインリポジトリのみ・worktree では不要）
+make install-hooks    # lefthook の pre-commit / pre-push フック登録
+```
+
+> `make install-hooks` が失敗する場合: `git config --unset-all --local core.hooksPath` を実行してから再試行する。
+
 ## Worktree 作成手順
 
 ```bash

--- a/docs/mlit-api-integration.md
+++ b/docs/mlit-api-integration.md
@@ -1,3 +1,11 @@
+---
+purpose: MLIT API クライアントの実装仕様（認証・キャッシュ・リトライ戦略）
+triggers: [mlit, client.go, geocode, land-prices, reinfolib, cache, retry]
+audience: backend-dev
+token_weight: heavy
+reads_next: [docs/llm/backend.md]
+---
+
 # 国交省不動産取引価格APIクライアント仕様
 
 `backend/internal/mlit/client.go` / `client_test.go` / `types.go`

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,10 @@
+---
+purpose: プロジェクト全体像・システム構成の概要
+triggers: [overview, project, system, architecture overview]
+audience: all
+token_weight: medium
+---
+
 # プロジェクト概要とアーキテクチャ
 
 ## ツールの目的

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,3 +1,10 @@
+---
+purpose: 内部通信認証・CORS・セキュリティ設計の仕様
+triggers: [security, auth, cors, api key, internal key, APP_INTERNAL_API_KEY]
+audience: backend-dev
+token_weight: medium
+---
+
 # セキュリティ設計
 
 ## 内部通信認証（APP_INTERNAL_API_KEY）

--- a/docs/usecases.md
+++ b/docs/usecases.md
@@ -1,3 +1,10 @@
+---
+purpose: ユーザーシナリオ・機能別ユースケース一覧
+triggers: [usecase, scenario, user story, feature]
+audience: all
+token_weight: medium
+---
+
 # ユースケース一覧
 
 Yield-Guard が解決するユーザーシナリオをまとめます。


### PR DESCRIPTION
## 概要

Claude Code でのトークン消費を削減するため、ドキュメント管理を「LLM Wiki」アーキテクチャに移行する。

## 背景と目的

- `CLAUDE.md`（252行）が毎会話で全量ロードされ、タスクと無関係な情報もトークンを消費していた
- `docs/`（7,500行超）は MCP 経由の遅延ロードを想定していたが、`.mcp.json` は外部リポジトリ（`docs-mcp-server`）依存かつ絶対パスを含むため gitignore されており、新環境では再現できない状態だった
- プロジェクト固有の知識（swagger パイプライン、worktree 手順等）がセッション毎に再導出されていた

## 変更内容

### CLAUDE.md のスリム化
- **252行 → 65行**（毎会話 約2,500トークン削減）
- API エンドポイント一覧・ディレクトリツリー・UI ルール詳細・swag 記法などを `docs/llm/` へ移動
- タスクエントリーテーブルを追加（作業種別ごとに読むべきドキュメントを明示）

### `docs/llm/` エントリードキュメントの新規追加（4本）

| ファイル | 内容 |
|---------|-----|
| `docs/llm/backend.md` | 重要ファイルパス・swag 記法・型生成パイプライン |
| `docs/llm/frontend.md` | コンポーネント一覧・UI 禁止/必須ルール・型生成コマンド |
| `docs/llm/domain.md` | 計算ロジックの所在・型変更時の注意・テストパターン |
| `docs/llm/worktree.md` | worktree 作成手順・PR チェックリスト・マージ方法 |

### 既存 `docs/*.md` に YAML frontmatter 付加
全13ファイルに `purpose` / `triggers` / `token_weight` / `reads_next` を追加。
LLM がタスクに応じて必要なドキュメントだけを選んで読み込めるようになる。

### `.mcp.json` の追加・git 管理化
外部リポジトリ依存を排除し `@modelcontextprotocol/server-filesystem` に切り替え。
相対パス（`./docs`）を採用することでマシン依存がなくなり、gitignore から外して git 管理対象にした。

## テスト計画

- [x] pre-push フック（vitest 376件・go test 全パッケージ）が通ることを確認
- [ ] 新規会話で `CLAUDE.md` のみがロードされ、必要に応じて `docs/llm/*.md` が参照されることを確認
- [ ] `mcp__docs__*` ツールが会話内で呼び出せることを確認