### PR TITLE
ci(terraform): Dependabot / fork PR で GCP 認証ステップをスキップ

### DIFF
--- a/.github/workflows/terraform-ci.yml
+++ b/.github/workflows/terraform-ci.yml
@@ -35,6 +35,10 @@ jobs:
     runs-on: ubuntu-24.04
 
     env:
+      # Dependabot and fork PRs do not receive secrets, so WIF authentication
+      # cannot succeed. Skip the GCP-dependent steps and fall back to a
+      # backend-less init so fmt / validate / tflint still provide signal.
+      SKIP_GCP: ${{ github.event_name == 'pull_request' && (github.actor == 'dependabot[bot]' || github.event.pull_request.head.repo.full_name != github.repository) }}
       TF_VAR_project_id: ${{ secrets.GCP_PROJECT_ID }}
       TF_VAR_env: ${{ inputs.environment || 'prod' }}
       TF_VAR_region: "asia-northeast1"
@@ -59,6 +63,7 @@ jobs:
         working-directory: terraform
 
       - name: Authenticate to Google Cloud (OIDC)
+        if: env.SKIP_GCP != 'true'
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3.0.0
         with:
           workload_identity_provider: ${{ inputs.environment == 'stg' && secrets.WIF_PROVIDER_STG || secrets.WIF_PROVIDER }}
@@ -66,7 +71,9 @@ jobs:
 
       - name: Terraform Init
         run: |
-          if [ "${{ inputs.environment }}" = "stg" ]; then
+          if [ "${SKIP_GCP}" = "true" ]; then
+            terraform init -backend=false
+          elif [ "${{ inputs.environment }}" = "stg" ]; then
             terraform init -backend-config=backend-stg.hcl -reconfigure
           else
             terraform init
@@ -90,6 +97,7 @@ jobs:
 
       - name: Terraform Plan
         id: plan
+        if: env.SKIP_GCP != 'true'
         run: |
           set -o pipefail
           terraform plan -out=tfplan -no-color 2>&1 | tee /tmp/plan.txt
@@ -97,7 +105,7 @@ jobs:
 
       - name: Post Plan to PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && env.SKIP_GCP != 'true'
         with:
           script: |
             const fs = require('fs');


### PR DESCRIPTION
## 概要

Dependabot PR や fork からの PR には repository secrets が渡らないため、`google-github-actions/auth` が `workload_identity_provider` 空でエラーになり、Terraform CI ジョブ全体が落ちていました。

```
google-github-actions/auth failed with: the GitHub Action workflow must specify
exactly one of "workload_identity_provider" or "credentials_json"!
```

実際に #861（GitHub Actions の Dependabot 更新）がこの理由で 7/26 から失敗したままになっています。

GCP 認証が必要なステップだけを条件付きでスキップし、認証不要な fmt / validate / tflint は引き続き実行してシグナルを残します。

## 変更内容

- ジョブ env に `SKIP_GCP` を追加（`pull_request` かつ Dependabot または fork の場合に true）
- `Authenticate to Google Cloud (OIDC)` — `SKIP_GCP` 時はスキップ
- `Terraform Init` — `SKIP_GCP` 時は `terraform init -backend=false` にフォールバック（GCS backend へアクセスしない）
- `Terraform Plan` — `SKIP_GCP` 時はスキップ（認証と backend が必須のため）
- `Post Plan to PR` — `SKIP_GCP` 時はスキップ（plan 結果がなく、Dependabot PR の GITHUB_TOKEN は read-only）

`workflow_dispatch` 経由の Plan / Apply は `SKIP_GCP` が false になるため、従来どおり動作します。

判定条件は `frontend-ci.yml` の Vercel deploy ジョブにある既存パターン（`github.actor != 'dependabot[bot]'` + 同一リポジトリ判定）に合わせています。

## 関連Issue

なし（#861 のブロッカー解消）

## テスト

- [x] 既存テストが通ること
- [x] 新規テストを追加した場合、全ケースがPASSすること

ローカルで認証なしのフォールバック経路を Terraform v1.14.9（CI と同一）で検証済み:

- `terraform init -backend=false` → 成功
- `terraform validate` → `Success! The configuration is valid.`
- `tflint --init` + `tflint --format compact` → exit 0

## 確認事項

- [x] コードレビュー観点での自己レビュー済み