### PR TITLE
fix: CostBreakdownの金額表記を万円に統一

### DIFF
--- a/frontend/src/components/CostBreakdown.tsx
+++ b/frontend/src/components/CostBreakdown.tsx
@@ -12,10 +12,7 @@ interface Props {
   yearlyResults: YearlyResult[];
 }
 
-const fmt = (n: number) =>
-  n >= 10_000_000
-    ? `${(n / 10_000_000).toFixed(1)}千万円`
-    : `${Math.round(n / 10_000).toLocaleString()}万円`;
+const fmt = (n: number) => `${Math.round(n / 10_000).toLocaleString()}万円`;
 
 const COLORS = [
   chartColors.primary,


### PR DESCRIPTION
## 概要
`CostBreakdown` コンポーネントの金額フォーマット関数が 1,000 万円以上の値を「千万円」表記（例: 1.5千万円）で表示していた。他のすべてのコンポーネントは「万円」で統一されているため、表記を統一する。

## 変更内容
- `frontend/src/components/CostBreakdown.tsx`: `fmt` 関数の `>= 10_000_000` 分岐を削除し、すべての金額を `万円` 単位で表示するよう修正
  - 例: 15,000,000円 → ~~1.5千万円~~ → **1,500万円**

## 関連Issue
なし

## テスト
- [x] 既存テストが通ること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み