### PR TITLE
chore(ai): デフォルト Gemini モデルを gemini-3.1-flash-lite に更新する

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,8 @@ GOOGLE_CLOUD_PROJECT=
 # Google AI Studio で取得: https://aistudio.google.com/app/apikey
 # 未設定時は AI サマリーカードが非表示になる（他機能に影響なし）
 GEMINI_API_KEY=
-# GEMINI_MODEL: 使用モデル（デフォルト: gemini-2.5-flash）
-# GEMINI_MODEL=gemini-2.5-flash
+# GEMINI_MODEL: 使用モデル（デフォルト: gemini-3.1-flash-lite）
+# GEMINI_MODEL=gemini-3.1-flash-lite
 
 # Firebase (フロントエンド)
 # Firebase Console で取得: https://console.firebase.google.com/

--- a/backend/internal/ai/gemini.go
+++ b/backend/internal/ai/gemini.go
@@ -20,7 +20,7 @@ import (
 const (
 	aiCacheTTL               = 24 * time.Hour
 	aiCallTimeout            = 5 * time.Second
-	defaultGeminiModel       = "gemini-2.5-flash"
+	defaultGeminiModel       = "gemini-3.1-flash-lite"
 	aiSummaryCacheCollection = "ai_summary_cache"
 )
 


### PR DESCRIPTION
## 概要
`backend/internal/ai/gemini.go` の `defaultGeminiModel` を `gemini-2.5-flash` から `gemini-3.1-flash-lite` に変更する。投資サマリー（〜900 tokens/call）・エリアサマリー（〜530 tokens/call）という小規模な呼び出し用途にはコスト効率重視の lite モデルが適している。

## 変更内容
- `backend/internal/ai/gemini.go` L23: `defaultGeminiModel` の値を更新
- `.env.example`: コメントとサンプル値を新モデル名に更新

## 関連Issue
Closes #745

## テスト
- [x] 既存テストが通ること（go test -race ./... PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み