### PR TITLE
fix(input): 数値入力フィールドの suffix 重なりと初期値・単位表示を修正する

### DIFF
--- a/frontend/src/components/LoanComparePanel.tsx
+++ b/frontend/src/components/LoanComparePanel.tsx
@@ -209,7 +209,7 @@ export function LoanComparePanel({ baseInput }: Props) {
                         : 0;
                     return (
                       <td key={i} className="px-3 py-2 text-center">
-                        {toMan(monthlyPayment)}万円
+                        {toMan(monthlyPayment) || "0"}万円
                       </td>
                     );
                   })}
@@ -325,7 +325,7 @@ export function LoanComparePanel({ baseInput }: Props) {
                     const equity = propertyValue * (1 - sc.ltv);
                     return (
                       <td key={i} className="px-3 py-2 text-center">
-                        {toMan(equity)}万円
+                        {toMan(equity) || "0"}万円
                       </td>
                     );
                   })}
@@ -342,7 +342,7 @@ export function LoanComparePanel({ baseInput }: Props) {
                       );
                     return (
                       <td key={i} className="px-3 py-2 text-center">
-                        {toMan(res.totalInterest)}万円
+                        {toMan(res.totalInterest) || "0"}万円
                       </td>
                     );
                   })}

--- a/frontend/src/components/sections/PropertyInfoSection.tsx
+++ b/frontend/src/components/sections/PropertyInfoSection.tsx
@@ -5,7 +5,7 @@ import { Select } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { AlertTriangle, ShieldCheck, HelpCircle } from "lucide-react";
 import type { InvestmentInput, BuildingType, RentDeclineHint } from "@/types/investment";
-import { toMan, fromMan, toPct, fromPct } from "@/lib/utils";
+import { toMan, fromMan, toManFloat, toPct, fromPct } from "@/lib/utils";
 import { BUILDING_TYPES, RENT_DECLINE_DEFAULTS } from "@/lib/investmentFormConstants";
 import { ZONING_TYPES, ZONING_META, type ZoningType } from "@/lib/zoning";
 import { RentValidationHint } from "@/components/RentValidationHint";
@@ -410,7 +410,7 @@ export function PropertyInfoSection({
             type="number"
             inputMode="decimal"
             suffix="m²"
-            value={String(input.landArea)}
+            value={input.landArea === 0 ? "" : String(input.landArea)}
             onChange={(e) => setNum("landArea", parseFloat(e.target.value) || 0)}
           />
           <div className="sm:col-span-2">
@@ -443,16 +443,18 @@ export function PropertyInfoSection({
             label="築年数"
             type="number"
             inputMode="numeric"
-            suffix="年（0=新築）"
-            value={String(input.buildingAge)}
+            suffix="年"
+            placeholder="0=新築"
+            value={input.buildingAge === 0 ? "" : String(input.buildingAge)}
             onChange={(e) => setNum("buildingAge", parseInt(e.target.value) || 0)}
           />
           <Input
             label="最寄り駅徒歩"
             type="number"
             inputMode="numeric"
-            suffix="分（0=未入力）"
-            value={String(input.stationMinutes)}
+            suffix="分"
+            placeholder="未入力可"
+            value={input.stationMinutes === 0 ? "" : String(input.stationMinutes)}
             onChange={(e) => setNum("stationMinutes", parseInt(e.target.value) || 0)}
           />
           <Select
@@ -517,7 +519,7 @@ export function PropertyInfoSection({
                   step="1"
                   min="0"
                   max="20"
-                  value={String(input.rentGrowthYears ?? 0)}
+                  value={(input.rentGrowthYears ?? 0) === 0 ? "" : String(input.rentGrowthYears)}
                   onChange={(e) => setNum("rentGrowthYears", parseInt(e.target.value) || 0)}
                 />
               </div>
@@ -537,10 +539,10 @@ export function PropertyInfoSection({
             <Input
               label="想定月額賃料"
               type="number"
-              inputMode="numeric"
-              suffix="円"
-              value={String(input.monthlyRent)}
-              onChange={(e) => setNum("monthlyRent", parseFloat(e.target.value) || 0)}
+              inputMode="decimal"
+              suffix="万円"
+              value={toManFloat(input.monthlyRent)}
+              onChange={(e) => setNum("monthlyRent", fromMan(e.target.value))}
               error={fieldError("monthlyRent")}
             />
             <RentValidationHint

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -26,9 +26,17 @@ export function formatTsubo(value: number): string {
   return `${Math.round(value).toLocaleString("ja-JP")}円/坪`;
 }
 
-/** 円 → 万円文字列 (入力フィールド向け) */
+/** 円 → 万円文字列 (入力フィールド向け、0のとき空文字) */
 export function toMan(yen: number): string {
+  if (yen === 0) return "";
   return String(Math.round(yen / 10_000));
+}
+
+/** 円 → 万円文字列・小数対応 (月額賃料など小数が生じるフィールド向け、0のとき空文字) */
+export function toManFloat(yen: number): string {
+  if (yen === 0) return "";
+  const v = yen / 10_000;
+  return v % 1 === 0 ? String(v) : v.toFixed(1);
 }
 
 /** 万円文字列 → 円 */


### PR DESCRIPTION
## 概要
フォームの数値入力フィールドで発生している2つの表示問題を修正する。

## 変更内容
### #736: suffix 重なりの修正
- `築年数`: suffix `年（0=新築）` → `年`、placeholder に `0=新築` を移動
- `最寄り駅徒歩`: suffix `分（0=未入力）` → `分`、placeholder に `未入力可` を移動
- value が 0 のとき空文字を返すことで placeholder が表示されるようにした

### #737: 初期値・単位の統一
- `想定月額賃料` の入力単位を `円` → `万円` に統一（他の価格フィールドと揃える）
  - `toManFloat()` ヘルパーを追加（小数を保持する万円変換、例: 85,000円 → "8.5"）
- `toMan()` が 0 のとき空文字を返すよう修正 → `土地取得価格`・`建物価格` の初期 placeholder が機能するようになった
- `土地面積`・`賃料上昇期間` も 0 のとき空文字でガード

## 関連Issue
Closes #736
Closes #737

## テスト
- [x] 既存テストが通ること（`make test`: 33 test files, 380 tests all passed）
- [x] `make lint` エラーなし（toast.tsx の既存 warning は本PRと無関係）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み