### PR TITLE
refactor(backend): fanOut を internal/concurrent パッケージへ切り出し（#812 PR-1）

### DIFF
--- a/backend/internal/api/helpers.go
+++ b/backend/internal/api/helpers.go
@@ -65,22 +65,6 @@ const (
 	coordsJapanOnly = true
 )
 
-// apiResult wraps a fetched value and error for channel-based fan-out patterns.
-type apiResult[T any] struct {
-	data T
-	err  error
-}
-
-// fanOut launches a goroutine calling fetch and sends the result to a buffered channel.
-func fanOut[T any](fetch func() (T, error)) <-chan apiResult[T] {
-	ch := make(chan apiResult[T], 1)
-	go func() {
-		d, e := fetch()
-		ch <- apiResult[T]{d, e}
-	}()
-	return ch
-}
-
 func badRequest(c *gin.Context, msg string) {
 	c.JSON(http.StatusBadRequest, gin.H{"error": msg})
 }

--- a/backend/internal/api/risk_handler.go
+++ b/backend/internal/api/risk_handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/yield-guard/backend/internal/concurrent"
 	"github.com/yield-guard/backend/internal/domain"
 	"github.com/yield-guard/backend/internal/mlit"
 )
@@ -37,30 +38,30 @@ func (h *Handler) GetUrbanRisks(c *gin.Context) {
 	var res result
 
 	// 4 API を並列取得。いずれか失敗してもログのみで他の結果は返す
-	locCh := fanOut(func() ([]domain.LocationOptimizationItem, error) { return h.mlitClient.FetchLocationOptimization(ctx, z, x, y) })
-	embCh := fanOut(func() ([]domain.EmbankmentItem, error) { return h.mlitClient.FetchEmbankment(ctx, z, x, y) })
-	rdCh := fanOut(func() ([]domain.UrbanRoadItem, error) { return h.mlitClient.FetchUrbanRoad(ctx, z, x, y) })
-	disCh := fanOut(func() ([]domain.DisasterHistoryItem, error) { return h.mlitClient.FetchDisasterHistory(ctx, z, x, y) })
+	locCh := concurrent.FanOut(func() ([]domain.LocationOptimizationItem, error) { return h.mlitClient.FetchLocationOptimization(ctx, z, x, y) })
+	embCh := concurrent.FanOut(func() ([]domain.EmbankmentItem, error) { return h.mlitClient.FetchEmbankment(ctx, z, x, y) })
+	rdCh := concurrent.FanOut(func() ([]domain.UrbanRoadItem, error) { return h.mlitClient.FetchUrbanRoad(ctx, z, x, y) })
+	disCh := concurrent.FanOut(func() ([]domain.DisasterHistoryItem, error) { return h.mlitClient.FetchDisasterHistory(ctx, z, x, y) })
 
-	if r := <-locCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchLocationOptimization failed", "z", z, "x", x, "y", y, "error", r.err)
+	if r := <-locCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchLocationOptimization failed", "z", z, "x", x, "y", y, "error", r.Err)
 	} else {
-		res.location = r.data
+		res.location = r.Data
 	}
-	if r := <-embCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchEmbankment failed", "z", z, "x", x, "y", y, "error", r.err)
+	if r := <-embCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchEmbankment failed", "z", z, "x", x, "y", y, "error", r.Err)
 	} else {
-		res.embank = r.data
+		res.embank = r.Data
 	}
-	if r := <-rdCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchUrbanRoad failed", "z", z, "x", x, "y", y, "error", r.err)
+	if r := <-rdCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchUrbanRoad failed", "z", z, "x", x, "y", y, "error", r.Err)
 	} else {
-		res.road = r.data
+		res.road = r.Data
 	}
-	if r := <-disCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchDisasterHistory failed", "z", z, "x", x, "y", y, "error", r.err)
+	if r := <-disCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchDisasterHistory failed", "z", z, "x", x, "y", y, "error", r.Err)
 	} else {
-		res.disaster = r.data
+		res.disaster = r.Data
 	}
 
 	risks := domain.BuildUrbanRisksFromAPIs(res.location, res.embank, res.road, res.disaster)
@@ -89,35 +90,35 @@ func (h *Handler) GetHazardInfo(c *gin.Context) {
 	z := 14
 	x, y := mlit.LatLngToTile(lat, lng, z)
 
-	floCh := fanOut(func() ([]domain.FloodHazardItem, error) { return h.mlitClient.FetchFloodHazard(ctx, z, x, y) })
-	stmCh := fanOut(func() ([]domain.StormHazardItem, error) { return h.mlitClient.FetchStormHazard(ctx, z, x, y) })
-	tsuCh := fanOut(func() ([]domain.TsunamiHazardItem, error) { return h.mlitClient.FetchTsunamiHazard(ctx, z, x, y) })
-	lsCh := fanOut(func() ([]domain.LandslideHazardItem, error) { return h.mlitClient.FetchLandslideHazard(ctx, z, x, y) })
+	floCh := concurrent.FanOut(func() ([]domain.FloodHazardItem, error) { return h.mlitClient.FetchFloodHazard(ctx, z, x, y) })
+	stmCh := concurrent.FanOut(func() ([]domain.StormHazardItem, error) { return h.mlitClient.FetchStormHazard(ctx, z, x, y) })
+	tsuCh := concurrent.FanOut(func() ([]domain.TsunamiHazardItem, error) { return h.mlitClient.FetchTsunamiHazard(ctx, z, x, y) })
+	lsCh := concurrent.FanOut(func() ([]domain.LandslideHazardItem, error) { return h.mlitClient.FetchLandslideHazard(ctx, z, x, y) })
 
 	var floods []domain.FloodHazardItem
 	var storms []domain.StormHazardItem
 	var tsunamis []domain.TsunamiHazardItem
 	var landslides []domain.LandslideHazardItem
 
-	if r := <-floCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchFloodHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	if r := <-floCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchFloodHazard failed", "z", z, "x", x, "y", y, "error", r.Err)
 	} else {
-		floods = r.data
+		floods = r.Data
 	}
-	if r := <-stmCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchStormHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	if r := <-stmCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchStormHazard failed", "z", z, "x", x, "y", y, "error", r.Err)
 	} else {
-		storms = r.data
+		storms = r.Data
 	}
-	if r := <-tsuCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchTsunamiHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	if r := <-tsuCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchTsunamiHazard failed", "z", z, "x", x, "y", y, "error", r.Err)
 	} else {
-		tsunamis = r.data
+		tsunamis = r.Data
 	}
-	if r := <-lsCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchLandslideHazard failed", "z", z, "x", x, "y", y, "error", r.err)
+	if r := <-lsCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchLandslideHazard failed", "z", z, "x", x, "y", y, "error", r.Err)
 	} else {
-		landslides = r.data
+		landslides = r.Data
 	}
 
 	risks := domain.BuildHazardRisks(floods, storms, tsunamis, landslides)

--- a/backend/internal/concurrent/fanout.go
+++ b/backend/internal/concurrent/fanout.go
@@ -1,0 +1,18 @@
+// Package concurrent は複数 API の並列取得など、パッケージ横断で使う並行処理ヘルパーを提供する。
+package concurrent
+
+// Result wraps a fetched value and error for channel-based fan-out patterns.
+type Result[T any] struct {
+	Data T
+	Err  error
+}
+
+// FanOut launches a goroutine calling fetch and sends the result to a buffered channel.
+func FanOut[T any](fetch func() (T, error)) <-chan Result[T] {
+	ch := make(chan Result[T], 1)
+	go func() {
+		d, e := fetch()
+		ch <- Result[T]{d, e}
+	}()
+	return ch
+}

--- a/backend/internal/concurrent/fanout_test.go
+++ b/backend/internal/concurrent/fanout_test.go
@@ -1,0 +1,39 @@
+package concurrent
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFanOut_Success(t *testing.T) {
+	ch := FanOut(func() (int, error) { return 42, nil })
+	r := <-ch
+	if r.Err != nil {
+		t.Fatalf("unexpected error: %v", r.Err)
+	}
+	if r.Data != 42 {
+		t.Errorf("Data = %d, want 42", r.Data)
+	}
+}
+
+func TestFanOut_Error(t *testing.T) {
+	wantErr := errors.New("fetch failed")
+	ch := FanOut(func() ([]string, error) { return nil, wantErr })
+	r := <-ch
+	if !errors.Is(r.Err, wantErr) {
+		t.Errorf("Err = %v, want %v", r.Err, wantErr)
+	}
+	if r.Data != nil {
+		t.Errorf("Data = %v, want nil", r.Data)
+	}
+}
+
+// FanOut はバッファ付きチャネルを返すため、受信されなくても goroutine がリークしない
+func TestFanOut_NonBlocking(t *testing.T) {
+	done := make(chan struct{})
+	FanOut(func() (int, error) {
+		defer close(done)
+		return 1, nil
+	})
+	<-done // 受信者不在でも fetch goroutine が完了できる
+}

--- a/backend/internal/service/investment_score.go
+++ b/backend/internal/service/investment_score.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/yield-guard/backend/internal/concurrent"
 	"github.com/yield-guard/backend/internal/domain"
 	"github.com/yield-guard/backend/internal/mlit"
 )
@@ -39,21 +40,6 @@ func NewInvestmentScoreService(client MLITClient) LocationService {
 	return &InvestmentScoreService{client: client}
 }
 
-type apiResult[T any] struct {
-	data T
-	err  error
-}
-
-// fanOut は api/helpers.go の同名関数のコピー。循環インポート回避のため複製している。
-func fanOut[T any](fetch func() (T, error)) <-chan apiResult[T] {
-	ch := make(chan apiResult[T], 1)
-	go func() {
-		d, e := fetch()
-		ch <- apiResult[T]{d, e}
-	}()
-	return ch
-}
-
 // CalcScoreForTile は指定タイル座標に対して複数 API を並列取得し投資適地スコアを返す。
 // 個別 API の失敗は警告ログのみでスキップする。コンテキストキャンセル時はエラーを返す。
 func (s *InvestmentScoreService) CalcScoreForTile(ctx context.Context, z, x, y int) (domain.InvestmentScoreResult, error) {
@@ -61,17 +47,17 @@ func (s *InvestmentScoreService) CalcScoreForTile(ctx context.Context, z, x, y i
 		return domain.InvestmentScoreResult{}, err
 	}
 
-	popCh := fanOut(func() ([]domain.PopulationForecastItem, error) { return s.client.FetchPopulationForecast(ctx, z, x, y) })
-	ridCh := fanOut(func() ([]mlit.StationRidership, error) { return s.client.FetchStationRidership(ctx, z, x, y) })
-	locCh := fanOut(func() ([]domain.LocationOptimizationItem, error) { return s.client.FetchLocationOptimization(ctx, z, x, y) })
-	embCh := fanOut(func() ([]domain.EmbankmentItem, error) { return s.client.FetchEmbankment(ctx, z, x, y) })
-	disCh := fanOut(func() ([]domain.DisasterHistoryItem, error) { return s.client.FetchDisasterHistory(ctx, z, x, y) })
-	zonCh := fanOut(func() ([]domain.UrbanZoningItem, error) { return s.client.FetchUrbanZoning(ctx, z, x, y) })
-	liqCh := fanOut(func() ([]domain.LiquefactionRiskItem, error) { return s.client.FetchLiquefaction(ctx, z, x, y) })
-	floCh := fanOut(func() ([]domain.FloodHazardItem, error) { return s.client.FetchFloodHazard(ctx, z, x, y) })
-	stoCh := fanOut(func() ([]domain.StormHazardItem, error) { return s.client.FetchStormHazard(ctx, z, x, y) })
-	tsuCh := fanOut(func() ([]domain.TsunamiHazardItem, error) { return s.client.FetchTsunamiHazard(ctx, z, x, y) })
-	lanCh := fanOut(func() ([]domain.LandslideHazardItem, error) { return s.client.FetchLandslideHazard(ctx, z, x, y) })
+	popCh := concurrent.FanOut(func() ([]domain.PopulationForecastItem, error) { return s.client.FetchPopulationForecast(ctx, z, x, y) })
+	ridCh := concurrent.FanOut(func() ([]mlit.StationRidership, error) { return s.client.FetchStationRidership(ctx, z, x, y) })
+	locCh := concurrent.FanOut(func() ([]domain.LocationOptimizationItem, error) { return s.client.FetchLocationOptimization(ctx, z, x, y) })
+	embCh := concurrent.FanOut(func() ([]domain.EmbankmentItem, error) { return s.client.FetchEmbankment(ctx, z, x, y) })
+	disCh := concurrent.FanOut(func() ([]domain.DisasterHistoryItem, error) { return s.client.FetchDisasterHistory(ctx, z, x, y) })
+	zonCh := concurrent.FanOut(func() ([]domain.UrbanZoningItem, error) { return s.client.FetchUrbanZoning(ctx, z, x, y) })
+	liqCh := concurrent.FanOut(func() ([]domain.LiquefactionRiskItem, error) { return s.client.FetchLiquefaction(ctx, z, x, y) })
+	floCh := concurrent.FanOut(func() ([]domain.FloodHazardItem, error) { return s.client.FetchFloodHazard(ctx, z, x, y) })
+	stoCh := concurrent.FanOut(func() ([]domain.StormHazardItem, error) { return s.client.FetchStormHazard(ctx, z, x, y) })
+	tsuCh := concurrent.FanOut(func() ([]domain.TsunamiHazardItem, error) { return s.client.FetchTsunamiHazard(ctx, z, x, y) })
+	lanCh := concurrent.FanOut(func() ([]domain.LandslideHazardItem, error) { return s.client.FetchLandslideHazard(ctx, z, x, y) })
 
 	// 地価トレンド: タイル中心座標→都道府県コードを逆引きし、新旧2期間を並列取得する
 	// 直近2年 vs その2年前の期間を動的に算出する
@@ -100,16 +86,16 @@ func (s *InvestmentScoreService) CalcScoreForTile(ctx context.Context, z, x, y i
 
 	input := domain.InvestmentScoreInput{}
 
-	if r := <-popCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchPopulationForecast failed", "error", r.err)
+	if r := <-popCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchPopulationForecast failed", "error", r.Err)
 	} else {
-		input.PopulationItems = r.data
+		input.PopulationItems = r.Data
 	}
-	if r := <-ridCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchStationRidership failed", "error", r.err)
+	if r := <-ridCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchStationRidership failed", "error", r.Err)
 	} else {
-		input.StationRiderships = make([]domain.StationRidershipResult, 0, len(r.data))
-		for _, st := range r.data {
+		input.StationRiderships = make([]domain.StationRidershipResult, 0, len(r.Data))
+		for _, st := range r.Data {
 			score := domain.CalcRidershipDemandScore(st.Passengers)
 			input.StationRiderships = append(input.StationRiderships, domain.StationRidershipResult{
 				StationName: st.StationName,
@@ -120,50 +106,50 @@ func (s *InvestmentScoreService) CalcScoreForTile(ctx context.Context, z, x, y i
 			})
 		}
 	}
-	if r := <-locCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchLocationOptimization failed", "error", r.err)
+	if r := <-locCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchLocationOptimization failed", "error", r.Err)
 	} else {
-		input.LocationItems = r.data
+		input.LocationItems = r.Data
 	}
-	if r := <-embCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchEmbankment failed", "error", r.err)
+	if r := <-embCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchEmbankment failed", "error", r.Err)
 	} else {
-		input.EmbankmentItems = r.data
+		input.EmbankmentItems = r.Data
 	}
-	if r := <-disCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchDisasterHistory failed", "error", r.err)
+	if r := <-disCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchDisasterHistory failed", "error", r.Err)
 	} else {
-		input.DisasterItems = r.data
+		input.DisasterItems = r.Data
 	}
-	if r := <-zonCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchUrbanZoning failed", "error", r.err)
+	if r := <-zonCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchUrbanZoning failed", "error", r.Err)
 	} else {
-		input.UrbanZoningItems = r.data
+		input.UrbanZoningItems = r.Data
 	}
-	if r := <-liqCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchLiquefaction failed", "error", r.err)
+	if r := <-liqCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchLiquefaction failed", "error", r.Err)
 	} else {
-		input.LiquefactionItems = r.data
+		input.LiquefactionItems = r.Data
 	}
-	if r := <-floCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchFloodHazard failed", "error", r.err)
+	if r := <-floCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchFloodHazard failed", "error", r.Err)
 	} else {
-		input.FloodItems = r.data
+		input.FloodItems = r.Data
 	}
-	if r := <-stoCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchStormHazard failed", "error", r.err)
+	if r := <-stoCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchStormHazard failed", "error", r.Err)
 	} else {
-		input.StormItems = r.data
+		input.StormItems = r.Data
 	}
-	if r := <-tsuCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchTsunamiHazard failed", "error", r.err)
+	if r := <-tsuCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchTsunamiHazard failed", "error", r.Err)
 	} else {
-		input.TsunamiItems = r.data
+		input.TsunamiItems = r.Data
 	}
-	if r := <-lanCh; r.err != nil {
-		slog.WarnContext(ctx, "FetchLandslideHazard failed", "error", r.err)
+	if r := <-lanCh; r.Err != nil {
+		slog.WarnContext(ctx, "FetchLandslideHazard failed", "error", r.Err)
 	} else {
-		input.LandslideItems = r.data
+		input.LandslideItems = r.Data
 	}
 
 	recentLand := <-recentLandCh


### PR DESCRIPTION
## 概要

Issue #812 の PR-1。`api/helpers.go` と `service/investment_score.go` に重複していた `fanOut` / `apiResult` を共有パッケージ `backend/internal/concurrent` に切り出しました。service（内側）が api（外側）のユーティリティのコピーを持つ配置の歪みを解消します。

## 変更内容

- `backend/internal/concurrent/fanout.go` を新設し、`FanOut[T]` / `Result[T]` としてエクスポート
- `api/helpers.go` から `fanOut` / `apiResult` を削除し、`risk_handler.go` の呼び出しを `concurrent.FanOut` に置換
- `service/investment_score.go` の複製（「循環インポート回避のため複製」コメント含む）を削除し、`concurrent.FanOut` を import
- `concurrent` パッケージにユニットテストを追加（成功・エラー・非ブロッキングの3ケース）

挙動変更はありません。score_handler の errgroup 化は PR-2 で行います。

## 関連Issue

#812（PR-1/2 のため本 PR ではクローズしない）

## テスト

- [x] 既存テストが通ること（`go test -race ./...` 全パッケージ PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること（`internal/concurrent` 3ケース PASS）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み