### PR TITLE
chore(hooks): lefthook pre-push を変更パスに応じた条件実行にする

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -16,9 +16,29 @@ pre-commit:
       glob: "frontend/src/**/*.{ts,tsx}"
       run: cd frontend && npm run type-check
 
+# pre-push は push 対象の diff に応じてテストを条件実行する (#795)
+# - 比較基準: @{push}（upstream 未設定の新規ブランチは origin/main との merge-base）
+# - 基準が解決できない場合は安全側に倒して全テストを実行する
+# - lefthook.yml 自体の変更時は両方実行する
 pre-push:
   commands:
     go-test:
-      run: cd backend && go test -race ./... -timeout 120s
+      run: |
+        base=$(git rev-parse -q --verify '@{push}' 2>/dev/null) \
+          || base=$(git rev-parse -q --verify origin/main 2>/dev/null) \
+          || base=""
+        if [ -z "$base" ] || git diff --name-only "$base...HEAD" | grep -qE '^(backend/|lefthook\.yml$)'; then
+          cd backend && go test -race ./... -timeout 120s
+        else
+          echo "backend: push 対象に変更がないためスキップ"
+        fi
     frontend-test:
-      run: cd frontend && npm test
+      run: |
+        base=$(git rev-parse -q --verify '@{push}' 2>/dev/null) \
+          || base=$(git rev-parse -q --verify origin/main 2>/dev/null) \
+          || base=""
+        if [ -z "$base" ] || git diff --name-only "$base...HEAD" | grep -qE '^(frontend/|docs/openapi/|lefthook\.yml$)'; then
+          cd frontend && npm test
+        else
+          echo "frontend: push 対象に変更がないためスキップ"
+        fi


### PR DESCRIPTION
## 概要

lefthook の pre-push は変更内容に関係なく backend の `go test` と frontend の `vitest` を常に両方実行していた。このため backend のみの変更でも vitest が走り、worktree では `node_modules` の実体インストールが必須になっていた。

push 対象の diff に含まれるパスに応じてテストを条件実行するように変更する。スキップしても CI では全テストが走るため、安全網は維持される。

## 変更内容

- `lefthook.yml` の pre-push を条件実行に変更
  - **go-test**: diff に `backend/` が含まれる場合のみ実行
  - **frontend-test**: diff に `frontend/` または `docs/openapi/`（生成型に影響）が含まれる場合のみ実行
  - `lefthook.yml` 自体の変更時は両方実行
- 比較基準の解決順序
  1. `@{push}`（upstream 設定済みブランチ）
  2. `origin/main` との merge-base（upstream 未設定の新規ブランチ）
  3. どちらも解決できない場合は**安全側に倒して全テスト実行**

## 関連Issue

Closes #795

## テスト

- [x] 既存テストが通ること
- [ ] 新規テストを追加した場合、全ケースがPASSすること（テスト追加なし）

動作検証（すべてローカルで実施）:

- [x] upstream 未設定の新規ブランチで base が `origin/main` にフォールバックすること
- [x] backend のみ変更のブランチで `lefthook run pre-push` → **go-test 実行 / frontend-test スキップ**を確認
- [x] パターンマッチの単体検証: frontend のみ変更 → go-test スキップ、`docs/openapi/` 変更 → frontend-test 実行
- [x] 本ブランチの push（lefthook.yml 変更）で両スイートが実行されることを実地確認

## 確認事項

- [x] コードレビュー観点での自己レビュー済み

## 期待効果

- backend のみの変更時に pre-push が高速化（vitest 分を短縮）
- worktree で「backend だけ触るのに `npm ci` が必須」という制約の解消
