### PR TITLE
fix(domain): 出口ヘッドライン売却価格・手残りに価格下落率を反映しIRRと統一する

### DIFF
--- a/backend/internal/domain/exit.go
+++ b/backend/internal/domain/exit.go
@@ -57,9 +57,20 @@ func calcTransferTax(capitalGain float64, holdingYears int) float64 {
 	return capitalGain * transferTaxRateForHolding(holdingYears)
 }
 
+// decayedSalePrice は収益還元法による想定売却価格に保有期間中の価格下落率を複利適用する。
+// priceDeclineRate が 0 以下の場合は減衰なしの価格をそのまま返す。
+func decayedSalePrice(salePrice, priceDeclineRate float64, years int) float64 {
+	if priceDeclineRate <= 0 {
+		return salePrice
+	}
+	return salePrice * math.Pow(1-priceDeclineRate, float64(years))
+}
+
 // calcExit は出口戦略（売却）の試算を行う
 //
-// 売却価格: NOI（純収益）/ 目標利回り（実質ベース）で収益還元法により算出
+// 売却価格: NOI（純収益）/ 目標利回り（実質ベース）で収益還元法により算出し、
+//
+//	PriceDeclineRate が指定されていれば保有期間分の価格下落を反映する
 // 取得費: 土地 + 建物簿価 + 取得時諸経費（税法上の取得費）
 // 売却費用: 仲介手数料の上限額を概算控除（消費税込み）
 // 税率: 保有5年超で長期(20.315%)、5年以下で短期(39.63%)。
@@ -79,10 +90,11 @@ func calcExit(input InvestmentInput, yearly []YearlyResult, accumulatedDepreciat
 
 	exitYear := yearly[holdIdx]
 
-	// 収益還元法: 売却価格 = NOI / 目標利回り（実質ベース）
+	// 収益還元法: 売却価格 = NOI / 目標利回り（実質ベース）に価格下落率を反映
 	// NOI = 実効賃料収入 - 運営経費（ローン利息は含まない）
+	// 価格下落を売却価格・手残り・IRR で同一前提とするため、ここで一括適用する。
 	noi := exitYear.AnnualRent - exitYear.AnnualExpenses
-	salePrice = noi / input.ExitYieldTarget
+	salePrice = decayedSalePrice(noi/input.ExitYieldTarget, input.PriceDeclineRate, input.HoldingYears)
 
 	sellExpenses := calcSellingExpenses(salePrice)
 	acquisitionCostForTax := calcAcquisitionCostForTax(input, accumulatedDepreciation)
@@ -96,36 +108,15 @@ func calcExit(input InvestmentInput, yearly []YearlyResult, accumulatedDepreciat
 	return
 }
 
-// calcTerminalValueWithDecline は価格下落率を考慮した売却時ターミナルバリューを計算する。
-// 売却費用・取得費・譲渡税は calcExit と共通のヘルパー（calcSellingExpenses /
-// calcAcquisitionCostForTax / calcTransferTax）を用いる。
-func calcTerminalValueWithDecline(
-	input InvestmentInput,
-	yearly []YearlyResult,
-	adjustedSalePrice float64,
-	accumulatedDepreciation float64,
-) float64 {
-	holdIdx := input.HoldingYears - 1
-	if holdIdx >= len(yearly) {
-		holdIdx = len(yearly) - 1
-	}
-	exitYear := yearly[holdIdx]
-	sellExpenses := calcSellingExpenses(adjustedSalePrice)
-	acquisitionCostForTax := calcAcquisitionCostForTax(input, accumulatedDepreciation)
-	capGain := adjustedSalePrice - sellExpenses - acquisitionCostForTax
-	transferTax := calcTransferTax(capGain, input.HoldingYears)
-	return adjustedSalePrice - sellExpenses - transferTax - exitYear.RemainingLoanBalance
-}
-
 // calcIRRNPV は IRR / NPV を計算して返す。
 // equity がゼロ以下（オーバーローン）または HoldingYears=0 の場合は計算が成立しないためゼロ値を返す。
+// terminal value には calcExit が算出した出口手残り（exitNet）を使う。
+// exitNet は価格下落率を反映済みのため、ここで再度減衰を適用しない（二重適用の防止）。
 func calcIRRNPV(
 	input InvestmentInput,
 	yearlyResults []YearlyResult,
 	equity float64,
 	exitNet float64,
-	exitSalePrice float64,
-	accumulatedDepreciation float64,
 ) irrNPVResult {
 	if equity <= 0 || input.HoldingYears <= 0 {
 		return irrNPVResult{}
@@ -134,14 +125,8 @@ func calcIRRNPV(
 	for i := 0; i < input.HoldingYears && i < len(yearlyResults); i++ {
 		irrCFs[i] = yearlyResults[i].AfterTaxCashFlow
 	}
-	irrTerminalValue := exitNet
-	if input.PriceDeclineRate > 0 {
-		decayFactor := math.Pow(1-input.PriceDeclineRate, float64(input.HoldingYears))
-		adjustedSalePrice := exitSalePrice * decayFactor
-		irrTerminalValue = calcTerminalValueWithDecline(input, yearlyResults, adjustedSalePrice, accumulatedDepreciation)
-	}
-	npv := CalcNPV(irrCFs, irrTerminalValue, input.DiscountRate, equity)
-	irr, _ := CalcIRR(irrCFs, irrTerminalValue, equity)
+	npv := CalcNPV(irrCFs, exitNet, input.DiscountRate, equity)
+	irr, _ := CalcIRR(irrCFs, exitNet, equity)
 	return irrNPVResult{irr: irr, npv: npv}
 }
 
@@ -171,9 +156,9 @@ func calcMultiExitComparison(input InvestmentInput, yearly []YearlyResult, miscE
 			continue
 		}
 
-		// 売却価格: NOI / exitYieldTarget（その年のNOIを使用）
+		// 売却価格: NOI / exitYieldTarget（その年のNOIを使用）に保有年数分の価格下落を反映
 		noi := exitYear.AnnualRent - exitYear.AnnualExpenses
-		salePrice := noi / input.ExitYieldTarget
+		salePrice := decayedSalePrice(noi/input.ExitYieldTarget, input.PriceDeclineRate, yr)
 
 		// 売却費用（仲介手数料上限・消費税込み）
 		sellExpenses := calcSellingExpenses(salePrice)

--- a/backend/internal/domain/exit_test.go
+++ b/backend/internal/domain/exit_test.go
@@ -1,6 +1,10 @@
 package domain
 
-import "testing"
+import (
+	"context"
+	"math"
+	"testing"
+)
 
 // TestCalcSellingExpenses は仲介手数料上限（消費税込み）の概算式を検証する。
 func TestCalcSellingExpenses(t *testing.T) {
@@ -84,4 +88,59 @@ func TestCalcAcquisitionCostForTax(t *testing.T) {
 			t.Errorf("簿価ゼロ下限が効いていない: got %.0f, want %.0f", got, want)
 		}
 	})
+}
+
+// TestDecayedSalePrice は価格下落率の複利適用とゼロ時のパススルーを検証する。
+func TestDecayedSalePrice(t *testing.T) {
+	// 下落率 0 以下は減衰なし
+	if got := decayedSalePrice(30_000_000, 0, 10); !approxEqual(got, 30_000_000, epsilon) {
+		t.Errorf("rate=0: got %.2f, want 30000000", got)
+	}
+	// 2% × 10年: 30,000,000 × 0.98^10
+	want := 30_000_000 * math.Pow(0.98, 10)
+	if got := decayedSalePrice(30_000_000, 0.02, 10); !approxEqual(got, want, epsilon) {
+		t.Errorf("rate=2%%/10y: got %.2f, want %.2f", got, want)
+	}
+}
+
+// TestAnalyze_PriceDecline_HeadlineReflected は #774 の修正を検証する。
+// PriceDeclineRate が出口ヘッドライン（売却価格・手残り・出口エクイティ）に反映され、
+// かつ IRR の terminal value と二重適用されていないことを確認する。
+func TestAnalyze_PriceDecline_HeadlineReflected(t *testing.T) {
+	base := InvestmentInput{
+		LandPrice:       5_000_000,
+		BuildingCost:    8_000_000,
+		BuildingAge:     10,
+		BuildingType:    BuildingTypeWood,
+		MonthlyRent:     80_000,
+		LoanAmount:      10_000_000,
+		AnnualLoanRate:  0.02,
+		LoanYears:       25,
+		HoldingYears:    10,
+		ExitYieldTarget: 0.06,
+		DiscountRate:    0.05,
+	}
+	base.Defaults()
+	zero := Analyze(context.Background(), base)
+
+	declined := base
+	declined.PriceDeclineRate = 0.02
+	declined.Defaults()
+	got := Analyze(context.Background(), declined)
+
+	// NOI は PriceDeclineRate に依存しないため、売却価格は zero × 0.98^10 に一致するはず
+	decay := math.Pow(0.98, float64(base.HoldingYears))
+	wantSalePrice := zero.ExitSalePrice * decay
+	if !approxEqual(got.ExitSalePrice, wantSalePrice, 1) {
+		t.Errorf("ExitSalePrice = %.0f, want %.0f (= %.0f × 0.98^10)。下落が反映されていない/二重適用の疑い",
+			got.ExitSalePrice, wantSalePrice, zero.ExitSalePrice)
+	}
+
+	// 手残り・出口エクイティも下落分だけ減少する
+	if !(got.ExitNetProceeds < zero.ExitNetProceeds) {
+		t.Errorf("ExitNetProceeds が減少していない: zero=%.0f declined=%.0f", zero.ExitNetProceeds, got.ExitNetProceeds)
+	}
+	if !(got.ExitTotalEquity < zero.ExitTotalEquity) {
+		t.Errorf("ExitTotalEquity が減少していない: zero=%.0f declined=%.0f", zero.ExitTotalEquity, got.ExitTotalEquity)
+	}
 }

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -82,8 +82,7 @@ func Analyze(ctx context.Context, input InvestmentInput) InvestmentResult {
 	ltvSensitivity := CalcLTVSensitivity(input, nil)
 
 	equity := yp.totalInvestment - input.LoanAmount
-	irrNPV := calcIRRNPV(input, sim.yearlyResults, equity, exitNet,
-		exitSalePrice, sim.accumulatedDepreciation)
+	irrNPV := calcIRRNPV(input, sim.yearlyResults, equity, exitNet)
 
 	multiExit := calcMultiExitComparison(input, sim.yearlyResults, yp.miscExpenses)
 	taxSim := CalcTaxSimulation(input, sim.yearlyResults, exitCapGain)


### PR DESCRIPTION
## 概要
出口戦略のヘッドライン指標（売却価格・手残り・出口エクイティ）が収益還元法のキャップレート価格のみで算出され、`PriceDeclineRate`（価格下落率）が反映されていなかった。一方 IRR は terminal value に価格下落を適用していたため、価格下落を入力しても**ヘッドラインの手残りは変わらず IRR だけが下がる**という指標間の不整合があった。

`calcExit` で価格下落を一度だけ適用し、売却価格・手残り・エクイティ・IRR がすべて同一前提を共有するように統一する。

## 変更内容
- `decayedSalePrice(salePrice, rate, years)` ヘルパーを追加し、収益還元価格に保有年数分の価格下落を複利適用
- `calcExit`: ヘッドライン売却価格に価格下落を反映（`ExitSalePrice`/`ExitNetProceeds`/`ExitTotalEquity` が `PriceDeclineRate>0` で連動）
- `calcMultiExitComparison`: 各保有年数の行にも `(1-rate)^yr` を反映し、テーブルとヘッドラインの前提を揃える
- `calcIRRNPV`: `calcExit` の手残り（下落反映済み）を terminal value に直接使用。二重適用防止用の `calcTerminalValueWithDecline` を削除し、引数 `exitSalePrice`/`accumulatedDepreciation` を撤去
- ドメイン型の変更なし → `make swagger` 不要

## 関連Issue
Closes #774

## テスト
- [x] 既存テストが通ること（`go test -race ./internal/domain/` 全緑。`PriceDeclineRate=0` 時は減衰なしで回帰なし）
- [x] 新規テスト
  - `TestDecayedSalePrice`: 複利適用とゼロ時パススルー
  - `TestAnalyze_PriceDecline_HeadlineReflected`: `ExitSalePrice == 下落なし価格 × 0.98^10`（二重適用がないこと）／手残り・エクイティの減少

## 確認事項
- [x] コードレビュー観点での自己レビュー済み（go-lint 0 issues）
- [ ] **挙動変更**: `PriceDeclineRate>0` 入力時にヘッドライン売却価格・手残りが下がる（意図した変更）。フロントの数値表示が従来より保守的になる点をレビューで確認
