### PR TITLE
refactor(backend): 利回り難易度の日本語ラベルを domain から service へ分離 (#819 PR-2)

### DIFF
--- a/backend/internal/domain/investment.go
+++ b/backend/internal/domain/investment.go
@@ -222,12 +222,13 @@ func CalcLandPriceStats(ctx context.Context, transactions []LandTransaction) Lan
 	}
 }
 
-// CalcYieldDifficulty は坪単価中央値・予算・目標利回りから利回り達成難易度を返す。
-// difficulty は "achievable" | "slightly-difficult" | "difficult"。
-// medianTsubo が 0 の場合は ("", "") を返す。
-func CalcYieldDifficulty(medianTsubo, budget, targetYield float64) (difficulty, label string) {
+// CalcYieldDifficulty は坪単価中央値・予算・目標利回りから利回り達成難易度コードを返す。
+// 戻り値は "achievable" | "slightly-difficult" | "difficult"。
+// medianTsubo が 0 の場合は "" を返す。
+// 日本語表示ラベルへの変換は呼び出し側（service 層）が担う。
+func CalcYieldDifficulty(medianTsubo, budget, targetYield float64) (difficulty string) {
 	if medianTsubo <= 0 {
-		return "", ""
+		return ""
 	}
 	var rentPerTsubo float64
 	if budget > 0 {
@@ -244,11 +245,11 @@ func CalcYieldDifficulty(medianTsubo, budget, targetYield float64) (difficulty, 
 	}
 	switch {
 	case rentPerTsubo <= 8000:
-		return "achievable", "達成可能"
+		return "achievable"
 	case rentPerTsubo <= 15000:
-		return "slightly-difficult", "やや困難"
+		return "slightly-difficult"
 	default:
-		return "difficult", "困難"
+		return "difficult"
 	}
 }
 

--- a/backend/internal/domain/investment_test.go
+++ b/backend/internal/domain/investment_test.go
@@ -3285,7 +3285,6 @@ func TestCalcYieldDifficulty(t *testing.T) {
 		budget      float64
 		targetYield float64
 		wantDiff    string
-		wantLabel   string
 	}{
 		{
 			name:        "medianTsubo=0 returns empty",
@@ -3293,7 +3292,6 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      0,
 			targetYield: 0.08,
 			wantDiff:    "",
-			wantLabel:   "",
 		},
 		{
 			name:        "no budget, low tsubo price -> achievable",
@@ -3301,8 +3299,7 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      0,
 			targetYield: 0.08,
 			// totalCostEst=100000*30+10000000=13000000, rentPerTsubo=13000000*0.08/12/30≈288
-			wantDiff:  "achievable",
-			wantLabel: "達成可能",
+			wantDiff: "achievable",
 		},
 		{
 			name:        "no budget, high tsubo price -> difficult",
@@ -3310,8 +3307,7 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      0,
 			targetYield: 0.08,
 			// totalCostEst=2000000*30+10000000=70000000, rentPerTsubo=70000000*0.08/12/30≈15556
-			wantDiff:  "difficult",
-			wantLabel: "困難",
+			wantDiff: "difficult",
 		},
 		{
 			name:        "budget mode: cheap area should be achievable",
@@ -3319,8 +3315,7 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      50_000_000,
 			targetYield: 0.08,
 			// tsuboCount=50000000/100000=500, rentPerTsubo=100000*0.08/12≈667
-			wantDiff:  "achievable",
-			wantLabel: "達成可能",
+			wantDiff: "achievable",
 		},
 		{
 			name:        "budget mode: expensive area should be difficult",
@@ -3328,8 +3323,7 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      50_000_000,
 			targetYield: 0.08,
 			// rentPerTsubo=3000000*0.08/12=20000
-			wantDiff:  "difficult",
-			wantLabel: "困難",
+			wantDiff: "difficult",
 		},
 		{
 			name:        "budget mode: different areas give different results (not all same)",
@@ -3337,18 +3331,14 @@ func TestCalcYieldDifficulty(t *testing.T) {
 			budget:      50_000_000,
 			targetYield: 0.08,
 			// rentPerTsubo=500000*0.08/12≈3333
-			wantDiff:  "achievable",
-			wantLabel: "達成可能",
+			wantDiff: "achievable",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			gotDiff, gotLabel := CalcYieldDifficulty(tt.medianTsubo, tt.budget, tt.targetYield)
+			gotDiff := CalcYieldDifficulty(tt.medianTsubo, tt.budget, tt.targetYield)
 			if gotDiff != tt.wantDiff {
 				t.Errorf("difficulty: got %q, want %q", gotDiff, tt.wantDiff)
-			}
-			if gotLabel != tt.wantLabel {
-				t.Errorf("label: got %q, want %q", gotLabel, tt.wantLabel)
 			}
 		})
 	}
@@ -3357,8 +3347,8 @@ func TestCalcYieldDifficulty(t *testing.T) {
 	t.Run("budget mode produces area-dependent results", func(t *testing.T) {
 		budget := 50_000_000.0
 		yield := 0.08
-		cheapDiff, _ := CalcYieldDifficulty(100_000, budget, yield)
-		expensiveDiff, _ := CalcYieldDifficulty(3_000_000, budget, yield)
+		cheapDiff := CalcYieldDifficulty(100_000, budget, yield)
+		expensiveDiff := CalcYieldDifficulty(3_000_000, budget, yield)
 		if cheapDiff == expensiveDiff {
 			t.Errorf("budget mode should give different difficulty for cheap (%s) vs expensive (%s) areas",
 				cheapDiff, expensiveDiff)

--- a/backend/internal/service/area_discovery.go
+++ b/backend/internal/service/area_discovery.go
@@ -19,6 +19,22 @@ import (
 // 全市区町村を対象にするとタイムアウトリスクがあるため制限する（東京都は62市区町村）。
 const areaDiscoveryLimit = 30
 
+// yieldDifficultyLabelFor は domain.CalcYieldDifficulty のコード値を日本語表示ラベルへ変換する。
+// 表示文言は domain（純粋計算層）から分離し service 層で管理する。
+// 未知コード・空コード（データ不足）は "" を返し、呼び出し側のフォールバックに委ねる。
+func yieldDifficultyLabelFor(code string) string {
+	switch code {
+	case "achievable":
+		return "達成可能"
+	case "slightly-difficult":
+		return "やや困難"
+	case "difficult":
+		return "困難"
+	default:
+		return ""
+	}
+}
+
 // AreaMLITClient はエリア探索に必要な国交省APIのサブセット
 type AreaMLITClient interface {
 	FetchMunicipalities(ctx context.Context, area string) ([]mlit.Municipality, error)
@@ -108,7 +124,8 @@ func (s *AreaDiscoveryService) Discover(ctx context.Context, prefecture string, 
 			item.MedianTsubo = stats.MedianTsubo
 			item.TransactionCount = stats.Count
 			item.DataSufficient = stats.Count >= 3
-			item.YieldDifficulty, item.YieldDifficultyLabel = domain.CalcYieldDifficulty(stats.MedianTsubo, budget, targetYield)
+			item.YieldDifficulty = domain.CalcYieldDifficulty(stats.MedianTsubo, budget, targetYield)
+			item.YieldDifficultyLabel = yieldDifficultyLabelFor(item.YieldDifficulty)
 
 			item.LandPriceTrend = domain.CalcLandPriceTrend(transactions)
 			results[idx] = item
@@ -172,7 +189,8 @@ func (s *AreaDiscoveryService) Summarize(ctx context.Context, area, municipality
 		item.MedianTsubo = stats.MedianTsubo
 		item.TransactionCount = stats.Count
 		item.DataSufficient = stats.Count >= 3
-		item.YieldDifficulty, item.YieldDifficultyLabel = domain.CalcYieldDifficulty(stats.MedianTsubo, budget, targetYield)
+		item.YieldDifficulty = domain.CalcYieldDifficulty(stats.MedianTsubo, budget, targetYield)
+		item.YieldDifficultyLabel = yieldDifficultyLabelFor(item.YieldDifficulty)
 		if item.YieldDifficultyLabel == "" {
 			item.YieldDifficulty = "unknown"
 			item.YieldDifficultyLabel = "データ不足"


### PR DESCRIPTION
## 概要

Issue #819 の PR-2。domain に埋まっていた利回り達成難易度の**日本語表示ラベル**を service 層へ分離する。（旧 #851 が base ブランチ削除で自動クローズされたため再作成）

## 変更内容
- `domain.CalcYieldDifficulty`: 戻り値をコード値のみ（`achievable` | `slightly-difficult` | `difficult`、データ不足は `""`）へ変更
- `service/area_discovery.go`: コード→日本語ラベル変換 `yieldDifficultyLabelFor` を新設し、Discover / Summarize で利用
- 既存の `unknown` / `データ不足` フォールバックは維持 → JSON フィールド出力は不変

## 関連Issue
Ref #819

## テスト
- [x] 既存テストが通ること（domain / service / api / ai 全 PASS）
- [x] `make swagger-check` 差分ゼロ

## 確認事項
- [x] コードレビュー観点での自己レビュー済み（レビューエージェント指摘反映済み）