### PR TITLE
refactor(backend): domain 層から OTel 依存を剥がし service 層へ span を巻き直す (#819 PR-1)

### DIFF
--- a/backend/internal/domain/cashflow.go
+++ b/backend/internal/domain/cashflow.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"math"
 	"sync"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 const dscrSafeThreshold = 1.2
@@ -345,13 +342,6 @@ func calcAllStressScenarios(ctx context.Context, input InvestmentInput) []Stress
 // 上乗せされる（resolveRateForYear の仕様による）。
 // この挙動はフロントエンドの注釈で明示されている。
 func calcStressScenario(ctx context.Context, base InvestmentInput, label string, rateDelta, vacDelta float64) StressScenarioResult {
-	_, span := otel.Tracer(domainTracerName).Start(ctx, "domain.calcStressScenario")
-	defer span.End()
-	span.SetAttributes(
-		attribute.String("domain.stress.label", label),
-		attribute.Float64("domain.stress.rate_delta", rateDelta),
-		attribute.Float64("domain.stress.vac_delta", vacDelta),
-	)
 	in := base
 
 	effectiveVacancy := in.VacancyRate + vacDelta

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -4,14 +4,9 @@ import (
 	"context"
 	"fmt"
 	"sort"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
-	domainTracerName = "domain"
-
 	// SqmPerTsubo は 1坪あたりの平方メートル数（mlit パッケージからも参照）
 	SqmPerTsubo = 3.30578
 
@@ -24,14 +19,6 @@ const (
 
 // Analyze は投資入力値から収支シミュレーション結果を算出する
 func Analyze(ctx context.Context, input InvestmentInput) InvestmentResult {
-	ctx, span := otel.Tracer(domainTracerName).Start(ctx, "domain.Analyze")
-	defer span.End()
-	span.SetAttributes(
-		attribute.Float64("domain.land_price", input.LandPrice),
-		attribute.Float64("domain.building_cost", input.BuildingCost),
-		attribute.Float64("domain.loan_amount", input.LoanAmount),
-	)
-
 	input.Defaults()
 
 	yp := initYieldParams(input)
@@ -184,10 +171,6 @@ func CalcDSCR(noi, annualDebtService float64) float64 {
 
 // CalcLandPriceStats は取引データから統計を算出する
 func CalcLandPriceStats(ctx context.Context, transactions []LandTransaction) LandPriceStats {
-	_, span := otel.Tracer(domainTracerName).Start(ctx, "domain.CalcLandPriceStats")
-	defer span.End()
-	span.SetAttributes(attribute.Int("domain.transaction_count", len(transactions)))
-
 	if len(transactions) == 0 {
 		return LandPriceStats{}
 	}

--- a/backend/internal/domain/theoretical_price.go
+++ b/backend/internal/domain/theoretical_price.go
@@ -5,9 +5,6 @@ import (
 	"math"
 	"sort"
 	"time"
-
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
 )
 
 const (
@@ -35,10 +32,6 @@ type TheoreticalPriceInput struct {
 //   RidershipCorrection  = RidershipCorrectionFactor(score) if score != ""
 //   TheoreticalPrice     = medianTsubo × (1+AgeCorr) × (1+StationCorr) × (1+RidershipCorr) × (area/SqmPerTsubo)
 func EstimateTheoreticalPrice(ctx context.Context, stats LandPriceStats, input TheoreticalPriceInput) (TheoreticalPriceResult, bool) {
-	_, span := otel.Tracer(domainTracerName).Start(ctx, "domain.EstimateTheoreticalPrice")
-	defer span.End()
-	span.SetAttributes(attribute.Int("domain.transaction_count", stats.Count))
-
 	if stats.MedianTsubo == 0 || input.LandArea <= 0 || input.ListingPrice <= 0 {
 		return TheoreticalPriceResult{}, false
 	}

--- a/backend/internal/service/investment.go
+++ b/backend/internal/service/investment.go
@@ -6,10 +6,17 @@ import (
 	"log/slog"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/yield-guard/backend/internal/ai"
 	"github.com/yield-guard/backend/internal/concurrent"
 	"github.com/yield-guard/backend/internal/domain"
 )
+
+// domainTracerName は domain 計算をラップする span のトレーサ名。
+// 従来 domain パッケージ内で生成していた span を service 層から発行するために使う。
+const domainTracerName = "domain"
 
 // InvestmentMLITClient は投資分析に必要な国交省APIのサブセット
 type InvestmentMLITClient interface {
@@ -43,7 +50,14 @@ func NewInvestmentAnalysisService(client InvestmentMLITClient, summarizer ai.Sum
 }
 
 func (s *InvestmentAnalysisService) Analyze(ctx context.Context, input domain.InvestmentInput) domain.InvestmentResult {
+	ctx, span := otel.Tracer(domainTracerName).Start(ctx, "domain.Analyze")
+	span.SetAttributes(
+		attribute.Float64("domain.land_price", input.LandPrice),
+		attribute.Float64("domain.building_cost", input.BuildingCost),
+		attribute.Float64("domain.loan_amount", input.LoanAmount),
+	)
 	result := domain.Analyze(ctx, input)
+	span.End()
 
 	// run Gemini in background; collect result within remaining context budget
 	aiCh := make(chan string, 1)

--- a/backend/internal/service/investment.go
+++ b/backend/internal/service/investment.go
@@ -50,13 +50,16 @@ func NewInvestmentAnalysisService(client InvestmentMLITClient, summarizer ai.Sum
 }
 
 func (s *InvestmentAnalysisService) Analyze(ctx context.Context, input domain.InvestmentInput) domain.InvestmentResult {
-	ctx, span := otel.Tracer(domainTracerName).Start(ctx, "domain.Analyze")
+	// span は domain.Analyze の計算のみを計測する。ctx を上書きすると span 終了後に走る
+	// AI 要約 goroutine が「終了済み span」を親とする ctx を受け取ってしまうため、
+	// 計算用には別の spanCtx を渡し、元の ctx は汚さない。
+	spanCtx, span := otel.Tracer(domainTracerName).Start(ctx, "domain.Analyze")
 	span.SetAttributes(
 		attribute.Float64("domain.land_price", input.LandPrice),
 		attribute.Float64("domain.building_cost", input.BuildingCost),
 		attribute.Float64("domain.loan_amount", input.LoanAmount),
 	)
-	result := domain.Analyze(ctx, input)
+	result := domain.Analyze(spanCtx, input)
 	span.End()
 
 	// run Gemini in background; collect result within remaining context budget

--- a/backend/internal/service/land_price.go
+++ b/backend/internal/service/land_price.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
 	"github.com/yield-guard/backend/internal/domain"
 	"github.com/yield-guard/backend/internal/mlit"
 )
@@ -71,7 +74,10 @@ func (s *LandPriceAnalysisService) Estimate(ctx context.Context, q mlit.LandPric
 	if err != nil {
 		return domain.TheoreticalPriceResult{}, err
 	}
+	ctx, span := otel.Tracer(domainTracerName).Start(ctx, "domain.EstimateTheoreticalPrice")
+	span.SetAttributes(attribute.Int("domain.transaction_count", stats.Count))
 	result, ok := domain.EstimateTheoreticalPrice(ctx, stats, in)
+	span.End()
 	if !ok {
 		return domain.TheoreticalPriceResult{}, ErrEstimateDataInsufficient
 	}

--- a/backend/internal/service/land_price.go
+++ b/backend/internal/service/land_price.go
@@ -74,10 +74,10 @@ func (s *LandPriceAnalysisService) Estimate(ctx context.Context, q mlit.LandPric
 	if err != nil {
 		return domain.TheoreticalPriceResult{}, err
 	}
-	ctx, span := otel.Tracer(domainTracerName).Start(ctx, "domain.EstimateTheoreticalPrice")
+	spanCtx, span := otel.Tracer(domainTracerName).Start(ctx, "domain.EstimateTheoreticalPrice")
+	defer span.End() // 純粋計算だが panic 時も確実に span を閉じる
 	span.SetAttributes(attribute.Int("domain.transaction_count", stats.Count))
-	result, ok := domain.EstimateTheoreticalPrice(ctx, stats, in)
-	span.End()
+	result, ok := domain.EstimateTheoreticalPrice(spanCtx, stats, in)
 	if !ok {
 		return domain.TheoreticalPriceResult{}, ErrEstimateDataInsufficient
 	}


### PR DESCRIPTION
## 概要

Issue #819 の PR-1。domain 層に混入していた OTel SDK 依存を剥がし、`docs/architecture.md` が定義する「外部通信なしの純粋計算層」に近づける。span 生成は service 層へ巻き直す。

## 変更内容
- domain から `otel.Tracer().Start()` を削除
  - `domain/investment.go`: `Analyze` / `CalcLandPriceStats`
  - `domain/theoretical_price.go`: `EstimateTheoreticalPrice`
  - `domain/cashflow.go`: `calcStressScenario`
  - `go.opentelemetry.io/otel` / `attribute` の import と `domainTracerName` 定数を削除
- service 層でトップレベル span を巻き直し（`internal/mlit` と同じく `otel.Tracer("domain").Start()` を直接利用）
  - `service/investment.go` `Analyze`: `domain.Analyze` を `domain.Analyze` span で囲み属性（land_price/building_cost/loan_amount）付与
  - `service/land_price.go` `Estimate`: `domain.EstimateTheoreticalPrice` を span で囲み `transaction_count` 付与
- 細粒度の内部 span（`CalcLandPriceStats` / `calcStressScenario`）は廃止（トップレベルのみ再現方針）
- `ctx` 引数は cancellation 伝搬の意図保持のため残置（シグネチャ不変）
- 結果: `go list -deps ./internal/domain/...` から opentelemetry が消え、domain は otel 非依存に

## 関連Issue
Ref #819

## テスト
- [x] 既存テストが通ること（`go test -race ./...` 全 PASS）
- [x] `make swagger-check` 差分ゼロ（JSON 契約不変）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み
