### PR TITLE
refactor(backend): NewHandler の依存注入を HandlerDeps で明示化

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"cloud.google.com/go/firestore"
+	"github.com/yield-guard/backend/internal/ai"
 	"github.com/yield-guard/backend/internal/api"
 	"github.com/yield-guard/backend/internal/geocode"
 	"github.com/yield-guard/backend/internal/logger"
@@ -80,8 +81,14 @@ func main() {
 
 	mlitClient := mlit.NewClientWithFirestore(mlitAPIKey, fsClient)
 	geocodeClient := geocode.NewNominatimClient(geocode.NewFirestoreCache(fsClient))
+	summarizer := ai.NewSummarizer(fsClient)
 	scoreSvc := service.NewInvestmentScoreService(mlitClient)
-	handler := api.NewHandler(mlitClient, geocodeClient, scoreSvc)
+	handler := api.NewHandler(api.HandlerDeps{
+		MLIT:       mlitClient,
+		Geocode:    geocodeClient,
+		Summarizer: summarizer,
+		Location:   scoreSvc,
+	})
 	router := api.NewRouter(handler, appInternalAPIKey)
 
 	srv := &http.Server{

--- a/backend/internal/api/area_handler_test.go
+++ b/backend/internal/api/area_handler_test.go
@@ -166,3 +166,36 @@ func TestHandleAreaSummary_Success(t *testing.T) {
 		t.Errorf("expected summary=%q, got %q", "達成可能", resp["summary"])
 	}
 }
+
+// TestHandleAreaSummary_WithInjectedSummarizer は HandlerDeps 経由で
+// Summarizer をモック注入でき、その出力が /api/area-discovery/summary の
+// レスポンスに反映されることを実証する（#818 PR-2）。
+func TestHandleAreaSummary_WithInjectedSummarizer(t *testing.T) {
+	client := &mockMLITClient{
+		fetchFunc: func(_ context.Context, _ mlit.LandPriceQuery) ([]domain.LandTransaction, error) {
+			return []domain.LandTransaction{
+				{Period: "2024年第1四半期", TradePrice: 5_000_000, Area: 50, PricePerSqm: 100_000, PricePerTsubo: 100_000},
+			}, nil
+		},
+		muniFunc: func(_ context.Context, _ string) ([]mlit.Municipality, error) {
+			return []mlit.Municipality{{ID: "13101", Name: "千代田区"}}, nil
+		},
+	}
+	const want = "AIによるエリア要約"
+	r := newTestRouterWithSummarizer(client, nil, stubSummarizer{area: want})
+	req := httptest.NewRequest(http.MethodGet, "/api/area-discovery/summary?area=13&municipality=13101", nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp map[string]string
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	// 注入した Summarizer が空文字でない要約を返すため fallback は使われない
+	if resp["summary"] != want {
+		t.Errorf("expected injected summary=%q, got %q", want, resp["summary"])
+	}
+}

--- a/backend/internal/api/handler.go
+++ b/backend/internal/api/handler.go
@@ -6,7 +6,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"cloud.google.com/go/firestore"
 	"github.com/gin-gonic/gin"
 	"github.com/yield-guard/backend/internal/ai"
 	"github.com/yield-guard/backend/internal/domain"
@@ -46,21 +45,25 @@ type Handler struct {
 	investmentSvc service.InvestmentService
 }
 
-func NewHandler(mlitClient mlitProvider, geocodeClient GeocodeClient, locationSvc service.LocationService, fsClient ...*firestore.Client) *Handler {
-	var fs *firestore.Client
-	if len(fsClient) > 0 {
-		fs = fsClient[0]
-	}
-	summarizer := ai.NewSummarizer(fs)
+// HandlerDeps は Handler が必要とする依存の明示的な集合。
+// 呼び出し側（main.go / テスト）が各依存を生成して注入する。
+type HandlerDeps struct {
+	MLIT       mlitProvider // #817 の合成インターフェース
+	Geocode    GeocodeClient
+	Summarizer ai.Summarizer
+	Location   service.LocationService
+}
+
+func NewHandler(deps HandlerDeps) *Handler {
 	return &Handler{
-		mlitClient:    mlitClient,
-		geocodeClient: geocodeClient,
-		locationSvc:   locationSvc,
-		areaSvc:       service.NewAreaDiscoveryService(mlitClient, summarizer),
-		riskSvc:       service.NewRiskAssessmentService(mlitClient),
-		landSvc:       service.NewLandPriceAnalysisService(mlitClient),
-		rentSvc:       service.NewRentStatsService(mlitClient),
-		investmentSvc: service.NewInvestmentAnalysisService(mlitClient, summarizer),
+		mlitClient:    deps.MLIT,
+		geocodeClient: deps.Geocode,
+		locationSvc:   deps.Location,
+		areaSvc:       service.NewAreaDiscoveryService(deps.MLIT, deps.Summarizer),
+		riskSvc:       service.NewRiskAssessmentService(deps.MLIT),
+		landSvc:       service.NewLandPriceAnalysisService(deps.MLIT),
+		rentSvc:       service.NewRentStatsService(deps.MLIT),
+		investmentSvc: service.NewInvestmentAnalysisService(deps.MLIT, deps.Summarizer),
 	}
 }
 

--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	"github.com/yield-guard/backend/internal/ai"
 	"github.com/yield-guard/backend/internal/domain"
 	"github.com/yield-guard/backend/internal/geocode"
 	"github.com/yield-guard/backend/internal/mlit"
@@ -294,16 +295,38 @@ func (m *mockLocationService) CalcScoreForTile(ctx context.Context, z, x, y int)
 	return domain.CalcInvestmentScore(domain.InvestmentScoreInput{}), nil
 }
 
+// stubSummarizer は ai.Summarizer のテスト用スタブ。
+// area は GenerateAreaSummary の戻り値（空文字ならハンドラ側の fallback が働く）。
+type stubSummarizer struct{ area string }
+
+func (s stubSummarizer) GenerateSummary(_ context.Context, _ domain.InvestmentInput, _ domain.InvestmentResult) string {
+	return ""
+}
+func (s stubSummarizer) GenerateAreaSummary(_ context.Context, _ domain.AreaDiscoveryItem) string {
+	return s.area
+}
+
 // newTestRouter はモッククライアントを使ったテスト用ルーターを返す。
-// locationSvc が nil の場合は mlitClient を使った InvestmentScoreService を生成する。
+// Summarizer は noop 相当（空文字）を注入する。
 func newTestRouter(client *mockMLITClient, geocodeClient GeocodeClient, locationSvc ...service.LocationService) *gin.Engine {
+	return newTestRouterWithSummarizer(client, geocodeClient, stubSummarizer{}, locationSvc...)
+}
+
+// newTestRouterWithSummarizer は Summarizer を明示注入できるテスト用ルーターを返す。
+// locationSvc が nil の場合は mlitClient を使った InvestmentScoreService を生成する。
+func newTestRouterWithSummarizer(client *mockMLITClient, geocodeClient GeocodeClient, summarizer ai.Summarizer, locationSvc ...service.LocationService) *gin.Engine {
 	var svc service.LocationService
 	if len(locationSvc) > 0 && locationSvc[0] != nil {
 		svc = locationSvc[0]
 	} else {
 		svc = service.NewInvestmentScoreService(client)
 	}
-	h := NewHandler(client, geocodeClient, svc)
+	h := NewHandler(HandlerDeps{
+		MLIT:       client,
+		Geocode:    geocodeClient,
+		Summarizer: summarizer,
+		Location:   svc,
+	})
 	return NewRouter(h, os.Getenv("APP_INTERNAL_API_KEY"))
 }
 


### PR DESCRIPTION
## 概要
`NewHandler` の依存注入を `HandlerDeps` 構造体で明示化する。`#818`（DI 不整合の解消）の **PR-2**（PR-1 の geocode 移動は #848 でマージ済み）。

従来 `NewHandler` は内部で `ai.NewSummarizer(fs)` を自前生成しており Summarizer だけ注入できず、可変長 `fsClient` 引数が意図を不明瞭にしていた。さらに `main.go` が `fsClient` を渡していなかったため、**本番の AI 要約が Firestore L2 キャッシュを使えていない潜在バグ**があった。

## 変更内容
- `NewHandler(mlitClient, geocodeClient, locationSvc, fsClient...)` を `NewHandler(HandlerDeps{MLIT, Geocode, Summarizer, Location})` に置換。可変長 `fsClient` と api 層の `firestore` import を廃止
- `ai.NewSummarizer` の生成を `main.go` へ移動し注入。`main.go` は `fsClient` を渡すようになったため **Firestore L2 要約キャッシュが有効化**（潜在バグの修正）
- テストヘルパ: `newTestRouter` は noop 相当の `stubSummarizer` を注入。`newTestRouterWithSummarizer` で任意の Summarizer を注入可能に
- `TestHandleAreaSummary_WithInjectedSummarizer` を追加し、モック注入した要約が HTTP レスポンスへ反映されることを実証

## 関連Issue
Closes #818（本 PR は PR-2。PR-1 geocode 移動は #848）

## テスト
- [x] 既存テストが通ること（`go test -race ./...` backend 全パッケージ緑）
- [x] Summarizer 注入の新規テストが PASS
- [x] `go build ./...` / `golangci-lint` 0 issues / gofmt clean

## 確認事項
- [x] コードレビュー観点での自己レビュー済み
- Go 型/struct タグ変更なし → `make swagger` 不要・フロント無変更。API レスポンスは不変（本番のみ要約キャッシュ配線が修正される）