### PR TITLE
refactor(backend): score_handler の並行処理を errgroup 化（#812 PR-2）

### DIFF
--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -2209,6 +2210,92 @@ func TestGetInvestmentScoreHeatmap_PartialFailure(t *testing.T) {
 	}
 	if len(resp.Tiles) != 0 {
 		t.Errorf("expected empty tiles on full failure, got %d", len(resp.Tiles))
+	}
+}
+
+// heatmapTileTotal はハンドラと同じ計算でバウンディングボックス内の総タイル数を返す
+func heatmapTileTotal(minLat, maxLat, minLng, maxLng float64, z int) int {
+	xMin, yMin := mlit.LatLngToTile(maxLat, minLng, z)
+	xMax, yMax := mlit.LatLngToTile(minLat, maxLng, z)
+	return (xMax - xMin + 1) * (yMax - yMin + 1)
+}
+
+// 1タイルだけ失敗しても全体は 200 を返し、成功タイルは欠けず FailedTiles に集計される
+func TestGetInvestmentScoreHeatmap_SingleTileFailure(t *testing.T) {
+	total := heatmapTileTotal(35.60, 35.70, 139.50, 139.80, 11)
+	if total < 2 {
+		t.Fatalf("test bbox must span at least 2 tiles, got %d", total)
+	}
+
+	var calls atomic.Int32
+	locSvc := &mockLocationService{
+		calcScoreFunc: func(_ context.Context, _, _, _ int) (domain.InvestmentScoreResult, error) {
+			if calls.Add(1) == 1 {
+				return domain.InvestmentScoreResult{}, errors.New("MLIT API error")
+			}
+			return domain.InvestmentScoreResult{TotalScore: 80, Grade: "A"}, nil
+		},
+	}
+	r := newTestRouter(&mockMLITClient{}, nil, locSvc)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/investment-score-heatmap?minLat=35.60&maxLat=35.70&minLng=139.50&maxLng=139.80&z=11",
+		nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 on single tile failure, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp domain.HeatmapResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.FailedTiles != 1 {
+		t.Errorf("expected FailedTiles=1, got %d", resp.FailedTiles)
+	}
+	if resp.TileCount != total-1 {
+		t.Errorf("expected TileCount=%d, got %d", total-1, resp.TileCount)
+	}
+	if len(resp.Tiles) != total-1 {
+		t.Errorf("expected %d tiles, got %d", total-1, len(resp.Tiles))
+	}
+}
+
+// タイル計算が panic してもリクエスト全体は落ちず、該当タイルのみ FailedTiles に集計される
+func TestGetInvestmentScoreHeatmap_PanicRecovery(t *testing.T) {
+	total := heatmapTileTotal(35.60, 35.70, 139.50, 139.80, 11)
+	if total < 2 {
+		t.Fatalf("test bbox must span at least 2 tiles, got %d", total)
+	}
+
+	var calls atomic.Int32
+	locSvc := &mockLocationService{
+		calcScoreFunc: func(_ context.Context, _, _, _ int) (domain.InvestmentScoreResult, error) {
+			if calls.Add(1) == 1 {
+				panic("unexpected nil in score calculation")
+			}
+			return domain.InvestmentScoreResult{TotalScore: 80, Grade: "A"}, nil
+		},
+	}
+	r := newTestRouter(&mockMLITClient{}, nil, locSvc)
+	req := httptest.NewRequest(http.MethodGet,
+		"/api/investment-score-heatmap?minLat=35.60&maxLat=35.70&minLng=139.50&maxLng=139.80&z=11",
+		nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 when a tile panics, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp domain.HeatmapResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp.FailedTiles != 1 {
+		t.Errorf("expected FailedTiles=1, got %d", resp.FailedTiles)
+	}
+	if resp.TileCount != total-1 {
+		t.Errorf("expected TileCount=%d, got %d", total-1, resp.TileCount)
 	}
 }
 

--- a/backend/internal/api/score_handler.go
+++ b/backend/internal/api/score_handler.go
@@ -5,10 +5,13 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"sync"
 
 	"github.com/gin-gonic/gin"
+	"github.com/yield-guard/backend/internal/concurrent"
 	"github.com/yield-guard/backend/internal/domain"
 	"github.com/yield-guard/backend/internal/mlit"
+	"golang.org/x/sync/errgroup"
 )
 
 const maxHeatmapTiles = 50
@@ -131,60 +134,47 @@ func (h *Handler) GetInvestmentScoreHeatmap(c *gin.Context) {
 
 	ctx := c.Request.Context()
 
-	sem := make(chan struct{}, 5)
-	type tileResult struct {
-		tile domain.HeatmapTile
-		err  error
-	}
-	results := make(chan tileResult, tileCount)
+	g, gctx := errgroup.WithContext(ctx)
+	g.SetLimit(5)
+
+	var mu sync.Mutex
+	tiles := make([]domain.HeatmapTile, 0, tileCount)
+	failedTiles := 0
 
 	for tx := xMin; tx <= xMax; tx++ {
 		for ty := yMin; ty <= yMax; ty++ {
-			go func(tx, ty int) {
-				select {
-				case <-ctx.Done():
-					results <- tileResult{err: ctx.Err()}
-					return
-				case sem <- struct{}{}:
-				}
-				// sem-release は先に登録（LIFO で後から実行）、recover は後に登録（先に実行）
-				// → パニック時もセマフォが必ず解放される
-				defer func() { <-sem }()
-				defer func() {
-					if r := recover(); r != nil {
-						results <- tileResult{err: fmt.Errorf("panic in CalcScoreForTile: %v", r)}
+			g.Go(func() error {
+				err := concurrent.SafeCall(func() error {
+					score, err := h.locationSvc.CalcScoreForTile(gctx, z, tx, ty)
+					if err != nil {
+						return err
 					}
-				}()
-				score, err := h.locationSvc.CalcScoreForTile(ctx, z, tx, ty)
+					lat, lng := mlit.TileToLatLng(tx, ty, z)
+					mu.Lock()
+					tiles = append(tiles, domain.HeatmapTile{
+						X:          tx,
+						Y:          ty,
+						Z:          z,
+						CenterLat:  lat,
+						CenterLng:  lng,
+						TotalScore: score.TotalScore,
+						Grade:      score.Grade,
+					})
+					mu.Unlock()
+					return nil
+				})
 				if err != nil {
-					results <- tileResult{err: err}
-					return
+					slog.WarnContext(gctx, "CalcScoreForTile failed", "error", err)
+					mu.Lock()
+					failedTiles++
+					mu.Unlock()
 				}
-				lat, lng := mlit.TileToLatLng(tx, ty, z)
-				results <- tileResult{tile: domain.HeatmapTile{
-					X:          tx,
-					Y:          ty,
-					Z:          z,
-					CenterLat:  lat,
-					CenterLng:  lng,
-					TotalScore: score.TotalScore,
-					Grade:      score.Grade,
-				}}
-			}(tx, ty)
+				// タイル単位の部分失敗は FailedTiles に集計し、リクエスト全体は失敗させない
+				return nil
+			})
 		}
 	}
-
-	tiles := make([]domain.HeatmapTile, 0, tileCount)
-	failedTiles := 0
-	for i := 0; i < tileCount; i++ {
-		r := <-results
-		if r.err != nil {
-			slog.WarnContext(ctx, "CalcScoreForTile failed", "error", r.err)
-			failedTiles++
-			continue
-		}
-		tiles = append(tiles, r.tile)
-	}
+	_ = g.Wait() // 各 goroutine は常に nil を返す（部分失敗は failedTiles に集計済み）
 
 	c.JSON(http.StatusOK, domain.HeatmapResponse{
 		Tiles:       tiles,

--- a/backend/internal/concurrent/safecall.go
+++ b/backend/internal/concurrent/safecall.go
@@ -1,0 +1,15 @@
+package concurrent
+
+import "fmt"
+
+// SafeCall は fn を実行し、panic を error に変換して返す。
+// errgroup 配下の goroutine で panic すると Wait がプロセス全体に再送出するため、
+// タイル単位の部分失敗として扱いたい呼び出しはこれで包む。
+func SafeCall(fn func() error) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("panic: %v", r)
+		}
+	}()
+	return fn()
+}

--- a/backend/internal/concurrent/safecall_test.go
+++ b/backend/internal/concurrent/safecall_test.go
@@ -1,0 +1,30 @@
+package concurrent
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestSafeCall_Success(t *testing.T) {
+	if err := SafeCall(func() error { return nil }); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSafeCall_Error(t *testing.T) {
+	wantErr := errors.New("fetch failed")
+	if err := SafeCall(func() error { return wantErr }); !errors.Is(err, wantErr) {
+		t.Errorf("err = %v, want %v", err, wantErr)
+	}
+}
+
+func TestSafeCall_Panic(t *testing.T) {
+	err := SafeCall(func() error { panic("boom") })
+	if err == nil {
+		t.Fatal("expected error from panic, got nil")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("err = %v, want message containing %q", err, "boom")
+	}
+}


### PR DESCRIPTION
## 概要

Issue #812 の PR-2（最終）。`GetInvestmentScoreHeatmap` の手書き goroutine + チャネル + セマフォ + panic recover を `errgroup.WithContext` + `g.SetLimit(5)` に置き換え、バックエンドの並行処理パターンを errgroup に統一します。

## 変更内容

- **1コミット目（セマンティクス固定）**: リファクタ前に現行挙動をテストで固定
  - `TestGetInvestmentScoreHeatmap_SingleTileFailure`: 1タイルだけ失敗しても 200 を返し、成功タイルは欠けず `FailedTiles=1` に集計される
  - `TestGetInvestmentScoreHeatmap_PanicRecovery`: タイル計算が panic してもリクエスト全体は落ちない
- **2コミット目（errgroup 化）**:
  - `score_handler.go` を `errgroup.WithContext` + `SetLimit(5)` に置換（並列度5は現行と同じ）
  - panic 対策は `concurrent.SafeCall` として `internal/concurrent` に吸収（x/sync v0.9.0 以降の errgroup は goroutine 内 panic を `Wait` で再送出するため必須）
  - タイル単位の部分失敗を `FailedTiles` に集計する現仕様は維持

## 関連Issue

Closes #812

## テスト

- [x] 既存テストが通ること（`go test -race ./...` 全パッケージ PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること（ヒートマップ2ケース + SafeCall 3ケース）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み