### PR TITLE
fix(ci): Vercel プレビュー削除ジョブが PR マージ時にキャンセルされる問題を修正

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -10,7 +10,7 @@ on:
       - "Makefile"
   pull_request:
     branches: [main]
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
       - "frontend/**"
       - "docs/openapi/**"
@@ -221,45 +221,3 @@ jobs:
         env:
           PREVIEW_URL: ${{ steps.preview.outputs.url }}
 
-  cleanup:
-    name: Delete Vercel preview on PR close
-    runs-on: ubuntu-24.04
-    if: |
-      github.event_name == 'pull_request' &&
-      github.event.action == 'closed' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      github.actor != 'dependabot[bot]'
-    permissions:
-      contents: read
-      pull-requests: read
-
-    steps:
-      - name: Get preview URL from PR comment
-        id: get-url
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        with:
-          script: |
-            const marker = '<!-- vercel-preview -->';
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const comment = comments.find(c => c.body.includes(marker));
-            if (!comment) { core.setOutput('url', ''); return; }
-            const match = comment.body.match(/https:\/\/[a-zA-Z0-9._-]+\.vercel\.app/);
-            core.setOutput('url', match ? match[0] : '');
-
-      - name: Install Vercel CLI
-        if: steps.get-url.outputs.url != ''
-        run: npm install -g vercel@51.8.0
-
-      - name: Delete preview deployment
-        if: steps.get-url.outputs.url != ''
-        continue-on-error: true
-        run: vercel rm "${{ steps.get-url.outputs.url }}" --yes
-        env:
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-          NO_COLOR: "1"

--- a/.github/workflows/vercel-preview-cleanup.yml
+++ b/.github/workflows/vercel-preview-cleanup.yml
@@ -1,0 +1,55 @@
+name: Delete Vercel preview on PR close
+
+on:
+  pull_request:
+    branches: [main]
+    types: [closed]
+    paths:
+      - "frontend/**"
+      - "docs/openapi/**"
+      - ".github/workflows/frontend-ci.yml"
+      - ".github/workflows/vercel-preview-cleanup.yml"
+      - "Makefile"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  cleanup:
+    name: Delete Vercel preview on PR close
+    runs-on: ubuntu-24.04
+    if: |
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.actor != 'dependabot[bot]'
+
+    steps:
+      - name: Get preview URL from PR comment
+        id: get-url
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
+        with:
+          script: |
+            const marker = '<!-- vercel-preview -->';
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const comment = comments.find(c => c.body.includes(marker));
+            if (!comment) { core.setOutput('url', ''); return; }
+            const match = comment.body.match(/https:\/\/[a-zA-Z0-9._-]+\.vercel\.app/);
+            core.setOutput('url', match ? match[0] : '');
+
+      - name: Install Vercel CLI
+        if: steps.get-url.outputs.url != ''
+        run: npm install -g vercel@51.8.0
+
+      - name: Delete preview deployment
+        if: steps.get-url.outputs.url != ''
+        continue-on-error: true
+        run: vercel rm "${{ steps.get-url.outputs.url }}" --yes
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          NO_COLOR: "1"

--- a/.github/workflows/vercel-preview-cleanup.yml
+++ b/.github/workflows/vercel-preview-cleanup.yml
@@ -4,12 +4,6 @@ on:
   pull_request:
     branches: [main]
     types: [closed]
-    paths:
-      - "frontend/**"
-      - "docs/openapi/**"
-      - ".github/workflows/frontend-ci.yml"
-      - ".github/workflows/vercel-preview-cleanup.yml"
-      - "Makefile"
 
 permissions:
   contents: read

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,6 +116,7 @@ graph TD
 | Backend CI | `backend/**`, `backend-ci.yml` | `golangci-lint` / `go test -race` / `go build` |
 | Frontend CI | `frontend/**`, `frontend-ci.yml` | `lint` / `tsc --noEmit` / `vitest run` / `build` / Vercel デプロイ（main push: 本番 / PR: プレビュー URL を PR コメントに自動投稿） |
 | E2E（Frontend CI内） | `frontend/**`, `frontend-ci.yml` | `playwright test`（PR: `@p1`+`@p2` のみ / main push: 全10件） |
+| Vercel プレビュー削除 | `frontend/**`, `vercel-preview-cleanup.yml` | PR クローズ時にプレビューデプロイを削除（`frontend-ci.yml` の `cancel-in-progress` による競合キャンセルを防ぐため独立ワークフロー化） |
 
 Dependabot により Go modules・npm の依存パッケージが毎週月曜（JST）に自動更新される（エコシステムごとに1PR）。
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -283,6 +283,7 @@ MLIT API クライアント（`backend/internal/mlit/client.go`）は以下の�
 - `terraform/cloud_run.tf` — Cloud Run v2 サービス定義
 - `.github/workflows/deploy-backend.yml` — バックエンドデプロイワークフロー（SHA 固定・Trivy スキャン）
 - `.github/workflows/frontend-ci.yml` — フロントエンド CI + Vercel デプロイワークフロー
+- `.github/workflows/vercel-preview-cleanup.yml` — PR クローズ時の Vercel プレビュー削除ワークフロー（`frontend-ci.yml` から分離）
 - `.github/dependabot.yml` — Dependabot 自動更新設定（gomod / npm / github-actions）
 - `backend/internal/telemetry/setup.go` — OTel TracerProvider / MeterProvider 初期化
 - `backend/internal/logger/logger.go` — Cloud Logging 準拠 slog ハンドラー


### PR DESCRIPTION
## 概要

PR マージ時に Vercel プレビューデプロイが削除されない問題を修正する。

## 原因

`frontend-ci.yml` の `concurrency.cancel-in-progress: true` と `cleanup` ジョブが同一ワークフローに同居していたことが原因。

PR マージ時に `pull_request: closed` イベントが発火して `cleanup` ジョブを含む新しいランが起動するが、ブランチ削除のタイミングで GitHub がそのランを `cancel-in-progress` の競合でキャンセルしてしまい、`cleanup` ジョブが実行される前に中断されていた（実際のランで duration `2s`・`cancelled` を確認）。

## 変更内容

- `frontend-ci.yml` から `cleanup` ジョブを削除し、`pull_request` トリガーの `types` から `closed` を除去
- `vercel-preview-cleanup.yml` を新規作成
  - `pull_request: [closed]` のみをトリガーとする独立したワークフロー
  - `concurrency` / `cancel-in-progress` を持たないため、マージ・ブランチ削除の競合に影響されない
  - ロジック（PR コメントから URL 取得 → `vercel rm`）は既存のものをそのまま移植

## テスト

- [ ] 次回 PR マージ時に `Delete Vercel preview on PR close` ワークフローが `success` で完了することを確認

## 関連

- PR #761 マージ時の CI ログで `cleanup` が `cancelled`（2s）になっていることを確認して原因特定