### PR TITLE
fix(backend): 基礎控除の高所得逓減（年収2,400万円超）を税務シミュレーションに実装する

### DIFF
--- a/backend/internal/domain/tax.go
+++ b/backend/internal/domain/tax.go
@@ -68,16 +68,18 @@ func calcSalaryDeduction(salary float64) float64 {
 	}
 }
 
-// calcSalaryTaxableIncome は給与年収から給与所得控除・基礎控除を差し引いた課税所得を返す。
-// 基礎控除は48万円（所得税法86条、2020年以降・所得2,400万円以下の場合）。
-func calcSalaryTaxableIncome(salary float64) float64 {
-	deduction := calcSalaryDeduction(salary)
-	const basicDeduction = 480_000
-	taxable := salary - deduction - basicDeduction
-	if taxable < 0 {
+// calcBasicDeduction は合計所得金額（基礎控除適用前）に応じた基礎控除額を返す（所得税法86条、2020年以降）。
+func calcBasicDeduction(totalIncome float64) float64 {
+	switch {
+	case totalIncome <= 24_000_000:
+		return 480_000
+	case totalIncome <= 24_500_000:
+		return 320_000
+	case totalIncome <= 25_000_000:
+		return 160_000
+	default:
 		return 0
 	}
-	return taxable
 }
 
 // CalcTaxSimulation は給与年収を元に損益通算と個人/法人比較を算出する。
@@ -96,7 +98,12 @@ func CalcTaxSimulation(input InvestmentInput, yearly []YearlyResult, exitCapital
 		holdingYears = len(yearly)
 	}
 
-	salaryTaxable := calcSalaryTaxableIncome(input.SalaryIncome)
+	salaryDeduction := calcSalaryDeduction(input.SalaryIncome)
+	salaryIncomeAmt := input.SalaryIncome - salaryDeduction
+	salaryTaxable := salaryIncomeAmt - calcBasicDeduction(salaryIncomeAmt)
+	if salaryTaxable < 0 {
+		salaryTaxable = 0
+	}
 	baselineTax := calcTotalTax(salaryTaxable)
 
 	// --- 損益通算シミュレーション (#399) ---
@@ -105,8 +112,12 @@ func CalcTaxSimulation(input InvestmentInput, yearly []YearlyResult, exitCapital
 
 	for i := 0; i < holdingYears; i++ {
 		yr := yearly[i]
-		// 合算課税所得: 給与課税所得 + 不動産課税所得（負なら損益通算で圧縮）
-		combinedTaxable := salaryTaxable + yr.TaxableIncome
+		// 合計所得金額（基礎控除前）= 給与所得金額 + 不動産課税所得
+		preBasic := salaryIncomeAmt + yr.TaxableIncome
+		if preBasic < 0 {
+			preBasic = 0
+		}
+		combinedTaxable := preBasic - calcBasicDeduction(preBasic)
 		if combinedTaxable < 0 {
 			combinedTaxable = 0
 		}
@@ -131,7 +142,11 @@ func CalcTaxSimulation(input InvestmentInput, yearly []YearlyResult, exitCapital
 		reTaxable := yearly[i].TaxableIncome
 
 		// 個人: 給与+不動産の合算から「給与のみ」を引いた差分を不動産帰属税とみなす
-		combinedTaxable := salaryTaxable + reTaxable
+		preBasic := salaryIncomeAmt + reTaxable
+		if preBasic < 0 {
+			preBasic = 0
+		}
+		combinedTaxable := preBasic - calcBasicDeduction(preBasic)
 		if combinedTaxable < 0 {
 			combinedTaxable = 0
 		}

--- a/backend/internal/domain/tax_test.go
+++ b/backend/internal/domain/tax_test.go
@@ -57,6 +57,29 @@ func TestCalcSalaryDeduction(t *testing.T) {
 	}
 }
 
+func TestCalcBasicDeduction(t *testing.T) {
+	tests := []struct {
+		name        string
+		totalIncome float64
+		want        float64
+	}{
+		{"2400万円以下: 上限", 24_000_000, 480_000},
+		{"2400万円超: 下限+1", 24_000_001, 320_000},
+		{"2450万円以下: 上限", 24_500_000, 320_000},
+		{"2450万円超: 下限+1", 24_500_001, 160_000},
+		{"2500万円以下: 上限", 25_000_000, 160_000},
+		{"2500万円超: ゼロ", 25_000_001, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := calcBasicDeduction(tt.totalIncome)
+			if got != tt.want {
+				t.Errorf("calcBasicDeduction(%.0f) = %.0f, want %.0f", tt.totalIncome, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCalcTaxSimulation_NilWhenNoSalary(t *testing.T) {
 	input := InvestmentInput{SalaryIncome: 0, HoldingYears: 10}
 	result := CalcTaxSimulation(input, []YearlyResult{}, 0)


### PR DESCRIPTION
## 概要

所得税法86条（2020年以降）に基づく基礎控除の逓減ロジックを実装する。
従来は年収に関わらず一律48万円を適用していたため、年収2,500万円超のユーザーで最大約21万円の税額過少計上が発生していた。

## 変更内容

- `calcBasicDeduction(totalIncome float64) float64` を追加（合計所得金額に応じて480K / 320K / 160K / 0円を返す）
- `CalcTaxSimulation` の損益通算ループ・所有形態比較ループを修正：基礎控除を「給与所得金額＋不動産課税所得」の合算に対して適用するよう変更
- 2,400万円・2,450万円・2,500万円各境界値のユニットテスト（`TestCalcBasicDeduction`）を追加
- 2,400万円以下のユーザーへの影響はなし（既存テストが全件PASS）

## 関連Issue

Closes #715

## テスト

- [x] 既存テストが通ること
- [x] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み