### PR TITLE
fix: Go を 1.25.12 に更新して GO-2026-5856 (crypto/tls) を修正

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-FROM golang:1.25.11-alpine AS builder
+FROM golang:1.25.12-alpine AS builder
 WORKDIR /app
 
 COPY go.mod go.sum ./

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/yield-guard/backend
 
-go 1.25.11
+go 1.25.12
 
 require (
 	cloud.google.com/go/firestore v1.22.0


### PR DESCRIPTION
## 概要

backend-ci の govulncheck が検出していた **GO-2026-5856**（`crypto/tls` の Encrypted Client Hello プライバシーリーク）を修正する。これは Go 標準ライブラリの脆弱性で、`crypto/tls@go1.25.11` に存在し `go1.25.12` で修正済み。サードパーティ依存ではなく **Go ツールチェーンのパッチ更新**が対処。

main の backend-ci は本件で継続的に赤（Test & Build → govulncheck exit 3）になっていた。

## 変更内容

- `backend/go.mod`: `go 1.25.11` → `go 1.25.12`（backend-ci は `go-version-file: backend/go.mod` でこの directive を読む）
- `backend/Dockerfile`: `golang:1.25.11-alpine` → `golang:1.25.12-alpine`（Cloud Run ビルド）

## 検証（ローカルで CI を再現）

CI と同じ Go 1.25.12 ツールチェーンで govulncheck を実行し、解消を確認:

```
GOTOOLCHAIN=go1.25.12 go run golang.org/x/vuln/cmd/govulncheck@v1.1.4 ./...
→ exit code 0
→ GO-2026-5856: 0 件（"No vulnerabilities found / affected by 0 vulnerabilities"）
```

- `go build ./...` / `go vet ./...` OK

> 補足: govulncheck は「呼び出しなし（uncalled）の依存脆弱性1件」を情報として報告するが、exit 0 で CI をブロックしない。本 PR の対象外。

## 関連

backend-ci の govulncheck 恒常赤の解消。

## テスト

- [x] 既存テストが通ること（pre-push で go-test 実行・PASS）
- [x] govulncheck 再現で GO-2026-5856 解消・exit 0 を確認

## 確認事項

- [x] コードレビュー観点での自己レビュー済み
