### PR TITLE
chore(dependabot): typescript / eslint のメジャー更新を ignore に追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,9 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      # openapi-typescript の peer が typescript@^5.x のため TS7 は npm ci が通らない
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      # eslint-config-next が依存する eslint-plugin-react が ESLint 10 未対応
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## 概要

`typescript` と `eslint` のメジャー更新はいずれも上流側の非対応でマージできず、毎週 CI が落ちる PR が再作成され続けていました。既存の `next` / `react` / `react-dom` と同じ方針で ignore に追加します。

### typescript 7.x（#859）

`openapi-typescript@7.13.0`（最新）の peer が依然 `typescript@^5.x` のため、`npm ci` が ERESOLVE で失敗します。

```
npm error Conflicting peer dependency: typescript@5.9.3
npm error   peer typescript@"^5.x" from openapi-typescript@7.13.0
```

### eslint 10.x（#858）

`eslint-config-next@16.3.0`（最新）が `eslint-plugin-react@^7.37.0` に依存していますが、その最新 7.37.5 の peer は `eslint: ^3 || ... || ^9.7` で ESLint 10 未対応です。`npm ci` は通るものの Lint で落ちます。

```
ESLint: 10.8.0
TypeError: Error while loading rule 'react/display-name':
  contextOrFilename.getFilename is not a function
```

## 変更内容

- `.github/dependabot.yml` の npm (`/frontend`) の `ignore` に以下を追加
  - `typescript` の `version-update:semver-major`
  - `eslint` の `version-update:semver-major`
- それぞれブロック理由をコメントで明記

マイナー / パッチ更新は `minor-and-patch` グループで従来どおり届きます。上流が対応したら ignore を外して個別に対応します。

## 関連Issue

なし（#858 / #859 をクローズしたことへの追従）

## テスト

- [x] 既存テストが通ること
- [x] 新規テストを追加した場合、全ケースがPASSすること

`.github/dependabot.yml` の YAML パースを確認済み。

## 確認事項

- [x] コードレビュー観点での自己レビュー済み