### PR TITLE
ci(frontend): vitest カバレッジに thresholds を設定して CI ゲート化する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ frontend/tsconfig.tsbuildinfo
 docs/openapi/openapi.json
 frontend/src/types/api.generated.ts
 
+# Vitest カバレッジレポート
+frontend/coverage/
+
 # Playwright
 frontend/playwright-report/
 frontend/test-results/

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -11,6 +11,14 @@ export default defineConfig({
       provider: "v8",
       reporter: ["text", "json-summary"],
       reportsDirectory: "./coverage",
+      // 初期値は実測 (2026-07: Stmts 65.8 / Branch 54.6 / Func 55.4 / Lines 67.6) の
+      // 2〜3pt 下。カバレッジ向上に合わせて段階的に引き上げる (#794)
+      thresholds: {
+        statements: 63,
+        branches: 52,
+        functions: 53,
+        lines: 65,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## 概要

バックエンド CI にはカバレッジ 80% 未満で fail するゲートがあるが、フロントエンドはカバレッジをサマリ表示するだけでゲートがなかった。`vitest.config.ts` に `coverage.thresholds` を追加し、閾値未満で `vitest run --coverage` が fail するようにする。

初期閾値は現状の実測値（Statements 65.8% / Branches 54.61% / Functions 55.35% / Lines 67.64%）の 2〜3pt 下に設定し、まず「カバレッジを下げない」ゲートとして機能させる。カバレッジ向上に合わせて段階的に引き上げる。

## 変更内容

- `frontend/vitest.config.ts` の `coverage` に `thresholds` を追加
  - statements: 63 / branches: 52 / functions: 53 / lines: 65
- `.gitignore` に `frontend/coverage/`（Vitest カバレッジレポート）を追加
  - ローカルで `npm test -- --coverage` を実行すると untracked ファイルとして残るため

## 関連Issue

Closes #794

## テスト

- [x] 既存テストが通ること（`npm test -- --coverage` → 396 passed、閾値クリアで exit 0）
- [x] 新規テストを追加した場合、全ケースがPASSすること（テスト追加なし）
- [x] ゲートの動作確認: `--coverage.thresholds.lines=99` で一時的に閾値超過させ、exit 1 で fail することを確認

## 確認事項

- [x] コードレビュー観点での自己レビュー済み

## 補足

- CI ワークフロー側の変更は不要（`frontend-ci.yml` は既に `npm test -- --coverage` を実行しているため、この変更だけでゲートが有効になる）
- `--coverage` なしのローカル `npm test` と lefthook pre-push には影響しない
