### PR TITLE
chore(backend): Go を 1.25.11 に上げて標準ライブラリ脆弱性(govulncheck)を解消する

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.25.10-alpine AS builder
+FROM golang:1.25.11-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/yield-guard/backend
 
-go 1.25.10
+go 1.25.11
 
 require (
 	cloud.google.com/go/firestore v1.22.0


### PR DESCRIPTION
## 概要
`govulncheck` が Go 標準ライブラリの脆弱性を検出し、Backend CI（Test & Build）が全PR・main で失敗するようになったため、Go を `1.25.10` → `1.25.11` に上げて解消する。

検出された脆弱性（いずれも `go1.25.11` で修正済み）:

| ID | 影響パッケージ | 内容 |
| --- | --- | --- |
| [GO-2026-5039](https://pkg.go.dev/vuln/GO-2026-5039) | `net/textproto` | エラーに任意入力がエスケープなしで含まれる |
| [GO-2026-5037](https://pkg.go.dev/vuln/GO-2026-5037) | `crypto/x509` | 候補ホスト名パースの非効率性 |

両者ともシンボルレベルで本コードから到達するため govulncheck が exit code 3 で失敗していた（`cmd/server/main.go` の `ListenAndServe`、`investment_handler.go` の `MonteCarlo` 経由）。

## 変更内容
- `backend/go.mod`: `go 1.25.10` → `go 1.25.11`（CI は `go-version-file: backend/go.mod` でこの値を使用）
- `backend/Dockerfile`: builder ベースイメージ `golang:1.25.10-alpine` → `golang:1.25.11-alpine`（デプロイされる実バイナリも patched stdlib にする）

## 関連Issue
なし（CI 復旧のための保守対応）

## テスト
- [x] 既存テストが通ること（`go build ./...` / `go test ./internal/domain/` 緑）
- [x] CI の govulncheck が green になること（go 1.25.11 で対象2件が解消される見込み）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み
- [x] このPRをマージ後、#777 / #770 を rebase すると govulncheck が解消される
