### PR TITLE
chore(frontend): API 契約テストを全バックエンド由来型へ拡大（Issue #811 PR-2）

### DIFF
--- a/backend/internal/domain/montecarlo.go
+++ b/backend/internal/domain/montecarlo.go
@@ -22,8 +22,8 @@ type MonteCarloResult struct {
 	IRRPercentiles    Percentiles    `json:"irrPercentiles"`
 	EquityPercentiles Percentiles    `json:"equityPercentiles"`
 	DeadCrossRate     float64        `json:"deadCrossRate"` // デッドクロス発生率 (0〜1)
-	IRRHistogram      []HistogramBin `json:"irrHistogram"`
-	EquityHistogram   []HistogramBin `json:"equityHistogram"`
+	IRRHistogram      []HistogramBin `json:"irrHistogram" extensions:"x-nullable"`   // サンプル0件時は null
+	EquityHistogram   []HistogramBin `json:"equityHistogram" extensions:"x-nullable"` // サンプル0件時は null
 	SuccessRate       float64        `json:"successRate"` // IRR > 0 の割合
 }
 

--- a/docs/openapi/swagger.json
+++ b/docs/openapi/swagger.json
@@ -1973,19 +1973,23 @@
                     "type": "number"
                 },
                 "equityHistogram": {
+                    "description": "サンプル0件時は null",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/domain.HistogramBin"
-                    }
+                    },
+                    "x-nullable": true
                 },
                 "equityPercentiles": {
                     "$ref": "#/definitions/domain.Percentiles"
                 },
                 "irrHistogram": {
+                    "description": "サンプル0件時は null",
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/domain.HistogramBin"
-                    }
+                    },
+                    "x-nullable": true
                 },
                 "irrPercentiles": {
                     "$ref": "#/definitions/domain.Percentiles"

--- a/frontend/src/types/__tests__/api-contract.ts
+++ b/frontend/src/types/__tests__/api-contract.ts
@@ -1,42 +1,107 @@
 /**
  * API 契約テスト（コンパイル時のみ・ランタイムでは実行されない）
  *
- * 手書き型 (types/investment.ts) と swagger.json 由来の生成型
+ * 手書き型 (types/investment.ts, lib/api.ts) と swagger.json 由来の生成型
  * (types/api.generated.ts) のドリフトを `tsc --noEmit` で検出する。
  * バックエンドの Go 型を変更したら `make swagger` → `npm run generate:types`
  * を実行すると、このファイルがコンパイルエラーになって不整合を知らせる。
  *
- * 検証は2段構え:
- * 1. AssertSameKeys — フィールドの追加・削除・改名を検出
+ * オブジェクト型の検証は CheckContract で2段構え:
+ * 1. キー集合一致 — フィールドの追加・削除・改名を検出
  *    （生成型は swag の制約で全フィールド optional のため、
  *      代入可能性チェックだけではフィールド欠落を検出できない）
- * 2. AssertAssignable — 同名フィールドの型不一致を検出
+ * 2. フィールド単位の代入可能性 — 同名フィールドの型不一致を検出
  *    （ネストした型も構造的に検証される）
+ * ユニオン型（enum 由来）は Equals でメンバー集合の完全一致を検証する。
  *
- * 対象: バックエンド由来の主要3型（Issue #811 PR-1）。PR-2 で全型へ拡大予定。
+ * フロント固有型はバックエンド契約に対応がないため対象外
+ * （investment.ts 冒頭のコメント参照）。
  */
 import type { components } from "@/types/api.generated";
-import type { InvestmentInput, InvestmentResult, LandPriceStats } from "@/types/investment";
+import type { AreaDiscoveryItem, AreaDiscoveryResponse, RentStatsResult } from "@/lib/api";
+import type {
+  AcquisitionCostBreakdown,
+  AppraisalComparisonResult,
+  BuildingType,
+  CapexEvent,
+  ClassifiedRenovationItem,
+  CriticalError,
+  GeocodeResult,
+  HeatmapResponse,
+  HeatmapTile,
+  HistogramBin,
+  InvestmentInput,
+  InvestmentResult,
+  InvestmentScoreResult,
+  LandPriceComparison,
+  LandPriceStats,
+  LandTransaction,
+  LTVSensitivityRow,
+  MonteCarloInput,
+  MonteCarloResult,
+  MultiExitRow,
+  Municipality,
+  OwnershipComparisonResult,
+  OwnershipScenario,
+  Percentiles,
+  PopulationForecastResult,
+  PopulationSnapshot,
+  RadarPoint,
+  RateAdjustment,
+  RenovationInput,
+  RenovationItem,
+  RenovationResult,
+  RentDeclineHint,
+  RidershipDemandScore,
+  SalaryLossCarryoverResult,
+  ScoreBreakdown,
+  ScoreItem,
+  StationRidershipResult,
+  StressScenarioResult,
+  TaxSimRow,
+  TaxSimulationResult,
+  TheoreticalPriceResult,
+  UrbanRisk,
+  UrbanRiskLevel,
+  YearlyResult,
+  YieldScenario,
+  YieldScenarios,
+  ZoningSummary,
+} from "@/types/investment";
 
 type Schemas = components["schemas"];
 
-/** キー集合が一致しない場合、差分キーを含むオブジェクト型に解決されてエラーになる */
-type AssertSameKeys<Hand, Gen> = [
+/** 同名フィールドのうち、手書き型が生成型に代入できないフィールド名を列挙する */
+type BadFields<Hand, Gen> = {
+  [K in keyof Hand & keyof Gen]: [Hand[K]] extends [Gen[K]] ? never : K;
+}[keyof Hand & keyof Gen];
+
+/**
+ * オブジェクト型の契約検証。合格なら true、不合格なら原因を示す
+ * オブジェクト型（missingInHandwritten / unknownToBackend / fieldTypeMismatch）
+ * に解決され、AssertAll の制約違反としてエラーになる。
+ */
+type CheckContract<Hand, Gen> = [
   Exclude<keyof Gen, keyof Hand>,
   Exclude<keyof Hand, keyof Gen>,
 ] extends [never, never]
-  ? true
+  ? [BadFields<Hand, Gen>] extends [never]
+    ? true
+    : { fieldTypeMismatch: BadFields<Hand, Gen> }
   : {
       missingInHandwritten: Exclude<keyof Gen, keyof Hand>;
       unknownToBackend: Exclude<keyof Hand, keyof Gen>;
     };
 
-/** Hand が Gen に代入不可能な場合、制約違反としてエラーになる */
-type AssertAssignable<Hand extends Gen, Gen> = Hand;
+/** ユニオン型のメンバー集合が完全一致するかを検証する */
+type Equals<Hand, Gen> = [Hand] extends [Gen]
+  ? [Gen] extends [Hand]
+    ? true
+    : { genOnlyMembers: Exclude<Gen, Hand> }
+  : { handOnlyMembers: Exclude<Hand, Gen> };
 
-type Expect<T extends true> = T;
+type AssertAll<Checks extends { [K in keyof Checks]: true }> = Checks;
 
-// ---- domain.InvestmentInput ----
 /**
  * フロント固有フィールド（バックエンドの simulate 契約に含まれないもの）。
  * ここに追加する場合は investment.ts 側のコメントにも明記すること。
@@ -45,28 +110,67 @@ type Expect<T extends true> = T;
 type FrontendOnlyInputFields = "stationMinutes";
 type ContractInvestmentInput = Omit<InvestmentInput, FrontendOnlyInputFields>;
 
-export type CheckInvestmentInputKeys = Expect<
-  AssertSameKeys<ContractInvestmentInput, Schemas["domain.InvestmentInput"]>
->;
-export type CheckInvestmentInputFields = AssertAssignable<
-  ContractInvestmentInput,
-  Schemas["domain.InvestmentInput"]
->;
+/** スキーマ名 → 対応する手書き型。バックエンド由来のオブジェクト型はここに全て列挙する */
+type HandwrittenBySchema = {
+  "api.GeocodeResult": GeocodeResult;
+  "domain.AcquisitionCostBreakdown": AcquisitionCostBreakdown;
+  "domain.AppraisalComparisonResult": AppraisalComparisonResult;
+  "domain.AreaDiscoveryItem": AreaDiscoveryItem;
+  "domain.AreaDiscoveryResponse": AreaDiscoveryResponse;
+  "domain.CapexEvent": CapexEvent;
+  "domain.ClassifiedRenovationItem": ClassifiedRenovationItem;
+  "domain.CriticalError": CriticalError;
+  "domain.HeatmapResponse": HeatmapResponse;
+  "domain.HeatmapTile": HeatmapTile;
+  "domain.HistogramBin": HistogramBin;
+  "domain.InvestmentInput": ContractInvestmentInput;
+  "domain.InvestmentResult": InvestmentResult;
+  "domain.InvestmentScoreResult": InvestmentScoreResult;
+  "domain.LTVSensitivityRow": LTVSensitivityRow;
+  "domain.LandPriceComparison": LandPriceComparison;
+  "domain.LandPriceStats": LandPriceStats;
+  "domain.LandTransaction": LandTransaction;
+  "domain.MonteCarloInput": MonteCarloInput;
+  "domain.MonteCarloResult": MonteCarloResult;
+  "domain.MultiExitRow": MultiExitRow;
+  "domain.OwnershipComparisonResult": OwnershipComparisonResult;
+  "domain.OwnershipScenario": OwnershipScenario;
+  "domain.Percentiles": Percentiles;
+  "domain.PopulationForecastResult": PopulationForecastResult;
+  "domain.PopulationSnapshot": PopulationSnapshot;
+  "domain.RadarPoint": RadarPoint;
+  "domain.RateAdjustment": RateAdjustment;
+  "domain.RenovationInput": RenovationInput;
+  "domain.RenovationItem": RenovationItem;
+  "domain.RenovationResult": RenovationResult;
+  "domain.RentDeclineHint": RentDeclineHint;
+  "domain.RentStatsResult": RentStatsResult;
+  "domain.SalaryLossCarryoverResult": SalaryLossCarryoverResult;
+  "domain.ScoreBreakdown": ScoreBreakdown;
+  "domain.ScoreItem": ScoreItem;
+  "domain.StationRidershipResult": StationRidershipResult;
+  "domain.StressScenarioResult": StressScenarioResult;
+  "domain.TaxSimRow": TaxSimRow;
+  "domain.TaxSimulationResult": TaxSimulationResult;
+  "domain.TheoreticalPriceResult": TheoreticalPriceResult;
+  "domain.UrbanRisk": UrbanRisk;
+  "domain.YearlyResult": YearlyResult;
+  "domain.YieldScenario": YieldScenario;
+  "domain.YieldScenarios": YieldScenarios;
+  "domain.ZoningSummary": ZoningSummary;
+  "mlit.Municipality": Municipality;
+};
 
-// ---- domain.InvestmentResult ----
-export type CheckInvestmentResultKeys = Expect<
-  AssertSameKeys<InvestmentResult, Schemas["domain.InvestmentResult"]>
->;
-export type CheckInvestmentResultFields = AssertAssignable<
-  InvestmentResult,
-  Schemas["domain.InvestmentResult"]
->;
+/** 全オブジェクト型の一括検証。不合格の型はスキーマ名付きでエラーに現れる */
+export type ContractChecks = AssertAll<{
+  [K in keyof HandwrittenBySchema]: CheckContract<HandwrittenBySchema[K], Schemas[K]>;
+}>;
 
-// ---- domain.LandPriceStats ----
-export type CheckLandPriceStatsKeys = Expect<
-  AssertSameKeys<LandPriceStats, Schemas["domain.LandPriceStats"]>
->;
-export type CheckLandPriceStatsFields = AssertAssignable<
-  LandPriceStats,
-  Schemas["domain.LandPriceStats"]
->;
+/** enum 由来のユニオン型はメンバー集合の完全一致を検証する */
+export type UnionChecks = AssertAll<{
+  buildingType: Equals<BuildingType, Schemas["domain.BuildingType"]>;
+  criticalErrorStatus: Equals<CriticalError["status"], Schemas["domain.CriticalErrorStatus"]>;
+  populationTrend: Equals<PopulationForecastResult["trend"], Schemas["domain.PopulationTrend"]>;
+  ridershipDemandScore: Equals<RidershipDemandScore, Schemas["domain.RidershipDemandScore"]>;
+  urbanRiskLevel: Equals<UrbanRiskLevel, Schemas["domain.UrbanRiskLevel"]>;
+}>;

--- a/frontend/src/types/__tests__/api-contract.ts
+++ b/frontend/src/types/__tests__/api-contract.ts
@@ -174,3 +174,27 @@ export type UnionChecks = AssertAll<{
   ridershipDemandScore: Equals<RidershipDemandScore, Schemas["domain.RidershipDemandScore"]>;
   urbanRiskLevel: Equals<UrbanRiskLevel, Schemas["domain.UrbanRiskLevel"]>;
 }>;
+
+/** UnionChecks で検証済みのユニオン型スキーマ（HandwrittenBySchema の対象外） */
+type CoveredUnionSchemas =
+  | "domain.BuildingType"
+  | "domain.CriticalErrorStatus"
+  | "domain.PopulationTrend"
+  | "domain.RidershipDemandScore"
+  | "domain.UrbanRiskLevel";
+
+/**
+ * 新スキーマの登録漏れガード。バックエンドに新しい型が追加されると
+ * uncoveredSchemas にスキーマ名が現れてエラーになる。
+ * 対応する手書き型を作って HandwrittenBySchema（オブジェクト型）または
+ * UnionChecks + CoveredUnionSchemas（ユニオン型）に登録すること。
+ */
+export type CoverageCheck = AssertAll<{
+  allSchemasCovered: [
+    Exclude<keyof Schemas, keyof HandwrittenBySchema | CoveredUnionSchemas>,
+  ] extends [never]
+    ? true
+    : {
+        uncoveredSchemas: Exclude<keyof Schemas, keyof HandwrittenBySchema | CoveredUnionSchemas>;
+      };
+}>;

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -1,3 +1,15 @@
+/**
+ * バックエンド API 契約に対応する手書き型定義。
+ *
+ * バックエンド由来の型は types/__tests__/api-contract.ts で生成型
+ * (api.generated.ts) との一致が `tsc --noEmit` により検証される。
+ *
+ * 以下はフロント固有型（バックエンド契約に対応スキーマがなく、契約検証の対象外）:
+ * - SimulationMode: 入力フォームの表示モード
+ * - LoanMethod: バックエンドでは string（値はバリデーションのみ）のためフロントで絞り込み
+ * - WatchlistStatus / WatchlistMetrics / WatchlistItem: localStorage 保存のクライアント専用データ
+ * - InvestmentInput.stationMinutes: 理論価格推定 API のクエリ用フィールド（simulate 契約外）
+ */
 export interface Municipality {
   id: string;
   name: string;
@@ -247,6 +259,8 @@ export interface LandTransaction {
   cityPlanning: string;
   buildingCoverage: string;
   floorAreaRatio: string;
+  buildingYear?: number; // 建築年（西暦）。データがない場合は省略
+  stationMinutes?: number; // 最寄り駅徒歩分。データがない場合は省略
 }
 
 export interface LandPriceStats {


### PR DESCRIPTION
## 概要

Issue #811 の PR-2。PR-1（#824）で主要3型に導入したコンパイル時 API 契約テストを、バックエンド由来の全型に拡大する。

## 変更内容

- `api-contract.ts` をスキーマ名キーのマッピング方式に書き換え、**47オブジェクト型**を mapped type で一括検証（不一致の型はスキーマ名付きで tsc エラーに現れる）
  - PR-1 の型ごとの個別チェックはこのマッピングに統合
  - enum 由来の**5ユニオン型**（`BuildingType` / `CriticalErrorStatus` / `PopulationTrend` / `RidershipDemandScore` / `UrbanRiskLevel`）はメンバー集合の完全一致を `Equals` で検証
  - `AreaDiscoveryItem` / `AreaDiscoveryResponse` / `RentStatsResult` は `lib/api.ts` に定義があるためそこから import（型置き場の統一は #815 で対応）
- 拡大により検出された既存ドリフト2件を同 PR 内で修正
  - `LandTransaction`: バックエンドが返す `buildingYear` / `stationMinutes` が手書き型に欠落 → optional で追加
  - `MonteCarloResult`: `irrHistogram` / `equityHistogram` は Go の `buildHistogram` がサンプル0件時に nil を返し null になり得るが、生成型に null がなかった → Go 側に `extensions:"x-nullable"` を付与（PR-1 と同パターン、swagger.json 再生成込み）
- Issue 記載のとおり `investment.ts` 冒頭にフロント固有型（`SimulationMode` / `LoanMethod` / `Watchlist*` / `InvestmentInput.stationMinutes`）を契約検証対象外と明記するコメントを追加

## 関連Issue

Closes #811（PR-3 のエイリアス化は任意扱いのため、必要になった時点で別 Issue として起票する想定。継続する場合は Close を外してください）

## テスト

- [x] 既存テストが通ること（`make lint` / `make test`: vitest 396件 PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること（契約テストは `tsc --noEmit` で検証。拡大過程で `LandTransaction` の欠落フィールドが `missingInHandwritten: "buildingYear" | "stationMinutes"`、`MonteCarloResult` の型不一致が `fieldTypeMismatch` として実際に検出されることを確認済み）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み