### PR TITLE
fix(ci): Dependabot PRのVercelデプロイをスキップ

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -135,7 +135,8 @@ jobs:
       (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
       (github.event_name == 'pull_request' &&
        github.event.action != 'closed' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       github.actor != 'dependabot[bot]')
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -221,7 +221,8 @@ jobs:
     if: |
       github.event_name == 'pull_request' &&
       github.event.action == 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## 概要

- Dependabot PRで「Deploy to Vercel」ジョブが常に失敗していた問題を修正

## 原因

GitHubのセキュリティポリシーにより、Dependabot PRでは通常のリポジトリシークレット（`VERCEL_TOKEN` 等）にアクセスできない。ログには `Secret source: Dependabot` と出力され、Vercel CLIが以下のエラーで失敗していた。

```
Error: No existing credentials found. Please run `vercel login` or pass "--token"
```

`deploy`ジョブの`if`条件にはフォーク除外（`head.repo.full_name == github.repository`）のみが含まれており、Dependabotの除外が漏れていた。

## 修正内容

`deploy`ジョブの条件に `github.actor != 'dependabot[bot]'` を追加。Dependabot PRでは依存パッケージの更新のみのためプレビューデプロイは不要。

## 関連PR

- #744（Dependabot Frontend patch updates）でこの問題を検出