### PR TITLE
refactor(domain): 出口計算の売却費用・取得費・譲渡税ロジックを共通ヘルパーに集約する

### DIFF
--- a/backend/internal/domain/exit.go
+++ b/backend/internal/domain/exit.go
@@ -21,6 +21,42 @@ type irrNPVResult struct {
 	npv float64
 }
 
+// calcSellingExpenses は売却価格から仲介手数料の上限額（消費税込み）を概算する。
+// 根拠: 宅建業法46条 上限 = 売却価格×3%+6万円（+消費税10%）
+func calcSellingExpenses(salePrice float64) float64 {
+	return (salePrice*0.03 + 60_000) * 1.10
+}
+
+// calcAcquisitionCostForTax は税法上の取得費を返す。
+// 取得費 = 土地取得費 + 建物簿価（減価償却累計控除後） + 取得時諸経費（MiscExpenseRate分のみ）。
+// 根拠: 所得税法38条（取得費に含まれる付随費用）。
+// 注意: 融資諸費用（loanFee = LoanAmount × LoanFeeRate）は資金調達コストであり
+//
+//	税法上の取得費に該当しないため除外する（所得税法基本通達38-8参照）。
+func calcAcquisitionCostForTax(input InvestmentInput, accumulatedDepreciation float64) float64 {
+	bookValueBuilding := math.Max(input.BuildingCost-accumulatedDepreciation, 0)
+	return input.LandPrice + bookValueBuilding +
+		(input.LandPrice+input.BuildingCost)*input.MiscExpenseRate
+}
+
+// transferTaxRateForHolding は保有年数から譲渡所得税率を返す（5年超=長期、5年以下=短期）。
+// 租税特別措置法31条の3の10年超軽減(14.21%)は居住用財産の特例のため投資用には適用しない。
+func transferTaxRateForHolding(holdingYears int) float64 {
+	if holdingYears > 5 {
+		return longTermTransferTaxRate
+	}
+	return shortTermTransferTaxRate
+}
+
+// calcTransferTax は譲渡所得と保有年数から譲渡所得税を返す。
+// 譲渡損益が 0 以下の場合は課税されないため 0 を返す。
+func calcTransferTax(capitalGain float64, holdingYears int) float64 {
+	if capitalGain <= 0 {
+		return 0
+	}
+	return capitalGain * transferTaxRateForHolding(holdingYears)
+}
+
 // calcExit は出口戦略（売却）の試算を行う
 //
 // 売却価格: NOI（純収益）/ 目標利回り（実質ベース）で収益還元法により算出
@@ -46,47 +82,21 @@ func calcExit(input InvestmentInput, yearly []YearlyResult, accumulatedDepreciat
 	noi := exitYear.AnnualRent - exitYear.AnnualExpenses
 	salePrice = noi / input.ExitYieldTarget
 
-	// 売却費用（仲介手数料上限額の概算・消費税込み）
-	// 根拠: 宅建業法46条 上限 = 売却価格×3%+6万円（+消費税10%）
-	sellExpenses := (salePrice*0.03+60_000) * 1.10
-
-	// 建物の税務上の簿価（定額法累計控除後）
-	bookValueBuilding := input.BuildingCost - accumulatedDepreciation
-	if bookValueBuilding < 0 {
-		bookValueBuilding = 0
-	}
-
-	// 取得費（税法上）= 土地取得費 + 建物簿価 + 取得時諸経費（MiscExpenseRate分のみ）
-	// 根拠: 所得税法38条（取得費に含まれる付随費用）
-	// 注意: 融資諸費用（loanFee = LoanAmount × LoanFeeRate）は資金調達コストであり
-	//       税法上の取得費に該当しないため除外する（所得税法基本通達38-8参照）。
-	acquisitionCostForTax := input.LandPrice + bookValueBuilding +
-		(input.LandPrice+input.BuildingCost)*input.MiscExpenseRate
+	sellExpenses := calcSellingExpenses(salePrice)
+	acquisitionCostForTax := calcAcquisitionCostForTax(input, accumulatedDepreciation)
 
 	// 譲渡所得 = 売却価格 - 売却費用 - 取得費（税法上）
 	capitalGain = salePrice - sellExpenses - acquisitionCostForTax
-
-	if capitalGain > 0 {
-		// 投資用物件の譲渡所得税: 保有5年超=長期(20.315%)、5年以下=短期(39.63%)の2段階
-		// 租税特別措置法31条の3の10年超軽減(14.21%)は居住用財産の特例のため対象外
-		var taxRate float64
-		if input.HoldingYears > 5 {
-			taxRate = longTermTransferTaxRate
-		} else {
-			taxRate = shortTermTransferTaxRate
-		}
-		transferTax = capitalGain * taxRate
-	}
+	transferTax = calcTransferTax(capitalGain, input.HoldingYears)
 
 	netProceeds = salePrice - sellExpenses - transferTax - exitYear.RemainingLoanBalance
 	totalEquity = netProceeds + exitYear.CumulativeCashFlow
 	return
 }
 
-// calcTerminalValueWithDecline は価格下落率を考慮した売却時ターミナルバリューを計算する
-// 注意: 売却費用・譲渡税の計算ロジックは calcExit と重複している。
-//
-//	税率・仲介手数料率を変更する際は両方を更新すること。
+// calcTerminalValueWithDecline は価格下落率を考慮した売却時ターミナルバリューを計算する。
+// 売却費用・取得費・譲渡税は calcExit と共通のヘルパー（calcSellingExpenses /
+// calcAcquisitionCostForTax / calcTransferTax）を用いる。
 func calcTerminalValueWithDecline(
 	input InvestmentInput,
 	yearly []YearlyResult,
@@ -98,22 +108,10 @@ func calcTerminalValueWithDecline(
 		holdIdx = len(yearly) - 1
 	}
 	exitYear := yearly[holdIdx]
-	sellExpenses := (adjustedSalePrice*0.03+60_000) * 1.10
-	bookValueBuilding := math.Max(input.BuildingCost-accumulatedDepreciation, 0)
-	// 取得費（税法上）: 融資諸費用(loanFee)は資金調達コストのため除外し MiscExpenseRate 分のみ算入
-	acquisitionCostForTax := input.LandPrice + bookValueBuilding +
-		(input.LandPrice+input.BuildingCost)*input.MiscExpenseRate
+	sellExpenses := calcSellingExpenses(adjustedSalePrice)
+	acquisitionCostForTax := calcAcquisitionCostForTax(input, accumulatedDepreciation)
 	capGain := adjustedSalePrice - sellExpenses - acquisitionCostForTax
-	var transferTax float64
-	if capGain > 0 {
-		var taxRate float64
-		if input.HoldingYears > 5 {
-			taxRate = longTermTransferTaxRate
-		} else {
-			taxRate = shortTermTransferTaxRate
-		}
-		transferTax = capGain * taxRate
-	}
+	transferTax := calcTransferTax(capGain, input.HoldingYears)
 	return adjustedSalePrice - sellExpenses - transferTax - exitYear.RemainingLoanBalance
 }
 
@@ -176,38 +174,24 @@ func calcMultiExitComparison(input InvestmentInput, yearly []YearlyResult, miscE
 		salePrice := noi / input.ExitYieldTarget
 
 		// 売却費用（仲介手数料上限・消費税込み）
-		sellExpenses := (salePrice*0.03 + 60_000) * 1.10
+		sellExpenses := calcSellingExpenses(salePrice)
 
 		// 建物の税務上の簿価: yearly[0..yr-1] の AnnualDepreciation を積算
 		yearDepreciation := 0.0
 		for i := 0; i < yr; i++ {
 			yearDepreciation += yearly[i].AnnualDepreciation
 		}
-		bookValueBuilding := input.BuildingCost - yearDepreciation
-		if bookValueBuilding < 0 {
-			bookValueBuilding = 0
-		}
 
 		// 取得費（税法上）= 土地 + 建物簿価 + MiscExpenseRate分のみ（融資諸費用は除外）
-		acquisitionCostForTax := input.LandPrice + bookValueBuilding +
-			(input.LandPrice+input.BuildingCost)*input.MiscExpenseRate
+		acquisitionCostForTax := calcAcquisitionCostForTax(input, yearDepreciation)
 
 		// 譲渡所得 = 売却価格 - 売却費用 - 取得費（税法上）
 		capitalGain := salePrice - sellExpenses - acquisitionCostForTax
 
 		// 譲渡税率: 5年以下=短期(39.63%)、5年超=長期(20.315%)
-		var taxRate float64
+		taxRate := transferTaxRateForHolding(yr)
 		isShortTerm := yr <= 5
-		if isShortTerm {
-			taxRate = shortTermTransferTaxRate
-		} else {
-			taxRate = longTermTransferTaxRate
-		}
-
-		transferTax := 0.0
-		if capitalGain > 0 {
-			transferTax = capitalGain * taxRate
-		}
+		transferTax := calcTransferTax(capitalGain, yr)
 
 		remainingLoan := exitYear.RemainingLoanBalance
 

--- a/backend/internal/domain/exit.go
+++ b/backend/internal/domain/exit.go
@@ -62,7 +62,9 @@ func calcTransferTax(capitalGain float64, holdingYears int) float64 {
 // 売却価格: NOI（純収益）/ 目標利回り（実質ベース）で収益還元法により算出
 // 取得費: 土地 + 建物簿価 + 取得時諸経費（税法上の取得費）
 // 売却費用: 仲介手数料の上限額を概算控除（消費税込み）
-// 税率: 保有5年超で長期、10年超で軽減税率を適用
+// 税率: 保有5年超で長期(20.315%)、5年以下で短期(39.63%)。
+//
+//	投資用物件には10年超軽減(14.21%)は適用しない（居住用財産の特例のため）。
 func calcExit(input InvestmentInput, yearly []YearlyResult, accumulatedDepreciation float64) (
 	salePrice, capitalGain, transferTax, netProceeds, totalEquity float64,
 ) {

--- a/backend/internal/domain/exit_test.go
+++ b/backend/internal/domain/exit_test.go
@@ -1,0 +1,87 @@
+package domain
+
+import "testing"
+
+// TestCalcSellingExpenses は仲介手数料上限（消費税込み）の概算式を検証する。
+func TestCalcSellingExpenses(t *testing.T) {
+	// 売却価格 30,000,000 円: (30,000,000×0.03 + 60,000) × 1.10 = 960,000 × 1.10 = 1,056,000
+	got := calcSellingExpenses(30_000_000)
+	want := 1_056_000.0
+	if !approxEqual(got, want, epsilon) {
+		t.Errorf("calcSellingExpenses(30,000,000) = %.2f, want %.2f", got, want)
+	}
+
+	// 売却価格 0 円: (0 + 60,000) × 1.10 = 66,000
+	if got := calcSellingExpenses(0); !approxEqual(got, 66_000, epsilon) {
+		t.Errorf("calcSellingExpenses(0) = %.2f, want 66000", got)
+	}
+}
+
+// TestTransferTaxRateForHolding は保有年数による短期/長期の税率切替（境界は5年）を検証する。
+func TestTransferTaxRateForHolding(t *testing.T) {
+	tests := []struct {
+		holdingYears int
+		want         float64
+	}{
+		{0, shortTermTransferTaxRate},
+		{5, shortTermTransferTaxRate}, // 5年“以下”は短期（境界は短期側）
+		{6, longTermTransferTaxRate},  // 5年“超”で長期
+		{20, longTermTransferTaxRate},
+	}
+	for _, tt := range tests {
+		if got := transferTaxRateForHolding(tt.holdingYears); got != tt.want {
+			t.Errorf("transferTaxRateForHolding(%d) = %v, want %v", tt.holdingYears, got, tt.want)
+		}
+	}
+}
+
+// TestCalcTransferTax は譲渡所得・保有年数からの譲渡税額と、譲渡損益0以下の非課税を検証する。
+func TestCalcTransferTax(t *testing.T) {
+	tests := []struct {
+		name         string
+		capitalGain  float64
+		holdingYears int
+		want         float64
+	}{
+		{"譲渡益・長期", 10_000_000, 6, 10_000_000 * longTermTransferTaxRate},
+		{"譲渡益・短期", 10_000_000, 5, 10_000_000 * shortTermTransferTaxRate},
+		{"譲渡損は非課税", -5_000_000, 10, 0},
+		{"譲渡益ゼロは非課税", 0, 10, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := calcTransferTax(tt.capitalGain, tt.holdingYears); !approxEqual(got, tt.want, epsilon) {
+				t.Errorf("calcTransferTax(%.0f, %d) = %.2f, want %.2f", tt.capitalGain, tt.holdingYears, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestCalcAcquisitionCostForTax は税法上の取得費（建物簿価＋諸経費、融資諸費用除外）と
+// 減価償却累計が建物価格を超えた場合の簿価ゼロ下限を検証する。
+func TestCalcAcquisitionCostForTax(t *testing.T) {
+	in := InvestmentInput{
+		LandPrice:       5_000_000,
+		BuildingCost:    10_000_000,
+		MiscExpenseRate: 0.07,
+		LoanAmount:      13_000_000,
+		LoanFeeRate:     0.02, // 取得費には算入されないことを確認する
+	}
+	misc := (in.LandPrice + in.BuildingCost) * in.MiscExpenseRate // 1,050,000
+
+	t.Run("償却途中（簿価あり）", func(t *testing.T) {
+		accDep := 4_000_000.0
+		want := in.LandPrice + (in.BuildingCost - accDep) + misc // 5,000,000 + 6,000,000 + 1,050,000
+		if got := calcAcquisitionCostForTax(in, accDep); !approxEqual(got, want, epsilon) {
+			t.Errorf("got %.0f, want %.0f", got, want)
+		}
+	})
+
+	t.Run("償却累計が建物価格超過→簿価ゼロ下限", func(t *testing.T) {
+		accDep := 12_000_000.0 // BuildingCost(10M) を超える
+		want := in.LandPrice + 0 + misc
+		if got := calcAcquisitionCostForTax(in, accDep); !approxEqual(got, want, epsilon) {
+			t.Errorf("簿価ゼロ下限が効いていない: got %.0f, want %.0f", got, want)
+		}
+	})
+}


### PR DESCRIPTION
## 概要
出口戦略（売却試算）で3箇所に重複していた「売却費用・税法上の取得費・譲渡所得税」の計算ロジックを共通ヘルパーに集約する。挙動は変更しない（リファクタのみ）。

`calcTerminalValueWithDecline` のコメントに「税率・仲介手数料率を変更する際は両方を更新すること」と注意書きがあったとおり、税制改定時に複数箇所を更新し忘れて不整合が生じるドリフトリスクがあった。これを単一実装に集約して解消する。

## 変更内容
- `exit.go` に共通ヘルパーを追加
  - `calcSellingExpenses(salePrice)` — 仲介手数料上限（消費税込み）
  - `calcAcquisitionCostForTax(input, accumulatedDepreciation)` — 税法上の取得費（建物簿価＋諸経費、融資諸費用は除外）
  - `transferTaxRateForHolding(holdingYears)` — 5年超=長期/5年以下=短期の税率
  - `calcTransferTax(capitalGain, holdingYears)` — 譲渡所得税（譲渡損なら0）
- `calcExit` / `calcTerminalValueWithDecline` / `calcMultiExitComparison` の3経路を上記ヘルパー利用に置き換え（+49 / −65 行）
- ドメイン型の変更なし → `make swagger` 不要

## 関連Issue
Refs #775

## テスト
- [x] 既存テストが通ること（`go test ./...` 全パッケージ緑、挙動不変のため回帰なし）
- [x] 新規テストを追加した場合、全ケースがPASSすること（リファクタのため新規テストなし）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み（`golangci-lint` / `gofmt` 0 issues）
