### PR TITLE
docs: overview.md のディレクトリ・テスト構成をパッケージ粒度で実態に合わせて更新（#813）

### DIFF
--- a/docs/metadata.json
+++ b/docs/metadata.json
@@ -1,12 +1,12 @@
 {
   "version": "1.0.0",
-  "lastUpdated": "2026-05-16T22:00:00",
+  "lastUpdated": "2026-07-06T09:00:00",
   "documents": [
     {
       "id": "overview",
       "path": "docs/overview.md",
       "title": "プロジェクト概要とアーキテクチャ",
-      "description": "Yield-Guard の目的・解決する3大リスク（相場判定・デッドクロス・出口戦略）・技術スタック（OpenTelemetry SDK / opentelemetry-operations-go 含む）・ディレクトリ構成・起動手順・計算の制約と免責事項。バックエンド環境変数（PORT/ALLOW_ORIGINS/MLIT_API_KEY/APP_INTERNAL_API_KEY/GOOGLE_CLOUD_PROJECT）・フロントエンド環境変数（APP_INTERNAL_API_KEY）の一覧を含む。GOOGLE_CLOUD_PROJECT 設定時は Cloud Trace / Cloud Monitoring へ OTel データを送信、未設定時は stdout。PWA対応（@ducanh2912/next-pwa・manifest.ts）を含む。フロントエンド（Vercel）・バックエンド（Cloud Run）のデプロイフローも記載。Makefile 便利ターゲット: make backend（バックエンドのみ起動）・make frontend（フロントエンドのみ起動）・make install（npm install）・make logs（Docker ログ表示、未起動時は案内メッセージ）・make swagger（OpenAPI スキーマ生成）を追加済み。OpenAPI 型自動生成パイプライン: swaggo/swag アノテーション → make swagger で docs/openapi/swagger.json（Swagger 2.0）生成 → swagger2openapi で docs/openapi/openapi.json（OpenAPI 3.0）変換 → npm run generate:types で frontend/src/types/api.generated.ts 自動生成。api.generated.ts・swagger.json・openapi.json は編集禁止・CI がドリフトを検出する。e2e fixtures は api.generated.ts の components[\"schemas\"] を satisfies で参照。@title 等のメタアノテーションは cmd/server/main.go の func main() 直前に記述すること（doc.go 単独では swag に読み取られない）。",
+      "description": "Yield-Guard の目的・解決する3大リスク（相場判定・デッドクロス・出口戦略）・技術スタック（OpenTelemetry SDK / opentelemetry-operations-go 含む）・ディレクトリ構成（パッケージ単位+責務1行: backend は api / service / domain / mlit / ai / concurrent / logger / telemetry、frontend は app / components / hooks / lib / types / e2e）・起動手順・計算の制約と免責事項。テスト構成もディレクトリ粒度（domain 計算・service ユースケース・api HTTPバインディング・mlit クライアント・フロント UI・API 型契約・E2E）で記載。バックエンド環境変数（PORT/ALLOW_ORIGINS/MLIT_API_KEY/APP_INTERNAL_API_KEY/GOOGLE_CLOUD_PROJECT）・フロントエンド環境変数（APP_INTERNAL_API_KEY）の一覧を含む。GOOGLE_CLOUD_PROJECT 設定時は Cloud Trace / Cloud Monitoring へ OTel データを送信、未設定時は stdout。PWA対応（@ducanh2912/next-pwa・manifest.ts）を含む。フロントエンド（Vercel）・バックエンド（Cloud Run）のデプロイフローも記載。Makefile 便利ターゲット: make backend（バックエンドのみ起動）・make frontend（フロントエンドのみ起動）・make install（npm install）・make logs（Docker ログ表示、未起動時は案内メッセージ）・make swagger（OpenAPI スキーマ生成）を追加済み。OpenAPI 型自動生成パイプライン: swaggo/swag アノテーション → make swagger で docs/openapi/swagger.json（Swagger 2.0）生成 → swagger2openapi で docs/openapi/openapi.json（OpenAPI 3.0）変換 → npm run generate:types で frontend/src/types/api.generated.ts 自動生成。api.generated.ts・swagger.json・openapi.json は編集禁止・CI がドリフトを検出する。e2e fixtures は api.generated.ts の components[\"schemas\"] を satisfies で参照。@title 等のメタアノテーションは cmd/server/main.go の func main() 直前に記述すること（doc.go 単独では swag に読み取られない）。",
       "tags": [
         "概要",
         "アーキテクチャ",

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -65,53 +65,34 @@ Yield-Guard は不動産投資判断を支援するシミュレーションツ�
 
 ## ディレクトリ構成
 
+パッケージ（ディレクトリ）単位で責務を示す。ファイル一覧は列挙しない（各パッケージ内は実コードを参照）。
+
 ```
 yield-guard/
 ├── backend/
 │   ├── Dockerfile                 # マルチステージビルド（BuildKitキャッシュ最適化）
-│   ├── cmd/server/main.go         # エントリポイント・グレースフルシャットダウン
+│   ├── cmd/server/                # エントリポイント・swag メタアノテーション・グレースフルシャットダウン
 │   └── internal/
-│       ├── domain/
-│       │   ├── types.go                    # ドメインモデル・BuildingType・耐用年数
-│       │   ├── investment.go               # 計算ロジック・Analyze・calcExit
-│       │   ├── investment_test.go          # ユニットテスト
-│       │   ├── theoretical_price.go        # 理論価格推定・補正計算
-│       │   └── theoretical_price_test.go   # ユニットテスト
-│       ├── mlit/
-│       │   ├── client.go          # 国交省APIクライアント・リトライ
-│       │   ├── cache.go           # TTL付きインメモリキャッシュ（24時間）
-│       │   ├── client_test.go     # ユニットテスト（httptest モック）
-│       │   ├── integration_test.go # 統合テスト（実API疎通・要APIキー）
-│       │   └── types.go           # APIレスポンス型・都道府県マップ
-│       └── api/
-│           ├── handler.go         # HTTPハンドラー・バリデーション
-│           └── router.go          # Ginルーター・CORS設定
+│       ├── api/                   # HTTPハンドラ（パース→service委譲→ステータス変換）・ルーター・CORS・認証・レートリミット・ジオコーダー
+│       ├── service/               # アプリケーションサービス層（投資スコア・エリア探索・都市リスク・土地価格・賃料などのユースケース）
+│       ├── domain/                # ドメインモデルと計算ロジック（利回り・デッドクロス・出口・税・理論価格・投資スコア等）
+│       ├── mlit/                  # 国交省APIクライアント（リトライ・インメモリキャッシュ・Firestore L2キャッシュ）
+│       ├── ai/                    # Gemini による投資サマリー生成（GEMINI_API_KEY 未設定時は no-op）
+│       ├── concurrent/            # 並行処理ヘルパー（FanOut / SafeCall）
+│       ├── logger/                # slog 構造化ログ設定
+│       └── telemetry/             # OpenTelemetry セットアップ・カスタムメトリクス
 ├── frontend/
 │   ├── Dockerfile                 # マルチステージビルド
+│   ├── e2e/                       # Playwright E2E（spec・fixtures・ページオブジェクト）
 │   └── src/
-│       ├── app/
-│       │   ├── layout.tsx
-│       │   ├── manifest.ts        # Web App Manifest（PWA）
-│       │   └── page.tsx           # Dashboard をレンダリング
-│       ├── components/
-│       │   ├── Dashboard.tsx      # メインUI・状態管理
-│       │   ├── InvestmentForm.tsx # 投資条件入力フォーム
-│       │   ├── YieldAnalysis.tsx  # 利回り分析・8%ゲージ
-│       │   ├── CashFlowChart.tsx  # CF推移グラフ・出口サマリー
-│       │   ├── DeadCrossChart.tsx # デッドクロス予測グラフ
-│       │   ├── LandPriceAnalysis.tsx # 土地相場分析
-│       │   └── ui/                # Shadcn/UIコンポーネント
-│       ├── lib/
-│       │   ├── api.ts             # fetchLandPrices / analyze / etc.
-│       │   └── utils.ts           # formatMan / formatPct / formatYen
-│       └── types/
-│           └── investment.ts      # TypeScript型定義・DEFAULT_INPUT
+│       ├── app/                   # App Router エントリ（layout / page / manifest）
+│       ├── components/            # UI コンポーネント（Dashboard 起点。sections/・ui/=Shadcn を含む）
+│       ├── hooks/                 # API 呼び出し・シミュレーション・ネットワーク状態等のカスタムフック
+│       ├── lib/                   # API クライアント・キャッシュ・PDF 生成・ユーティリティ
+│       └── types/                 # 手書き型（investment.ts）+ 生成型（api.generated.ts、git管理外・CI で毎回生成）
+├── docs/                          # ドキュメント（docs-mcp-server 用）・openapi/swagger.json（コミット対象）
 ├── docker-compose.yml             # backend + frontend 一括起動
 ├── .env.example                   # 環境変数テンプレート
-├── docs/                          # ドキュメント（docs-mcp-server用）
-│   ├── metadata.json
-│   ├── overview.md
-│   └── ...
 └── .mcp.json                      # docs-mcp-server 設定
 ```
 
@@ -251,15 +232,17 @@ CI（GitHub Actions）では `go test -race -coverprofile=coverage.out` を実�
 
 ### テスト構成
 
-| レイヤー | ファイル | ツール | テスト数 |
-|---|---|---|---|
-| ドメイン計算 | `backend/internal/domain/investment_test.go` | go test | 複数（境界値テスト含む） |
-| 理論価格推定 | `backend/internal/domain/theoretical_price_test.go` | go test | 9 |
-| MLIT クライアント | `backend/internal/mlit/client_test.go` | go test / httptest | 複数 |
-| フロントエンド UI | `frontend/src/components/__tests__/*.test.tsx` | Vitest + RTL | 複数 |
-| E2E（ユーザーフロー） | `frontend/e2e/**/*.spec.ts` | Playwright + page.route() | 10 |
+ディレクトリ単位で示す（個別ファイル・テスト数は列挙しない）。
 
-境界値テストは `acquisition_costs`・`investment`・`property_tax` の各計算に追加されている。
+| レイヤー | 場所 | ツール・方針 |
+|---|---|---|
+| ドメイン計算 | `backend/internal/domain/*_test.go` | go test（境界値テスト含む） |
+| サービス層（ユースケース） | `backend/internal/service/*_test.go` | go test（MLIT クライアント・Summarizer をモック注入） |
+| HTTP バインディング | `backend/internal/api/*_test.go` | go test / httptest（パラメータ検証・ステータス変換のみ） |
+| MLIT クライアント | `backend/internal/mlit/*_test.go` | go test / httptest（`integration_test.go` のみ実API・要APIキー） |
+| フロントエンド UI | `frontend/src/**/__tests__/` | Vitest + React Testing Library |
+| API 型契約 | `frontend/src/types/__tests__/api-contract.ts` | tsc --noEmit（生成型と手書き型の整合を型レベルで検証） |
+| E2E（ユーザーフロー） | `frontend/e2e/**/*.spec.ts` | Playwright + page.route() |
 
 #### フロントエンドテストの方針
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -338,7 +338,7 @@ export async function simulate(input: MonteCarloInput): Promise<MonteCarloResult
   return postJson<MonteCarloResult>("/investment/simulate", input);
 }
 
-/** 住所文字列から緯度・経度を取得（バックエンド経由でGoogle Maps Geocoding API を呼び出す） */
+/** 住所文字列から緯度・経度を取得（バックエンド経由で Nominatim (OpenStreetMap) を呼び出す） */
 export function fetchGeocode(address: string): Promise<GeocodeResult> {
   return cachedFetch(`geocode:${address}`, TTL_MARKET, async () => {
     const q = new URLSearchParams({ address });


### PR DESCRIPTION
## 概要

Issue #813。`docs/overview.md` のディレクトリツリー・テスト構成表が handler 1ファイル・domain 4ファイル時代のままだったため、現行の実態（12ハンドラ + service / ai / concurrent / logger / telemetry、Firestore L2 キャッシュ、geocode 等）に合わせて更新します。docs-mcp 経由で LLM の設計判断の入口になるため、腐りにくい粒度に書き直すのが主眼です。

## 変更内容

- ディレクトリツリーを**パッケージ単位 + 責務1行**に書き直し（ファイル列挙を廃止）
  - backend: `api` / `service` / `domain` / `mlit` / `ai` / `concurrent` / `logger` / `telemetry`
  - frontend: `app` / `components` / `hooks` / `lib` / `types` / `e2e`
- テスト構成表もディレクトリ粒度へ（テスト数の列を廃止し、service 層テスト・API 型契約テストの行を追加）
- `docs/metadata.json` の overview エントリの description と `lastUpdated` を更新
- `frontend/src/lib/api.ts` の `fetchGeocode` コメントを実装どおり「Nominatim (OpenStreetMap)」に修正（従来は「Google Maps Geocoding API」と記載）

備考: service 層の記述は現行 main の内容（投資スコア・エリア探索・都市リスク・土地価格・賃料）に合わせ「などのユースケース」としています。#838（investment 系）マージ後もパッケージ粒度のため記述変更は不要です。

## 関連Issue

Closes #813

## テスト

- [x] 既存テストが通ること（frontend tsc --noEmit / eslint 通過。docs とコメントのみの変更で Go コードは未変更）
- [ ] 新規テストを追加した場合、全ケースがPASSすること（該当なし）

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
- [x] ツリー・テスト表が現行コードと矛盾しないことを実ディレクトリと突き合わせて確認