### PR TITLE
refactor(frontend): 手書き型を生成型エイリアスに置換（Issue #811 PR-3）

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ frontend:
 ## swagger: OpenAPI スキーマを生成 (docs/openapi/swagger.json)
 ##   型ファイルも更新するには別途 cd frontend && npm run generate:types を実行すること
 swagger:
-	cd backend && swag init -g cmd/server/main.go -o ../docs/openapi --outputTypes json
+	cd backend && swag init -g cmd/server/main.go -o ../docs/openapi --outputTypes json --requiredByDefault
 	@echo "==> Generated docs/openapi/swagger.json"
 
 ## swagger-check: swagger.json のドリフトをローカルで確認 (PR 前チェック用)

--- a/backend/internal/domain/montecarlo.go
+++ b/backend/internal/domain/montecarlo.go
@@ -11,9 +11,9 @@ import (
 // MonteCarloInput はモンテカルロシミュレーションの入力値
 type MonteCarloInput struct {
 	Base             InvestmentInput `json:"base"`
-	Simulations      int             `json:"simulations"`      // 試行回数 (デフォルト 1000、最大 10000)
-	VacancyRateSigma float64         `json:"vacancyRateSigma"` // 空室率の標準偏差 (デフォルト 0.05)
-	LoanRateSigma    float64         `json:"loanRateSigma"`    // 金利の標準偏差 (デフォルト 0.005)
+	Simulations      int             `json:"simulations,omitempty"`      // 試行回数 (デフォルト 1000、最大 10000)
+	VacancyRateSigma float64         `json:"vacancyRateSigma,omitempty"` // 空室率の標準偏差 (デフォルト 0.05)
+	LoanRateSigma    float64         `json:"loanRateSigma,omitempty"`    // 金利の標準偏差 (デフォルト 0.005)
 }
 
 // MonteCarloResult はモンテカルロシミュレーションの結果

--- a/backend/internal/domain/types.go
+++ b/backend/internal/domain/types.go
@@ -106,19 +106,19 @@ type InvestmentInput struct {
 	// 賃料下落率: 毎年この割合だけ実効賃料が低下する（例: 0.01 = 年1%下落）
 	RentDeclineRate float64 `json:"rentDeclineRate"`
 
-	// 割引率: NPV/IRR計算用 (例: 0.05 = 5%)
-	DiscountRate float64 `json:"discountRate"`
+	// 割引率: NPV/IRR計算用 (例: 0.05 = 5%)。省略時は Defaults() で 0.05
+	DiscountRate float64 `json:"discountRate,omitempty"`
 	// 物件価格下落率: 売却価格に毎年この割合の累乗で下落を反映 (例: 0.02 = 年2%下落)
-	PriceDeclineRate float64 `json:"priceDeclineRate"`
+	PriceDeclineRate float64 `json:"priceDeclineRate,omitempty"`
 	// 減価償却方式: "straight-line"（定額法）| "declining-balance"（定率法）
-	DepreciationMethod string `json:"depreciationMethod"`
+	DepreciationMethod string `json:"depreciationMethod,omitempty"`
 
 	// 目標表面利回り（例: 0.08 = 8%）。0 の場合は Defaults() で 0.08 にセットされる。
 	YieldTarget float64 `json:"yieldTarget"`
 
 	// 返済方式: "equal-payment"（元利均等）| "equal-principal"（元金均等）
 	// 省略時は Defaults() で "equal-payment" にセットされる。
-	LoanMethod string `json:"loanMethod"`
+	LoanMethod string `json:"loanMethod,omitempty"`
 
 	// 変動金利スケジュール: 指定年以降に適用する金利ステップ（空=固定金利）
 	// LoanRateDelta はスケジュール後の金利にも加算される。

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ Gin は標準 `net/http` との互換性が高く、ミドルウェア合成が�
 
 React Server Components（RSC）によるサーバーサイドレンダリングで初期表示を高速化しつつ、インタラクティブ部分は Client Components として分離できる。
 Vercel との統合により、プレビュー URL・エッジキャッシュ・環境変数管理が統一されている。
-型安全な API Routes と `fetch` ラッパーにより、バックエンドとのインターフェース不整合をビルド時に検出できる。
+バックエンドとのインターフェース不整合は、swagger.json 由来の生成型（`api.generated.ts`）を主要型として直接使用し、フロント固有の手書き型も契約テスト（`types/__tests__/api-contract.ts`）で生成型と照合するため、`tsc --noEmit` でビルド時に検出できる。
 
 ### Cloud Run
 

--- a/docs/llm/backend.md
+++ b/docs/llm/backend.md
@@ -2,7 +2,7 @@
 purpose: バックエンド開発（Go / API / swagger）の出発点
 triggers: [go, handler, router, swagger, api endpoint, mlit client, domain type]
 reads_next: [docs/api-reference.md, docs/mlit-api-integration.md]
-last_updated: 2026-05-21
+last_updated: 2026-07-05
 ---
 
 ## 重要ファイル
@@ -44,7 +44,7 @@ func (h *Handler) HandlerFunc(c *gin.Context) {
 
 ```
 backend/internal/domain/*.go  (Go struct + swag アノテーション)
-    ↓ make swagger
+    ↓ make swagger（--requiredByDefault 付き）
 docs/openapi/swagger.json     (コミット対象 — 編集禁止)
     ↓ npm run generate:types
 frontend/src/types/api.generated.ts  (git 管理外 — CI で毎回生成)
@@ -52,6 +52,23 @@ frontend/src/types/api.generated.ts  (git 管理外 — CI で毎回生成)
 
 - `swagger.json` は git 管理対象。変更したら必ずコミットに含める
 - `api.generated.ts` は git 管理外。ローカルで使う場合は `npm run generate:types` を実行
+
+## struct タグ = TypeScript 契約（Issue #811 以降）
+
+フロントエンドの主要型は `api.generated.ts` の再エクスポートのため、
+**Go の struct タグがそのまま TS の型を決める**。タグの付け外しは契約変更になる。
+
+| Go 側の実態 | 付けるタグ | 生成される TS 型 |
+|------------|-----------|----------------|
+| 常に出力される（デフォルト） | なし | required |
+| 省略され得る（`Defaults()` 補完・条件付き出力） | `json:"...,omitempty"` | optional (`?`) |
+| null を出し得る（`*T` や omitempty なしスライスの nil） | `extensions:"x-nullable"` | `\| null` |
+| `*T` + `omitempty`（null は出ない） | そのまま | optional・x-nullable 不要 |
+
+- 型を変更すると `frontend/src/types/__tests__/api-contract.ts`（契約テスト）と
+  フロントの使用箇所が `tsc --noEmit` で fail する。**frontend の修正を同一 PR に含めること**
+- 新しいレスポンス型を追加したら api-contract.ts の `HandwrittenBySchema` にも登録する
+  （登録漏れは `CoverageCheck` が tsc エラーで検出する）
 
 ## テスト実行
 

--- a/docs/llm/frontend.md
+++ b/docs/llm/frontend.md
@@ -2,7 +2,7 @@
 purpose: フロントエンド開発（Next.js / TSX / UI）の出発点
 triggers: [tsx, react, component, tailwind, shadcn, recharts, frontend, ui]
 reads_next: [docs/frontend-components.md, docs/usecases.md]
-last_updated: 2026-05-21
+last_updated: 2026-07-05
 ---
 
 ## 重要ファイル
@@ -16,8 +16,9 @@ last_updated: 2026-05-21
 | `frontend/src/components/DeadCrossChart.tsx` | デッドクロス可視化（ResponsiveContainer の参照実装） |
 | `frontend/src/components/WatchlistPanel.tsx` | ウォッチリスト（Badge + アイコンの参照実装） |
 | `frontend/src/lib/` | API クライアント・計算ユーティリティ |
-| `frontend/src/types/investment.ts` | 手動定義 TypeScript 型 |
+| `frontend/src/types/investment.ts` | API 型定義（バックエンド一致型は生成型の再エクスポート + フロント固有の手書き型） |
 | `frontend/src/types/api.generated.ts` | 自動生成型（編集禁止・git 管理外） |
+| `frontend/src/types/__tests__/api-contract.ts` | 契約テスト（手書き型と生成型の一致を tsc で検証） |
 
 ## TypeScript 型の再生成
 
@@ -25,6 +26,18 @@ last_updated: 2026-05-21
 # make swagger が実行済みであること（swagger.json が最新であること）が前提
 cd frontend && npm run generate:types
 ```
+
+## API 型の追加・変更ルール（Issue #811 以降）
+
+- バックエンドと厳密一致する型は `investment.ts` で `Schemas["domain.X"]` の再エクスポート。
+  **手書きで二重定義しない**（フィールドコメントは Go 側コメントが JSDoc として引き継がれる）
+- 手書きが許されるのは: 生成型の string をユニオンに絞る型（`LoanMethod` / `GeocodeResult` 等）、
+  フロント固有フィールドを持つ型（`InvestmentInput.stationMinutes`）、フロント固有型（`Watchlist*` 等）。
+  手書き型は `api-contract.ts` の検証対象になる
+- 新しい API 型を追加したら `api-contract.ts` の `HandwrittenBySchema` に1行登録する
+  （登録漏れは `CoverageCheck` が tsc エラーで知らせる）
+- 契約テストが fail したら: Go 側の実態（omitempty 有無・nil 可能性）を確認し、
+  タグ修正か手書き型修正かを判断する（`docs/llm/backend.md` のタグ対応表参照）
 
 ## UI デザインルール
 

--- a/docs/openapi/swagger.json
+++ b/docs/openapi/swagger.json
@@ -1196,6 +1196,11 @@
     "definitions": {
         "api.GeocodeResult": {
             "type": "object",
+            "required": [
+                "lat",
+                "lng",
+                "locationType"
+            ],
             "properties": {
                 "lat": {
                     "type": "number"
@@ -1210,6 +1215,14 @@
         },
         "domain.AcquisitionCostBreakdown": {
             "type": "object",
+            "required": [
+                "brokerageFee",
+                "propertyTaxProration",
+                "realEstateAcquisitionTax",
+                "registrationTax",
+                "stampDuty",
+                "total"
+            ],
             "properties": {
                 "brokerageFee": {
                     "description": "仲介手数料（税込）",
@@ -1238,6 +1251,12 @@
         },
         "domain.AppraisalComparisonResult": {
             "type": "object",
+            "required": [
+                "appraisalCount",
+                "appraisalMedianPerSqm",
+                "appraisalTrend",
+                "trendLabel"
+            ],
             "properties": {
                 "appraisalCount": {
                     "description": "標準地点数",
@@ -1259,6 +1278,18 @@
         },
         "domain.AreaDiscoveryItem": {
             "type": "object",
+            "required": [
+                "centerLat",
+                "centerLng",
+                "dataSufficient",
+                "landPriceTrend",
+                "medianTsubo",
+                "municipalityCode",
+                "municipalityName",
+                "transactionCount",
+                "yieldDifficulty",
+                "yieldDifficultyLabel"
+            ],
             "properties": {
                 "centerLat": {
                     "description": "市区町村代表緯度",
@@ -1302,6 +1333,10 @@
         },
         "domain.AreaDiscoveryResponse": {
             "type": "object",
+            "required": [
+                "items",
+                "prefecture"
+            ],
             "properties": {
                 "items": {
                     "type": "array",
@@ -1351,6 +1386,10 @@
         },
         "domain.CapexEvent": {
             "type": "object",
+            "required": [
+                "amount",
+                "year"
+            ],
             "properties": {
                 "amount": {
                     "description": "金額（円）",
@@ -1364,6 +1403,15 @@
         },
         "domain.ClassifiedRenovationItem": {
             "type": "object",
+            "required": [
+                "cost",
+                "expectedMonthlyRentIncrease",
+                "isCapitalExpenditure",
+                "isSelfWork",
+                "name",
+                "selfLaborHours",
+                "virtualLaborCost"
+            ],
             "properties": {
                 "cost": {
                     "type": "number"
@@ -1390,6 +1438,11 @@
         },
         "domain.CriticalError": {
             "type": "object",
+            "required": [
+                "code",
+                "message",
+                "status"
+            ],
             "properties": {
                 "code": {
                     "type": "string"
@@ -1415,6 +1468,11 @@
         },
         "domain.HeatmapResponse": {
             "type": "object",
+            "required": [
+                "failedTiles",
+                "tileCount",
+                "tiles"
+            ],
             "properties": {
                 "failedTiles": {
                     "type": "integer"
@@ -1432,6 +1490,15 @@
         },
         "domain.HeatmapTile": {
             "type": "object",
+            "required": [
+                "centerLat",
+                "centerLng",
+                "grade",
+                "totalScore",
+                "x",
+                "y",
+                "z"
+            ],
             "properties": {
                 "centerLat": {
                     "type": "number"
@@ -1458,6 +1525,11 @@
         },
         "domain.HistogramBin": {
             "type": "object",
+            "required": [
+                "count",
+                "max",
+                "min"
+            ],
             "properties": {
                 "count": {
                     "type": "integer"
@@ -1472,6 +1544,30 @@
         },
         "domain.InvestmentInput": {
             "type": "object",
+            "required": [
+                "actualVacancyRate",
+                "annualLoanRate",
+                "annualPropertyTax",
+                "buildingAge",
+                "buildingCost",
+                "buildingType",
+                "exitYieldTarget",
+                "expenseRate",
+                "holdingYears",
+                "incomeTaxRate",
+                "landArea",
+                "landPrice",
+                "loanAmount",
+                "loanRateDelta",
+                "loanYears",
+                "miscExpenseRate",
+                "monthlyRent",
+                "rateAdjustmentSchedule",
+                "rentDeclineRate",
+                "vacancyRate",
+                "vacancyRateDelta",
+                "yieldTarget"
+            ],
             "properties": {
                 "actualVacancyRate": {
                     "description": "現況空室率: 現時点の実際の空室状況（0の場合はVacancyRateと同一とみなす）",
@@ -1521,7 +1617,7 @@
                     "type": "string"
                 },
                 "discountRate": {
-                    "description": "割引率: NPV/IRR計算用 (例: 0.05 = 5%)",
+                    "description": "割引率: NPV/IRR計算用 (例: 0.05 = 5%)。省略時は Defaults() で 0.05",
                     "type": "number"
                 },
                 "exitYears": {
@@ -1658,6 +1754,34 @@
         },
         "domain.InvestmentResult": {
             "type": "object",
+            "required": [
+                "acquisitionCosts",
+                "aiSummary",
+                "criticalErrors",
+                "deadCrossYear",
+                "dscr",
+                "exitCapitalGain",
+                "exitNetProceeds",
+                "exitSalePrice",
+                "exitTotalEquity",
+                "exitTransferTax",
+                "grossYield",
+                "irr",
+                "isAboveYieldTarget",
+                "ltvSensitivity",
+                "marketGrossYield",
+                "miscExpenses",
+                "netYield",
+                "npv",
+                "requiredCostReduction",
+                "requiredMonthlyRent",
+                "stressScenarios",
+                "totalInterest",
+                "totalInvestment",
+                "yearlyResults",
+                "yieldScenarios",
+                "yieldTarget"
+            ],
             "properties": {
                 "acquisitionCosts": {
                     "$ref": "#/definitions/domain.AcquisitionCostBreakdown"
@@ -1788,6 +1912,11 @@
         },
         "domain.InvestmentScoreResult": {
             "type": "object",
+            "required": [
+                "breakdown",
+                "grade",
+                "totalScore"
+            ],
             "properties": {
                 "breakdown": {
                     "$ref": "#/definitions/domain.ScoreBreakdown"
@@ -1803,6 +1932,14 @@
         },
         "domain.LTVSensitivityRow": {
             "type": "object",
+            "required": [
+                "annualCF",
+                "cfYield",
+                "dscr",
+                "equity",
+                "loanAmount",
+                "ltv"
+            ],
             "properties": {
                 "annualCF": {
                     "description": "年間キャッシュフロー（円）",
@@ -1832,6 +1969,15 @@
         },
         "domain.LandPriceComparison": {
             "type": "object",
+            "required": [
+                "assessment",
+                "diffFromAverage",
+                "diffFromMedian",
+                "inputArea",
+                "inputLandPrice",
+                "inputPricePerTsubo",
+                "stats"
+            ],
             "properties": {
                 "assessment": {
                     "description": "\"割安\" / \"相場\" / \"割高\"",
@@ -1859,6 +2005,15 @@
         },
         "domain.LandPriceStats": {
             "type": "object",
+            "required": [
+                "averageTsubo",
+                "count",
+                "lowDataWarning",
+                "maxTsubo",
+                "medianTsubo",
+                "minTsubo",
+                "transactions"
+            ],
             "properties": {
                 "averageTsubo": {
                     "type": "number"
@@ -1907,6 +2062,17 @@
         },
         "domain.LandTransaction": {
             "type": "object",
+            "required": [
+                "area",
+                "buildingCoverage",
+                "cityPlanning",
+                "district",
+                "floorAreaRatio",
+                "period",
+                "pricePerSqm",
+                "pricePerTsubo",
+                "tradePrice"
+            ],
             "properties": {
                 "area": {
                     "type": "number"
@@ -1947,6 +2113,9 @@
         },
         "domain.MonteCarloInput": {
             "type": "object",
+            "required": [
+                "base"
+            ],
             "properties": {
                 "base": {
                     "$ref": "#/definitions/domain.InvestmentInput"
@@ -1967,6 +2136,15 @@
         },
         "domain.MonteCarloResult": {
             "type": "object",
+            "required": [
+                "deadCrossRate",
+                "equityHistogram",
+                "equityPercentiles",
+                "irrHistogram",
+                "irrPercentiles",
+                "simulationCount",
+                "successRate"
+            ],
             "properties": {
                 "deadCrossRate": {
                     "description": "デッドクロス発生率 (0〜1)",
@@ -2005,6 +2183,16 @@
         },
         "domain.MultiExitRow": {
             "type": "object",
+            "required": [
+                "cumulativeCf",
+                "exitEquity",
+                "isShortTermWarn",
+                "remainingLoan",
+                "salePrice",
+                "transferTax",
+                "transferTaxRate",
+                "year"
+            ],
             "properties": {
                 "cumulativeCf": {
                     "type": "number"
@@ -2037,6 +2225,11 @@
         },
         "domain.OwnershipComparisonResult": {
             "type": "object",
+            "required": [
+                "breakevenYear",
+                "corporate",
+                "individual"
+            ],
             "properties": {
                 "breakevenYear": {
                     "description": "法人が有利になる年 (-1=保有期間内に逆転なし)",
@@ -2052,6 +2245,13 @@
         },
         "domain.OwnershipScenario": {
             "type": "object",
+            "required": [
+                "annualTax",
+                "cumulativeBurden",
+                "label",
+                "totalTaxBurden",
+                "transferTax"
+            ],
             "properties": {
                 "annualTax": {
                     "description": "各年の所得税負担（保有年数分）",
@@ -2082,6 +2282,13 @@
         },
         "domain.Percentiles": {
             "type": "object",
+            "required": [
+                "p10",
+                "p25",
+                "p50",
+                "p75",
+                "p90"
+            ],
             "properties": {
                 "p10": {
                     "type": "number"
@@ -2102,6 +2309,12 @@
         },
         "domain.PopulationForecastResult": {
             "type": "object",
+            "required": [
+                "changeRate30yr",
+                "snapshots",
+                "trend",
+                "vacancyRateDelta"
+            ],
             "properties": {
                 "changeRate30yr": {
                     "description": "30年後変化率 (例: -0.32)",
@@ -2124,6 +2337,10 @@
         },
         "domain.PopulationSnapshot": {
             "type": "object",
+            "required": [
+                "pop",
+                "year"
+            ],
             "properties": {
                 "pop": {
                     "type": "number"
@@ -2150,6 +2367,10 @@
         },
         "domain.RadarPoint": {
             "type": "object",
+            "required": [
+                "category",
+                "score"
+            ],
             "properties": {
                 "category": {
                     "type": "string"
@@ -2161,6 +2382,10 @@
         },
         "domain.RateAdjustment": {
             "type": "object",
+            "required": [
+                "afterYear",
+                "rate"
+            ],
             "properties": {
                 "afterYear": {
                     "description": "AfterYear: この年（1始まり）以降に Rate を適用（例: 6 = 6年目から）",
@@ -2174,6 +2399,14 @@
         },
         "domain.RenovationInput": {
             "type": "object",
+            "required": [
+                "annualBaseRent",
+                "annualExpenses",
+                "effectiveTaxRate",
+                "items",
+                "propertyPrice",
+                "selfLaborRatePerHour"
+            ],
             "properties": {
                 "annualBaseRent": {
                     "type": "number"
@@ -2200,6 +2433,13 @@
         },
         "domain.RenovationItem": {
             "type": "object",
+            "required": [
+                "cost",
+                "expectedMonthlyRentIncrease",
+                "isSelfWork",
+                "name",
+                "selfLaborHours"
+            ],
             "properties": {
                 "cost": {
                     "type": "number"
@@ -2220,6 +2460,18 @@
         },
         "domain.RenovationResult": {
             "type": "object",
+            "required": [
+                "actualYield",
+                "annualRentIncrease",
+                "capitalExpenditures",
+                "classifiedItems",
+                "isRecoverable",
+                "recoveryYears",
+                "repairExpenses",
+                "taxSavings",
+                "totalRenovationCost",
+                "virtualLaborCost"
+            ],
             "properties": {
                 "actualYield": {
                     "type": "number"
@@ -2259,6 +2511,13 @@
         },
         "domain.RentDeclineHint": {
             "type": "object",
+            "required": [
+                "basis",
+                "dataPointCount",
+                "fallbackUsed",
+                "hintRate",
+                "note"
+            ],
             "properties": {
                 "basis": {
                     "description": "\"land_appraisal\" | \"fallback\"",
@@ -2282,6 +2541,12 @@
         },
         "domain.RentStatsResult": {
             "type": "object",
+            "required": [
+                "average",
+                "count",
+                "low_confidence",
+                "median"
+            ],
             "properties": {
                 "average": {
                     "description": "月額賃料 平均値（円）",
@@ -2334,6 +2599,12 @@
         },
         "domain.SalaryLossCarryoverResult": {
             "type": "object",
+            "required": [
+                "baselineSalaryTax",
+                "salaryIncomeYen",
+                "totalTaxSaving",
+                "yearlyRows"
+            ],
             "properties": {
                 "baselineSalaryTax": {
                     "description": "不動産なし時の所得税（年額）",
@@ -2357,6 +2628,18 @@
         },
         "domain.ScoreBreakdown": {
             "type": "object",
+            "required": [
+                "disasterHistory",
+                "embankment",
+                "hazardRisk",
+                "landPriceTrend",
+                "liquefactionRisk",
+                "locationOptimization",
+                "population",
+                "radarData",
+                "ridership",
+                "urbanArea"
+            ],
             "properties": {
                 "disasterHistory": {
                     "$ref": "#/definitions/domain.ScoreItem"
@@ -2395,6 +2678,11 @@
         },
         "domain.ScoreItem": {
             "type": "object",
+            "required": [
+                "description",
+                "label",
+                "score"
+            ],
             "properties": {
                 "description": {
                     "type": "string"
@@ -2409,6 +2697,13 @@
         },
         "domain.StationRidershipResult": {
             "type": "object",
+            "required": [
+                "correction",
+                "demandScore",
+                "lineName",
+                "passengers",
+                "stationName"
+            ],
             "properties": {
                 "correction": {
                     "description": "理論価格補正係数",
@@ -2436,6 +2731,15 @@
         },
         "domain.StressScenarioResult": {
             "type": "object",
+            "required": [
+                "breakEvenYear",
+                "dscr",
+                "interestRateDelta",
+                "isSafe",
+                "label",
+                "totalCashFlow",
+                "vacancyRateDelta"
+            ],
             "properties": {
                 "breakEvenYear": {
                     "description": "累積税引後CFが初めて正転する年（-1=なし）",
@@ -2464,6 +2768,13 @@
         },
         "domain.TaxSimRow": {
             "type": "object",
+            "required": [
+                "combinedIncome",
+                "combinedTax",
+                "reTaxableIncome",
+                "taxDifference",
+                "year"
+            ],
             "properties": {
                 "combinedIncome": {
                     "description": "給与+不動産 合算課税所得",
@@ -2488,6 +2799,10 @@
         },
         "domain.TaxSimulationResult": {
             "type": "object",
+            "required": [
+                "ownershipComparison",
+                "salaryLossCarryover"
+            ],
             "properties": {
                 "ownershipComparison": {
                     "$ref": "#/definitions/domain.OwnershipComparisonResult"
@@ -2499,6 +2814,18 @@
         },
         "domain.TheoreticalPriceResult": {
             "type": "object",
+            "required": [
+                "ageCorrection",
+                "deviationPct",
+                "hasRidershipData",
+                "hasStationData",
+                "isLowDataWarning",
+                "medianBuildingAge",
+                "medianStationMinutes",
+                "ridershipCorrection",
+                "stationCorrection",
+                "theoreticalPriceJPY"
+            ],
             "properties": {
                 "ageCorrection": {
                     "description": "築年数補正 (-0.3〜0.3)",
@@ -2552,6 +2879,12 @@
         },
         "domain.UrbanRisk": {
             "type": "object",
+            "required": [
+                "code",
+                "description",
+                "level",
+                "title"
+            ],
             "properties": {
                 "code": {
                     "description": "リスクコード（例: URBANIZATION_CONTROL）",
@@ -2590,6 +2923,25 @@
         },
         "domain.YearlyResult": {
             "type": "object",
+            "required": [
+                "afterTaxCashFlow",
+                "annualDepreciation",
+                "annualExpenses",
+                "annualInterest",
+                "annualLoanPayment",
+                "annualPrincipal",
+                "annualRent",
+                "capexAmount",
+                "cashFlow",
+                "cumulativeCashFlow",
+                "effectiveRate",
+                "incomeTax",
+                "isDeadCrossYear",
+                "isInDeadCrossZone",
+                "remainingLoanBalance",
+                "taxableIncome",
+                "year"
+            ],
             "properties": {
                 "afterTaxCashFlow": {
                     "type": "number"
@@ -2651,6 +3003,10 @@
         },
         "domain.YieldScenario": {
             "type": "object",
+            "required": [
+                "annualRent",
+                "grossYield"
+            ],
             "properties": {
                 "annualRent": {
                     "description": "年間実効賃料収入（空室控除後）",
@@ -2664,6 +3020,11 @@
         },
         "domain.YieldScenarios": {
             "type": "object",
+            "required": [
+                "optimistic",
+                "pessimistic",
+                "standard"
+            ],
             "properties": {
                 "optimistic": {
                     "description": "楽観: 空室率 × 0.5",
@@ -2693,6 +3054,11 @@
         },
         "domain.ZoningSummary": {
             "type": "object",
+            "required": [
+                "buildingCoverage",
+                "cityPlanning",
+                "floorAreaRatio"
+            ],
             "properties": {
                 "buildingCoverage": {
                     "description": "最頻の建ぺい率（例: 60%）",
@@ -2710,6 +3076,10 @@
         },
         "mlit.Municipality": {
             "type": "object",
+            "required": [
+                "id",
+                "name"
+            ],
             "properties": {
                 "id": {
                     "description": "市区町村コード (例: \"13101\")",

--- a/frontend/src/components/__tests__/helpers.ts
+++ b/frontend/src/components/__tests__/helpers.ts
@@ -131,6 +131,7 @@ export function makeResult(overrides: Partial<InvestmentResult> = {}): Investmen
     irr: 0.07,
     npv: 1_200_000,
     totalInterest: 3_500_000,
+    aiSummary: "",
     ...overrides,
   };
 }

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -351,7 +351,7 @@ export interface RentStatsResult {
   median: number;
   average: number;
   count: number;
-  low_confidence?: boolean;
+  low_confidence: boolean; // サンプル数3件未満で信頼性低（バックエンドが常に出力）
 }
 
 /** エリア賃料相場（中央値・平均値・件数）を取得（XIT001 賃貸） */

--- a/frontend/src/types/investment.ts
+++ b/frontend/src/types/investment.ts
@@ -1,80 +1,70 @@
 /**
- * バックエンド API 契約に対応する手書き型定義。
+ * バックエンド API 契約に対応する型定義。
  *
- * バックエンド由来の型は types/__tests__/api-contract.ts で生成型
- * (api.generated.ts) との一致が `tsc --noEmit` により検証される。
+ * バックエンドと厳密に一致する型は生成型 (api.generated.ts) の再エクスポート。
+ * フィールドコメントは Go 側のコメントが JSDoc として生成型に引き継がれている。
+ * 生成型との整合は types/__tests__/api-contract.ts で `tsc --noEmit` により検証される。
  *
- * 以下はフロント固有型（バックエンド契約に対応スキーマがなく、契約検証の対象外）:
- * - SimulationMode: 入力フォームの表示モード
- * - LoanMethod: バックエンドでは string（値はバリデーションのみ）のためフロントで絞り込み
- * - WatchlistStatus / WatchlistMetrics / WatchlistItem: localStorage 保存のクライアント専用データ
- * - InvestmentInput.stationMinutes: 理論価格推定 API のクエリ用フィールド（simulate 契約外）
+ * 手書きのまま残している型:
+ * - バックエンドより厳しい絞り込みを持つ型（生成型は string のためユニオンで補強）:
+ *   LoanMethod / GeocodeResult.locationType / RentDeclineHint.basis /
+ *   AppraisalComparisonResult.trendLabel / LandPriceComparison.assessment
+ * - InvestmentInput: フロント固有フィールド stationMinutes（理論価格推定 API の
+ *   クエリ用、simulate 契約外）を含むため
+ * - フロント固有型（バックエンド契約に対応スキーマがなく、契約検証の対象外）:
+ *   SimulationMode / WatchlistStatus / WatchlistMetrics / WatchlistItem
  */
-export interface Municipality {
-  id: string;
-  name: string;
-}
+import type { components } from "@/types/api.generated";
 
-export interface CriticalError {
-  code: string;
-  status: "REJECT" | "WARNING";
-  message: string;
-}
+type Schemas = components["schemas"];
 
-export interface AcquisitionCostBreakdown {
-  brokerageFee: number;
-  stampDuty: number;
-  registrationTax: number;
-  realEstateAcquisitionTax: number;
-  propertyTaxProration: number;
-  total: number;
-}
+// ==== バックエンド生成型の再エクスポート ====
 
-export type BuildingType =
-  "木造" | "軽量鉄骨(4mm以下)" | "軽量鉄骨(3mm以下)" | "重量鉄骨" | "RC造" | "SRC造";
+export type Municipality = Schemas["mlit.Municipality"];
+export type CriticalError = Schemas["domain.CriticalError"];
+export type AcquisitionCostBreakdown = Schemas["domain.AcquisitionCostBreakdown"];
+export type BuildingType = Schemas["domain.BuildingType"];
+export type RidershipDemandScore = Schemas["domain.RidershipDemandScore"];
+export type TheoreticalPriceResult = Schemas["domain.TheoreticalPriceResult"];
+export type StationRidershipResult = Schemas["domain.StationRidershipResult"];
+export type RateAdjustment = Schemas["domain.RateAdjustment"];
+export type MultiExitRow = Schemas["domain.MultiExitRow"];
+export type CapexEvent = Schemas["domain.CapexEvent"];
+export type YearlyResult = Schemas["domain.YearlyResult"];
+export type StressScenarioResult = Schemas["domain.StressScenarioResult"];
+export type YieldScenario = Schemas["domain.YieldScenario"];
+export type YieldScenarios = Schemas["domain.YieldScenarios"];
+export type LTVSensitivityRow = Schemas["domain.LTVSensitivityRow"];
+export type InvestmentResult = Schemas["domain.InvestmentResult"];
+export type TaxSimRow = Schemas["domain.TaxSimRow"];
+export type SalaryLossCarryoverResult = Schemas["domain.SalaryLossCarryoverResult"];
+export type OwnershipScenario = Schemas["domain.OwnershipScenario"];
+export type OwnershipComparisonResult = Schemas["domain.OwnershipComparisonResult"];
+export type TaxSimulationResult = Schemas["domain.TaxSimulationResult"];
+export type LandTransaction = Schemas["domain.LandTransaction"];
+export type LandPriceStats = Schemas["domain.LandPriceStats"];
+export type ZoningSummary = Schemas["domain.ZoningSummary"];
+export type UrbanRiskLevel = Schemas["domain.UrbanRiskLevel"];
+export type UrbanRisk = Schemas["domain.UrbanRisk"];
+export type PopulationSnapshot = Schemas["domain.PopulationSnapshot"];
+export type PopulationForecastResult = Schemas["domain.PopulationForecastResult"];
+export type Percentiles = Schemas["domain.Percentiles"];
+export type HistogramBin = Schemas["domain.HistogramBin"];
+export type MonteCarloResult = Schemas["domain.MonteCarloResult"];
+export type RenovationItem = Schemas["domain.RenovationItem"];
+export type ClassifiedRenovationItem = Schemas["domain.ClassifiedRenovationItem"];
+export type RenovationInput = Schemas["domain.RenovationInput"];
+export type RenovationResult = Schemas["domain.RenovationResult"];
+export type ScoreItem = Schemas["domain.ScoreItem"];
+export type RadarPoint = Schemas["domain.RadarPoint"];
+export type ScoreBreakdown = Schemas["domain.ScoreBreakdown"];
+export type InvestmentScoreResult = Schemas["domain.InvestmentScoreResult"];
+export type HeatmapTile = Schemas["domain.HeatmapTile"];
+export type HeatmapResponse = Schemas["domain.HeatmapResponse"];
 
-export type RidershipDemandScore = "A" | "B" | "C" | "D" | "E";
-
-export interface TheoreticalPriceResult {
-  theoreticalPriceJPY: number;
-  deviationPct: number;
-  ageCorrection: number;
-  stationCorrection: number;
-  ridershipCorrection: number;
-  medianBuildingAge: number;
-  medianStationMinutes: number;
-  isLowDataWarning: boolean;
-  hasStationData: boolean;
-  ridershipScore?: RidershipDemandScore;
-  hasRidershipData: boolean;
-}
-
-export interface StationRidershipResult {
-  stationName: string;
-  lineName: string;
-  passengers: number;
-  demandScore: RidershipDemandScore;
-  correction: number;
-}
+// ==== 手書き型（フロント側でユニオンに絞り込み） ====
 
 export type LoanMethod = "equal-payment" | "equal-principal";
-
-export interface RateAdjustment {
-  afterYear: number; // この年（1始まり）以降に適用（例: 6 = 6年目から）
-  rate: number; // 絶対値の年利（例: 0.02 = 2%）
-}
-
-export interface MultiExitRow {
-  year: number;
-  salePrice: number;
-  transferTaxRate: number;
-  transferTax: number;
-  remainingLoan: number;
-  cumulativeCf: number;
-  exitEquity: number;
-  irr?: number; // 収束しない場合は省略（Go側 omitempty）
-  isShortTermWarn: boolean;
-}
 
 export interface InvestmentInput {
   landPrice: number;
@@ -129,166 +119,11 @@ export interface InvestmentInput {
   isFirstRegistration?: boolean;
 }
 
-export interface CapexEvent {
-  year: number; // 何年目に発生（1〜保有年数）
-  amount: number; // 金額（円）
-}
-
-export interface YearlyResult {
-  year: number;
-  annualRent: number; // 実効賃料収入（空室控除後）
-  annualLoanPayment: number;
-  annualInterest: number;
-  annualPrincipal: number;
-  annualDepreciation: number;
-  annualExpenses: number;
-  taxableIncome: number;
-  incomeTax: number;
-  capexAmount: number; // 大規模修繕費（当年発生額）
-  cashFlow: number;
-  afterTaxCashFlow: number;
-  remainingLoanBalance: number;
-  cumulativeCashFlow: number;
-  isDeadCrossYear: boolean;
-  isInDeadCrossZone: boolean; // デッドクロス継続ゾーン
-  effectiveRate: number; // その年の適用金利（年利）
-}
-
-export interface StressScenarioResult {
-  label: string;
-  interestRateDelta: number;
-  vacancyRateDelta: number;
-  totalCashFlow: number;
-  dscr: number;
-  breakEvenYear: number; // 累積CFが正転する年（-1=なし）
-  isSafe: boolean; // DSCR >= 1.0 && breakEvenYear <= holdingYears
-}
-
-export interface YieldScenario {
-  annualRent: number; // 年間実効賃料収入（空室控除後）
-  grossYield: number; // 総投資利回り（満室想定年収/総投資額）
-}
-
-export interface YieldScenarios {
-  optimistic: YieldScenario; // 楽観: 空室率 × 0.5
-  standard: YieldScenario; // 標準: 空室率 × 1.0
-  pessimistic: YieldScenario; // 悲観: 空室率 × 1.5
-}
-
-export interface LTVSensitivityRow {
-  ltv: number; // 借入比率（例: 0.70）
-  equity: number; // 自己資金（円）
-  loanAmount: number; // 借入額（円）
-  dscr: number; // 借入金償還余裕率
-  annualCF: number; // 年間キャッシュフロー（円）
-  cfYield: number; // CF利回り（annualCF / 総投資額）
-}
-
-export interface InvestmentResult {
-  totalInvestment: number;
-  miscExpenses: number;
-  grossYield: number; // 総投資利回り（満室想定年収/総投資額。諸費用込み）
-  marketGrossYield: number; // 表面利回り（満室想定年収/物件価格[土地+建物]。市場慣行ベース・8%判定基準）
-  netYield: number;
-  isAboveYieldTarget: boolean;
-  yieldTarget: number;
-  requiredCostReduction: number;
-  requiredMonthlyRent: number;
-  deadCrossYear: number;
-  yearlyResults: YearlyResult[];
-  criticalErrors: CriticalError[];
-  acquisitionCosts: AcquisitionCostBreakdown;
-  exitSalePrice: number;
-  exitCapitalGain: number;
-  exitTransferTax: number;
-  exitNetProceeds: number;
-  exitTotalEquity: number;
-  stressScenarios: StressScenarioResult[];
-  yieldScenarios: YieldScenarios;
-  dscr: number; // 1年目 DSCR（NOI / 年間返済額）
-  ltvSensitivity: LTVSensitivityRow[]; // LTV 感度分析（50%〜90%）
-  irr: number | null; // 内部収益率（収束しない場合は null）
-  npv: number; // 正味現在価値
-  totalInterest: number; // 保有期間の総支払利息
-  aiSummary?: string;
-  multiExitComparison?: MultiExitRow[]; // 複数保有年数の出口比較
-  taxSimulation?: TaxSimulationResult; // 損益通算・個人/法人比較（salaryIncome>0時のみ）
-}
-
-export interface TaxSimRow {
-  year: number;
-  reTaxableIncome: number;
-  combinedIncome: number;
-  combinedTax: number;
-  taxDifference: number; // 正=節税 / 負=増税
-}
-
-export interface SalaryLossCarryoverResult {
-  salaryIncomeYen: number;
-  baselineSalaryTax: number;
-  yearlyRows: TaxSimRow[];
-  totalTaxSaving: number;
-}
-
-export interface OwnershipScenario {
-  label: string;
-  annualTax: number[];
-  transferTax: number;
-  totalTaxBurden: number;
-  cumulativeBurden: number[];
-}
-
-export interface OwnershipComparisonResult {
-  individual: OwnershipScenario;
-  corporate: OwnershipScenario;
-  breakevenYear: number; // -1 = 保有期間内に法人有利年なし
-}
-
-export interface TaxSimulationResult {
-  salaryLossCarryover: SalaryLossCarryoverResult;
-  ownershipComparison: OwnershipComparisonResult;
-}
-
-export interface LandTransaction {
-  period: string;
-  district: string;
-  tradePrice: number;
-  area: number;
-  pricePerSqm: number;
-  pricePerTsubo: number;
-  cityPlanning: string;
-  buildingCoverage: string;
-  floorAreaRatio: string;
-  buildingYear?: number; // 建築年（西暦）。データがない場合は省略
-  stationMinutes?: number; // 最寄り駅徒歩分。データがない場合は省略
-}
-
-export interface LandPriceStats {
-  count: number;
-  averageTsubo: number;
-  medianTsubo: number;
-  minTsubo: number;
-  maxTsubo: number;
-  transactions: LandTransaction[];
-  lowDataWarning: boolean;
-  warningMessage?: string;
-  zoning?: ZoningSummary;
-  urbanRisks?: UrbanRisk[];
-}
-
-export interface ZoningSummary {
-  cityPlanning: string;
-  buildingCoverage: string;
-  floorAreaRatio: string;
-}
-
-export type UrbanRiskLevel = "ERROR" | "WARNING" | "INFO";
-
-export interface UrbanRisk {
-  code: string;
-  level: UrbanRiskLevel;
-  title: string;
-  description: string;
+export interface MonteCarloInput {
+  base: InvestmentInput;
+  simulations?: number;
+  vacancyRateSigma?: number;
+  loanRateSigma?: number;
 }
 
 export interface LandPriceComparison {
@@ -301,24 +136,28 @@ export interface LandPriceComparison {
   assessment: "割安" | "相場" | "割高";
 }
 
-export interface PopulationSnapshot {
-  year: number;
-  pop: number;
-}
-
-export interface PopulationForecastResult {
-  snapshots: PopulationSnapshot[];
-  changeRate30yr: number;
-  vacancyRateDelta: number;
-  trend: "増加" | "現状維持" | "緩やかな減少" | "急激な減少";
-}
-
 export interface AppraisalComparisonResult {
   appraisalMedianPerSqm: number; // 公示価格中央値（円/m²）
   appraisalCount: number; // 標準地点数
   appraisalTrend: number; // 平均変動率（小数: 0.05 = +5%）
   trendLabel: "上昇" | "安定" | "下落";
 }
+
+export interface RentDeclineHint {
+  hintRate: number;
+  basis: "land_appraisal" | "fallback";
+  dataPointCount: number;
+  fallbackUsed: boolean;
+  note: string;
+}
+
+export interface GeocodeResult {
+  lat: number;
+  lng: number;
+  locationType: "ROOFTOP" | "RANGE_INTERPOLATED" | "GEOMETRIC_CENTER" | "APPROXIMATE";
+}
+
+// ==== フロント固有型・定数 ====
 
 export const DEFAULT_INPUT: InvestmentInput = {
   landPrice: 5_000_000,
@@ -361,37 +200,6 @@ export const BUILDING_USEFUL_LIFE: Record<BuildingType, number> = {
 
 export type SimulationMode = "quick" | "full";
 
-export interface Percentiles {
-  p10: number;
-  p25: number;
-  p50: number;
-  p75: number;
-  p90: number;
-}
-
-export interface HistogramBin {
-  min: number;
-  max: number;
-  count: number;
-}
-
-export interface MonteCarloResult {
-  simulationCount: number;
-  irrPercentiles: Percentiles;
-  equityPercentiles: Percentiles;
-  deadCrossRate: number;
-  irrHistogram: HistogramBin[] | null;
-  equityHistogram: HistogramBin[] | null;
-  successRate: number;
-}
-
-export interface MonteCarloInput {
-  base: InvestmentInput;
-  simulations?: number;
-  vacancyRateSigma?: number;
-  loanRateSigma?: number;
-}
-
 export const QUICK_MODE_DEFAULTS: Partial<InvestmentInput> = {
   landArea: 100,
   buildingAge: 0,
@@ -413,79 +221,6 @@ export const QUICK_MODE_DEFAULTS: Partial<InvestmentInput> = {
   rateAdjustmentSchedule: [],
 };
 
-export interface RenovationItem {
-  name: string;
-  cost: number;
-  expectedMonthlyRentIncrease: number;
-  isSelfWork: boolean;
-  selfLaborHours: number;
-}
-
-export interface ClassifiedRenovationItem extends RenovationItem {
-  isCapitalExpenditure: boolean;
-  virtualLaborCost: number;
-}
-
-export interface RenovationInput {
-  propertyPrice: number;
-  annualBaseRent: number;
-  annualExpenses: number;
-  effectiveTaxRate: number;
-  selfLaborRatePerHour: number;
-  items: RenovationItem[];
-}
-
-export interface RenovationResult {
-  recoveryYears: number;
-  isRecoverable: boolean;
-  taxSavings: number;
-  virtualLaborCost: number;
-  capitalExpenditures: number;
-  repairExpenses: number;
-  actualYield: number;
-  totalRenovationCost: number;
-  annualRentIncrease: number;
-  classifiedItems: ClassifiedRenovationItem[];
-}
-
-export interface ScoreItem {
-  score: number;
-  label: string;
-  description: string;
-}
-
-export interface RadarPoint {
-  category: string;
-  score: number;
-}
-
-export interface ScoreBreakdown {
-  population: ScoreItem;
-  ridership: ScoreItem;
-  urbanArea: ScoreItem;
-  locationOptimization: ScoreItem;
-  hazardRisk: ScoreItem;
-  liquefactionRisk: ScoreItem;
-  embankment: ScoreItem;
-  disasterHistory: ScoreItem;
-  landPriceTrend: ScoreItem;
-  radarData: RadarPoint[];
-}
-
-export interface InvestmentScoreResult {
-  totalScore: number;
-  grade: string;
-  breakdown: ScoreBreakdown;
-}
-
-export interface RentDeclineHint {
-  hintRate: number;
-  basis: "land_appraisal" | "fallback";
-  dataPointCount: number;
-  fallbackUsed: boolean;
-  note: string;
-}
-
 export const DEFAULT_RENOVATION_INPUT: RenovationInput = {
   propertyPrice: 10_000_000,
   annualBaseRent: 1_200_000,
@@ -494,22 +229,6 @@ export const DEFAULT_RENOVATION_INPUT: RenovationInput = {
   selfLaborRatePerHour: 0,
   items: [],
 };
-
-export interface HeatmapTile {
-  x: number;
-  y: number;
-  z: number;
-  centerLat: number;
-  centerLng: number;
-  totalScore: number;
-  grade: string;
-}
-
-export interface HeatmapResponse {
-  tiles: HeatmapTile[];
-  tileCount: number;
-  failedTiles?: number;
-}
 
 export type WatchlistStatus = "検討中" | "見送り" | "購入済み";
 
@@ -533,10 +252,4 @@ export interface WatchlistItem {
   status: WatchlistStatus;
   addedAt: string; // ISO 8601
   metrics?: WatchlistMetrics;
-}
-
-export interface GeocodeResult {
-  lat: number;
-  lng: number;
-  locationType: "ROOFTOP" | "RANGE_INTERPOLATED" | "GEOMETRIC_CENTER" | "APPROXIMATE";
 }


### PR DESCRIPTION
## 概要

Issue #811 の PR-3（任意ステップ）。PR-2 までで契約検証が安定したため、バックエンドと厳密一致する手書き型を生成型の再エクスポートに置換し、二重管理を解消する。

## 変更内容

### バックエンド: 生成型の required/optional を正確化（エイリアス化の前提）

- これまで swag は全フィールドを optional として出力していたため、そのままエイリアス化するとアプリ全体の型安全性が劣化する問題があった
- `swag init` に `--requiredByDefault` を追加（Makefile）。`omitempty` 付きフィールドは optional のまま維持されることを検証済みで、required/optional の分割が手書き型と一致することを確認してから置換した
- バックエンドがデフォルト補完する実質 optional なリクエストフィールドに `omitempty` を付与
  - `InvestmentInput`: `loanMethod` / `discountRate` / `priceDeclineRate` / `depreciationMethod`（`Defaults()` が補完）
  - `MonteCarloInput`: `simulations` / `vacancyRateSigma` / `loanRateSigma`（`RunMonteCarlo` が補完）
- swagger.json は全 definition に `required` 配列が付くため diff が大きいが機械的な再生成

### フロントエンド: 37型をエイリアス化

- バックエンドと厳密一致する37型を `Schemas["domain.X"]` の再エクスポートに置換し手書き定義を削除（investment.ts: −370行）。フィールドコメントは Go 側コメントが JSDoc として生成型に引き継がれている
- 手書きのまま残した型（investment.ts 冒頭コメントに明記）
  - 生成型の string をユニオンに絞り込む型: `LoanMethod` / `GeocodeResult` / `RentDeclineHint` / `AppraisalComparisonResult` / `LandPriceComparison`
  - フロント固有フィールドを持つ `InvestmentInput`（`stationMinutes`）とそれを参照する `MonteCarloInput`
  - フロント固有型: `SimulationMode` / `Watchlist*`
- required 化に伴う修正2件: テストフィクスチャ `makeResult` に `aiSummary: ""` を追加、`RentStatsResult.low_confidence` を required に変更（いずれも Go が omitempty なしで常に出力するフィールド）

### ドキュメント更新

- `docs/llm/backend.md`: struct タグ → TS 契約の対応表（omitempty / x-nullable / requiredByDefault）と「Go 型変更は frontend 修正を同一 PR に含める」ルールを追記
- `docs/llm/frontend.md`: 再エクスポート方針・手書き型が許される条件・`HandwrittenBySchema` 登録手順を追記
- `docs/architecture.md`: 「インターフェース不整合をビルド時に検出できる」の根拠を実装済みの機構（生成型 + 契約テスト）に更新

## 関連Issue

#811（PR-2 で Close 済み。本 PR は任意の PR-3 に相当）

## テスト

- [x] 既存テストが通ること（`make lint` / `make test`: go test -race + vitest 396件 PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること（型のみの変更のため新規テストなし）
- [x] 検証手順: Go の `netYield` を意図的に改名 → 契約テストだけでなく実使用箇所（`WatchlistPanel.tsx` / `YieldAnalysis.tsx` 等）が直接 tsc で fail することを確認後 revert。エイリアス化によりドリフト検出が「契約テスト経由」から「使用箇所直撃」に強化された

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
