### PR TITLE
chore: リポジトリ直下の整理と Makefile の POSIX 準拠化（#804 / #806）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
-frontend/node_modules
+# 依存パッケージ（場所を問わず）
+node_modules/
+
 frontend/.next
+
+# PDF エクスポートの動作確認生成物（リポジトリ直下のみ）
+/*.pdf
 
 # PWA ビルド生成物（Workbox自動生成ファイル）
 frontend/public/workbox-*.js

--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ mlit-land-prices:
 	@test -n "$(quarter)"   || (echo "ERROR: quarter は必須です (例: quarter=1)"; exit 1)
 	@test -n "$(to_year)"   || (echo "ERROR: to_year は必須です (例: to_year=2024)"; exit 1)
 	@test -n "$(to_quarter)"|| (echo "ERROR: to_quarter は必須です (例: to_quarter=4)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \
@@ -154,7 +154,7 @@ mlit-land-prices:
 ##   使い方: make mlit-municipalities area=13
 mlit-municipalities:
 	@test -n "$(area)" || (echo "ERROR: area は必須です (例: area=13)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \
@@ -168,7 +168,7 @@ mlit-station-ridership:
 	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
 	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
 	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \
@@ -181,7 +181,7 @@ mlit-station-ridership:
 mlit-land-appraisals:
 	@test -n "$(area)" || (echo "ERROR: area は必須です (例: area=13)"; exit 1)
 	@test -n "$(year)" || (echo "ERROR: year は必須です (例: year=2024)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \
@@ -195,7 +195,7 @@ mlit-population-forecast:
 	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
 	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
 	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \
@@ -213,7 +213,7 @@ mlit-urban-zoning:
 	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
 	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
 	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \
@@ -226,7 +226,7 @@ mlit-liquefaction:
 	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
 	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
 	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \
@@ -239,7 +239,7 @@ mlit-flood-hazard:
 	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
 	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
 	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \
@@ -252,7 +252,7 @@ mlit-storm-hazard:
 	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
 	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
 	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \
@@ -265,7 +265,7 @@ mlit-tsunami-hazard:
 	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
 	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
 	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \
@@ -278,7 +278,7 @@ mlit-landslide-hazard:
 	@test -n "$(z)" || (echo "ERROR: z は必須です (例: z=14)"; exit 1)
 	@test -n "$(x)" || (echo "ERROR: x は必須です (例: x=14547)"; exit 1)
 	@test -n "$(y)" || (echo "ERROR: y は必須です (例: y=6451)"; exit 1)
-	@source .env 2>/dev/null; \
+	@. ./.env 2>/dev/null; \
 	 curl -s \
 	   -H "Ocp-Apim-Subscription-Key: $$MLIT_API_KEY" \
 	   --compressed \


### PR DESCRIPTION
## 概要

リポジトリ直下の整理（#804）と Makefile の POSIX 準拠化（#806）。どちらも小規模な chore のためまとめて対応する。

## 変更内容

### #804: .gitignore の整理

- `node_modules/` を追加（場所を問わず ignore）
  - 従来は `frontend/node_modules` のみで、リポジトリ直下に生成される `node_modules/` は開発者のグローバル gitignore 頼みだった
  - `frontend/node_modules` 行は包含されるため削除
- `/*.pdf` を追加（リポジトリ直下のみ。`docs/` 等のサブディレクトリの PDF には影響しない）
- 直下に放置されていた PDF エクスポート生成物（`yield-guard-report-20260524.pdf`）を削除

### #806: Makefile の POSIX 準拠化

- `mlit-*` 系ターゲット 11 箇所の `source .env` を `. ./.env` に置換
  - make はレシピを `/bin/sh` で実行するため、dash 環境（Linux）では `source` が使えなかった
  - `make dev` / `make integration` は既に `. ../.env` 形式のため変更なし

## 関連Issue

Closes #804
Closes #806

## テスト

- [x] 既存テストが通ること（テスト対象コードの変更なし）
- [ ] 新規テストを追加した場合、全ケースがPASSすること（テスト追加なし）

動作検証:

- [x] `git check-ignore -v` で `node_modules`（直下・frontend とも）と直下 PDF が新ルールで ignore されること
- [x] `docs/` 配下の PDF が誤って ignore されないこと
- [x] 置換後のレシピを `sh -n` で構文検証
- [x] `make mlit-municipalities area=13` を実行し、`. ./.env` 経由で API キーが読み込まれ実データ取得に成功すること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
