### PR TITLE
chore: backend Go 変更時に swagger.json を自動再生成する pre-commit フック

### DIFF
--- a/docs/llm/backend.md
+++ b/docs/llm/backend.md
@@ -53,9 +53,10 @@ frontend/src/types/api.generated.ts  (git 管理外 — CI で毎回生成)
 - `swagger.json` は git 管理対象。変更したら必ずコミットに含める
 - `api.generated.ts` は git 管理外。ローカルで使う場合は `npm run generate:types` を実行
 
-> `backend/**/*.go` をコミットすると pre-commit フック（lefthook）が `make swagger` を自動実行し、
-> 差分があれば `swagger.json` を再生成してステージする（#840）。`swag` 未導入なら警告のみで通し、
-> CI の drift チェックが最終ゲートになる。手動で `make swagger` してもよい。
+> `backend/**/*.go`（非テスト）をコミットすると pre-commit フック（lefthook）が swagger.json の
+> ドリフトを検出する（#840）。不整合ならコミットを止めるので、`make swagger` を実行して
+> `docs/openapi/swagger.json` を stage し直す。フックは `git add` せずコミット内容を書き換えない。
+> `swag` 未導入 / CI（v1.16.6）と別バージョンなら誤検出を避けて警告のみで通し、CI の drift チェックが最終ゲートになる。
 
 ## struct タグ = TypeScript 契約（Issue #811 以降）
 

--- a/docs/llm/backend.md
+++ b/docs/llm/backend.md
@@ -2,7 +2,7 @@
 purpose: バックエンド開発（Go / API / swagger）の出発点
 triggers: [go, handler, router, swagger, api endpoint, mlit client, domain type]
 reads_next: [docs/api-reference.md, docs/mlit-api-integration.md]
-last_updated: 2026-07-05
+last_updated: 2026-07-12
 ---
 
 ## 重要ファイル
@@ -52,6 +52,10 @@ frontend/src/types/api.generated.ts  (git 管理外 — CI で毎回生成)
 
 - `swagger.json` は git 管理対象。変更したら必ずコミットに含める
 - `api.generated.ts` は git 管理外。ローカルで使う場合は `npm run generate:types` を実行
+
+> `backend/**/*.go` をコミットすると pre-commit フック（lefthook）が `make swagger` を自動実行し、
+> 差分があれば `swagger.json` を再生成してステージする（#840）。`swag` 未導入なら警告のみで通し、
+> CI の drift チェックが最終ゲートになる。手動で `make swagger` してもよい。
 
 ## struct タグ = TypeScript 契約（Issue #811 以降）
 

--- a/docs/llm/backend.md
+++ b/docs/llm/backend.md
@@ -54,9 +54,10 @@ frontend/src/types/api.generated.ts  (git 管理外 — CI で毎回生成)
 - `api.generated.ts` は git 管理外。ローカルで使う場合は `npm run generate:types` を実行
 
 > `backend/**/*.go`（非テスト）をコミットすると pre-commit フック（lefthook）が swagger.json の
-> ドリフトを検出する（#840）。不整合ならコミットを止めるので、`make swagger` を実行して
-> `docs/openapi/swagger.json` を stage し直す。フックは `git add` せずコミット内容を書き換えない。
-> `swag` 未導入 / CI（v1.16.6）と別バージョンなら誤検出を避けて警告のみで通し、CI の drift チェックが最終ゲートになる。
+> ドリフトを検出する（#840）。不整合ならコミットを止めるので、再生成された
+> `docs/openapi/swagger.json` を stage し直して再コミットする。フックは `git add` せずコミット内容を書き換えない。
+> `swag` 未導入なら警告のみで通し、CI の drift チェックが最終ゲートになる。
+> swag は CI と同じ `v1.16.6` を使うこと（別バージョンだと整形差でローカルは通っても CI で落ちうる）。
 
 ## struct タグ = TypeScript 契約（Issue #811 以降）
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,6 +13,26 @@ pre-commit:
     go-lint:
       glob: "backend/**/*.go"
       run: cd backend && golangci-lint run ./...
+    # Go 型・swag アノテーション変更時に swagger.json を再生成して同一コミットに含める (#840)
+    # 未インストール時は警告のみで通す（CI backend-ci.yml の drift チェックが最終ゲート）
+    # 導入: go install github.com/swaggo/swag/cmd/swag@v1.16.6
+    swagger:
+      glob: "backend/**/*.go"
+      run: |
+        set -e
+        # 非テストの backend Go が staged のときだけ再生成（テストのみの変更はスキップ）
+        if ! git diff --cached --name-only | grep -E '^backend/.*\.go$' | grep -qv '_test\.go$'; then
+          exit 0
+        fi
+        if command -v swag >/dev/null 2>&1; then
+          make swagger >/dev/null
+          if ! git diff --quiet docs/openapi/swagger.json; then
+            git add docs/openapi/swagger.json
+            echo "==> swagger.json を再生成してステージしました (#840)"
+          fi
+        else
+          echo "WARN: swag 未インストールのため swagger 再生成をスキップ（go install github.com/swaggo/swag/cmd/swag@v1.16.6 で導入 / CI が最終ゲート）"
+        fi
     frontend-format:
       glob: "frontend/src/**/*.{ts,tsx,css}"
       run: npx --prefix frontend prettier --write {staged_files} && git add {staged_files}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -13,25 +13,33 @@ pre-commit:
     go-lint:
       glob: "backend/**/*.go"
       run: cd backend && golangci-lint run ./...
-    # Go 型・swag アノテーション変更時に swagger.json を再生成して同一コミットに含める (#840)
-    # 未インストール時は警告のみで通す（CI backend-ci.yml の drift チェックが最終ゲート）
+    # Go 型・swag アノテーション変更時に swagger.json のドリフトを検出しコミットを止める (#840)
+    # ここでは git add せず「make swagger して stage せよ」と促すだけ（コミット内容は書き換えない）。
+    # swag 未導入 / CI と別バージョンなら誤検出を避けて WARN のみで通す（CI backend-ci.yml が最終ゲート）。
     # 導入: go install github.com/swaggo/swag/cmd/swag@v1.16.6
     swagger:
       glob: "backend/**/*.go"
       run: |
         set -e
-        # 非テストの backend Go が staged のときだけ再生成（テストのみの変更はスキップ）
+        # 非テストの backend Go が staged のときだけチェック（テストのみの変更はスキップ）
         if ! git diff --cached --name-only | grep -E '^backend/.*\.go$' | grep -qv '_test\.go$'; then
           exit 0
         fi
-        if command -v swag >/dev/null 2>&1; then
-          make swagger >/dev/null
-          if ! git diff --quiet docs/openapi/swagger.json; then
-            git add docs/openapi/swagger.json
-            echo "==> swagger.json を再生成してステージしました (#840)"
-          fi
-        else
-          echo "WARN: swag 未インストールのため swagger 再生成をスキップ（go install github.com/swaggo/swag/cmd/swag@v1.16.6 で導入 / CI が最終ゲート）"
+        if ! command -v swag >/dev/null 2>&1; then
+          echo "WARN: swag 未インストールのため swagger drift チェックをスキップ（go install github.com/swaggo/swag/cmd/swag@v1.16.6 で導入 / CI が最終ゲート）"
+          exit 0
+        fi
+        # CI と同じ swag バージョンでのみ判定する（版ずれの誤ブロックを避ける）。backend-ci.yml と同期
+        if ! swag --version 2>/dev/null | grep -q '1\.16\.6'; then
+          echo "WARN: swag が v1.16.6 以外のため swagger drift チェックをスキップ（CI が最終ゲート）"
+          exit 0
+        fi
+        make swagger >/dev/null
+        if ! git diff --quiet docs/openapi/swagger.json; then
+          echo "ERROR: swagger.json が Go 型と不整合です (#840)"
+          echo "  → 'make swagger' を実行し docs/openapi/swagger.json を stage してから再コミットしてください"
+          echo "  （未ステージの型変更があるとその差分も検出されます。必要なら stage するか退避してください）"
+          exit 1
         fi
     frontend-format:
       glob: "frontend/src/**/*.{ts,tsx,css}"

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -14,9 +14,11 @@ pre-commit:
       glob: "backend/**/*.go"
       run: cd backend && golangci-lint run ./...
     # Go 型・swag アノテーション変更時に swagger.json のドリフトを検出しコミットを止める (#840)
-    # ここでは git add せず「make swagger して stage せよ」と促すだけ（コミット内容は書き換えない）。
-    # swag 未導入 / CI と別バージョンなら誤検出を避けて WARN のみで通す（CI backend-ci.yml が最終ゲート）。
-    # 導入: go install github.com/swaggo/swag/cmd/swag@v1.16.6
+    # ここでは git add せず、再生成した差分を stage せよと促すだけ（コミット内容＝index は書き換えない）。
+    # swag 未導入なら誤検出を避けて WARN のみで通す（CI backend-ci.yml の drift チェックが最終ゲート）。
+    # swag は CI と同じ v1.16.6 を使うこと（別バージョンだと整形差でローカルは通っても CI で落ちうる）。
+    #   導入: go install github.com/swaggo/swag/cmd/swag@v1.16.6
+    #   ※ v1.16.6 でも `swag --version` は "v1.16.4" と出る（swag 側の定数上げ忘れ）ため版判定はしない
     swagger:
       glob: "backend/**/*.go"
       run: |
@@ -29,16 +31,11 @@ pre-commit:
           echo "WARN: swag 未インストールのため swagger drift チェックをスキップ（go install github.com/swaggo/swag/cmd/swag@v1.16.6 で導入 / CI が最終ゲート）"
           exit 0
         fi
-        # CI と同じ swag バージョンでのみ判定する（版ずれの誤ブロックを避ける）。backend-ci.yml と同期
-        if ! swag --version 2>/dev/null | grep -q '1\.16\.6'; then
-          echo "WARN: swag が v1.16.6 以外のため swagger drift チェックをスキップ（CI が最終ゲート）"
-          exit 0
-        fi
         make swagger >/dev/null
         if ! git diff --quiet docs/openapi/swagger.json; then
           echo "ERROR: swagger.json が Go 型と不整合です (#840)"
-          echo "  → 'make swagger' を実行し docs/openapi/swagger.json を stage してから再コミットしてください"
-          echo "  （未ステージの型変更があるとその差分も検出されます。必要なら stage するか退避してください）"
+          echo "  docs/openapi/swagger.json を再生成しました。差分を確認して stage し、再コミットしてください"
+          echo "  （未ステージの型変更が原因の場合は、それを stage/退避してから make swagger し直す）"
           exit 1
         fi
     frontend-format:


### PR DESCRIPTION
## 概要

Go 型・swag アノテーションを変更したのに `make swagger` を忘れて `swagger.json` がドリフトする事故を、コミット時点で検出して止める。CI（backend-ci.yml の drift チェック）は既に最終ゲートとして存在するが、コミット時に早期検出することで push 前に気付ける。Issue #840 Phase 3 の follow-up。

## 方式（ブロック / リマインド）

サブエージェントによるレビュー2回を経た設計。フックはコミット内容（index）を一切書き換えない。

- `lefthook.yml` の pre-commit に `swagger` コマンドを追加
  - `backend/**/*.go`（非テスト）が staged のとき `make swagger` で再生成し、`swagger.json` にドリフトがあればコミットを中断して再生成物の stage を促す
  - **`git add` しない** → `parallel: true` 下で index に書く2つ目のライターにならず、index.lock 競合を作らない
  - `swag` 未導入なら誤検出を避けて WARN のみで通す（gitleaks フックと同じ思想／CI が最終ゲート）
  - 判定は `git diff --cached --name-only` ベースでシェル非依存。`set -e` により swag 実行失敗（壊れたアノテーション）はコミットを中断
- `docs/llm/backend.md` にフックの挙動を注記

## レビューで直した点

1回目（自動 `git add` 方式に対して）:
- **index.lock 競合（High）**: `git add` を廃止して解消
- **未ステージ WIP の自動混入（High）**: 自動コミットしなくなり解消（未ステージ型変更時は「安全側の誤ブロック」に留め、メッセージで退避を促す）

2回目（ブロック方式に対して）:
- **swag バージョンガードによる silent no-op（High）**: `swag@v1.16.6` は `swag --version` で `v1.16.4` と出力する（swag 側の定数上げ忘れ）ため、`grep '1.16.6'` が絶対に一致せず drift チェックが全ユーザーで無効化されていた。**バージョンガードを廃止**して解消（別バージョンでも「再生成して stage すればローカルは通る」ため、この判定は実質的な保護を生まず致命バグだけを持ち込んでいた）

## 検証（swag 実インストールで e2e 確認）

| シナリオ | 結果 |
|---|---|
| スキーマ変更を stage・swagger 未再生成 | **BLOCK**（exit 1） |
| 再生成して swagger.json を stage | **PASS**（exit 0） |
| `domain/types_test.go` のみ / docs / frontend のみ | SKIP |
| swag 未導入 | WARN で通過 |

（判定 grep は実機 BSD grep、run スクリプトは `sh -n` + swag 実行で確認）

## 関連Issue

Part of #840（Phase 3: swagger フック）

## テスト

- [x] 既存テストが通ること（pre-push で go-test / frontend-test 実行・PASS）
- [x] フックの block / pass / skip / warn を swag 実インストールで e2e 確認

## 確認事項

- [x] コードレビュー観点での自己レビュー済み（サブエージェント2回のレビューを反映）
