### PR TITLE
fix(domain): 譲渡税の短期/長期判定の簡略化を明示し境界テストを追加する

### DIFF
--- a/backend/internal/domain/exit.go
+++ b/backend/internal/domain/exit.go
@@ -41,6 +41,11 @@ func calcAcquisitionCostForTax(input InvestmentInput, accumulatedDepreciation fl
 
 // transferTaxRateForHolding は保有年数から譲渡所得税率を返す（5年超=長期、5年以下=短期）。
 // 租税特別措置法31条の3の10年超軽減(14.21%)は居住用財産の特例のため投資用には適用しない。
+//
+// 簡略化: 税法上の長期/短期は「譲渡した年の1月1日時点で所有期間が5年超」で判定する
+// （租税特別措置法31条）。本実装は取得月を持たないため holdingYears > 5 の単純比較で近似する。
+// このため厳密には取得から概ね6年保有しないと長期にならないケースがある（境界年は短期＝保守側に倒れる）。
+// 取得日入力を伴う厳密判定は別タスク（取得時期の1/1基準対応）として切り出す。
 func transferTaxRateForHolding(holdingYears int) float64 {
 	if holdingYears > 5 {
 		return longTermTransferTaxRate

--- a/backend/internal/domain/exit_test.go
+++ b/backend/internal/domain/exit_test.go
@@ -144,3 +144,54 @@ func TestAnalyze_PriceDecline_HeadlineReflected(t *testing.T) {
 		t.Errorf("ExitTotalEquity が減少していない: zero=%.0f declined=%.0f", zero.ExitTotalEquity, got.ExitTotalEquity)
 	}
 }
+
+// TestMultiExit_TransferTaxBoundary は短期/長期の境界（5年=短期 / 6年=長期）が
+// 出口比較テーブルの税率・短期警告フラグに反映されることを検証する（#776）。
+// 本ツールは保有年数による簡略判定のため、5年=短期・6年=長期となる。
+func TestMultiExit_TransferTaxBoundary(t *testing.T) {
+	in := InvestmentInput{
+		LandPrice:       5_000_000,
+		BuildingCost:    8_000_000,
+		BuildingAge:     10,
+		BuildingType:    BuildingTypeWood,
+		MonthlyRent:     90_000,
+		LoanAmount:      10_000_000,
+		AnnualLoanRate:  0.02,
+		LoanYears:       25,
+		HoldingYears:    10,
+		ExitYieldTarget: 0.06,
+		ExitYears:       []int{5, 6},
+	}
+	in.Defaults()
+	res := Analyze(context.Background(), in)
+
+	rowByYear := map[int]MultiExitRow{}
+	for _, r := range res.MultiExitComparison {
+		rowByYear[r.Year] = r
+	}
+
+	r5, ok5 := rowByYear[5]
+	r6, ok6 := rowByYear[6]
+	if !ok5 || !ok6 {
+		t.Fatalf("expected rows for year 5 and 6, got years %v", func() []int {
+			var ys []int
+			for _, r := range res.MultiExitComparison {
+				ys = append(ys, r.Year)
+			}
+			return ys
+		}())
+	}
+
+	if !r5.IsShortTermWarn {
+		t.Errorf("5年目は短期判定（IsShortTermWarn=true）であるべき")
+	}
+	if !approxEqual(r5.TransferTaxRate, shortTermTransferTaxRate, epsilon) {
+		t.Errorf("5年目税率 = %.5f, want 短期 %.5f", r5.TransferTaxRate, shortTermTransferTaxRate)
+	}
+	if r6.IsShortTermWarn {
+		t.Errorf("6年目は長期判定（IsShortTermWarn=false）であるべき")
+	}
+	if !approxEqual(r6.TransferTaxRate, longTermTransferTaxRate, epsilon) {
+		t.Errorf("6年目税率 = %.5f, want 長期 %.5f", r6.TransferTaxRate, longTermTransferTaxRate)
+	}
+}

--- a/frontend/src/components/MultiExitCompareTable.tsx
+++ b/frontend/src/components/MultiExitCompareTable.tsx
@@ -122,6 +122,11 @@ export default function MultiExitCompareTable({ rows }: MultiExitCompareTablePro
         ※
         緑ハイライト列が出口エクイティ最大。短期譲渡税（保有5年以下）は税率39.63%、長期（5年超）は20.315%が適用されます。
       </p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        ※
+        長期/短期は税法上「譲渡した年の1月1日時点で所有期間5年超」で判定します（本ツールは保有年数で簡略判定）。
+        取得時期によっては実質的に取得から約6年の保有が必要になるため、5〜6年目の売却は税率を保守的にご確認ください。
+      </p>
     </div>
   );
 }


### PR DESCRIPTION
## 概要
譲渡所得税の短期/長期判定が `holdingYears > 5` の単純比較になっている。税法上の長期は「**譲渡した年の1月1日時点で所有期間が5年超**」（租税特別措置法31条）であり、実質的には取得から概ね6年保有が必要になる。本ツールは取得月を持たないため簡略判定を採用しているが、その旨が明示されていなかった。

低優先（#776）相応に、**簡略化である旨を明示**し、**境界テストを追加**する対応を行う（取得日入力を伴う厳密判定は別タスクとして切り出し）。

## 変更内容
- `exit.go` `transferTaxRateForHolding`: 簡略判定（1/1基準の近似・境界年は短期＝保守側）であることを単一ソースのコメントとして明記
- `MultiExitCompareTable.tsx`: 出口比較テーブルの脚注に「長期/短期は譲渡年1/1基準で実質約6年保有が必要・5〜6年目は税率を保守的に確認」の注記を追加
- 境界テスト追加（`TestMultiExit_TransferTaxBoundary`）: 出口比較行で 5年=短期(39.63%, 短期警告あり) / 6年=長期(20.315%) を検証
- ドメイン型の変更なし → `make swagger` 不要

## 関連Issue
Closes #776

## テスト
- [x] 既存テストが通ること（`go test -race ./internal/domain/` 全緑 / frontend `tsc --noEmit`・`eslint` クリーン）
- [x] 新規テスト `TestMultiExit_TransferTaxBoundary` が PASS

## 確認事項
- [x] コードレビュー観点での自己レビュー済み（pre-commit 全フック通過）
- [ ] 取得日入力による厳密な1/1基準判定は本PRの対象外（必要なら別issueで対応）
