### PR TITLE
refactor(backend): MLITClient の fat interface を consumer 定義の小 interface に分割

### DIFF
--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -14,28 +14,28 @@ import (
 	"github.com/yield-guard/backend/internal/service"
 )
 
-// MLITClient は国交省APIクライアントのインターフェース（テスト時にモック注入可能）
-type MLITClient interface {
-	FetchLandPrices(ctx context.Context, q mlit.LandPriceQuery) ([]domain.LandTransaction, error)
-	FetchMunicipalities(ctx context.Context, area string) ([]mlit.Municipality, error)
+// mlitFetcher は Handler が直接呼ぶ MLIT メソッドのサブセット（consumer = Handler）。
+// station-ridership / population-forecast / municipalities の各エンドポイントで使う。
+type mlitFetcher interface {
 	FetchStationRidership(ctx context.Context, z, x, y int) ([]mlit.StationRidership, error)
 	FetchPopulationForecast(ctx context.Context, z, x, y int) ([]domain.PopulationForecastItem, error)
-	FetchLandAppraisals(ctx context.Context, area, city string, year int, division string) ([]domain.LandAppraisalItem, error)
-	FetchLocationOptimization(ctx context.Context, z, x, y int) ([]domain.LocationOptimizationItem, error)
-	FetchEmbankment(ctx context.Context, z, x, y int) ([]domain.EmbankmentItem, error)
-	FetchUrbanRoad(ctx context.Context, z, x, y int) ([]domain.UrbanRoadItem, error)
-	FetchDisasterHistory(ctx context.Context, z, x, y int) ([]domain.DisasterHistoryItem, error)
-	FetchUrbanZoning(ctx context.Context, z, x, y int) ([]domain.UrbanZoningItem, error)
-	FetchLiquefaction(ctx context.Context, z, x, y int) ([]domain.LiquefactionRiskItem, error)
-	FetchFloodHazard(ctx context.Context, z, x, y int) ([]domain.FloodHazardItem, error)
-	FetchStormHazard(ctx context.Context, z, x, y int) ([]domain.StormHazardItem, error)
-	FetchTsunamiHazard(ctx context.Context, z, x, y int) ([]domain.TsunamiHazardItem, error)
-	FetchLandslideHazard(ctx context.Context, z, x, y int) ([]domain.LandslideHazardItem, error)
-	FetchRentStats(ctx context.Context, q mlit.LandPriceQuery, areaSqm float64) (domain.RentStatsResult, error)
+	FetchMunicipalities(ctx context.Context, area string) ([]mlit.Municipality, error)
+}
+
+// mlitProvider は NewHandler が全 service を組み立てるのに必要な合成インターフェース。
+// 各要素は利用側（service / handler）が所有する小インターフェースで、fat interface を
+// 再宣言せず埋め込みで束ねる。*mlit.Client（本番）とテストモックの両方が満たす。
+type mlitProvider interface {
+	mlitFetcher
+	service.AreaMLITClient
+	service.RiskMLITClient
+	service.LandMLITClient
+	service.RentMLITClient
+	service.InvestmentMLITClient
 }
 
 type Handler struct {
-	mlitClient    MLITClient
+	mlitClient    mlitFetcher
 	geocodeClient GeocodeClient
 	locationSvc   service.LocationService
 	areaSvc       service.AreaService
@@ -45,7 +45,7 @@ type Handler struct {
 	investmentSvc service.InvestmentService
 }
 
-func NewHandler(mlitClient MLITClient, geocodeClient GeocodeClient, locationSvc service.LocationService, fsClient ...*firestore.Client) *Handler {
+func NewHandler(mlitClient mlitProvider, geocodeClient GeocodeClient, locationSvc service.LocationService, fsClient ...*firestore.Client) *Handler {
 	var fs *firestore.Client
 	if len(fsClient) > 0 {
 		fs = fsClient[0]

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -153,7 +153,9 @@ func TestParseZoom(t *testing.T) {
 	}
 }
 
-// mockMLITClient は MLITClient インターフェースのテスト用モック
+// mockMLITClient は MLIT クライアントのテスト用モック。
+// NewHandler(mlitProvider) と service.NewInvestmentScoreService(service.MLITClient) の
+// 両方を満たすため、国交省 API の全メソッドを実装する。
 type mockMLITClient struct {
 	fetchFunc            func(ctx context.Context, q mlit.LandPriceQuery) ([]domain.LandTransaction, error)
 	muniFunc             func(ctx context.Context, area string) ([]mlit.Municipality, error)
@@ -293,7 +295,7 @@ func (m *mockLocationService) CalcScoreForTile(ctx context.Context, z, x, y int)
 
 // newTestRouter はモッククライアントを使ったテスト用ルーターを返す。
 // locationSvc が nil の場合は mlitClient を使った InvestmentScoreService を生成する。
-func newTestRouter(client MLITClient, geocodeClient GeocodeClient, locationSvc ...service.LocationService) *gin.Engine {
+func newTestRouter(client *mockMLITClient, geocodeClient GeocodeClient, locationSvc ...service.LocationService) *gin.Engine {
 	var svc service.LocationService
 	if len(locationSvc) > 0 && locationSvc[0] != nil {
 		svc = locationSvc[0]


### PR DESCRIPTION
## 概要
`api.MLITClient` の 16 メソッド fat interface を廃し、利用側（consumer）が所有する小インターフェースへ分割する。Go の慣習「interface は使う側で定義」に沿え、テストモックの実装負担と依存の見通しが改善する。

#816（service 層整備）で各 service は既に自前の小 interface を持つため、残っていた api 層の fat interface を解消する。挙動・JSON API 契約は不変。

## 変更内容
- `api.MLITClient`（16 メソッド）を削除
- `mlitFetcher`（consumer = Handler）を新設: Handler が直接呼ぶ 3 メソッド（station-ridership / population-forecast / municipalities）のみ。`Handler.mlitClient` の型に採用
- `mlitProvider` を新設: `NewHandler` の合成ルート interface。`mlitFetcher` + `service.{Area,Risk,Land,Rent,Investment}MLITClient` を**埋め込み合成**し、シグネチャの再宣言を排除
- `NewHandler` の引数を `mlitProvider` に変更（本番の `*mlit.Client` がコンパイル時に充足）
- テストヘルパ `newTestRouter` の引数を具象 `*mockMLITClient` に変更（score service = `service.MLITClient` も組むため。`mlitProvider` は score 専用の UrbanZoning/Liquefaction を含まない）

## 関連Issue
Refs #817

## テスト
- [x] 既存テストが通ること（`go test -race ./...` backend 全パッケージ緑）
- [x] `go build ./...`（`*mlit.Client` が `mlitProvider` を満たすことをコンパイルで担保）
- [x] `golangci-lint` 0 issues
- Go 型/struct タグ変更なしのため `make swagger` は不要

## 確認事項
- [x] コードレビュー観点での自己レビュー済み