### PR TITLE
ci(frontend): npm 依存の脆弱性チェックを CI に追加する

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -49,6 +49,13 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # ランタイム依存 (dependencies) の high 以上の既知脆弱性でゲートする (#801)
+      # devDependencies はビルド時のみ使用のため対象外。
+      # 修正版未リリースの advisory でブロックされた場合は package.json の
+      # overrides で一時回避するか、修正版リリースまで本ステップを一時 skip する
+      - name: npm audit (runtime dependencies)
+        run: npm audit --omit=dev --audit-level=high
+
       - name: Generate TypeScript types
         run: npm run generate:types
 


### PR DESCRIPTION
## 概要

Go 側は backend CI に govulncheck の脆弱性ゲートがあるが、npm 側にはなかった。frontend CI に `npm audit` のステップを追加し、ランタイム依存の high 以上の既知脆弱性でマージをブロックする。

issue #801 の案A（npm audit）を採用。ノイズが問題になったら案B（osv-scanner）への移行を検討する。

## 変更内容

- `frontend-ci.yml` の ci job（`npm ci` 直後）に `npm audit --omit=dev --audit-level=high` を追加
  - `--omit=dev`: ビルド時のみ使用する devDependencies は対象外。ランタイムに載る dependencies のみゲート
  - `--audit-level=high`: high / critical のみ fail（moderate 以下は通す）
- 修正版未リリースの advisory でブロックされた場合の運用（`overrides` で一時回避 or ステップ一時 skip）をコメントに明記

## 関連Issue

Closes #801

## テスト

- [x] 既存テストが通ること（テストコードの変更なし）
- [ ] 新規テストを追加した場合、全ケースがPASSすること（テスト追加なし）

動作検証:

- [x] ローカルで `npm audit --omit=dev --audit-level=high` → exit 0 を確認（現状は moderate 2 件のみ: next 同梱の postcss。Dependabot の next 更新で解消見込みのためゲートは通る）
- [x] workflow YAML の構文検証
- [x] この PR の CI で新ステップが pass すること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
