### PR TITLE
fix(ci): LFS フォントを CI で取得できるよう checkout に lfs:true を追加

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -37,6 +37,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          lfs: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
@@ -89,6 +91,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          lfs: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
@@ -143,6 +147,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          lfs: true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:


### PR DESCRIPTION
## 概要

PR #757（Git LFS フォント移行）のフォローアップ修正。

## 問題

PR #757 マージ後の main ブランチ CI で E2E の PDF テストが失敗した。

```
Error: page.waitForEvent: Test timeout of 30000ms exceeded.
e2e/pdf-export.spec.ts — PDF ダウンロードイベントが発生しない
```

## 原因

`actions/checkout` はデフォルト `lfs: false` のため、LFS 移行後のフォントファイルが LFS ポインタテキスト（130 B）のまま checkout される。pdfmake が virtualfs 経由で TTF を読み込む際に無効なバイナリとして扱われ、PDF 生成がサイレントに失敗してダウンロードイベントが発火しない。

## 修正

3 つの job（`ci` / `e2e` / `deploy`）の `actions/checkout` に `lfs: true` を追加。

```yaml
- uses: actions/checkout@...
  with:
    lfs: true
```

## チェックリスト

- [x] `ci` job の checkout に `lfs: true` 追加
- [x] `e2e` job の checkout に `lfs: true` 追加
- [x] `deploy` job の checkout に `lfs: true` 追加

Closes #753 フォローアップ