### PR TITLE
fix: ツールチップが透明になる不具合を修正（--popover CSS変数の追加）

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -19,6 +19,8 @@
   --color-destructive-foreground: hsl(var(--destructive-foreground));
   --color-card: hsl(var(--card));
   --color-card-foreground: hsl(var(--card-foreground));
+  --color-popover: hsl(var(--popover));
+  --color-popover-foreground: hsl(var(--popover-foreground));
 
   --color-success-bg: hsl(var(--success-bg));
   --color-success-fg: hsl(var(--success-fg));
@@ -46,6 +48,8 @@
     --foreground: 222 47% 11%;
     --card: 0 0% 100%;
     --card-foreground: 222 47% 11%;
+    --popover: 0 0% 100%;
+    --popover-foreground: 222 47% 11%;
     --primary: 221 83% 53%;
     --primary-foreground: 0 0% 100%;
     --secondary: 210 40% 96%;
@@ -93,6 +97,8 @@
     --foreground: 210 40% 96%;
     --card: 222 47% 11%;
     --card-foreground: 210 40% 96%;
+    --popover: 222 47% 11%;
+    --popover-foreground: 210 40% 96%;
     --primary: 217 91% 60%;
     --primary-foreground: 0 0% 100%;
     --secondary: 217 33% 17%;


### PR DESCRIPTION
## 概要

- `globals.css` に `--popover` / `--popover-foreground` CSS 変数が未定義だったため、Shadcn の `TooltipContent` で使われる `bg-popover` / `text-popover-foreground` クラスが解決できず、ツールチップの背景が透明・テキストが不可視になっていた
- `:root`（ライトモード）・`.dark`（ダークモード）・`@theme`（Tailwind クラス登録）の3箇所に変数を追加

## 変更内容

- `frontend/src/app/globals.css`: `--popover` / `--popover-foreground` を追加

## 影響範囲

`bg-popover` / `text-popover-foreground` を使用する全箇所に自動適用：
- `src/components/ui/tooltip.tsx`（`TooltipContent`）
- `src/components/sections/PropertyInfoSection.tsx`（カスタムポップオーバー）

## 確認方法

- [ ] 各ツールチップをクリックして背景色・テキストが正常に表示されることを確認
- [ ] ライトモード・ダークモード両方で確認