### PR TITLE
chore(frontend): 手書き型と生成型の API 契約テストを追加（Issue #811 PR-1）

### DIFF
--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -383,7 +383,7 @@ type InvestmentResult struct {
 	ExitNetProceeds float64 `json:"exitNetProceeds"` // 売却手取り（税・残債控除後）
 	ExitTotalEquity float64 `json:"exitTotalEquity"` // 最終手残り（売却手取り+累積CF）
 
-	IRR *float64 `json:"irr"` // 内部収益率（収束しない場合は null）
+	IRR *float64 `json:"irr" extensions:"x-nullable"` // 内部収益率（収束しない場合は null）
 	NPV float64  `json:"npv"` // 正味現在価値
 
 	StressScenarios []StressScenarioResult `json:"stressScenarios"`

--- a/docs/openapi/swagger.json
+++ b/docs/openapi/swagger.json
@@ -1706,7 +1706,8 @@
                 },
                 "irr": {
                     "description": "内部収益率（収束しない場合は null）",
-                    "type": "number"
+                    "type": "number",
+                    "x-nullable": true
                 },
                 "isAboveYieldTarget": {
                     "type": "boolean"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "format:check": "prettier --check \"src/**/*.{ts,tsx,css}\" \"*.mjs\"",
     "lint": "eslint src/",
     "type-check": "tsc --noEmit",
+    "pretype-check": "test -f src/types/api.generated.ts || test ! -f ../docs/openapi/swagger.json || npm run generate:types",
     "generate:types": "swagger2openapi ../docs/openapi/swagger.json --outfile ../docs/openapi/openapi.json && openapi-typescript ../docs/openapi/openapi.json -o src/types/api.generated.ts",
     "pretest": "test -f src/types/api.generated.ts || test ! -f ../docs/openapi/swagger.json || npm run generate:types",
     "prebuild": "test -f src/types/api.generated.ts || test ! -f ../docs/openapi/swagger.json || npm run generate:types",

--- a/frontend/src/types/__tests__/api-contract.ts
+++ b/frontend/src/types/__tests__/api-contract.ts
@@ -1,0 +1,72 @@
+/**
+ * API 契約テスト（コンパイル時のみ・ランタイムでは実行されない）
+ *
+ * 手書き型 (types/investment.ts) と swagger.json 由来の生成型
+ * (types/api.generated.ts) のドリフトを `tsc --noEmit` で検出する。
+ * バックエンドの Go 型を変更したら `make swagger` → `npm run generate:types`
+ * を実行すると、このファイルがコンパイルエラーになって不整合を知らせる。
+ *
+ * 検証は2段構え:
+ * 1. AssertSameKeys — フィールドの追加・削除・改名を検出
+ *    （生成型は swag の制約で全フィールド optional のため、
+ *      代入可能性チェックだけではフィールド欠落を検出できない）
+ * 2. AssertAssignable — 同名フィールドの型不一致を検出
+ *    （ネストした型も構造的に検証される）
+ *
+ * 対象: バックエンド由来の主要3型（Issue #811 PR-1）。PR-2 で全型へ拡大予定。
+ */
+import type { components } from "@/types/api.generated";
+import type { InvestmentInput, InvestmentResult, LandPriceStats } from "@/types/investment";
+
+type Schemas = components["schemas"];
+
+/** キー集合が一致しない場合、差分キーを含むオブジェクト型に解決されてエラーになる */
+type AssertSameKeys<Hand, Gen> = [
+  Exclude<keyof Gen, keyof Hand>,
+  Exclude<keyof Hand, keyof Gen>,
+] extends [never, never]
+  ? true
+  : {
+      missingInHandwritten: Exclude<keyof Gen, keyof Hand>;
+      unknownToBackend: Exclude<keyof Hand, keyof Gen>;
+    };
+
+/** Hand が Gen に代入不可能な場合、制約違反としてエラーになる */
+type AssertAssignable<Hand extends Gen, Gen> = Hand;
+
+type Expect<T extends true> = T;
+
+// ---- domain.InvestmentInput ----
+/**
+ * フロント固有フィールド（バックエンドの simulate 契約に含まれないもの）。
+ * ここに追加する場合は investment.ts 側のコメントにも明記すること。
+ * - stationMinutes: 理論価格推定 API (/land-prices/estimate) のクエリ用
+ */
+type FrontendOnlyInputFields = "stationMinutes";
+type ContractInvestmentInput = Omit<InvestmentInput, FrontendOnlyInputFields>;
+
+export type CheckInvestmentInputKeys = Expect<
+  AssertSameKeys<ContractInvestmentInput, Schemas["domain.InvestmentInput"]>
+>;
+export type CheckInvestmentInputFields = AssertAssignable<
+  ContractInvestmentInput,
+  Schemas["domain.InvestmentInput"]
+>;
+
+// ---- domain.InvestmentResult ----
+export type CheckInvestmentResultKeys = Expect<
+  AssertSameKeys<InvestmentResult, Schemas["domain.InvestmentResult"]>
+>;
+export type CheckInvestmentResultFields = AssertAssignable<
+  InvestmentResult,
+  Schemas["domain.InvestmentResult"]
+>;
+
+// ---- domain.LandPriceStats ----
+export type CheckLandPriceStatsKeys = Expect<
+  AssertSameKeys<LandPriceStats, Schemas["domain.LandPriceStats"]>
+>;
+export type CheckLandPriceStatsFields = AssertAssignable<
+  LandPriceStats,
+  Schemas["domain.LandPriceStats"]
+>;

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -60,7 +60,7 @@ export interface MultiExitRow {
   remainingLoan: number;
   cumulativeCf: number;
   exitEquity: number;
-  irr?: number | null;
+  irr?: number; // 収束しない場合は省略（Go側 omitempty）
   isShortTermWarn: boolean;
 }
 
@@ -69,7 +69,7 @@ export interface InvestmentInput {
   landArea: number; // 土地面積 (m²)
   buildingCost: number;
   buildingAge: number; // 築年数 (0=新築)
-  stationMinutes: number; // 最寄り駅徒歩分 (0=未入力)
+  stationMinutes: number; // 最寄り駅徒歩分 (0=未入力)。フロント固有: 理論価格推定APIに渡す入力で、simulate契約には含まれない（api-contract.ts で除外）
   miscExpenseRate: number;
   monthlyRent: number;
   vacancyRate: number; // 想定空室率（長期シミュレーション用）
@@ -112,6 +112,9 @@ export interface InvestmentInput {
 
   // 税務シミュレーション用（任意）。0 の場合は損益通算・法人比較を計算しない。
   salaryIncome?: number; // 給与年収（円）
+
+  // 所有権保存登記（新築直売）か移転登記（中古・転売）か。省略時はバックエンドが buildingAge==0 から自動判定。
+  isFirstRegistration?: boolean;
 }
 
 export interface CapexEvent {


### PR DESCRIPTION
## 概要

Issue #811 の PR-1（契約テストの追加・非破壊）。CI で生成している `api.generated.ts` が src から一切 import されておらず、バックエンドの Go 型変更が `tsc --noEmit` で検出できない問題に対し、手書き型（`types/investment.ts`）と生成型を相互検証するコンパイル時契約テストを追加する。

## 変更内容

- `frontend/src/types/__tests__/api-contract.ts` を新規作成（主要3型: `InvestmentInput` / `InvestmentResult` / `LandPriceStats`）
  - **キー集合一致チェック**: フィールドの追加・削除・改名を検出。生成型は swag の制約で全フィールド optional のため、Issue 記載の代入チェックだけではフィールド欠落・改名を検出できず、この層を追加した
  - **代入可能性チェック**: 同名フィールドの型不一致を検出（ネスト型も構造的に検証される）
- 契約テストが検出した既存ドリフト3件を同 PR 内で修正
  - 手書き `InvestmentInput` に `isFirstRegistration?: boolean` が欠落 → 追加
  - `InvestmentResult.irr` は Go が null を返す（`*float64`）が生成型は `number` のみ → Go 側に `extensions:"x-nullable"` を付与し生成型を `number | null` に修正（swagger.json 再生成込み）
  - `MultiExitRow.irr` の手書き型 `number | null` → Go 側は `omitempty` で null を出さないため `irr?: number` に修正
- `stationMinutes` はバックエンドの simulate 契約に存在しないフロント固有フィールド（理論価格推定 API のクエリ用）のため、除外リストとして契約テスト側に明記
- `package.json` に `pretype-check` フックを追加（`api.generated.ts` 未生成時に `type-check` が壊れないよう、既存の `pretest` / `prebuild` と同じガードを適用）

## 関連Issue

#811（移行手順 PR-1/3。PR-2 で全レスポンス型へ拡大予定のため Close しない）

## テスト

- [x] 既存テストが通ること（`make lint` / `make test`: vitest 396件 PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること（契約テストは `tsc --noEmit` で検証）
- [x] Issue 記載の検証手順: Go の `netYield` を意図的に改名 → `make swagger && npm run generate:types && npx tsc --noEmit` が `missingInHandwritten: "netYieldRenamed"; unknownToBackend: "netYield"` で fail することを確認後 revert

## 確認事項

- [x] コードレビュー観点での自己レビュー済み