### PR TITLE
fix(domain): 新築物件の登録免許税・仲介手数料計算を修正

### DIFF
--- a/backend/internal/domain/acquisition_costs.go
+++ b/backend/internal/domain/acquisition_costs.go
@@ -131,7 +131,15 @@ func CalcAcquisitionCosts(landPrice, buildingCost float64, opts AcquisitionCostO
 		brokerageBase = landPrice
 	}
 	brokerage := CalcBrokerageFee(brokerageBase, opts.BrokerageMultiplier)
-	stamp := CalcStampDuty(totalPrice)
+
+	// 新築: 売買契約書(土地)と請負契約書(建物)に分けて印紙税を計算する。
+	// 合算すると上位ブラケットに入り過大計上になるため（例: 土地800万+建物400万 → 合算20,000円 vs 分割12,000円）。
+	var stamp float64
+	if opts.IsNewBuilding {
+		stamp = CalcStampDuty(landPrice) + CalcStampDuty(buildingCost)
+	} else {
+		stamp = CalcStampDuty(totalPrice)
+	}
 
 	assessedLand := opts.AssessedLandValue
 	if assessedLand == 0 {

--- a/backend/internal/domain/acquisition_costs.go
+++ b/backend/internal/domain/acquisition_costs.go
@@ -55,15 +55,16 @@ func CalcStampDuty(price float64) float64 {
 // 適用税率（根拠: 租税特別措置法・不動産登記法）:
 //   - 土地所有権移転: 固定資産税評価額 × 2.0%（本則。軽減措置 〜2026/3/31 期限切れ）
 //   - 建物所有権移転（中古）: 固定資産税評価額 × 2.0%
-//   - 建物所有権保存（新築）: 固定資産税評価額 × 0.15%（軽減措置 〜2027/3/31）
+//   - 建物所有権保存（新築）: 固定資産税評価額 × 0.4%（本則）
+//     ※ 自己居住用軽減措置（0.15%、租税特別措置法72条の2）は投資用賃貸物件に適用不可
 //   - 抵当権設定: 融資額 × 0.4%（投資用物件は住宅ローン軽減0.1%対象外）
 func CalcRegistrationTax(landAssessed, buildingAssessed, loanAmount float64, isNewBuilding bool) float64 {
 	landTransfer := landAssessed * 0.02
 
 	var buildingTransfer float64
 	if isNewBuilding {
-		// 根拠: 租税特別措置法72条の2 新築住宅用建物の所有権保存登記 軽減措置
-		buildingTransfer = buildingAssessed * 0.0015
+		// 所有権保存登記（本則0.4%）。自己居住用軽減(0.15%)は投資用物件に適用不可
+		buildingTransfer = buildingAssessed * 0.004
 	} else {
 		buildingTransfer = buildingAssessed * 0.02
 	}
@@ -123,7 +124,13 @@ func DefaultAcquisitionCostOptions() AcquisitionCostOptions {
 // 評価額が未入力（0）の場合は推定モード（土地: landPrice×70%、建物: buildingCost×60%）を使用する。
 func CalcAcquisitionCosts(landPrice, buildingCost float64, opts AcquisitionCostOptions) AcquisitionCostBreakdown {
 	totalPrice := landPrice + buildingCost
-	brokerage := CalcBrokerageFee(totalPrice, opts.BrokerageMultiplier)
+
+	// 新築は建物が請負契約（宅建業法の仲介対象外）のため、仲介手数料の基準は土地代金のみ
+	brokerageBase := totalPrice
+	if opts.IsNewBuilding {
+		brokerageBase = landPrice
+	}
+	brokerage := CalcBrokerageFee(brokerageBase, opts.BrokerageMultiplier)
 	stamp := CalcStampDuty(totalPrice)
 
 	assessedLand := opts.AssessedLandValue

--- a/backend/internal/domain/acquisition_costs_test.go
+++ b/backend/internal/domain/acquisition_costs_test.go
@@ -112,10 +112,10 @@ func TestCalcRegistrationTax(t *testing.T) {
 			buildingAssessed: 10_000_000,
 			loanAmount:       25_000_000,
 			isNew:            true,
-			// 土地: 400,000
-			// 建物(新築): 10,000,000×0.0015=15,000
-			// 抵当権: 100,000
-			want: 515_000,
+			// 土地: 20,000,000×0.02=400,000
+			// 建物(新築保存登記・本則): 10,000,000×0.004=40,000
+			// 抵当権: 25,000,000×0.004=100,000
+			want: 540_000,
 		},
 		{
 			name:             "融資なし",
@@ -258,9 +258,9 @@ func TestCalcRegistrationTax_Patterns(t *testing.T) {
 			loanAmount:       0,
 			isNew:            true,
 			// 土地: 10,000,000×0.02=200,000
-			// 建物(新築): 8,000,000×0.0015=12,000
+			// 建物(新築保存登記・本則): 8,000,000×0.004=32,000
 			// 抵当権: 0
-			want: 212_000,
+			want: 232_000,
 		},
 		{
 			name:             "中古・融資なし（土地移転+建物移転）",
@@ -327,6 +327,34 @@ func TestCalcAcquisitionCosts(t *testing.T) {
 	// 不動産取得税: 土地24,500,000×0.5×0.03=367,500, 建物14,400,000×0.03=432,000 → 合計799,500
 	if math.Abs(result.RealEstateAcquisitionTax-799_500) > 1 {
 		t.Errorf("RealEstateAcquisitionTax = %.0f, want 799500", result.RealEstateAcquisitionTax)
+	}
+	wantTotal := result.BrokerageFee + result.StampDuty + result.RegistrationTax + result.RealEstateAcquisitionTax
+	if result.Total != wantTotal {
+		t.Errorf("Total = %.0f, want %.0f", result.Total, wantTotal)
+	}
+}
+
+func TestCalcAcquisitionCosts_NewBuilding(t *testing.T) {
+	// 5900万円: 土地3500万 + 建物2400万, ローン3000万, 新築
+	landPrice := 35_000_000.0
+	buildingCost := 24_000_000.0
+	opts := AcquisitionCostOptions{
+		BrokerageMultiplier: 1.0,
+		LoanAmount:          30_000_000,
+		IsNewBuilding:       true,
+	}
+	result := CalcAcquisitionCosts(landPrice, buildingCost, opts)
+
+	// 仲介手数料: 土地のみ基準 (35,000,000×0.03+60,000)×1.1 = 1,221,000
+	if result.BrokerageFee != 1_221_000 {
+		t.Errorf("BrokerageFee = %.0f, want 1221000", result.BrokerageFee)
+	}
+	// 登録免許税: 土地移転2% + 建物保存登記(本則)0.4% + 抵当権0.4%
+	// 土地推定: 35,000,000×0.7=24,500,000 → 24,500,000×0.02=490,000
+	// 建物推定: 24,000,000×0.6=14,400,000 → 14,400,000×0.004=57,600
+	// 抵当権: 30,000,000×0.004=120,000 → 合計: 667,600
+	if result.RegistrationTax != 667_600 {
+		t.Errorf("RegistrationTax = %.0f, want 667600", result.RegistrationTax)
 	}
 	wantTotal := result.BrokerageFee + result.StampDuty + result.RegistrationTax + result.RealEstateAcquisitionTax
 	if result.Total != wantTotal {

--- a/backend/internal/domain/acquisition_costs_test.go
+++ b/backend/internal/domain/acquisition_costs_test.go
@@ -349,6 +349,11 @@ func TestCalcAcquisitionCosts_NewBuilding(t *testing.T) {
 	if result.BrokerageFee != 1_221_000 {
 		t.Errorf("BrokerageFee = %.0f, want 1221000", result.BrokerageFee)
 	}
+	// 印紙税: 売買契約書(土地35M)+請負契約書(建物24M)を分割計算
+	// CalcStampDuty(35,000,000)=20,000 + CalcStampDuty(24,000,000)=20,000 → 40,000
+	if result.StampDuty != 40_000 {
+		t.Errorf("StampDuty = %.0f, want 40000", result.StampDuty)
+	}
 	// 登録免許税: 土地移転2% + 建物保存登記(本則)0.4% + 抵当権0.4%
 	// 土地推定: 35,000,000×0.7=24,500,000 → 24,500,000×0.02=490,000
 	// 建物推定: 24,000,000×0.6=14,400,000 → 14,400,000×0.004=57,600

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -65,13 +65,17 @@ func Analyze(ctx context.Context, input InvestmentInput) InvestmentResult {
 
 	criticalErrors := calcCriticalErrors(input, sim.deadCrossYear, dp.usefulLife)
 	stressScenarios := calcAllStressScenarios(ctx, input)
+	isNewBuilding := input.BuildingAge == 0
+	if input.IsFirstRegistration != nil {
+		isNewBuilding = *input.IsFirstRegistration
+	}
 	acquisitionCosts := CalcAcquisitionCosts(
 		input.LandPrice,
 		input.BuildingCost,
 		AcquisitionCostOptions{
 			BrokerageMultiplier: 1.0,
 			LoanAmount:          input.LoanAmount,
-			IsNewBuilding:       input.BuildingAge == 0,
+			IsNewBuilding:       isNewBuilding,
 		},
 	)
 	yieldScenarios := calcYieldScenarios(input, yp.totalInvestment)

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -71,6 +71,7 @@ func Analyze(ctx context.Context, input InvestmentInput) InvestmentResult {
 		AcquisitionCostOptions{
 			BrokerageMultiplier: 1.0,
 			LoanAmount:          input.LoanAmount,
+			IsNewBuilding:       input.BuildingAge == 0,
 		},
 	)
 	yieldScenarios := calcYieldScenarios(input, yp.totalInvestment)

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -3499,3 +3499,52 @@ func TestCalcLandPriceTrend_InsufficientSamplesPerYear(t *testing.T) {
 		t.Errorf("insufficient samples: got %q, want 不明", got)
 	}
 }
+
+// TestAnalyze_AcquisitionCosts_NewBuild は Analyze() 経由で IsFirstRegistration が
+// 正しく導線に乗ることを検証する（regression guard for investment.go:isNewBuilding derivation）
+func TestAnalyze_AcquisitionCosts_NewBuild(t *testing.T) {
+	base := InvestmentInput{
+		LandPrice:    35_000_000,
+		BuildingCost: 24_000_000,
+		BuildingAge:  0, // 新築 → IsNewBuilding=true が自動設定されるべき
+		MonthlyRent:  120_000,
+		LoanAmount:   30_000_000,
+		AnnualLoanRate: 0.015,
+		LoanYears:    35,
+		ExpenseRate:  0.2,
+		VacancyRate:  0.05,
+	}
+
+	result := Analyze(context.Background(), base)
+	ac := result.AcquisitionCosts
+
+	// 仲介手数料: 土地のみ基準 (35M×0.03+6万)×1.1 = 1,221,000
+	if ac.BrokerageFee != 1_221_000 {
+		t.Errorf("新築: BrokerageFee = %.0f, want 1,221,000 (土地代金のみ基準)", ac.BrokerageFee)
+	}
+	// 印紙税: 分割計算 35M(20,000) + 24M(20,000) = 40,000
+	if ac.StampDuty != 40_000 {
+		t.Errorf("新築: StampDuty = %.0f, want 40,000 (売買/請負 分割)", ac.StampDuty)
+	}
+	// 登録免許税: 保存登記(0.4%) を使用していること
+	// 土地推定=24.5M→490,000 + 建物推定=14.4M→57,600 + 抵当権=120,000 → 667,600
+	if ac.RegistrationTax != 667_600 {
+		t.Errorf("新築: RegistrationTax = %.0f, want 667,600 (保存登記0.4%%)", ac.RegistrationTax)
+	}
+
+	// IsFirstRegistration=false で明示的に移転登記(2%)を強制できること（築0年転売物件）
+	falseVal := false
+	base2 := base
+	base2.IsFirstRegistration = &falseVal
+	result2 := Analyze(context.Background(), base2)
+	ac2 := result2.AcquisitionCosts
+
+	// 仲介手数料: 中古扱いなので土地+建物合計基準
+	if ac2.BrokerageFee != 2_013_000 {
+		t.Errorf("築0年転売: BrokerageFee = %.0f, want 2,013,000 (合計基準)", ac2.BrokerageFee)
+	}
+	// 登録免許税: 移転登記(2%)を使用 → 建物: 14.4M×0.02=288,000 → 898,000
+	if ac2.RegistrationTax != 898_000 {
+		t.Errorf("築0年転売: RegistrationTax = %.0f, want 898,000 (移転登記2%%)", ac2.RegistrationTax)
+	}
+}

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -154,6 +154,11 @@ type InvestmentInput struct {
 
 	// 税務シミュレーション用（任意）。0 の場合は損益通算・法人比較を計算しない。
 	SalaryIncome float64 `json:"salaryIncome,omitempty"` // 給与年収（円）
+
+	// IsFirstRegistration は所有権保存登記（開発業者直売の新築）か移転登記（中古・転売）かを示す。
+	// nil の場合は BuildingAge == 0 から自動判定する。
+	// 築0年でも非開発業者からの転売（移転登記 2%）の場合は false を明示的に指定すること。
+	IsFirstRegistration *bool `json:"isFirstRegistration,omitempty"`
 }
 
 // CapexEvent は大規模修繕費の発生スケジュール1件

--- a/docs/openapi/swagger.json
+++ b/docs/openapi/swagger.json
@@ -1555,6 +1555,10 @@
                     "description": "保険料率 (例: 0.003 = 0.3%)",
                     "type": "number"
                 },
+                "isFirstRegistration": {
+                    "description": "IsFirstRegistration は所有権保存登記（開発業者直売の新築）か移転登記（中古・転売）かを示す。\nnil の場合は BuildingAge == 0 から自動判定する。\n築0年でも非開発業者からの転売（移転登記 2%）の場合は false を明示的に指定すること。",
+                    "type": "boolean"
+                },
                 "landArea": {
                     "description": "土地面積 (m²)",
                     "type": "number"


### PR DESCRIPTION
## 概要

新築物件（`buildingAge == 0`）における取得時諸経費の計算に2つの誤りがあったため修正する。

## 変更内容

### 1. 登録免許税（所有権保存登記）の税率修正

新築建物の登録免許税は**所有権保存登記**（0.4% 本則）が適用されるが、誤って自己居住用軽減措置（0.15%、租税特別措置法72条の2）を使用していた。

- 軽減措置（0.15%）の適用要件には「自己の居住の用に供する」が含まれており、**投資用賃貸物件には適用不可**
- `IsNewBuilding=true` 時の税率を `0.0015` → `0.004` に修正

また `Analyze()` から `CalcAcquisitionCosts` を呼ぶ際に `IsNewBuilding` を渡していなかったため、常に中古扱い（移転登記 2%）が適用されていた点も合わせて修正。

| | 旧（バグ） | 新（正） |
|---|---|---|
| 新築保存登記 | 常に移転登記 2% | 保存登記本則 0.4% |
| 中古移転登記 | 2%（変更なし） | 2% |

### 2. 仲介手数料の計算基準修正

新築物件の建物は**請負契約**（工務店・ハウスメーカーとの直接契約）であり、宅地建物取引業法第46条の仲介報酬規定の対象外。仲介手数料の計算基準を `landPrice + buildingCost` → **`landPrice` のみ**に修正。

- `CalcAcquisitionCosts` に `IsNewBuilding` フラグを追加し、`true` の場合は `landPrice` を基準に `CalcBrokerageFee` を呼ぶよう変更

## 関連Issue

なし（コードレビュー中に発見）

## テスト

- [x] 既存テストが通ること（`make test` PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること
  - `TestCalcRegistrationTax` / `TestCalcRegistrationTax_Patterns`：期待値を新税率に更新
  - `TestCalcAcquisitionCosts_NewBuilding`：新築シナリオのテストケースを新規追加

## 確認事項

- [x] コードレビュー観点での自己レビュー済み