### PR TITLE
fix(frontend): オフラインバナーの文言を実装に合わせて修正

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -232,8 +232,8 @@ export function Dashboard({ initialParams }: DashboardProps = {}) {
           <div className="mb-4 flex items-center gap-2 rounded-md border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
             <WifiOff className="h-4 w-4 shrink-0" />
             <span>
-              <strong>オフラインモード：</strong>
-              シミュレーションはデバイス内で計算されます。「相場を取得」はネットワーク接続が回復するまで使用できません。
+              <strong>オフライン中：</strong>
+              シミュレーションの実行と「相場を取得」はネットワーク接続が必要です。接続が回復してから再実行してください。
             </span>
           </div>
         )}

--- a/frontend/src/components/__tests__/Dashboard.test.tsx
+++ b/frontend/src/components/__tests__/Dashboard.test.tsx
@@ -254,4 +254,18 @@ describe("Dashboard", () => {
     expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText).toHaveBeenCalledWith(expect.any(String));
   });
+
+  it("オフライン時にバナーで実行不可であることを案内する", () => {
+    // useNetworkStatus は navigator.onLine を参照する
+    const onLineSpy = vi.spyOn(navigator, "onLine", "get").mockReturnValue(false);
+
+    render(<Dashboard />);
+
+    // シミュレーション・相場取得の両方が要ネットワークであることを案内する
+    expect(screen.getByText(/接続が回復してから再実行してください/)).toBeInTheDocument();
+    // 実装と乖離した旧文言（デバイス内で計算）が復活していないこと
+    expect(screen.queryByText(/デバイス内で計算/)).not.toBeInTheDocument();
+
+    onLineSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## 概要
オフラインバナーの文言が実装と乖離していたため修正する。バナーは「シミュレーションはデバイス内で計算されます」と表示していたが、`useAnalyzeApi` は常に `POST /api/investment/analyze` を叩いており、Service Worker は POST をキャッシュ再生できないためオフラインではシミュレーション自体が失敗する。ユーザーに実際とは異なる期待を与える UX バグを解消する。

## 変更内容
- `Dashboard.tsx` のオフラインバナー文言を、シミュレーション実行・相場取得の**両方**がネットワーク接続を必要とする実態に合わせて修正
  - 旧: 「オフラインモード：シミュレーションはデバイス内で計算されます。「相場を取得」はネットワーク接続が回復するまで使用できません。」
  - 新: 「オフライン中：シミュレーションの実行と「相場を取得」はネットワーク接続が必要です。接続が回復してから再実行してください。」
- `Dashboard.test.tsx` に回帰テストを追加（オフライン時に新文言が表示され、旧文言「デバイス内で計算」が復活しないことを検証）

なお計算のクライアント実行（Go → WASM）による本実装は別 Issue #823 のスコープであり、本 PR は文言修正のみ。

## 関連Issue
Closes #814

## テスト
- [x] 既存テストが通ること（Dashboard.test.tsx 全 12 ケース PASS）
- [x] 新規テストを追加した場合、全ケースがPASSすること

## 確認事項
- [x] コードレビュー観点での自己レビュー済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)