### PR TITLE
ci(security): gitleaks によるシークレットスキャンを pre-commit と CI に導入する

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,43 @@
+name: Secret Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 2 * * 1"  # 毎週月曜 02:00 UTC（全履歴の定期スキャン）
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GITLEAKS_VERSION: "8.30.1"
+  GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+
+jobs:
+  gitleaks:
+    name: gitleaks (full history)
+    runs-on: ubuntu-24.04
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0  # 全履歴スキャンのため
+
+      - name: Install gitleaks (pinned + checksum verified)
+        run: |
+          curl -sSfL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo install gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Scan full git history
+        run: gitleaks detect --redact --verbose

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,15 @@ swagger-check: swagger
 install:
 	cd frontend && npm install
 
-## install-hooks: lefthook git フックをインストール
+## install-hooks: lefthook git フックと gitleaks をインストール
 install-hooks:
 	@if ! command -v lefthook >/dev/null 2>&1; then \
 	  echo "==> Installing lefthook via brew..."; \
 	  brew install lefthook; \
+	fi
+	@if ! command -v gitleaks >/dev/null 2>&1; then \
+	  echo "==> Installing gitleaks via brew..."; \
+	  brew install gitleaks; \
 	fi
 	lefthook install
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,6 +1,15 @@
 pre-commit:
   parallel: true
   commands:
+    # シークレットの誤コミット防止 (#800)。未インストール時は警告のみで通す
+    # （CI の secret-scan.yml が最終ゲート）。導入: make install-hooks
+    gitleaks:
+      run: |
+        if command -v gitleaks >/dev/null 2>&1; then
+          gitleaks protect --staged --redact
+        else
+          echo "WARN: gitleaks が未インストールのためシークレットスキャンをスキップしました (make install-hooks で導入)"
+        fi
     go-lint:
       glob: "backend/**/*.go"
       run: cd backend && golangci-lint run ./...


### PR DESCRIPTION
## 概要

シークレット（`MLIT_API_KEY` / `APP_INTERNAL_API_KEY` 等）の誤コミットを機械的に検知する仕組みがなく、人間の注意力に依存していた。gitleaks を pre-commit と CI の 2 段構えで導入する。

## 変更内容

- **`lefthook.yml`**: pre-commit に `gitleaks protect --staged --redact` を追加
  - 未インストール環境では警告を出してスキップ（コミットをブロックしない）。最終ゲートは CI 側が担う
- **`Makefile`**: `install-hooks` に gitleaks の brew インストールを追加
- **`.github/workflows/secret-scan.yml`**（新規）: 全履歴スキャン
  - トリガー: PR / main への push / 週次（月曜 02:00 UTC）/ 手動
  - gitleaks-action ではなくバイナリ直接ダウンロード方式を採用（Organization 利用時のライセンス要件を回避し、バージョン + SHA256 チェックサムで固定できるため）
  - `--redact` により検出時もシークレット本体はログに出さない

## 導入時の全履歴スキャン

issue の検討事項に従い、導入前にローカルで `gitleaks detect` を全履歴（1286 コミット）に対して実行し、**leak なし・誤検知なし**を確認済み。誤検知がなかったため `.gitleaks.toml`（allowlist）は作成していない。

## 関連Issue

Closes #800

## テスト

- [x] 既存テストが通ること（テスト対象コードの変更なし）
- [ ] 新規テストを追加した場合、全ケースがPASSすること（テスト追加なし）

動作検証:

- [x] 全履歴スキャン（1286 コミット）で leak なしを確認
- [x] 疑似シークレット（GitHub PAT 形式のダミー）をステージして pre-commit が **exit 1 でブロック**することを確認
- [x] クリーンな状態で pre-commit が通ることを確認
- [x] workflow YAML の構文検証
- [x] この PR の CI で Secret Scan job が pass すること

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
