### PR TITLE
fix(e2e): KpiStrip と WatchlistCompareTable に data-testid を追加（#755）

### DIFF
--- a/frontend/src/components/KpiStrip.tsx
+++ b/frontend/src/components/KpiStrip.tsx
@@ -74,6 +74,7 @@ export function KpiStrip({ result, yieldTarget = 0.08, holdingYears = 30 }: KpiS
     <div
       role="region"
       aria-label="KPIサマリ"
+      data-testid="kpi-strip"
       className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-5"
     >
       <KpiCell

--- a/frontend/src/components/WatchlistCompareTable.tsx
+++ b/frontend/src/components/WatchlistCompareTable.tsx
@@ -126,7 +126,7 @@ function DscrTrendIcon({ dscr }: { dscr: number | null }) {
 
 export default function WatchlistCompareTable({ items }: WatchlistCompareTableProps) {
   return (
-    <Card className="rounded-xl shadow-sm">
+    <Card className="rounded-xl shadow-sm" data-testid="watchlist-compare-table">
       <CardHeader className="pb-2">
         <CardTitle className="flex items-center gap-2 text-base font-semibold">
           <BarChart2 className="h-4 w-4 text-primary" aria-hidden="true" />


### PR DESCRIPTION
## 概要

verify-yield スキル（Playwright E2E）で KpiStrip（A-2）と WatchlistCompareTable（D-3/D-4）の検出が失敗していた問題を修正する。
コンポーネントに `data-testid` を付与し、テストセレクターと待機時間を安定させる。

## 変更内容

- `KpiStrip.tsx`: root `<div>` に `data-testid="kpi-strip"` を追加
- `WatchlistCompareTable.tsx`: root `<Card>` に `data-testid="watchlist-compare-table"` を追加
- `verify-yield.md`（E2E スクリプト）:
  - D-3 の `waitForTimeout` を 800ms → 2000ms に延長（`dynamic()` のレンダリング待ち）
  - 比較テーブル表示確認前に `scrollIntoViewIfNeeded()` を追加（ページ下部への自動スクロール）
  - D-3 セレクターを `table[hasText]` → `[data-testid="watchlist-compare-table"]` に変更

## 関連Issue

Closes #755

## テスト

- [x] 既存テストが通ること（vitest 380/380、go test 全パッケージ）
- [ ] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み