### PR TITLE
ci(vercel): PR プレビューをステージング API に向ける（CORS 修正 + コメント文言是正）

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -203,7 +203,7 @@ jobs:
           script: |
             const marker = '<!-- vercel-preview -->';
             const url = process.env.PREVIEW_URL;
-            const body = `${marker}\n## Vercel プレビュー\n\n${url}\n\n> ⚠️ このプレビューは本番 API (\`NEXT_PUBLIC_API_URL\`) を使用しています。`;
+            const body = `${marker}\n## Vercel プレビュー\n\n${url}\n\n> このプレビューはステージング API (\`BACKEND_URL\` の Preview 環境変数) を使用しています。API 変更を含む PR は stg バックエンドの再デプロイ (deploy-backend-stg.yml) が必要です。`;
             const { data: comments } = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
## 概要

PR プレビューをステージング API に向ける（#802）。

調査の結果、issue の前提と実態が異なっていた:

- API 呼び出しは `NEXT_PUBLIC_API_URL`（コード上未使用）ではなく、**Next.js rewrites + `BACKEND_URL`** のサーバーサイドプロキシ
- Vercel の Preview 環境変数 `BACKEND_URL` は **既にステージングを指していた**（46日前設定済み）
- しかし stg の `ALLOW_ORIGINS` が本番フロント URL のみだったため、プレビューオリジン（rewrites がブラウザの Origin ヘッダを転送する）が **403 で拒否され、プレビューの POST 系 API は実質壊れていた**

つまり本 issue の実作業は「向き先の変更」ではなく「CORS の修正 + 文言の是正」だった。

## 変更内容

### リポジトリ内（この PR）

- `frontend-ci.yml` のプレビューコメント文言を修正
  - 「⚠️ 本番 API (`NEXT_PUBLIC_API_URL`) を使用」（二重に誤った記述）→「ステージング API (`BACKEND_URL` の Preview 環境変数) を使用」
  - API 変更を含む PR では stg 再デプロイが必要という運用注意を追記

### リポジトリ外（実施済み）

1. **stg バックエンドの再デプロイ**: stg のイメージが古く（`e179d06` 時点）タグも Artifact Registry から消えていて新リビジョンが作れなかったため、`deploy-backend-stg.yml` を実行して main から再ビルド・デプロイ
2. **stg の `ALLOW_ORIGINS` 更新**（gcloud）: `https://yield-guard-alpha.vercel.app` → `https://yield-guard-alpha.vercel.app,*.vercel.app`（`router.go` 実装済みの suffix 一致を利用）
   - ローカル terraform が prod 向け初期化のため terraform apply は使用せず。`terraform.stg.tfvars` の `vercel_frontend_url`（仮置きコメント付きだった行）は同じ値に更新済みで、次回 stg apply でも巻き戻らない
3. **Vercel 側**: 変更なし（Preview の `BACKEND_URL` は設定済みだったため）

## 関連Issue

Closes #802

## テスト

- [x] 既存テストが通ること（テスト対象コードの変更なし）
- [ ] 新規テストを追加した場合、全ケースがPASSすること（テスト追加なし）

動作検証:

- [x] CORS 修正前: プレビュー形式 Origin で GET / POST / preflight すべて 403 を確認
- [x] CORS 修正後: preflight 204 / GET は認証層まで到達（401 = CORS 通過）。無関係オリジン（`https://evil.example.com`）は引き続き 403
- [x] プレビュー → stg の配線確認: Vercel Preview 環境の `BACKEND_URL` が stg URL であること（`vercel env pull --environment=preview`）+ `next.config.mjs` の rewrites がビルド時に `BACKEND_URL` を参照すること
- [x] ブラウザでこの PR のプレビューを開き、分析実行が成功すること
  - stg Cloud Run ログで到達を確認済み: `POST /api/investment/analyze` → 200（2026-07-05 10:22 JST、municipalities / rent-stats も 200）
  - 注: プレビューは Vercel SSO 保護のため curl では検証不可（Hobby プランは Protection Bypass for Automation 非対応）。ブラウザ実機 + Cloud Run ログで確認した

## 確認事項

- [x] コードレビュー観点での自己レビュー済み

## 補足

- `*.vercel.app` は Vercel 上の任意サイトのオリジンを許可する（現行 suffix 一致実装の最小粒度）。stg 限定・内部 API キー認証・レートリミットありのため許容と判断。絞る場合はマッチャーを `*-<scope>.vercel.app` 対応に拡張する
- Production の Vercel 環境変数に `BACKEND_URL` が見当たらないが本番プロキシは 200 で動作している（team 共有 env の可能性）。別途確認推奨
