### PR TITLE
テスト強化: DSCR 境界値テスト追加 + バックエンドカバレッジ閾値 80% 設定

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -69,6 +69,7 @@ jobs:
           echo '```' >> $GITHUB_STEP_SUMMARY
           cat coverage.txt >> $GITHUB_STEP_SUMMARY
           echo '```' >> $GITHUB_STEP_SUMMARY
+          grep total coverage.txt | awk '{gsub(/%/,"",$3); if ($3+0 < 80) { print "Coverage " $3 "% is below 80% threshold"; exit 1 }}'
 
       - name: Cache govulncheck binary
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5

--- a/frontend/src/lib/__tests__/verdict.test.ts
+++ b/frontend/src/lib/__tests__/verdict.test.ts
@@ -94,3 +94,28 @@ describe("calcVerdict", () => {
     expect(v.autoComment).toContain("0.90");
   });
 });
+
+describe("calcVerdict – DSCR 境界値", () => {
+  it("DSCR 1.19 → CAUTION（1.20 未満）", () => {
+    const v = calcVerdict(makeInput(), makeResult({ criticalErrors: [] }), 1.19, 1.0);
+    expect(v.level).toBe("CAUTION");
+  });
+
+  it("DSCR 1.20 → PASS（閾値ちょうど、他条件 OK）", () => {
+    const v = calcVerdict(makeInput(), makeResult({ criticalErrors: [] }), 1.2, 1.0);
+    expect(v.level).toBe("PASS");
+  });
+
+  it("DSCR 0 → REJECT（1.00 未満）", () => {
+    const v = calcVerdict(makeInput(), makeResult({ criticalErrors: [] }), 0, 0);
+    expect(v.level).toBe("REJECT");
+  });
+
+  it("DSCR 1.20 でも criticalErrors に REJECT があれば REJECT", () => {
+    const result = makeResult({
+      criticalErrors: [{ code: "NEGATIVE_CF", status: "REJECT", message: "キャッシュフロー赤字" }],
+    });
+    const v = calcVerdict(makeInput(), result, 1.2, 1.0);
+    expect(v.level).toBe("REJECT");
+  });
+});


### PR DESCRIPTION
## 概要

- フロントエンド: `calcVerdict` の DSCR 境界値テストを追加（#687）
- バックエンド CI: テストカバレッジ閾値 80% を設定（#688）

## 変更内容

### `verdict.test.ts`（#687）

既存テストは DSCR=1.1 / 1.3 / 0.8 など「明確に範囲内」の値を使っており、判定境界（1.19/1.20）の挙動が未検証だった。新規 describe ブロック `calcVerdict – DSCR 境界値` に以下 4 ケースを追加:

| DSCR | criticalErrors | 期待値 |
|------|--------------|--------|
| 1.19 | なし | CAUTION |
| 1.20 | なし（他条件 OK） | PASS |
| 0 | なし | REJECT |
| 1.20 | REJECT エラーあり | REJECT |

### `backend-ci.yml`（#688）

`go test` ステップで既に `coverage.txt` を生成済みだったため、その末尾の `total` 行を `awk` で評価する 1 行を追加。現状のカバレッジ 81.8% は閾値を満たしており、CI は引き続き通過する。

## テスト

- `npm test -- verdict.test.ts`: 12 テスト全通過
- `vitest run`（全体）: 380 テスト通過
- `go test -race ./...`: 全パス、total 81.8%

## 関連 issue

- Closes #687
- Closes #688
- Parent Epic: #669