### PR TITLE
refactor(backend): 投資スコアの日本語 Grade ラベルを domain から service へ分離 (#819 PR-3)

### DIFF
--- a/backend/internal/api/handler_test.go
+++ b/backend/internal/api/handler_test.go
@@ -292,7 +292,30 @@ func (m *mockLocationService) CalcScoreForTile(ctx context.Context, z, x, y int)
 	if m.calcScoreFunc != nil {
 		return m.calcScoreFunc(ctx, z, x, y)
 	}
-	return domain.CalcInvestmentScore(domain.InvestmentScoreInput{}), nil
+	// 実 service.InvestmentScoreService と同様、domain が返すコード値 grade を日本語ラベルへ
+	// 変換してから返す（本番 LocationService の出力契約に合わせ、grade が code のまま漏れるのを防ぐ）。
+	result := domain.CalcInvestmentScore(domain.InvestmentScoreInput{})
+	result.Grade = testGradeLabel(result.Grade)
+	return result, nil
+}
+
+// testGradeLabel は service.gradeLabelFor と同じ変換。
+// テストからは service パッケージの unexported 関数を参照できないため複製している。
+func testGradeLabel(code string) string {
+	switch code {
+	case "excellent":
+		return "優良"
+	case "good":
+		return "良好"
+	case "average":
+		return "普通"
+	case "caution":
+		return "注意"
+	case "warning":
+		return "要注意"
+	default:
+		return code
+	}
 }
 
 // stubSummarizer は ai.Summarizer のテスト用スタブ。

--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -222,12 +222,13 @@ func CalcLandPriceStats(ctx context.Context, transactions []LandTransaction) Lan
 	}
 }
 
-// CalcYieldDifficulty は坪単価中央値・予算・目標利回りから利回り達成難易度を返す。
-// difficulty は "achievable" | "slightly-difficult" | "difficult"。
-// medianTsubo が 0 の場合は ("", "") を返す。
-func CalcYieldDifficulty(medianTsubo, budget, targetYield float64) (difficulty, label string) {
+// CalcYieldDifficulty は坪単価中央値・予算・目標利回りから利回り達成難易度コードを返す。
+// 戻り値は "achievable" | "slightly-difficult" | "difficult"。
+// medianTsubo が 0 の場合は "" を返す。
+// 日本語表示ラベルへの変換は呼び出し側（service 層）が担う。
+func CalcYieldDifficulty(medianTsubo, budget, targetYield float64) (difficulty string) {
 	if medianTsubo <= 0 {
-		return "", ""
+		return ""
 	}
 	var rentPerTsubo float64
 	if budget > 0 {
@@ -244,11 +245,11 @@ func CalcYieldDifficulty(medianTsubo, budget, targetYield float64) (difficulty, 
 	}
 	switch {
 	case rentPerTsubo <= 8000:
-		return "achievable", "達成可能"
+		return "achievable"
 	case rentPerTsubo <= 15000:
-		return "slightly-difficult", "やや困難"
+		return "slightly-difficult"
 	default:
-		return "difficult", "困難"
+		return "difficult"
 	}
 }
 

--- a/backend/internal/domain/investment_score.go
+++ b/backend/internal/domain/investment_score.go
@@ -64,18 +64,21 @@ func CalcInvestmentScore(input InvestmentScoreInput) InvestmentScoreResult {
 	}
 }
 
+// gradeFromScore は総合スコアから評価コードを返す。
+// 戻り値は "excellent" | "good" | "average" | "caution" | "warning"。
+// 日本語表示ラベルへの変換は呼び出し側（service 層）が担う。
 func gradeFromScore(score int) string {
 	switch {
 	case score >= 80:
-		return "優良"
+		return "excellent"
 	case score >= 65:
-		return "良好"
+		return "good"
 	case score >= 50:
-		return "普通"
+		return "average"
 	case score >= 35:
-		return "注意"
+		return "caution"
 	default:
-		return "要注意"
+		return "warning"
 	}
 }
 

--- a/backend/internal/domain/investment_score_test.go
+++ b/backend/internal/domain/investment_score_test.go
@@ -12,16 +12,16 @@ func TestGradeFromScore_Boundaries(t *testing.T) {
 		score int
 		want  string
 	}{
-		{100, "優良"},
-		{80, "優良"},
-		{79, "良好"},
-		{65, "良好"},
-		{64, "普通"},
-		{50, "普通"},
-		{49, "注意"},
-		{35, "注意"},
-		{34, "要注意"},
-		{0, "要注意"},
+		{100, "excellent"},
+		{80, "excellent"},
+		{79, "good"},
+		{65, "good"},
+		{64, "average"},
+		{50, "average"},
+		{49, "caution"},
+		{35, "caution"},
+		{34, "warning"},
+		{0, "warning"},
 	}
 	for _, tc := range tests {
 		got := gradeFromScore(tc.score)

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -3285,7 +3285,6 @@ func TestCalcYieldDifficulty(t *testing.T) {
 		budget      float64
 		targetYield float64
 		wantDiff    string
-		wantLabel   string
 	}{
 		{
 			name:        "medianTsubo=0 returns empty",
@@ -3293,7 +3292,6 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      0,
 			targetYield: 0.08,
 			wantDiff:    "",
-			wantLabel:   "",
 		},
 		{
 			name:        "no budget, low tsubo price -> achievable",
@@ -3301,8 +3299,7 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      0,
 			targetYield: 0.08,
 			// totalCostEst=100000*30+10000000=13000000, rentPerTsubo=13000000*0.08/12/30≈288
-			wantDiff:  "achievable",
-			wantLabel: "達成可能",
+			wantDiff: "achievable",
 		},
 		{
 			name:        "no budget, high tsubo price -> difficult",
@@ -3310,8 +3307,7 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      0,
 			targetYield: 0.08,
 			// totalCostEst=2000000*30+10000000=70000000, rentPerTsubo=70000000*0.08/12/30≈15556
-			wantDiff:  "difficult",
-			wantLabel: "困難",
+			wantDiff: "difficult",
 		},
 		{
 			name:        "budget mode: cheap area should be achievable",
@@ -3319,8 +3315,7 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      50_000_000,
 			targetYield: 0.08,
 			// tsuboCount=50000000/100000=500, rentPerTsubo=100000*0.08/12≈667
-			wantDiff:  "achievable",
-			wantLabel: "達成可能",
+			wantDiff: "achievable",
 		},
 		{
 			name:        "budget mode: expensive area should be difficult",
@@ -3328,8 +3323,7 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      50_000_000,
 			targetYield: 0.08,
 			// rentPerTsubo=3000000*0.08/12=20000
-			wantDiff:  "difficult",
-			wantLabel: "困難",
+			wantDiff: "difficult",
 		},
 		{
 			name:        "budget mode: different areas give different results (not all same)",
@@ -3337,18 +3331,14 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      50_000_000,
 			targetYield: 0.08,
 			// rentPerTsubo=500000*0.08/12≈3333
-			wantDiff:  "achievable",
-			wantLabel: "達成可能",
+			wantDiff: "achievable",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotDiff, gotLabel := CalcYieldDifficulty(tt.medianTsubo, tt.budget, tt.targetYield)
+			gotDiff := CalcYieldDifficulty(tt.medianTsubo, tt.budget, tt.targetYield)
 			if gotDiff != tt.wantDiff {
 				t.Errorf("difficulty: got %q, want %q", gotDiff, tt.wantDiff)
-			}
-			if gotLabel != tt.wantLabel {
-				t.Errorf("label: got %q, want %q", gotLabel, tt.wantLabel)
 			}
 		})
 	}
@@ -3357,8 +3347,8 @@ func TestCalcYieldDifficulty(t *testing.T) {
 	t.Run("budget mode produces area-dependent results", func(t *testing.T) {
 		budget := 50_000_000.0
 		yield := 0.08
-		cheapDiff, _ := CalcYieldDifficulty(100_000, budget, yield)
-		expensiveDiff, _ := CalcYieldDifficulty(3_000_000, budget, yield)
+		cheapDiff := CalcYieldDifficulty(100_000, budget, yield)
+		expensiveDiff := CalcYieldDifficulty(3_000_000, budget, yield)
 		if cheapDiff == expensiveDiff {
 			t.Errorf("budget mode should give different difficulty for cheap (%s) vs expensive (%s) areas",
 				cheapDiff, expensiveDiff)

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -2539,8 +2539,8 @@ func TestCalcInvestmentScore_EmptyInput(t *testing.T) {
 	if result.TotalScore != 50 {
 		t.Errorf("empty input should yield base score 50, got %d", result.TotalScore)
 	}
-	if result.Grade != "普通" {
-		t.Errorf("empty input grade = %q, want 普通", result.Grade)
+	if result.Grade != "average" {
+		t.Errorf("empty input grade = %q, want average", result.Grade)
 	}
 	if len(result.Breakdown.RadarData) != 5 {
 		t.Errorf("expected 5 radar categories, got %d", len(result.Breakdown.RadarData))

--- a/backend/internal/service/area_discovery.go
+++ b/backend/internal/service/area_discovery.go
@@ -19,6 +19,22 @@ import (
 // 全市区町村を対象にするとタイムアウトリスクがあるため制限する（東京都は62市区町村）。
 const areaDiscoveryLimit = 30
 
+// yieldDifficultyLabelFor は domain.CalcYieldDifficulty のコード値を日本語表示ラベルへ変換する。
+// 表示文言は domain（純粋計算層）から分離し service 層で管理する。
+// 未知コード・空コード（データ不足）は "" を返し、呼び出し側のフォールバックに委ねる。
+func yieldDifficultyLabelFor(code string) string {
+	switch code {
+	case "achievable":
+		return "達成可能"
+	case "slightly-difficult":
+		return "やや困難"
+	case "difficult":
+		return "困難"
+	default:
+		return ""
+	}
+}
+
 // AreaMLITClient はエリア探索に必要な国交省APIのサブセット
 type AreaMLITClient interface {
 	FetchMunicipalities(ctx context.Context, area string) ([]mlit.Municipality, error)
@@ -108,7 +124,8 @@ func (s *AreaDiscoveryService) Discover(ctx context.Context, prefecture string, 
 			item.MedianTsubo = stats.MedianTsubo
 			item.TransactionCount = stats.Count
 			item.DataSufficient = stats.Count >= 3
-			item.YieldDifficulty, item.YieldDifficultyLabel = domain.CalcYieldDifficulty(stats.MedianTsubo, budget, targetYield)
+			item.YieldDifficulty = domain.CalcYieldDifficulty(stats.MedianTsubo, budget, targetYield)
+			item.YieldDifficultyLabel = yieldDifficultyLabelFor(item.YieldDifficulty)
 
 			item.LandPriceTrend = domain.CalcLandPriceTrend(transactions)
 			results[idx] = item
@@ -172,7 +189,8 @@ func (s *AreaDiscoveryService) Summarize(ctx context.Context, area, municipality
 		item.MedianTsubo = stats.MedianTsubo
 		item.TransactionCount = stats.Count
 		item.DataSufficient = stats.Count >= 3
-		item.YieldDifficulty, item.YieldDifficultyLabel = domain.CalcYieldDifficulty(stats.MedianTsubo, budget, targetYield)
+		item.YieldDifficulty = domain.CalcYieldDifficulty(stats.MedianTsubo, budget, targetYield)
+		item.YieldDifficultyLabel = yieldDifficultyLabelFor(item.YieldDifficulty)
 		if item.YieldDifficultyLabel == "" {
 			item.YieldDifficulty = "unknown"
 			item.YieldDifficultyLabel = "データ不足"

--- a/backend/internal/service/investment_score.go
+++ b/backend/internal/service/investment_score.go
@@ -166,5 +166,27 @@ func (s *InvestmentScoreService) CalcScoreForTile(ctx context.Context, z, x, y i
 		input.HasLandPriceTrend = true
 	}
 
-	return domain.CalcInvestmentScore(input), nil
+	result := domain.CalcInvestmentScore(input)
+	// domain はコード値を返す。API 契約（grade は日本語）を維持するため service で変換する。
+	result.Grade = gradeLabelFor(result.Grade)
+	return result, nil
+}
+
+// gradeLabelFor は domain.CalcInvestmentScore が返す評価コードを日本語表示ラベルへ変換する。
+// 表示文言は domain（純粋計算層）から分離し service 層で管理する。
+func gradeLabelFor(code string) string {
+	switch code {
+	case "excellent":
+		return "優良"
+	case "good":
+		return "良好"
+	case "average":
+		return "普通"
+	case "caution":
+		return "注意"
+	case "warning":
+		return "要注意"
+	default:
+		return code
+	}
 }


### PR DESCRIPTION
## 概要

Issue #819 の PR-3（最終）。domain に埋まっていた投資適地スコアの**日本語 Grade ラベル**（優良/良好/普通/注意/要注意）を service 層へ分離する。これで domain は標準ライブラリ＋internal のみに依存する純粋計算層になる。

> ⚠️ このPRは #851（PR-2）にスタックしています。base は `refactor/issue819-yield-label`。PR-1→PR-2 マージ後に自動で main へリターゲットされます。

## 変更内容
- `domain.gradeFromScore`: 戻り値をコード値（`excellent` | `good` | `average` | `caution` | `warning`）へ変更
- `service/investment_score.go`: `gradeLabelFor` を新設し、`CalcInvestmentScore` の唯一の呼び出し点で結果の `Grade` を日本語ラベルへ変換
  - 単体スコア（`GetInvestmentScore`）・ヒートマップ（`GetInvestmentScoreHeatmap`）とも `CalcScoreForTile` 経由のため1点変換で両対応
- `grade` の JSON 値（日本語）は不変 → API 契約維持
- **結果**: `go list -deps ./internal/domain/...` が外部依存ゼロ（otel 含む）に。`docs/architecture.md` の「domain=純粋計算層」と一致

## 関連Issue
Closes #819

## テスト
- [x] 既存テストが通ること（全パッケージ PASS）
- [x] domain テストの grade 期待値をコード値へ更新（`gradeFromScore` / `CalcInvestmentScore`）
- [x] service 経由の api テストは日本語 grade のまま PASS（変換点が service に移っただけ）
- [x] `make swagger-check` 差分ゼロ（JSON 契約不変）

## 確認事項
- [x] コードレビュー観点での自己レビュー済み
